### PR TITLE
[FIX] for XM800 cycler shotgun

### DIFF
--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -357,7 +357,7 @@
 
 /obj/item/gun/projectile/shotgun/automatic/dual_tube/attack_self__legacy__attackchain(mob/living/user)
 	if(!chambered && length(magazine.contents))
-		pump()
+		pump(user)
 	else
 		toggle_tube(user)
 
@@ -376,6 +376,6 @@
 /obj/item/gun/projectile/shotgun/automatic/dual_tube/AltClick(mob/living/user)
 	if(user.incapacitated() || !Adjacent(user) || !istype(user))
 		return
-	pump()
+	pump(user)
 
 // DOUBLE BARRELED SHOTGUN, IMPROVISED SHOTGUN, and CANE SHOTGUN are in revolver.dm


### PR DESCRIPTION

## What Does This PR Do
XM800 cycler shotgun was not usable, because `pump()` proc did not send `user` argument resulting in earlier return in parent class, fixed by adding user to proc calls `pump(user)` 


## Why It's Good For The Game
Bugs = bad

## Testing
On localhost insured i can shoot

<hr>

### Declaration

- [ ] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Fixed a bug that was preventing the XM800 cycler shotgun from being reloaded and fired.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
