### PR TITLE
Adds contortionist's envirosuit (Plasmaman contortionist's)

### DIFF
--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -275,6 +275,15 @@
 	cost = 30
 	job = list("Life Support Specialist")
 
+/datum/uplink_item/jobspecific/contortionist_plasmaman
+	name = "Contortionist's Plasma Envirosuit"
+	desc = "A highly flexible envirosuit that will help you navigate the ventilation loops of the station internally, specialized for Plasmamen. Comes with pockets and ID slot, but can't be used without stripping off most gear, including backpack, belt, and exosuit. Free hands are also necessary to crawl around inside."
+	reference = "AIRJP"
+	item = /obj/item/clothing/under/plasmaman/atmospherics/contortionist
+	cost = 30
+	job = list("Life Support Specialist")
+	species = list("Plasmaman")
+
 /datum/uplink_item/jobspecific/energizedfireaxe
 	name = "Energized Fire Axe"
 	desc = "A fire axe with a massive energy charge built into it. Upon striking someone while charged it will throw them backwards while stunning them briefly, but will take some time to charge up again. It is also much sharper than a regular axe and can pierce light armor."

--- a/code/modules/clothing/under/jobs/plasmamen/engineering_plasmasuits.dm
+++ b/code/modules/clothing/under/jobs/plasmamen/engineering_plasmasuits.dm
@@ -39,7 +39,7 @@
 	if(!user.get_int_organ(/obj/item/organ/internal/heart/gland/ventcrawling)) // This is such a snowflaky check
 		user.ventcrawler = VENTCRAWLER_NONE
 
-/obj/item/clothing/under/plasmaman/atmospherics/contortionist/proc/check_clothing(mob/user as mob)
+/obj/item/clothing/under/plasmaman/atmospherics/contortionist/proc/check_clothing(mob/user)
 	//Allowed to wear: glasses, shoes, gloves, pockets, mask, jumpsuit (obviously), and helmet (obviously)
 	var/list/slot_must_be_empty = list(ITEM_SLOT_BACK, ITEM_SLOT_HANDCUFFED, ITEM_SLOT_LEGCUFFED, ITEM_SLOT_LEFT_HAND, ITEM_SLOT_RIGHT_HAND, ITEM_SLOT_BELT, ITEM_SLOT_OUTER_SUIT)
 	for(var/slot_id in slot_must_be_empty)

--- a/code/modules/clothing/under/jobs/plasmamen/engineering_plasmasuits.dm
+++ b/code/modules/clothing/under/jobs/plasmamen/engineering_plasmasuits.dm
@@ -41,7 +41,7 @@
 
 /obj/item/clothing/under/plasmaman/atmospherics/contortionist/proc/check_clothing(mob/user as mob)
 	//Allowed to wear: glasses, shoes, gloves, pockets, mask, jumpsuit (obviously), and helmet (obviously)
-	var/list/slot_must_be_empty = list(ITEM_SLOT_BACK,ITEM_SLOT_HANDCUFFED,ITEM_SLOT_LEGCUFFED,ITEM_SLOT_LEFT_HAND,ITEM_SLOT_RIGHT_HAND,ITEM_SLOT_BELT,ITEM_SLOT_OUTER_SUIT)
+	var/list/slot_must_be_empty = list(ITEM_SLOT_BACK, ITEM_SLOT_HANDCUFFED, ITEM_SLOT_LEGCUFFED, ITEM_SLOT_LEFT_HAND, ITEM_SLOT_RIGHT_HAND, ITEM_SLOT_BELT, ITEM_SLOT_OUTER_SUIT)
 	for(var/slot_id in slot_must_be_empty)
 		if(user.get_item_by_slot(slot_id))
 			to_chat(user,"<span class='warning'>You can't fit inside while wearing [user.get_item_by_slot(slot_id)].</span>")

--- a/code/modules/clothing/under/jobs/plasmamen/engineering_plasmasuits.dm
+++ b/code/modules/clothing/under/jobs/plasmamen/engineering_plasmasuits.dm
@@ -20,3 +20,30 @@
 	item_state = "atmos_envirosuit"
 	item_color = "atmos_envirosuit"
 
+/obj/item/clothing/under/plasmaman/atmospherics/contortionist
+	name = "atmospherics plasma envirosuit"
+	desc = "An airtight suit designed to be used by plasmemen for squeezing through narrow vents."
+	resistance_flags = FIRE_PROOF
+
+/obj/item/clothing/under/plasmaman/atmospherics/contortionist/equipped(mob/living/carbon/human/user, slot)
+	. = ..()
+	if(slot != ITEM_SLOT_JUMPSUIT)
+		return
+	if(!user.ventcrawler)
+		user.ventcrawler = VENTCRAWLER_ALWAYS
+
+/obj/item/clothing/under/plasmaman/atmospherics/contortionist/dropped(mob/living/carbon/human/user)
+	. = ..()
+	if(user.get_item_by_slot(ITEM_SLOT_JUMPSUIT) != src)
+		return
+	if(!user.get_int_organ(/obj/item/organ/internal/heart/gland/ventcrawling)) // This is such a snowflaky check
+		user.ventcrawler = VENTCRAWLER_NONE
+
+/obj/item/clothing/under/plasmaman/atmospherics/contortionist/proc/check_clothing(mob/user as mob)
+	//Allowed to wear: glasses, shoes, gloves, pockets, mask, jumpsuit (obviously), and helmet (obviously)
+	var/list/slot_must_be_empty = list(ITEM_SLOT_BACK,ITEM_SLOT_HANDCUFFED,ITEM_SLOT_LEGCUFFED,ITEM_SLOT_LEFT_HAND,ITEM_SLOT_RIGHT_HAND,ITEM_SLOT_BELT,ITEM_SLOT_OUTER_SUIT)
+	for(var/slot_id in slot_must_be_empty)
+		if(user.get_item_by_slot(slot_id))
+			to_chat(user,"<span class='warning'>You can't fit inside while wearing \the [user.get_item_by_slot(slot_id)].</span>")
+			return 0
+	return 1

--- a/code/modules/clothing/under/jobs/plasmamen/engineering_plasmasuits.dm
+++ b/code/modules/clothing/under/jobs/plasmamen/engineering_plasmasuits.dm
@@ -45,5 +45,5 @@
 	for(var/slot_id in slot_must_be_empty)
 		if(user.get_item_by_slot(slot_id))
 			to_chat(user,"<span class='warning'>You can't fit inside while wearing [user.get_item_by_slot(slot_id)].</span>")
-			return 0
-	return 1
+			return FALSE
+	return TRUE

--- a/code/modules/clothing/under/jobs/plasmamen/engineering_plasmasuits.dm
+++ b/code/modules/clothing/under/jobs/plasmamen/engineering_plasmasuits.dm
@@ -44,6 +44,6 @@
 	var/list/slot_must_be_empty = list(ITEM_SLOT_BACK,ITEM_SLOT_HANDCUFFED,ITEM_SLOT_LEGCUFFED,ITEM_SLOT_LEFT_HAND,ITEM_SLOT_RIGHT_HAND,ITEM_SLOT_BELT,ITEM_SLOT_OUTER_SUIT)
 	for(var/slot_id in slot_must_be_empty)
 		if(user.get_item_by_slot(slot_id))
-			to_chat(user,"<span class='warning'>You can't fit inside while wearing \the [user.get_item_by_slot(slot_id)].</span>")
+			to_chat(user,"<span class='warning'>You can't fit inside while wearing [user.get_item_by_slot(slot_id)].</span>")
 			return 0
 	return 1

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -474,6 +474,14 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 			if(!C.check_clothing(src))//return values confuse me right now
 				return
 
+	if(ishuman(src))
+		var/mob/living/carbon/human/H = src
+		if(H.w_uniform && istype(H.w_uniform, /obj/item/clothing/under/plasmaman/atmospherics/contortionist))
+			var/obj/item/clothing/under/plasmaman/atmospherics/contortionist/C = H.w_uniform
+			if(!C.check_clothing(src))
+				return
+
+
 	var/obj/machinery/atmospherics/unary/vent_found
 
 	if(clicked_on)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Adds the contortionist's envirosuit, a plasmaman-friendly, plasmaman-exclusive alternative to the contortionist's jumpsuit that can only be worn by plasmamen and allows you to wear a helmet while ventcrawling.
## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
All species should have the joy of contortionist's jumpsuit. Lots of plasmamen atmos techs are denied this.
## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/user-attachments/assets/e40c585a-6659-4568-a650-01a787b6f883)
![image](https://github.com/user-attachments/assets/b23f83f9-067a-430f-81cf-4480a306be04)

## Testing

<!-- How did you test the PR, if at all? -->
Ran paracode, plasmamen can buy contortionist's envirosuit as an alternative, other species cannot.
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
![image](https://github.com/user-attachments/assets/a27b03fb-f350-4d7d-8f35-5df3d0d6499c)

<hr>

## Changelog

:cl:
add: Contortionist's envirosuit, a Plasmaman-friendly alternative to the contortionist's jumpsuit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
