### PR TITLE
rerun plant updatepaths post cere-medbay remap

### DIFF
--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -7991,7 +7991,7 @@
 	},
 /area/station/command/office/cmo)
 "blG" = (
-/obj/item/kirbyplants,
+/obj/item/kirbyplants/large,
 /turf/simulated/floor/wood,
 /area/station/medical/psych)
 "blK" = (
@@ -9615,7 +9615,7 @@
 	},
 /area/station/hallway/primary/fore/north)
 "bvI" = (
-/obj/item/kirbyplants,
+/obj/item/kirbyplants/large,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitebluecorner"
@@ -66786,7 +66786,7 @@
 	},
 /area/station/hallway/primary/starboard/south)
 "nwN" = (
-/obj/item/kirbyplants,
+/obj/item/kirbyplants/large,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitebluecorner"
@@ -102602,7 +102602,7 @@
 /area/station/maintenance/starboard)
 "wfg" = (
 /obj/machinery/alarm/directional/north,
-/obj/item/kirbyplants,
+/obj/item/kirbyplants/large,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whiteblue"


### PR DESCRIPTION
## What Does This PR Do
This PR runs the updatepaths from #28046 again, catching missed paths from #27936.
## Why It's Good For The Game
No quantum plants.
## Testing
Visual inspection.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
:cl:
fix: Farragus: plants in medbay now spawn properly.
/:cl:
