### PR TITLE
Protolathe chemical capacity is now based on their installed beakers

### DIFF
--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -57,7 +57,9 @@ Note: Must be placed west/left of and R&D console to function.
 
 /obj/machinery/r_n_d/protolathe/RefreshParts()
 	var/T = 0
+	reagents.maximum_volume = 0
 	for(var/obj/item/reagent_containers/glass/G in component_parts)
+		reagents.maximum_volume += G.reagents.maximum_volume
 		G.reagents.trans_to(src, G.reagents.total_volume)
 	for(var/obj/item/stock_parts/matter_bin/M in component_parts)
 		T += M.rating


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes the chemical capacity of protolathes scale with the beakers. Other machinery do it already, the proto just was missing the code for it and was defaulting to 100.

## Why It's Good For The Game
Fixes #28477. Protolathes also have two beakers, so turns out they're supposed to have 200 capacity on roundstart, not 100.

## Images of changes
![Proto](https://github.com/user-attachments/assets/b24af8c8-9373-4643-a342-aa379a77d40f)

## Testing
Started an instance and checked the research computer.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Fix protolate chemical capacity not scaling with beakers. Roundstart machines now have 200 capacity.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
