### PR TITLE
Fixes #28428

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -136,7 +136,7 @@
 	item["name"] = I.name
 
 	frozen_items += list(item)
-	if(preserve_status == CRYO_OBJECTIVE)
+	if(preserve_status == CRYO_OBJECTIVE || istype(I, /obj/item/card/id/captains_spare))
 		objective_items += I
 	I.forceMove(src)
 	RegisterSignal(I, COMSIG_MOVABLE_MOVED, PROC_REF(item_got_removed))


### PR DESCRIPTION
## What Does This PR Do

Fixes #28428, emagging cryo console now drops Captain's Spare ID if it is stored inside.

## Why It's Good For The Game

Bug gone is good.

## Testing

Loaded up server, joined as Captain, cryoed with my carapace, NAD and the Spare

Spawned an Assistant and inhabited him, spawned an emag and used it on console, NAD and Spare popped out but not the carapace.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Emagging cryo console now correctly drops Captain's Spare ID if it is stored inside
/:cl:
