### PR TITLE
Re-Colors WT-550 TTX rounds

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -58,6 +58,8 @@
 /obj/item/projectile/bullet/toxinbullet
 	damage = 15
 	damage_type = TOX
+	color = COLOR_GREEN
+
 
 /obj/item/projectile/bullet/incendiary
 	immolate = 1


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Recolors WT-550 TTX rounds

## Why It's Good For The Game

There is now a visual que to you being shot with TTX rounds.

## Images of changes

https://github.com/user-attachments/assets/1fada639-51d2-46ce-b1c3-ebcd66ab9791


## Testing

Complied, shot WT round as above

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>
![image](https://github.com/user-attachments/assets/75d15fa4-df41-4ac0-8079-e2fba3f66ac6)

## Changelog

:cl:
tweak: WT-550 TTX rounds are now green
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
