### PR TITLE
More holopad placement

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -17615,6 +17615,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
@@ -18816,10 +18817,6 @@
 "blf" = (
 /turf/simulated/floor/wood,
 /area/station/procedure/trainer_office)
-"blg" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/lounge)
 "blh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -31294,7 +31291,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
 "cgK" = (
@@ -33953,6 +33949,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/north)
 "crV" = (
@@ -54579,21 +54576,6 @@
 	icon_state = "cafeteria"
 	},
 /area/station/medical/reception)
-"gOT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutral"
-	},
-/area/station/hallway/secondary/entry/lounge)
 "gPb" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
@@ -64151,6 +64133,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutral"
@@ -73940,14 +73923,18 @@
 	},
 /area/station/medical/reception)
 "qJN" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/north)
+/area/station/hallway/primary/central/se)
 "qKh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -101335,7 +101322,7 @@ aXB
 aZY
 aVc
 bgw
-gOT
+bda
 aSW
 bgt
 bkc
@@ -102626,7 +102613,7 @@ sYL
 sYL
 sYL
 brn
-blg
+mgM
 bqr
 bvb
 btA
@@ -117052,7 +117039,7 @@ tDt
 kEA
 meh
 crU
-qJN
+cvJ
 cGo
 cvJ
 fDx
@@ -120641,7 +120628,7 @@ xig
 xBy
 tgQ
 bFO
-gVV
+qJN
 lLv
 eEA
 cdW
@@ -122937,7 +122924,7 @@ bmq
 bmq
 bAv
 bAk
-bHy
+brW
 bDa
 bOU
 aTY
@@ -123708,7 +123695,7 @@ bmq
 bzo
 aUS
 pcF
-brW
+bHy
 bDb
 bEy
 aUO
@@ -124993,7 +124980,7 @@ gxs
 bdT
 bdT
 bAk
-bHy
+brW
 aRy
 bEp
 aVI

--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -443,6 +443,7 @@
 	c_tag = "Firing Range"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/security/range)
 "adm" = (
@@ -8376,6 +8377,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -9759,7 +9761,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -10351,6 +10352,7 @@
 	c_tag = "Holodeck West";
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "aKS" = (
@@ -10717,6 +10719,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "blue"
@@ -12070,7 +12073,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "aQD" = (
-/obj/machinery/hologram/holopad,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -12541,6 +12543,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore)
 "aSc" = (
@@ -14337,6 +14340,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/security/checkpoint/secondary)
 "aXE" = (
@@ -14523,6 +14527,7 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/grimey,
 /area/station/service/bar)
 "aYe" = (
@@ -17289,6 +17294,7 @@
 	dir = 4
 	},
 /obj/machinery/light,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
 	},
@@ -18813,7 +18819,7 @@
 "blg" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/entry/lounge)
 "blh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -19027,6 +19033,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/east)
 "blP" = (
@@ -19064,9 +19071,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/east)
 "blX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
-/area/station/hallway/primary/port/east)
+/area/station/hallway/primary/central/nw)
 "bmc" = (
 /turf/simulated/wall/r_wall,
 /area/station/command/bridge)
@@ -19084,6 +19094,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/west)
 "bmf" = (
@@ -19670,6 +19681,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/ne)
 "bnN" = (
@@ -19955,6 +19967,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -21060,12 +21073,15 @@
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "brW" = (
-/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/station/service/bar)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/west)
 "brX" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -22813,6 +22829,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/ne)
 "byy" = (
@@ -22982,6 +22999,7 @@
 	name = "west bump";
 	pixel_x = -28
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/south)
 "bzs" = (
@@ -23480,7 +23498,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
 "bBo" = (
-/obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/supply/sorting)
@@ -24872,6 +24889,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
 "bHr" = (
@@ -26115,10 +26133,10 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/south)
 "bMc" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/stripes/line,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/south)
+/turf/simulated/floor/plating,
+/area/station/maintenance/assembly_line)
 "bMd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -26197,7 +26215,6 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/north,
-/obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -28495,6 +28512,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -29233,7 +29251,6 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
 "bYJ" = (
@@ -30035,7 +30052,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -30313,6 +30329,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkgreen"
@@ -30412,6 +30429,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "cdy" = (
@@ -30787,6 +30805,11 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"ceX" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/south)
 "cfb" = (
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
@@ -30932,7 +30955,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -31123,6 +31145,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
 "cgj" = (
@@ -31138,7 +31161,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
 "cgk" = (
-/obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/cable{
@@ -31272,6 +31294,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
 "cgK" = (
@@ -32468,6 +32491,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -37459,7 +37483,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -37739,6 +37762,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -37792,6 +37816,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "cFY" = (
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple"
@@ -38322,7 +38347,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -39519,9 +39543,8 @@
 /area/station/maintenance/assembly_line)
 "cME" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/station/maintenance/assembly_line)
+/area/station/hallway/secondary/entry/north)
 "cMF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
@@ -39629,7 +39652,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -41844,6 +41866,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "cVs" = (
@@ -42322,6 +42345,7 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 2
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "whiteblue"
@@ -42753,6 +42777,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
+"cZf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "cZg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -44999,6 +45033,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
 "diC" = (
@@ -48183,6 +48218,13 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
+"dIH" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "blue"
+	},
+/area/station/command/bridge)
 "dIQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -48402,6 +48444,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
 "dOb" = (
@@ -48650,6 +48693,19 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/meeting_room)
+"dUO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/nw)
 "dUS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -50191,6 +50247,10 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/station/security/permabrig)
+"eGn" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/supply/office)
 "eGo" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/machinery/light/small{
@@ -50642,6 +50702,15 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine/supermatter)
+"eQz" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitebluefull"
+	},
+/area/station/medical/medbay)
 "eQJ" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -51829,7 +51898,6 @@
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "fuU" = (
-/obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -52843,6 +52911,19 @@
 /obj/structure/chair/sofa/corp,
 /turf/simulated/floor/transparent/glass,
 /area/station/hallway/primary/central/south)
+"fWk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/sw)
 "fWC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -53248,6 +53329,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
+"gik" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/supply/storage)
 "gin" = (
 /obj/structure/railing{
 	dir = 4
@@ -54485,6 +54579,21 @@
 	icon_state = "cafeteria"
 	},
 /area/station/medical/reception)
+"gOT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/station/hallway/secondary/entry/lounge)
 "gPb" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
@@ -54629,6 +54738,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
+"gSA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/east)
 "gSC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56376,6 +56498,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
+"hNV" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitegreenfull"
+	},
+/area/station/medical/virology)
 "hOa" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -58241,6 +58369,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
 "iRc" = (
@@ -58399,6 +58528,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "whiteblue"
@@ -58774,6 +58904,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
+"jfB" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
+/area/station/service/bar)
 "jfQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58905,6 +59039,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
 "jkn" = (
@@ -59212,6 +59347,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -59321,6 +59457,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/gravitygenerator)
+"jty" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/station/science/xenobiology)
 "jtO" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -61287,6 +61429,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"kvB" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/control)
 "kvZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61395,7 +61543,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hardsuitstorage)
 "kyf" = (
-/obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -61408,6 +61555,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -62017,6 +62165,10 @@
 	icon_state = "brown"
 	},
 /area/station/supply/miningdock)
+"kMC" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/carpet,
+/area/station/public/vacant_office)
 "kNq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -62070,9 +62222,15 @@
 	},
 /area/station/science/robotics/chargebay)
 "kOt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
-/area/station/public/dorms)
+/area/station/hallway/primary/central/west)
 "kOE" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -62155,7 +62313,6 @@
 	},
 /area/station/maintenance/asmaint2)
 "kQY" = (
-/obj/machinery/hologram/holopad,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/shaft_miner,
 /turf/simulated/floor/plasteel,
@@ -62377,6 +62534,18 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
+"kWc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/station/public/dorms)
 "kWz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -63269,6 +63438,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
+"ltt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "ltR" = (
 /obj/structure/plasticflaps{
 	opacity = 1
@@ -63630,6 +63806,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/west)
 "lFH" = (
@@ -64581,16 +64758,24 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "mdt" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/area/station/science/hallway)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/port/west)
 "mdx" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -64676,6 +64861,10 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
+"mfF" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/hardsuitstorage)
 "mfM" = (
 /turf/simulated/floor/plasteel,
 /area/station/science/lobby)
@@ -65078,6 +65267,17 @@
 	icon_state = "cafeteria"
 	},
 /area/station/medical/reception)
+"mpZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/service/chapel)
 "mqP" = (
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Secure Gate";
@@ -65726,6 +65926,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
+"mJg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "mJi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/molten_object/large,
@@ -66275,6 +66481,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/south)
 "mXZ" = (
@@ -66765,6 +66972,7 @@
 /area/station/turret_protected/aisat/interior)
 "nrD" = (
 /obj/machinery/alarm/directional/west,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -69838,6 +70046,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
+"oNx" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/engine,
+/area/station/engineering/control)
 "oND" = (
 /obj/machinery/light{
 	dir = 8
@@ -72187,6 +72402,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
+"qdg" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/port/east)
 "qdm" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -73721,11 +73940,14 @@
 	},
 /area/station/medical/reception)
 "qJN" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/area/station/medical/medbay3)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/north)
 "qKh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -74346,6 +74568,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hardsuitstorage)
+"rbC" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
+/area/station/service/library)
 "rbZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/oil/maybe,
@@ -78677,6 +78903,16 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
+"tzB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/south)
 "tzE" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -79355,6 +79591,10 @@
 	icon_state = "white"
 	},
 /area/station/science/hallway)
+"tQk" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/supply/sorting)
 "tQB" = (
 /obj/effect/mapping_helpers/airlock/access/any/command/captain,
 /obj/machinery/door/firedoor,
@@ -79574,6 +79814,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/assembly_line)
+"tUM" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "blue"
+	},
+/area/station/command/bridge)
 "tVd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
@@ -80784,6 +81032,13 @@
 /obj/machinery/atmospherics/portable/pump,
 /turf/simulated/floor/plasteel,
 /area/station/science/toxins/mixing)
+"uDY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/sw)
 "uEc" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/machinery/door/poddoor/preopen{
@@ -82745,6 +83000,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -83160,6 +83416,19 @@
 /obj/machinery/power/apc/directional/west,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
+"vWm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/south)
 "vWw" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -83222,6 +83491,15 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/control)
+"vYg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/se)
 "vYh" = (
 /obj/item/radio/intercom{
 	name = "east bump";
@@ -85228,6 +85506,15 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/medical/cloning)
+"xcw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitebluefull"
+	},
+/area/station/medical/reception)
 "xcB" = (
 /obj/structure/chair{
 	dir = 8
@@ -85647,6 +85934,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/assembly_line)
+"xnE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/north)
 "xnF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -85677,6 +85970,10 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/robotics)
+"xoz" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/exit)
 "xoE" = (
 /obj/machinery/power/apc/directional/west,
 /obj/structure/cable{
@@ -86940,9 +87237,10 @@
 	},
 /area/station/science/xenobiology)
 "xUR" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/carpet/arcade,
-/area/station/public/arcade)
+/turf/simulated/floor/plasteel,
+/area/station/supply/miningdock)
 "xUW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -98202,7 +98500,7 @@ aOP
 qMv
 aPJ
 feN
-feN
+cME
 aUk
 fay
 aVY
@@ -100257,7 +100555,7 @@ aLB
 aKN
 aGn
 oan
-feN
+cME
 aRS
 aUV
 aUV
@@ -100266,7 +100564,7 @@ aTo
 aTo
 aTo
 aTo
-aTo
+ltt
 bdn
 bgH
 bjU
@@ -100287,7 +100585,7 @@ jXy
 kEt
 iUj
 vwz
-bLZ
+ceX
 aSn
 aaa
 aaa
@@ -100525,7 +100823,7 @@ bcW
 bgl
 bhK
 aSf
-blg
+aSf
 aSf
 bqf
 brj
@@ -100544,7 +100842,7 @@ twG
 bKU
 bLC
 bwT
-bMc
+bLZ
 aSn
 aaa
 aaa
@@ -101037,7 +101335,7 @@ aXB
 aZY
 aVc
 bgw
-bda
+gOT
 aSW
 bgt
 bkc
@@ -101818,7 +102116,7 @@ bss
 bqr
 brU
 brU
-bvn
+kMC
 bBH
 bAm
 bqr
@@ -102328,7 +102626,7 @@ sYL
 sYL
 sYL
 brn
-mgM
+blg
 bqr
 bvb
 btA
@@ -104380,7 +104678,7 @@ bdx
 bcQ
 aTu
 bgq
-blH
+mdt
 bjY
 blM
 bnv
@@ -105156,7 +105454,7 @@ bpc
 blM
 bnA
 bnD
-bvv
+bnD
 bvp
 bvT
 bzQ
@@ -105405,7 +105703,7 @@ aWi
 aXQ
 aXQ
 bbl
-bdd
+aXQ
 beR
 bgz
 puM
@@ -105917,7 +106215,7 @@ aLx
 aVi
 aWm
 aXQ
-aXQ
+bdd
 bal
 bcT
 aVi
@@ -106187,7 +106485,7 @@ brv
 bug
 bvt
 bwb
-bvv
+bnD
 bBQ
 bzA
 blM
@@ -106956,7 +107254,7 @@ blM
 bnH
 bnD
 bnD
-bnD
+bvv
 bwd
 bsk
 blM
@@ -107998,7 +108296,7 @@ bxb
 bIX
 bQf
 rBg
-bOh
+gik
 ozC
 ojs
 vAZ
@@ -109299,7 +109597,7 @@ aab
 aaa
 cam
 cnm
-qat
+xUR
 lxA
 cam
 aaa
@@ -110056,7 +110354,7 @@ bNM
 bQj
 bSp
 bUm
-bBn
+eGn
 bVJ
 bBn
 bBn
@@ -111064,7 +111362,7 @@ dil
 biF
 dmv
 bkg
-blX
+qdg
 blQ
 bsR
 svp
@@ -111076,7 +111374,7 @@ byl
 wbT
 lje
 wKl
-wKl
+tQk
 wKl
 lje
 bMk
@@ -112608,7 +112906,7 @@ hdm
 bpm
 bqq
 brJ
-brJ
+blX
 bum
 brJ
 bwB
@@ -112617,7 +112915,7 @@ bCt
 wNl
 wxi
 rFd
-wxi
+kOt
 wxi
 wxi
 wxi
@@ -112625,7 +112923,7 @@ igI
 eum
 bQn
 kgz
-kgz
+uDY
 bUY
 bST
 rSd
@@ -113147,7 +113445,7 @@ bSi
 bSi
 bSi
 bTy
-cok
+fWk
 cfi
 cgS
 cgS
@@ -113428,7 +113726,7 @@ wIB
 cKf
 vXu
 cMw
-cME
+cJx
 cMx
 cLf
 cOr
@@ -113942,7 +114240,7 @@ vPC
 kRy
 ifN
 jXc
-cLG
+bMc
 cNG
 cLf
 cKb
@@ -114146,7 +114444,7 @@ bdO
 aSC
 ldZ
 bgP
-yhp
+dUO
 bkv
 uhY
 aaa
@@ -114472,7 +114770,7 @@ uVt
 cXJ
 uVt
 uVt
-uVt
+mfF
 cRw
 rgM
 cRo
@@ -114723,7 +115021,7 @@ rgM
 dsK
 uVt
 cWy
-uVt
+mfF
 xHz
 uVt
 cXJ
@@ -115253,7 +115551,7 @@ cSE
 qRu
 cRb
 cTD
-cRb
+oNx
 cRb
 cRb
 cRb
@@ -115445,7 +115743,7 @@ qUH
 fcC
 fcC
 ngD
-dXn
+tUM
 dXn
 egz
 taA
@@ -116714,7 +117012,7 @@ aRE
 baE
 bhd
 bhd
-bhd
+xnE
 biI
 bnf
 bkz
@@ -116739,7 +117037,7 @@ spy
 vrd
 drs
 tSR
-cev
+tzB
 cev
 mnp
 nYg
@@ -116754,7 +117052,7 @@ tDt
 kEA
 meh
 crU
-cvJ
+qJN
 cGo
 cvJ
 fDx
@@ -118015,7 +118313,7 @@ qlh
 wqU
 wqU
 wqU
-wqU
+dIH
 wqU
 bqS
 jxq
@@ -118030,7 +118328,7 @@ nSl
 izs
 fqA
 cdN
-cgj
+vWm
 cfv
 aUQ
 rPM
@@ -118507,7 +118805,7 @@ gMv
 sLv
 chc
 aRx
-bdN
+kWc
 aDN
 aYJ
 buM
@@ -118851,7 +119149,7 @@ cSU
 cSU
 ePY
 dhv
-ePY
+kvB
 ePY
 tky
 fFY
@@ -119536,7 +119834,7 @@ chc
 bbi
 aPm
 gEU
-kOt
+aPm
 aDP
 aDP
 igR
@@ -120632,7 +120930,7 @@ cEr
 cEr
 cPS
 cQU
-cSd
+daO
 deJ
 dfF
 cSd
@@ -120849,7 +121147,7 @@ bKN
 bKN
 bQO
 cbm
-cbm
+vYg
 cbm
 bVS
 cbm
@@ -121672,7 +121970,7 @@ ddt
 cZU
 deK
 dfG
-cSd
+daO
 dgR
 dhE
 qla
@@ -121835,7 +122133,7 @@ aSP
 aEv
 aFI
 lFV
-xUR
+aGN
 fmN
 aKK
 aJw
@@ -123130,7 +123428,7 @@ agu
 vGf
 iMp
 aWY
-aWY
+mJg
 wam
 aWY
 jDV
@@ -123149,7 +123447,7 @@ btw
 bri
 bto
 buR
-bmq
+jfB
 bmq
 bAv
 bAk
@@ -123401,7 +123699,7 @@ beF
 bot
 bjm
 bmq
-brW
+bmM
 btq
 bmq
 bmq
@@ -123410,7 +123708,7 @@ bmq
 bzo
 aUS
 pcF
-bHy
+brW
 bDb
 bEy
 aUO
@@ -123931,7 +124229,7 @@ bLh
 ktW
 fuU
 bOB
-bZR
+xcw
 bZR
 bZR
 bZR
@@ -123949,9 +124247,9 @@ rcW
 hoz
 cfF
 cjB
-ckZ
+eQz
 cmm
-cnx
+bZm
 coa
 iHE
 mTj
@@ -125203,7 +125501,7 @@ bmt
 bof
 bof
 bof
-bof
+buv
 bof
 bof
 bxG
@@ -125955,7 +126253,7 @@ aFK
 kiu
 aPm
 aSM
-aVt
+cZf
 aXf
 aXf
 mOi
@@ -128828,7 +129126,7 @@ pMM
 ckr
 bWi
 oyt
-qJN
+cfY
 chD
 cpy
 cpL
@@ -130374,7 +130672,7 @@ cjG
 cQk
 wYg
 cxs
-cxH
+hNV
 ctx
 cuL
 cQn
@@ -131879,7 +132177,7 @@ bch
 bem
 bfY
 bkn
-bcp
+rbC
 blj
 blj
 blj
@@ -133947,7 +134245,7 @@ blj
 bCR
 bau
 bFz
-bHI
+gSA
 cfy
 bDq
 bKT
@@ -134255,7 +134553,7 @@ bGG
 qZN
 cSH
 cXA
-cEH
+jty
 cZv
 nXu
 sqC
@@ -135528,7 +135826,7 @@ chW
 cFH
 chW
 cdi
-mdt
+izl
 fbS
 pLR
 izl
@@ -136241,7 +136539,7 @@ aGY
 bJe
 pHF
 aUX
-aUX
+mpZ
 aZF
 bcP
 bgb
@@ -136517,7 +136815,7 @@ boJ
 qyq
 aYP
 xmi
-bHI
+gSA
 cXh
 bED
 bED
@@ -140110,7 +140408,7 @@ aab
 aaa
 ktQ
 ylC
-bmm
+xoz
 bBl
 bCT
 wKx
@@ -140377,7 +140675,7 @@ jwn
 bAK
 cYe
 bHV
-bmm
+xoz
 bGJ
 ciY
 csL

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -284,6 +284,7 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
 "adZ" = (
@@ -900,6 +901,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluefull"
 	},
@@ -1223,6 +1225,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -1386,6 +1389,7 @@
 	dir = 8
 	},
 /obj/machinery/light,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -1796,6 +1800,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -6262,6 +6267,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -6814,6 +6820,7 @@
 "aBQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -6825,6 +6832,7 @@
 /area/station/supply/storage)
 "aBT" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -9589,7 +9597,6 @@
 	},
 /area/station/hallway/primary/fore/east)
 "aKu" = (
-/obj/machinery/hologram/holopad,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -11158,6 +11165,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
 "aPH" = (
@@ -12317,6 +12325,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/effect/landmark/lightsout,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -15696,7 +15705,6 @@
 /turf/simulated/floor/transparent/glass,
 /area/station/aisat)
 "bea" = (
-/obj/machinery/hologram/holopad,
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -16780,6 +16788,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -17231,7 +17240,6 @@
 	},
 /area/station/engineering/atmos)
 "biU" = (
-/obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -17244,7 +17252,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -17401,13 +17408,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/service/hydroponics)
 "bjn" = (
-/obj/machinery/hologram/holopad,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "greenblue"
@@ -18128,6 +18133,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "blF" = (
@@ -18802,6 +18808,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -21306,6 +21313,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -22203,6 +22211,10 @@
 	},
 /turf/simulated/floor/greengrid,
 /area/station/turret_protected/ai)
+"bzC" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/medbay)
 "bzD" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/blue,
@@ -26822,7 +26834,6 @@
 /turf/simulated/floor/wood,
 /area/station/command/meeting_room)
 "bMN" = (
-/obj/machinery/hologram/holopad,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -26936,7 +26947,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/ai_upload)
 "bNc" = (
-/obj/machinery/hologram/holopad,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -28104,6 +28114,7 @@
 	c_tag = "Command Meeting Room";
 	dir = 1
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/station/command/meeting_room)
 "bQI" = (
@@ -29168,6 +29179,7 @@
 /obj/structure/disposalpipe/junction/reversed{
 	dir = 2
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -29867,6 +29879,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -31651,6 +31664,16 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/security/detective)
+"ccK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/medbay)
 "ccO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -35062,7 +35085,6 @@
 	},
 /area/station/engineering/control)
 "cpt" = (
-/obj/machinery/hologram/holopad,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -35073,6 +35095,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/hologram/holopad,
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -35263,6 +35286,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -35359,6 +35383,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -37695,20 +37720,8 @@
 /area/station/science/robotics/showroom)
 "cxd" = (
 /obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery/hollow,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/station/public/locker)
+/turf/simulated/floor/plasteel,
+/area/station/supply/miningdock)
 "cxe" = (
 /obj/structure/musician/piano,
 /turf/simulated/floor/plasteel{
@@ -39436,6 +39449,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -40176,6 +40190,7 @@
 	},
 /area/station/hallway/primary/central/south)
 "cEW" = (
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutral"
@@ -46575,6 +46590,7 @@
 	location = "hall7c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -47435,14 +47451,12 @@
 /turf/simulated/floor/plating,
 /area/station/science/robotics/chargebay)
 "dfq" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/chemistry)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
+/area/station/command/office/captain)
 "dft" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
@@ -50821,6 +50835,7 @@
 	},
 /obj/effect/landmark/start/roboticist,
 /obj/effect/turf_decal/stripes/corner,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/science/robotics)
 "dvp" = (
@@ -54908,6 +54923,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "dSz" = (
@@ -55745,7 +55761,6 @@
 	},
 /area/station/hallway/secondary/exit)
 "dWK" = (
-/obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -57253,6 +57268,10 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/storage)
+"ewg" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/break_room)
 "ewj" = (
 /obj/structure/railing{
 	dir = 1
@@ -57378,6 +57397,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
 "ezR" = (
@@ -57655,6 +57675,13 @@
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/arrival/station)
+"eHy" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/carpet,
+/area/station/command/office/hop)
 "eHD" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
@@ -57924,6 +57951,12 @@
 	icon_state = "darkred"
 	},
 /area/station/security/prisonershuttle)
+"eNR" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/supply/lobby)
 "eOk" = (
 /obj/structure/lattice,
 /obj/machinery/camera{
@@ -58096,6 +58129,12 @@
 	icon_state = "red"
 	},
 /area/station/security/storage)
+"eSJ" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "eSW" = (
 /obj/structure/table,
 /obj/item/storage/fancy/crayons,
@@ -59060,6 +59099,19 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/science/xenobiology)
+"fxV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/hologram/holopad,
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "fyn" = (
 /obj/machinery/economy/vending/coffee,
 /obj/machinery/light{
@@ -59230,6 +59282,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/aisat)
+"fDw" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/carpet/arcade,
+/area/station/public/arcade)
 "fDS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59576,6 +59632,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
 	},
@@ -60485,6 +60542,21 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central/se)
+"gkX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/exit)
 "gls" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -60706,9 +60778,16 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/north)
 "gua" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel/dark,
-/area/station/medical/surgery/observation)
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/east)
 "guk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -61537,6 +61616,15 @@
 "gQW" = (
 /turf/simulated/wall/r_wall,
 /area/station/science/toxins/launch)
+"gRp" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkredcorners"
+	},
+/area/station/security/prison/cell_block/a)
 "gRI" = (
 /obj/structure/chair/office,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -61544,6 +61632,19 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/legal/courtroom/gallery)
+"gSI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/research)
 "gTw" = (
 /obj/structure/table/wood,
 /obj/item/folder/white,
@@ -61902,6 +62003,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/office/rd)
+"hhk" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whiteblue"
+	},
+/area/station/medical/reception)
 "hhn" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/crate/trashcart,
@@ -62073,6 +62188,10 @@
 /obj/structure/table/wood,
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/bar)
+"hlP" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
+/area/station/public/vacant_office)
 "hlY" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 4
@@ -62100,15 +62219,17 @@
 	},
 /area/station/hallway/primary/central/north)
 "hmr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/research)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/port/north)
 "hmz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -63216,6 +63337,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredcorners"
 	},
@@ -63743,6 +63865,16 @@
 	icon_state = "showroomfloor"
 	},
 /area/station/medical/surgery)
+"ify" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/research)
 "igc" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
@@ -63868,6 +64000,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
 	},
@@ -65150,6 +65283,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/station/science/research)
+"iWg" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/public/fitness)
 "iWz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -65731,17 +65870,12 @@
 	},
 /area/station/maintenance/port)
 "joI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor/engine,
+/area/station/engineering/controlroom)
 "joU" = (
 /obj/machinery/economy/vending/cigarette,
 /obj/effect/turf_decal/delivery/hollow,
@@ -66136,6 +66270,15 @@
 	icon_state = "chapel"
 	},
 /area/station/service/chapel)
+"jDD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/central/north)
 "jDK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9
@@ -66785,6 +66928,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"jVr" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/central/ne)
 "jVv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -67489,6 +67638,13 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
+"krh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/bridge)
 "krm" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -67689,6 +67845,12 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/break_room)
+"kxX" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/central/sw)
 "kxY" = (
 /obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -68013,6 +68175,12 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison/cell_block/a)
+"kGX" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos/distribution)
 "kHj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -68061,6 +68229,7 @@
 	name = "south bump";
 	pixel_y = -28
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
 "kID" = (
@@ -68167,6 +68336,19 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/east)
+"kLv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel/dark,
+/area/station/medical/morgue)
 "kLU" = (
 /obj/structure/girder,
 /turf/simulated/floor/plasteel{
@@ -68271,6 +68453,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
 "kPt" = (
@@ -68884,6 +69067,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/surgery/observation)
 "lhu" = (
@@ -68915,6 +69099,14 @@
 	icon_state = "darkredcorners"
 	},
 /area/station/security/prisonershuttle)
+"liy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/aft/north)
 "liC" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
@@ -69255,6 +69447,15 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/research)
+"lrq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/south)
 "lrT" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -69658,6 +69859,12 @@
 "lBR" = (
 /turf/simulated/wall,
 /area/station/hallway/primary/starboard/east)
+"lCp" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/central/north)
 "lCu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/newscaster/directional/north,
@@ -71151,6 +71358,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/coldroom)
+"myU" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/starboard/west)
 "mzg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -71334,6 +71556,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port2)
+"mDz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel/grimy,
+/area/station/service/library)
 "mEG" = (
 /turf/simulated/floor/wood,
 /area/station/security/detective)
@@ -71529,6 +71757,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -71878,6 +72107,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
+"mTj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/research)
 "mTs" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -72175,7 +72411,6 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
 "mZT" = (
@@ -72937,6 +73172,12 @@
 /obj/machinery/power/apc/directional/east,
 /turf/simulated/floor/plating,
 /area/station/medical/coldroom)
+"ntW" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/central/se)
 "ntZ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
@@ -73382,6 +73623,12 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central/north)
+"nGL" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/central/south)
 "nHY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -73761,6 +74008,21 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/command/bridge)
+"nWy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/port/west)
 "nWB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -73944,6 +74206,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
 "nZA" = (
@@ -74204,7 +74467,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/hologram/holopad,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
@@ -74241,6 +74503,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"okW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/east)
 "oll" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -74688,6 +74965,12 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/paramedic)
+"ouF" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/station/service/kitchen)
 "ouO" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/maintenance,
@@ -75351,18 +75634,9 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/smes)
 "oOe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/station/supply/storage)
+/turf/simulated/floor/plasteel,
+/area/station/public/fitness)
 "oOF" = (
 /obj/machinery/atmospherics/portable/canister/sleeping_agent,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -77203,6 +77477,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -77338,6 +77613,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/south)
+"pQP" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "yellow"
+	},
+/area/station/engineering/break_room)
 "pRI" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -77361,6 +77643,21 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central/ne)
+"pSJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/starboard/south)
 "pSW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -77587,6 +77884,11 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
+"pWR" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/break_room)
 "pWT" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/decal/cleanable/dirt,
@@ -77898,6 +78200,12 @@
 	icon_state = "neutral"
 	},
 /area/station/legal/courtroom/gallery)
+"qiX" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/station/service/barber)
 "qjH" = (
 /obj/structure/cable,
 /obj/effect/spawner/window/reinforced/grilled,
@@ -79386,6 +79694,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central/south)
+"qZH" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whiteblue"
+	},
+/area/station/medical/reception)
 "qZV" = (
 /obj/structure/chair/comfy/teal,
 /turf/simulated/floor/plasteel/white,
@@ -79557,6 +79875,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -80438,6 +80757,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
+"rza" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/fore/north)
 "rzs" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/camera{
@@ -80629,11 +80955,10 @@
 /area/station/medical/surgery/primary)
 "rEP" = (
 /obj/machinery/hologram/holopad,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
 	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/medical/morgue)
+/area/station/hallway/primary/central/east)
 "rEQ" = (
 /obj/structure/weightmachine/weightlifter,
 /turf/simulated/floor/plasteel,
@@ -81022,6 +81347,12 @@
 	icon_state = "arrival"
 	},
 /area/station/hallway/secondary/entry/east)
+"rRc" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/supply/storage)
 "rRd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -81034,6 +81365,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/storage)
+"rRs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/public/fitness)
 "rRw" = (
 /obj/structure/table,
 /obj/item/storage/box/gloves{
@@ -81777,6 +82116,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
 "sjn" = (
@@ -82348,6 +82688,10 @@
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
+"sup" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/atmos)
 "suy" = (
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/camera{
@@ -82686,14 +83030,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "sFm" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
 	},
-/turf/simulated/floor/plasteel/white,
-/area/station/science/research)
+/area/station/hallway/primary/central/nw)
 "sFH" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
@@ -82777,6 +83118,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -82933,6 +83275,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "redfull"
 	},
@@ -82960,6 +83303,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"sLB" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/bridge)
 "sLI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -83432,6 +83779,7 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/research)
 "sYB" = (
@@ -83627,6 +83975,10 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/sleeper)
+"tbD" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel/dark,
+/area/station/medical/morgue)
 "tbP" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -83757,6 +84109,13 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/storage)
+"teW" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/fore/south)
 "tfY" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
@@ -84125,6 +84484,7 @@
 	name = "south bump";
 	pixel_y = -28
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
 	},
@@ -84355,6 +84715,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/black,
 /area/station/service/chapel)
 "tzQ" = (
@@ -85179,6 +85540,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison/cell_block/a)
+"tUp" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore/east)
 "tUE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -85296,6 +85669,17 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/medical/cloning)
+"tWO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/lounge)
 "tWW" = (
 /obj/machinery/hydroponics/constructable{
 	desc = "These are connected with an irrigation tube. You see a little pipe connecting the trays.";
@@ -85704,6 +86088,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -85834,7 +86219,6 @@
 /area/station/security/warden)
 "uhI" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -86405,22 +86789,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/electrical_shop)
 "uAI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/hologram/holopad,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "darkredcorners"
-	},
-/area/station/security/prison/cell_block/a)
+/turf/simulated/floor/engine,
+/area/station/engineering/controlroom)
 "uAP" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -87303,7 +87677,6 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/theatre)
 "uXN" = (
-/obj/machinery/hologram/holopad,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -88353,6 +88726,12 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
+"vFq" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/north)
 "vFs" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Storage"
@@ -88714,6 +89093,14 @@
 	icon_state = "neutral"
 	},
 /area/station/maintenance/starboard)
+"vMT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/station/supply/storage)
 "vNB" = (
 /obj/structure/table,
 /obj/item/storage/box/evidence,
@@ -89888,6 +90275,13 @@
 /obj/item/stack/package_wrap,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/ce)
+"wrF" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/public/locker)
 "wsg" = (
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/south)
@@ -90153,6 +90547,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/security/storage)
 "wyn" = (
@@ -90406,6 +90801,7 @@
 /obj/structure/disposalpipe/junction/reversed{
 	dir = 8
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
 "wDU" = (
@@ -90416,6 +90812,12 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/misc_lab)
+"wDY" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/central/west)
 "wEA" = (
 /obj/machinery/economy/vending/coffee,
 /obj/effect/turf_decal/delivery/hollow,
@@ -91982,6 +92384,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/research)
 "xxz" = (
@@ -92831,6 +93234,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
 "xUg" = (
@@ -117039,12 +117443,12 @@ aUi
 bpA
 brB
 hZn
-adU
+kGX
 bvF
 uCR
 bzO
 bzN
-bBy
+ewg
 bDo
 bER
 bgJ
@@ -117286,7 +117690,7 @@ ban
 bam
 ban
 ban
-ban
+eSJ
 uTw
 rIO
 aYt
@@ -117533,7 +117937,7 @@ aJS
 aLj
 aMH
 aOb
-aPH
+sup
 aQW
 aSD
 iYX
@@ -118036,7 +118440,7 @@ aFd
 aFd
 aFd
 aFd
-aFd
+joI
 aFd
 aFd
 aFd
@@ -118588,7 +118992,7 @@ byt
 bzS
 bEV
 bDt
-bQt
+pQP
 bQp
 bQt
 bKl
@@ -118826,7 +119230,7 @@ aVF
 jgG
 ban
 ban
-ban
+eSJ
 ban
 ban
 jgG
@@ -119613,7 +120017,7 @@ buy
 aOg
 bwY
 bOg
-bzW
+pWR
 bBG
 bKp
 bEX
@@ -119862,7 +120266,7 @@ bhk
 biU
 bkJ
 bmG
-bob
+fxV
 bob
 bob
 btp
@@ -121396,7 +121800,7 @@ aPH
 aXw
 aYN
 bay
-aPH
+sup
 bdu
 beR
 bgj
@@ -121634,7 +122038,7 @@ aCW
 ayK
 aCW
 aCW
-aCW
+uAI
 aEl
 aGh
 aGh
@@ -122442,7 +122846,7 @@ bxf
 byG
 bAe
 bBO
-bDC
+hmr
 bDC
 bGQ
 bOo
@@ -124250,7 +124654,7 @@ bBR
 bOt
 brW
 jyz
-vHe
+nWy
 bWH
 bYj
 bZJ
@@ -124771,7 +125175,7 @@ bZL
 cdz
 cdz
 cdz
-cdz
+mDz
 civ
 ckh
 clB
@@ -125064,13 +125468,13 @@ cKr
 cKr
 gtR
 hqk
-lID
+mTj
 tep
 row
 ubB
 sQG
-hmr
 lwS
+ify
 lwS
 nEk
 vKf
@@ -126555,10 +126959,10 @@ byK
 bAo
 bCa
 bDL
-bFp
+bFo
 bGZ
 bhm
-bFo
+bFp
 bMJ
 bOA
 bIV
@@ -126860,7 +127264,7 @@ fBk
 fBk
 fBk
 svR
-yid
+gSI
 cPn
 dFm
 eoh
@@ -127255,7 +127659,7 @@ ovL
 doS
 ovL
 pvf
-qGl
+vFq
 gpy
 ovL
 doS
@@ -127271,7 +127675,7 @@ aAr
 dGS
 adt
 ani
-afJ
+lrq
 alx
 aoo
 aoo
@@ -127888,7 +128292,7 @@ uLd
 sUQ
 pTN
 ctm
-sFm
+wsl
 cPn
 dff
 dgs
@@ -128345,11 +128749,11 @@ qYV
 bmX
 bom
 bqn
-npJ
+lCp
 kEN
 fcl
 fcl
-fcl
+sFm
 sPx
 fcl
 bCf
@@ -128358,13 +128762,13 @@ bFs
 fcl
 fcl
 fcl
-fcl
+sFm
 fcl
 gKs
 hzo
 bUL
 hzo
-hzo
+wDY
 qxR
 hzo
 hzo
@@ -128380,12 +128784,12 @@ crq
 vji
 vji
 vji
-vji
+kxX
 raa
 vji
 vji
 vji
-vji
+kxX
 cDd
 cGy
 xqH
@@ -128578,7 +128982,7 @@ aDD
 gpU
 uSD
 kdu
-aEF
+teW
 aHS
 fcY
 aXA
@@ -128594,7 +128998,7 @@ aYY
 otH
 aSe
 bdH
-aEF
+teW
 aEF
 npn
 bjo
@@ -128817,7 +129221,7 @@ rPU
 eiT
 aoo
 aoY
-ast
+hlP
 aqN
 arF
 aoo
@@ -129089,7 +129493,7 @@ aBu
 aBy
 aLD
 xXU
-qbI
+rza
 aFA
 aGv
 aHJ
@@ -129367,7 +129771,7 @@ bcp
 bdK
 bff
 aYZ
-bdQ
+ouF
 bjt
 wny
 aYZ
@@ -129698,8 +130102,8 @@ dyL
 dyL
 dyL
 drN
-dyL
 kSr
+dyL
 dyL
 cMg
 sRR
@@ -130143,7 +130547,7 @@ aYC
 blk
 aYZ
 rnb
-npJ
+lCp
 fwU
 kgl
 abj
@@ -130152,7 +130556,7 @@ abj
 bwf
 sHI
 bFP
-byU
+sLB
 bFy
 bHk
 bJc
@@ -130166,7 +130570,7 @@ chi
 cbT
 chi
 cbT
-cnv
+chi
 cbT
 chh
 ciD
@@ -130186,7 +130590,7 @@ cEr
 cEr
 cEQ
 cIT
-ckv
+nGL
 cHG
 cIW
 lLY
@@ -130420,13 +130824,13 @@ bKN
 ciB
 bWR
 bWT
-cbT
+eHy
 chi
 cbT
 cdF
 cbT
 chi
-chi
+cnv
 bWT
 clN
 cnr
@@ -131774,9 +132178,9 @@ dHT
 dIJ
 cWH
 dKo
-gkk
 dKo
-hVf
+dKo
+gkX
 dKo
 dNc
 pAd
@@ -132301,7 +132705,7 @@ dKo
 dNb
 dMY
 dOw
-joI
+dXJ
 dNc
 dNQ
 dOw
@@ -132937,7 +133341,7 @@ atD
 wKI
 juJ
 awm
-asB
+tWO
 aBj
 azv
 aAG
@@ -132954,7 +133358,7 @@ lnl
 seH
 seH
 seH
-seH
+tUp
 aTj
 aWm
 seH
@@ -133028,14 +133432,14 @@ dGU
 doZ
 doZ
 doZ
-doZ
+liy
 doZ
 dfB
 doZ
 doZ
 doZ
 cnV
-doZ
+liy
 doZ
 doZ
 tiQ
@@ -133576,7 +133980,7 @@ dKo
 dKo
 dKo
 dVp
-dKo
+gkk
 dKo
 dKo
 dKo
@@ -134304,17 +134708,17 @@ cJh
 rQz
 eAi
 cPD
-cPD
+qZH
 uFH
 nQF
 mTs
 dat
 cZF
 cXg
-cXg
+diy
 dcg
 dcs
-dfq
+tsp
 tsp
 dgH
 diz
@@ -134724,7 +135128,7 @@ eKO
 uTN
 slc
 adL
-hbv
+okW
 anW
 jJl
 apm
@@ -134763,7 +135167,7 @@ baZ
 aGK
 bbC
 bfu
-bfu
+eNR
 bhW
 bfu
 ayB
@@ -135233,7 +135637,7 @@ vcE
 giE
 kLd
 kNa
-vcE
+gua
 vcE
 gnm
 fPG
@@ -135797,7 +136201,7 @@ bfu
 wVi
 bfq
 bov
-hgo
+jDD
 tmJ
 kgl
 abj
@@ -135806,12 +136210,12 @@ abj
 bwf
 ipZ
 bCl
-aZe
+krh
 bFQ
 bWX
 bJn
 bJf
-bNe
+dfq
 bLc
 jMb
 bSR
@@ -135840,7 +136244,7 @@ cxk
 mWq
 cyv
 rfw
-ckv
+nGL
 cHK
 ppu
 cMt
@@ -136360,7 +136764,7 @@ ppr
 hdI
 rsV
 gIn
-gIn
+hhk
 sIv
 xDF
 kXM
@@ -136368,7 +136772,7 @@ fhh
 iRF
 cMq
 gfB
-cMq
+bzC
 cMq
 lDF
 tox
@@ -137597,7 +138001,7 @@ blF
 bbe
 jjp
 dog
-npJ
+lCp
 kEN
 uHV
 uHV
@@ -137610,13 +138014,13 @@ wjN
 bqu
 uHV
 uHV
-uHV
+jVr
 uHV
 oAm
 lmQ
 bVd
 lmQ
-lmQ
+rEP
 bYF
 lmQ
 iNB
@@ -137624,7 +138028,7 @@ lmQ
 lmQ
 nYW
 lmQ
-lmQ
+rEP
 lmQ
 oAm
 wvz
@@ -137632,12 +138036,12 @@ crS
 nAC
 hIZ
 rfW
-hIZ
+ntW
 hIZ
 hIZ
 gkl
 wRp
-hIZ
+ntW
 hIZ
 cGD
 kCi
@@ -137670,7 +138074,7 @@ vOe
 git
 duk
 wAG
-rEP
+dxH
 tkI
 vPD
 mkS
@@ -137829,8 +138233,8 @@ aCN
 aBS
 aCN
 aCN
-oOe
-aBS
+aLa
+rRc
 aBS
 aBS
 aBS
@@ -137929,7 +138333,7 @@ duk
 lrh
 dxH
 dvt
-dvt
+tbD
 nMf
 dBk
 vVW
@@ -138642,7 +139046,7 @@ bNj
 bPe
 bQW
 bSX
-aWl
+myU
 mqO
 bYK
 cay
@@ -138658,7 +139062,7 @@ vdW
 vdW
 bYH
 nmt
-cuu
+pSJ
 nEw
 cxn
 cyC
@@ -138875,7 +139279,7 @@ aSb
 bfN
 ben
 bil
-bfA
+cxd
 bij
 bjN
 bsC
@@ -138955,7 +139359,7 @@ jfB
 hbl
 hbl
 dvw
-kfx
+kLv
 tdW
 tdW
 oVu
@@ -139370,7 +139774,7 @@ aBn
 aCO
 aDX
 aEW
-aEW
+vMT
 aDX
 aDX
 aNk
@@ -140241,7 +140645,7 @@ kDF
 cSH
 cki
 kxH
-cSH
+ccK
 cSH
 oYX
 dgX
@@ -140472,7 +140876,7 @@ cUM
 rHr
 cMz
 fuu
-hvf
+pkg
 xcR
 sbr
 diN
@@ -140698,7 +141102,7 @@ ogI
 mrk
 eNt
 emy
-aWl
+myU
 iRk
 bYN
 ccu
@@ -140714,7 +141118,7 @@ bXW
 jSg
 hTV
 fiV
-cuu
+pSJ
 cvW
 cxn
 bAd
@@ -141506,7 +141910,7 @@ lJc
 rLr
 bTt
 cSH
-cSH
+ccK
 dcE
 cSH
 cSH
@@ -141520,7 +141924,7 @@ doj
 oLH
 lPJ
 dBK
-gua
+doj
 doj
 jIB
 imY
@@ -142000,7 +142404,7 @@ crW
 crW
 crW
 crW
-cxd
+cjk
 crW
 crW
 crW
@@ -142258,7 +142662,7 @@ crW
 ctn
 crW
 cjk
-crW
+wrF
 cDo
 crW
 cBP
@@ -143550,7 +143954,7 @@ cBT
 hZL
 cuw
 cFn
-cuM
+iWg
 cId
 csi
 kkC
@@ -144830,7 +145234,7 @@ ckV
 brS
 oNd
 cyV
-cIk
+fDw
 cIj
 cIk
 pNl
@@ -145575,7 +145979,7 @@ vGr
 mNS
 eDu
 vrh
-uAI
+aYm
 tSY
 aej
 uqL
@@ -146346,7 +146750,7 @@ naG
 rGZ
 nlY
 aPx
-bsE
+gRp
 kfk
 vRp
 mZT
@@ -146896,7 +147300,7 @@ cWh
 ipz
 cLr
 tEA
-tEA
+qiX
 lSa
 rwU
 cTd
@@ -148424,7 +148828,7 @@ abj
 abj
 iuY
 cFK
-cFK
+oOe
 nuq
 cGW
 cDr
@@ -148441,7 +148845,7 @@ vUX
 vUX
 nIH
 cAu
-cuM
+iWg
 cUI
 cWf
 cAu
@@ -149204,7 +149608,7 @@ czg
 bIE
 xLh
 qgm
-qgm
+rRs
 bIE
 czg
 bOp

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -429,6 +429,12 @@
 "afH" = (
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/pod_3)
+"afQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
+/area/station/service/bar)
 "afT" = (
 /obj/structure/table,
 /obj/item/reagent_containers/drinks/coffee{
@@ -1219,6 +1225,19 @@
 	icon_state = "showroomfloor"
 	},
 /area/station/service/kitchen)
+"alV" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/engine,
+/area/station/engineering/control)
 "alW" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
@@ -1402,9 +1421,15 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/fitness)
 "anh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
-/area/station/public/fitness)
+/area/station/hallway/primary/aft/south)
 "ani" = (
 /obj/structure/table,
 /obj/item/paper{
@@ -6159,9 +6184,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hardsuitstorage)
 "aIT" = (
-/obj/effect/landmark/start/atmospheric,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/command/bridge)
 "aIU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -8948,11 +8975,18 @@
 /turf/simulated/floor/bluegrid,
 /area/station/turret_protected/ai_upload)
 "aSW" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/area/station/turret_protected/ai_upload)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/south)
 "aSY" = (
 /obj/machinery/porta_turret{
 	dir = 8
@@ -9797,6 +9831,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -11249,11 +11284,10 @@
 /area/station/engineering/engine_foyer)
 "bay" = (
 /obj/machinery/hologram/holopad,
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/simulated/floor/plasteel{
+	icon_state = "darkgrey"
 	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/bridge)
+/area/station/public/fitness)
 "baB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -11821,6 +11855,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/north)
 "bco" = (
@@ -11857,9 +11892,21 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/engine_foyer)
 "bcs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel,
-/area/station/supply/storage)
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/bridge)
 "bcu" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -12024,6 +12071,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard)
 "bcR" = (
@@ -12524,6 +12572,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/north)
 "bej" = (
@@ -12689,6 +12738,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/north)
 "bey" = (
@@ -17194,6 +17244,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/east)
 "brw" = (
@@ -18738,6 +18789,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/east)
 "bvQ" = (
@@ -18753,6 +18805,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/east)
 "bvS" = (
@@ -19942,9 +19995,18 @@
 	},
 /area/station/aisat)
 "bzs" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/east)
+/area/station/hallway/primary/central/south)
 "bzw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -21193,7 +21255,6 @@
 	},
 /area/station/hallway/secondary/entry/lounge)
 "bDz" = (
-/obj/machinery/hologram/holopad,
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_y = 32
@@ -21390,6 +21451,7 @@
 	c_tag = "Bridge - Starboard Access";
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkbluecorners"
@@ -21552,21 +21614,15 @@
 	},
 /area/station/aisat/service)
 "bFh" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/control)
+/area/station/hallway/primary/central/west)
 "bFi" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -21696,6 +21752,7 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/east)
 "bFH" = (
@@ -23132,6 +23189,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/east)
 "bLu" = (
@@ -23913,6 +23971,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/station/public/vacant_office)
 "bOR" = (
@@ -24392,6 +24451,7 @@
 	codes_txt = "patrol;next_patrol=13.2-Tcommstore";
 	location = "13.1-Engineering-Enter"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/north)
 "bQS" = (
@@ -24770,6 +24830,7 @@
 /area/station/command/teleporter)
 "bSi" = (
 /obj/machinery/requests_console/directional/east,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/ai_monitored/storage/eva)
 "bSj" = (
@@ -24816,7 +24877,6 @@
 	name = "south bump";
 	pixel_y = -30
 	},
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -25152,7 +25212,6 @@
 /area/station/service/library)
 "bTy" = (
 /obj/machinery/light/small,
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "bTz" = (
@@ -25463,6 +25522,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitehall"
@@ -26424,7 +26484,6 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/maintenance/turbine)
 "bYi" = (
-/obj/machinery/hologram/holopad,
 /obj/structure/extinguisher_cabinet{
 	name = "west bump";
 	pixel_x = -27
@@ -27215,6 +27274,7 @@
 	dir = 5
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
 "cbC" = (
@@ -33880,7 +33940,6 @@
 /obj/structure/chair/office/light{
 	dir = 8
 	},
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -40380,6 +40439,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/ne)
 "dnm" = (
@@ -42354,6 +42414,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
 "ejG" = (
@@ -42681,6 +42742,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "esm" = (
@@ -45431,6 +45493,22 @@
 	icon_state = "whiteyellow"
 	},
 /area/station/medical/chemistry)
+"fBI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/east)
 "fBQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -45521,6 +45599,7 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
 "fDE" = (
@@ -46017,6 +46096,15 @@
 	icon_state = "caution"
 	},
 /area/station/engineering/controlroom)
+"fOD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/medical/surgery/observation)
 "fOL" = (
 /obj/machinery/computer/security{
 	dir = 1
@@ -46255,15 +46343,16 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "fTT" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitehall"
-	},
-/area/station/science/lobby)
+/turf/simulated/floor/engine,
+/area/station/engineering/control)
 "fTV" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/wood,
@@ -46931,6 +47020,12 @@
 	icon_state = "white"
 	},
 /area/station/maintenance/asmaint)
+"ggY" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/bridge)
 "ghd" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/plasteel{
@@ -47153,6 +47248,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -47281,15 +47377,12 @@
 	},
 /area/station/command/bridge)
 "grr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/carpet,
-/area/station/service/library)
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/south)
 "gry" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -48591,6 +48684,7 @@
 	ext_button_link_id = "enginesm_btn_ext";
 	int_button_link_id = "enginesm_btn_int"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "gVS" = (
@@ -48990,6 +49084,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard)
 "hfR" = (
@@ -50155,6 +50250,15 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/exam_room)
+"hEI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore/north)
 "hEP" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/reinforced/normal{
@@ -50903,6 +51007,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/purple,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
 "hTM" = (
@@ -51947,6 +52052,13 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
+"iud" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/turf_decal/delivery/blue/hollow,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/station/medical/exam_room)
 "iue" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -53770,6 +53882,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hardsuitstorage)
 "joP" = (
@@ -54159,6 +54272,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
 "jAZ" = (
@@ -54776,7 +54890,6 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/doctor,
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -55592,6 +55705,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -56285,6 +56399,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/nw)
 "kvh" = (
@@ -56364,6 +56479,19 @@
 	icon_state = "red"
 	},
 /area/station/security/permabrig)
+"kxk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/supply/storage)
 "kxo" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -59558,6 +59686,22 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central/north)
+"lOs" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/port/west)
 "lOE" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -60978,7 +61122,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/security/brig)
 "myk" = (
@@ -62955,6 +63098,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgreycheck"
 	},
@@ -64434,6 +64578,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
 "nWJ" = (
@@ -65129,6 +65274,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -68246,6 +68392,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
+"pLB" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/carpet,
+/area/station/service/library)
 "pLD" = (
 /obj/machinery/door_timer/cell_1{
 	pixel_x = -32
@@ -69657,15 +69807,12 @@
 	},
 /area/station/science/research)
 "qth" = (
+/obj/effect/spawner/random/dirt/maybe,
 /obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "dark"
 	},
-/area/station/science/rnd)
+/area/station/supply/expedition)
 "qto" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/camera{
@@ -69852,6 +69999,7 @@
 	dir = 8;
 	initialize_directions = 11
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/gravitygenerator)
 "qvE" = (
@@ -71243,7 +71391,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -72599,7 +72746,6 @@
 /turf/simulated/floor/plating,
 /area/station/supply/miningdock)
 "rGJ" = (
-/obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -72897,6 +73043,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/gravitygenerator)
+"rMP" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/purple{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos)
 "rNt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -74077,12 +74233,21 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/lobby)
 "soE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "whitepurple"
 	},
 /area/station/science/research)
 "soF" = (
@@ -74140,6 +74305,13 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
+"sph" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/bridge)
 "spj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -75159,6 +75331,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/control)
 "sNG" = (
@@ -75633,6 +75806,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -76172,6 +76346,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -76826,6 +77001,16 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
+"tAx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/station/science/rnd)
 "tAy" = (
 /obj/structure/extinguisher_cabinet{
 	name = "west bump";
@@ -77907,8 +78092,11 @@
 /area/station/security/permabrig)
 "uel" = (
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/wood,
-/area/station/service/bar)
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/station/hallway/primary/central/south)
 "uep" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80295,6 +80483,15 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/medbay)
+"vjn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/south)
 "vjy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -80344,7 +80541,7 @@
 "vkO" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
-/area/station/ai_monitored/storage/eva)
+/area/station/hallway/secondary/bridge)
 "vkR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -81038,6 +81235,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -82444,6 +82642,13 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/research)
+"woG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/south)
 "woK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/item/pen,
@@ -83146,6 +83351,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/east)
+"wFA" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
+/area/station/service/library)
 "wFC" = (
 /obj/effect/spawner/random/barrier/grille_often,
 /turf/simulated/floor/plating,
@@ -84130,6 +84339,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/toxins/mixing)
+"xdp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/se)
 "xdy" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
@@ -84447,6 +84666,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -84568,6 +84788,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluecorners"
 	},
@@ -84667,6 +84888,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/east)
 "xpD" = (
@@ -98101,7 +98323,7 @@ aaa
 aaa
 aaa
 bgW
-cmm
+grr
 bUS
 bgW
 aaa
@@ -99642,7 +99864,7 @@ uWq
 uWq
 uWq
 uWq
-uWq
+woG
 bBv
 dgb
 cdT
@@ -100402,7 +100624,7 @@ bnX
 bpz
 brv
 qFK
-bzs
+qFK
 bxK
 qFK
 dgj
@@ -104000,7 +104222,7 @@ brK
 bpK
 uxE
 bBI
-bVW
+lOs
 bxT
 bzH
 aNQ
@@ -104759,7 +104981,7 @@ aRo
 cjv
 aRo
 cjv
-nYP
+kxk
 aRo
 aRo
 biI
@@ -105010,7 +105232,7 @@ nSQ
 xlE
 kBn
 aWj
-bcs
+aRo
 hjj
 aRo
 hjj
@@ -105588,7 +105810,7 @@ cCD
 cCN
 ctP
 cDh
-fre
+fOD
 cNs
 cDf
 cuS
@@ -106320,7 +106542,7 @@ bBQ
 bBQ
 ugu
 bBQ
-bBQ
+pLB
 bBQ
 bBQ
 bBQ
@@ -106835,7 +107057,7 @@ bBS
 bzK
 bHs
 bBQ
-grr
+teW
 bFw
 bOp
 bFw
@@ -107864,7 +108086,7 @@ bzK
 bKE
 bBQ
 bKZ
-bFw
+wFA
 bOs
 bPZ
 bFw
@@ -107891,7 +108113,7 @@ hci
 cwj
 jNa
 cue
-cpb
+iud
 imZ
 bNx
 cDO
@@ -109149,7 +109371,7 @@ hCu
 fBQ
 bJc
 bKL
-hCu
+bFh
 tJc
 hCu
 pxk
@@ -110385,7 +110607,7 @@ xjB
 pPV
 avE
 jCB
-apP
+fJF
 akD
 pnB
 sPh
@@ -110432,11 +110654,11 @@ bBX
 bqc
 bHq
 qyb
-bJs
+bcs
 bKT
 buj
 fla
-vkO
+bOR
 bXV
 bTF
 bWA
@@ -111667,7 +111889,7 @@ jse
 nlw
 dOQ
 jse
-apP
+fJF
 apP
 mxD
 oSm
@@ -111718,7 +111940,7 @@ bqc
 bLR
 bFI
 bJs
-bKT
+sph
 bMW
 bPp
 bSh
@@ -111949,7 +112171,7 @@ aaa
 aOG
 aQj
 bOA
-aSW
+beA
 aUm
 aVy
 aWY
@@ -112480,7 +112702,7 @@ aIb
 bkW
 btY
 boE
-boE
+aIT
 btQ
 bAj
 boE
@@ -112500,7 +112722,7 @@ bZl
 bZl
 bZl
 caO
-jdP
+aSW
 bcX
 cdW
 oqO
@@ -114005,7 +114227,7 @@ aYz
 aMi
 ebf
 aMi
-aKG
+hEI
 aUp
 kpn
 aKG
@@ -114031,7 +114253,7 @@ bDZ
 bFO
 vXg
 bJq
-bay
+nxu
 gHh
 nxu
 dhm
@@ -114041,7 +114263,7 @@ hYz
 cKR
 nmc
 lOK
-car
+uel
 cbE
 qBP
 mOc
@@ -114067,7 +114289,7 @@ tPc
 bIS
 noA
 tPc
-tPc
+anh
 pAU
 tPc
 taS
@@ -114078,7 +114300,7 @@ cgx
 pPn
 sbG
 hrO
-cOO
+vjn
 cOO
 lVz
 cvI
@@ -114288,7 +114510,7 @@ bDY
 bFP
 sxN
 bJr
-bNd
+vkO
 bNd
 bOM
 bQr
@@ -115332,7 +115554,7 @@ bcX
 cee
 cHM
 cgB
-fTT
+iFm
 cie
 ckZ
 cHQ
@@ -115564,7 +115786,7 @@ aIH
 bkW
 bum
 boE
-boE
+aIT
 sLs
 bAj
 bCA
@@ -115584,7 +115806,7 @@ bZn
 bZn
 aZJ
 caR
-fSz
+bzs
 bcX
 cee
 cfu
@@ -117115,7 +117337,7 @@ bEl
 bHC
 qgk
 bJp
-bLg
+ggY
 bZX
 cbi
 bWX
@@ -117635,7 +117857,7 @@ bQD
 bSo
 chF
 bTU
-bWZ
+qth
 bWZ
 bZD
 bZX
@@ -117648,8 +117870,8 @@ hYA
 pho
 evt
 clr
-qth
 kqw
+tAx
 jDj
 fNQ
 uHp
@@ -117929,7 +118151,7 @@ kqP
 pLH
 lHJ
 kgx
-pwf
+wsu
 eNY
 vpj
 tCf
@@ -118186,7 +118408,7 @@ cEK
 cuR
 jOM
 kgx
-wsu
+pwf
 eNY
 quz
 vrZ
@@ -118918,7 +119140,7 @@ bLt
 bOV
 jIR
 bfI
-hBq
+xdp
 bfI
 hBq
 jFF
@@ -119975,7 +120197,7 @@ cNk
 vXJ
 cNk
 qPp
-dnN
+soE
 cwR
 tqF
 wcT
@@ -120708,7 +120930,7 @@ bGi
 bEv
 byK
 qFs
-qFs
+afQ
 qFs
 qFs
 bGd
@@ -120966,7 +121188,7 @@ kWp
 bwC
 bAv
 bAv
-uel
+bEv
 bEv
 udl
 bHO
@@ -121947,7 +122169,7 @@ aii
 apY
 akh
 tHk
-anh
+akh
 anc
 aWd
 akh
@@ -122976,7 +123198,7 @@ akh
 cXD
 ald
 aio
-aio
+bay
 aio
 apW
 cYx
@@ -124003,7 +124225,7 @@ aio
 ajp
 akn
 akh
-anh
+akh
 akh
 akh
 akh
@@ -125584,7 +125806,7 @@ bmm
 bnM
 bam
 dSN
-fQt
+fBI
 bqx
 aoG
 aMh
@@ -126662,7 +126884,7 @@ gpe
 cuw
 jvU
 jvU
-soE
+jvU
 jFN
 tlO
 sgH
@@ -127137,7 +127359,7 @@ bnt
 ceF
 oJW
 ciE
-bFh
+kfn
 dmN
 fLw
 bow
@@ -127641,7 +127863,7 @@ bmh
 bof
 kVO
 dOA
-bpn
+nVA
 bpn
 bpn
 bpn
@@ -127665,7 +127887,7 @@ axh
 axh
 blr
 pRz
-fWW
+juS
 fWW
 rqW
 pmE
@@ -128430,7 +128652,7 @@ cnH
 cnr
 rAE
 cnH
-cnH
+rMP
 ptm
 lDq
 ptm
@@ -129715,7 +129937,7 @@ tUW
 eow
 eSE
 fWW
-aIT
+scq
 fWW
 fWW
 sGe
@@ -130959,7 +131181,7 @@ iJz
 enh
 vZU
 aHi
-vIz
+alV
 aDL
 kGw
 ebV
@@ -130971,7 +131193,7 @@ kRX
 ebV
 qUA
 mVG
-bbC
+fTT
 aCg
 nFZ
 nMt


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Adds more holopads around the smaller stations and adjusts the distance between some.
## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Holopads being only really there for RP, there's no incentive for them to be upgraded. Infact, I'd argue that most players didn't even know it could be upgraded to increase its range. The AI shouldn't have to flicker between each holopad because they moved out of range, or out of the area. Instead, they should have the option to act more as a "physical" assistant to the crew rather than a force inside each machine.
## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
Some holopads on BoxStation
![image](https://github.com/user-attachments/assets/9443d7ae-3acc-4eb7-8f9b-a71a9ba71197)

Some holopads on MetaStation
![image](https://github.com/user-attachments/assets/b9905cc9-f09a-49f5-8ce2-5cfaa8234dd3)

Some holopads on DeltaStation
![image](https://github.com/user-attachments/assets/56a8b34c-f18b-4a56-ab04-4c205330dc3b)

## Testing

<!-- How did you test the PR, if at all? -->
Ran paracode, rolled AI. Connected to a holopad and wandered about the halls and departments on each map without having to stop frequently.
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Added more holopads everywhere on Box, Meta, and Delta
tweak: Adjusted the distance between some holopads on Box, Meta, and Delta for the AI to seamlessly transition
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
