### PR TITLE
Adds CI checks to ensure each area has an air alarm and fire alarm on station.

### DIFF
--- a/code/controllers/subsystem/non_firing/SSmapping.dm
+++ b/code/controllers/subsystem/non_firing/SSmapping.dm
@@ -111,7 +111,7 @@ SUBSYSTEM_DEF(mapping)
 		log_startup_progress("Skipping space ruins...")
 
 	var/empty_z_traits = list(REACHABLE_BY_CREW, REACHABLE_SPACE_ONLY)
-#ifdef GAME_TESTS
+#if defined(GAME_TESTS) || defined(MAP_TESTS)
 	preloadTemplates(path = "_maps/map_files/tests/")
 	empty_z_traits |= GAME_TEST_LEVEL
 #endif

--- a/code/tests/game_tests.dm
+++ b/code/tests/game_tests.dm
@@ -46,5 +46,8 @@
 
 #ifdef MAP_TESTS
 #include "test_areas_apcs.dm"
+#include "test_areas_air_alarms.dm"
+#include "test_areas_fire_alarms.dm"
 #include "test_map_tests.dm"
+
 #endif

--- a/code/tests/test_areas_air_alarms.dm
+++ b/code/tests/test_areas_air_alarms.dm
@@ -3,7 +3,7 @@
 	var/list/optional_areas = list(/area/station/science/toxins/test, /area/station/maintenance/electrical_shop)
 
 /datum/game_test/area_air_alarms/Run()
-	for(var/area/station/A as anything in SSmapping.existing_station_areas)
+	for(var/area/station/A in SSmapping.existing_station_areas)
 		if(A.there_can_be_many || A.outdoors)
 			continue
 		if(is_type_in_list(A, optional_areas))

--- a/code/tests/test_areas_air_alarms.dm
+++ b/code/tests/test_areas_air_alarms.dm
@@ -1,0 +1,12 @@
+/datum/game_test/area_air_alarms
+	/// Sometimes, areas may have air, or not. We dont really care about these areas.
+	var/list/optional_areas = list(/area/station/science/toxins/test, /area/station/maintenance/electrical_shop)
+
+/datum/game_test/area_air_alarms/Run()
+	for(var/area/station/A in SSmapping.existing_station_areas)
+		if(A.there_can_be_many || !A.outdoors)
+			continue
+		if(is_type_in_list(A, optional_areas))
+			continue
+		if(length(A.air_alarms) == 0)
+			TEST_FAIL("Area [A.type] has [length(A.air_alarms)] air alarms, instead of at least 1.")

--- a/code/tests/test_areas_air_alarms.dm
+++ b/code/tests/test_areas_air_alarms.dm
@@ -3,7 +3,7 @@
 	var/list/optional_areas = list(/area/station/science/toxins/test, /area/station/maintenance/electrical_shop)
 
 /datum/game_test/area_air_alarms/Run()
-	for(var/area/station/A in SSmapping.existing_station_areas)
+	for(var/area/station/A as anything in SSmapping.existing_station_areas)
 		if(A.there_can_be_many || !A.outdoors)
 			continue
 		if(is_type_in_list(A, optional_areas))

--- a/code/tests/test_areas_air_alarms.dm
+++ b/code/tests/test_areas_air_alarms.dm
@@ -4,7 +4,7 @@
 
 /datum/game_test/area_air_alarms/Run()
 	for(var/area/station/A as anything in SSmapping.existing_station_areas)
-		if(A.there_can_be_many || !A.outdoors)
+		if(A.there_can_be_many || A.outdoors)
 			continue
 		if(is_type_in_list(A, optional_areas))
 			continue

--- a/code/tests/test_areas_fire_alarms.dm
+++ b/code/tests/test_areas_fire_alarms.dm
@@ -3,10 +3,10 @@
 	var/list/optional_areas = list(/area/station/science/toxins/test, /area/station/maintenance/electrical_shop)
 
 /datum/game_test/area_fire_alarms/Run()
-	for(var/area/station/A as anything in SSmapping.existing_station_areas)
+	for(var/area/station/A in SSmapping.existing_station_areas)
 		if(A.there_can_be_many || A.outdoors)
 			continue
 		if(is_type_in_list(A, optional_areas))
 			continue
 		if(length(A.firealarms) == 0)
-			TEST_FAIL("Area [A.type] has [length(A.firealarms)] air alarms, instead of at least 1.")
+			TEST_FAIL("Area [A.type] has [length(A.firealarms)] fire alarms, instead of at least 1.")

--- a/code/tests/test_areas_fire_alarms.dm
+++ b/code/tests/test_areas_fire_alarms.dm
@@ -4,7 +4,7 @@
 
 /datum/game_test/area_fire_alarms/Run()
 	for(var/area/station/A as anything in SSmapping.existing_station_areas)
-		if(A.there_can_be_many || !A.outdoors)
+		if(A.there_can_be_many || A.outdoors)
 			continue
 		if(is_type_in_list(A, optional_areas))
 			continue

--- a/code/tests/test_areas_fire_alarms.dm
+++ b/code/tests/test_areas_fire_alarms.dm
@@ -1,0 +1,12 @@
+/datum/game_test/area_fire_alarms
+	/// Sometimes, areas may have air, or not. We dont really care about these areas.
+	var/list/optional_areas = list(/area/station/science/toxins/test, /area/station/maintenance/electrical_shop)
+
+/datum/game_test/area_fire_alarms/Run()
+	for(var/area/station/A in SSmapping.existing_station_areas)
+		if(A.there_can_be_many || !A.outdoors)
+			continue
+		if(is_type_in_list(A, optional_areas))
+			continue
+		if(length(A.firealarms) == 0)
+			TEST_FAIL("Area [A.type] has [length(A.firealarms)] air alarms, instead of at least 1.")

--- a/code/tests/test_areas_fire_alarms.dm
+++ b/code/tests/test_areas_fire_alarms.dm
@@ -3,7 +3,7 @@
 	var/list/optional_areas = list(/area/station/science/toxins/test, /area/station/maintenance/electrical_shop)
 
 /datum/game_test/area_fire_alarms/Run()
-	for(var/area/station/A in SSmapping.existing_station_areas)
+	for(var/area/station/A as anything in SSmapping.existing_station_areas)
 		if(A.there_can_be_many || !A.outdoors)
 			continue
 		if(is_type_in_list(A, optional_areas))

--- a/code/tests/test_runner.dm
+++ b/code/tests/test_runner.dm
@@ -27,7 +27,7 @@
 	// Run map tests first in case unit tests futz with map state
 	RunMap()
 	#endif
-	#if  defined(GAME_TESTS) || defnied(MAP_TESTS)
+	#if  defined(GAME_TESTS) || defined(MAP_TESTS)
 	Run()
 	#endif
 	SSticker.reboot_helper("Unit Test Reboot", "tests ended", 0)

--- a/code/tests/test_runner.dm
+++ b/code/tests/test_runner.dm
@@ -27,7 +27,7 @@
 	// Run map tests first in case unit tests futz with map state
 	RunMap()
 	#endif
-	#ifdef GAME_TESTS
+	#if  defined(GAME_TESTS) || defnied(MAP_TESTS)
 	Run()
 	#endif
 	SSticker.reboot_helper("Unit Test Reboot", "tests ended", 0)

--- a/code/tests/test_runner.dm
+++ b/code/tests/test_runner.dm
@@ -27,7 +27,7 @@
 	// Run map tests first in case unit tests futz with map state
 	RunMap()
 	#endif
-	#if  defined(GAME_TESTS) || defined(MAP_TESTS)
+	#if defined(GAME_TESTS) || defined(MAP_TESTS)
 	Run()
 	#endif
 	SSticker.reboot_helper("Unit Test Reboot", "tests ended", 0)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Title

## Why It's Good For The Game

Allows engineers to fix alarms without having to bring their own in lesser used areas.

## Testing

Complied, didnt explode.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
