### PR TITLE
AI holograms can switch between holopads more seamlessly

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -367,7 +367,9 @@ GLOBAL_LIST_EMPTY(holopads)
 		var/obj/machinery/hologram/holopad/another = pad
 		if(another == src)
 			continue
-		if(another.validate_location(T))
+		if(T.loc != get_area(another))
+			continue
+		if(another.validate_location(T, holo_owner))
 			var/obj/effect/overlay/holo_pad_hologram/h = masters[holo_owner]
 			unset_holo(holo_owner)
 			another.set_holo(holo_owner, h)
@@ -385,10 +387,12 @@ GLOBAL_LIST_EMPTY(holopads)
 	return TRUE
 
 //Can we display holos there
-//Area check instead of line of sight check because this is a called a lot if AI wants to move around.
-/obj/machinery/hologram/holopad/proc/validate_location(turf/T)
-	if(T.z == z && (get_dist(T, src) <= holo_range) && T.loc == get_area(src))
-		return TRUE
+/obj/machinery/hologram/holopad/proc/validate_location(turf/T, mob/living/user)
+	if(T.z == z && (get_dist(T, src) <= holo_range))
+		if(is_ai(user)) //For AI, the area check is done on trying to find another holopad instead
+			return TRUE
+		if(T.loc == get_area(src))
+			return TRUE
 	return FALSE
 
 
@@ -396,7 +400,7 @@ GLOBAL_LIST_EMPTY(holopads)
 	if(masters[user])
 		var/obj/effect/overlay/holo_pad_hologram/holo = masters[user]
 		var/transfered = FALSE
-		if(!validate_location(new_turf))
+		if(!validate_location(new_turf, user))
 			if(!transfer_to_nearby_pad(new_turf,user))
 				clear_holo(user)
 				return FALSE

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -388,11 +388,10 @@ GLOBAL_LIST_EMPTY(holopads)
 
 //Can we display holos there
 /obj/machinery/hologram/holopad/proc/validate_location(turf/T, mob/living/user)
+	if(!is_ai(user) && T.loc != get_area(src)) //For AI, the area check is done on trying to find another holopad instead
+		return FALSE
 	if(T.z == z && (get_dist(T, src) <= holo_range))
-		if(is_ai(user)) //For AI, the area check is done on trying to find another holopad instead
-			return TRUE
-		if(T.loc == get_area(src))
-			return TRUE
+		return TRUE
 	return FALSE
 
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes the hologram transfer on holopads for AI more flexible by changing where the area check is done for it specifically, while other mobs are still constrained to the area they're calling to. This prevents cases where the hologram gets cancelled when changing areas even though you're still within range of the old one.

## Why It's Good For The Game
The way transfering holograms for AI was too rigid, and didn't make sense for it. Old comment made it sound like it was a perf save, but the distance check was done all the time regardless _and_ looped through all holopads.

## Images of changes
https://github.com/user-attachments/assets/a1dd161a-63d7-4825-b4cd-113ce041c1da

## Testing
Used holopads as an AI and moved around.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Range check for holopad projections is more flexible for AI
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
