### PR TITLE
Vendors can be righted much faster

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1131,7 +1131,7 @@
 		throw_at(target, 1, 1, spin = FALSE)
 	if(rightable)
 		layer = ABOVE_MOB_LAYER
-		AddComponent(/datum/component/tilted, 14 SECONDS, block_interactions_until_righted, rot_angle)
+		AddComponent(/datum/component/tilted, 4 SECONDS, block_interactions_until_righted, rot_angle)
 
 /// Untilt a tilted object.
 /atom/movable/proc/untilt(mob/living/user, duration = 10 SECONDS)

--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -565,7 +565,7 @@
 		return
 	if(!I.use_tool(src, user, 0, volume = 0))
 		return
-	default_unfasten_wrench(user, I, time = 4 SECONDS)
+	default_unfasten_wrench(user, I, time = 6 SECONDS)
 
 //Override this proc to do per-machine checks on the inserted item, but remember to call the parent to handle these generic checks before your logic!
 /obj/machinery/economy/vending/proc/item_slot_check(mob/user, obj/item/I)

--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -565,7 +565,7 @@
 		return
 	if(!I.use_tool(src, user, 0, volume = 0))
 		return
-	default_unfasten_wrench(user, I, time = 6 SECONDS)
+	default_unfasten_wrench(user, I, time = 4 SECONDS)
 
 //Override this proc to do per-machine checks on the inserted item, but remember to call the parent to handle these generic checks before your logic!
 /obj/machinery/economy/vending/proc/item_slot_check(mob/user, obj/item/I)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes vendors take 4 seconds to stand back up after falling, down from 14.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
14 seconds is a massively long time, to the point that people tend to leave vendors on the floor to avoid the hassle. It's disruptive to normal gameplay and the opportunity cost of avoiding an single strategy that has other safeguards isn't worth the trouble to the rest of the crew.

Even with a 4 second righting time, it can't reasonably be exploited for combat.  For one, you can't vendorcrush somebody until they unflatten from the first crush, making combo-crushing the same person impossible, and 4 seconds is a _long_ time to be standing still undisturbed in combat. If you have 4 seconds to spare to right a vendor in the situation that two people are fighting you, the second person gets 4 seconds of free hits on you while you wait.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Crushed myself with a vendor, righted the vendor and wrenched and unwrenched the vendor.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

![vendorright](https://github.com/user-attachments/assets/1e2aa311-ef91-4588-8696-3480efca9f9f)

## Changelog

:cl:
tweak: Vendors are much faster to right.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
