### PR TITLE
Touches up Delta Robotics, Mech Bay, and R&D

### DIFF
--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -44582,7 +44582,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 1;
 	id_tag = "researchdesk1";
-	name = "Research Desk Shutters"
+	name = "Research and Development Front Desk Shutters"
 	},
 /turf/simulated/floor/plating,
 /area/station/science/rnd)
@@ -45422,13 +45422,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/xenobiology)
-"cWY" = (
-/obj/effect/landmark/start/scientist,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/science/rnd)
 "cXa" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/latex,
@@ -45660,6 +45653,7 @@
 /area/station/science/rnd)
 "cYq" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel,
 /area/station/science/rnd)
 "cYr" = (
@@ -45872,10 +45866,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
 /obj/machinery/firealarm/directional/west,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = -5;
+	pixel_y = 5
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurple"
@@ -46228,6 +46224,7 @@
 /obj/structure/table,
 /obj/item/clipboard,
 /obj/item/toy/figure/crew/scientist,
+/obj/item/clothing/glasses/welding,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/rnd)
 "daL" = (
@@ -46553,13 +46550,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/rnd)
 "dcc" = (
 /obj/structure/chair/office/light{
 	dir = 4
 	},
+/obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplecorner"
 	},
@@ -46993,13 +46990,13 @@
 	},
 /obj/machinery/door_control{
 	id = "researchdesk1";
-	name = "Primary Research Shutters";
+	name = "Research and Development Front Desk Shutters";
 	pixel_x = -8;
 	pixel_y = -26
 	},
 /obj/machinery/door_control{
 	id = "researchdesk2";
-	name = "Secondary Research Shutters";
+	name = "Research and Development Lab Shutters";
 	pixel_x = 8;
 	pixel_y = -26
 	},
@@ -47452,10 +47449,6 @@
 /area/station/science/research)
 "dfo" = (
 /turf/simulated/wall/r_wall,
-/area/station/science/robotics/chargebay)
-"dfp" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
 /area/station/science/robotics/chargebay)
 "dfq" = (
 /obj/machinery/hologram/holopad,
@@ -49338,7 +49331,7 @@
 	req_access = list(29)
 	},
 /obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/shutters{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id_tag = "roboticsshutters";
 	name = "Mech Bay Shutters"
 	},
@@ -49568,7 +49561,7 @@
 /area/station/science/xenobiology)
 "doR" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/shutters{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id_tag = "roboticsshutters";
 	name = "Mech Bay Shutters"
 	},
@@ -49838,7 +49831,7 @@
 /area/station/science/robotics)
 "dqm" = (
 /obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
+	dir = 1;
 	id_tag = "robodesk";
 	name = "Robotics Desk Shutters"
 	},
@@ -50358,9 +50351,6 @@
 /obj/item/healthanalyzer,
 /obj/item/storage/firstaid/regular/empty,
 /obj/item/storage/firstaid/regular/empty,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/requests_console/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -50911,7 +50901,6 @@
 	},
 /area/station/science/robotics)
 "dvo" = (
-/obj/effect/landmark/start/roboticist,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
@@ -63281,9 +63270,11 @@
 	dir = 8;
 	name = "Robotics Surgery"
 	},
-/obj/effect/mapping_helpers/airlock/polarized,
 /obj/effect/mapping_helpers/airlock/windoor/access/any/science/robotics{
 	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "RoboSurgery"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -63929,6 +63920,13 @@
 	icon_state = "darkred"
 	},
 /area/station/security/brig)
+"ihx" = (
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/landmark/start/roboticist,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/science/robotics)
 "ihK" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	autolink_id = "air_out";
@@ -69795,11 +69793,11 @@
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 2;
-	name = s;
+	name = "Research and Development Lab Shutters";
 	id_tag = "researchdesk2"
 	},
 /turf/simulated/floor/plating,
-/area/station/science/robotics/chargebay)
+/area/station/science/rnd)
 "lzY" = (
 /obj/structure/table/wood,
 /obj/machinery/alarm/directional/east,
@@ -73241,14 +73239,14 @@
 /obj/effect/mapping_helpers/airlock/polarized{
 	id = "rnd"
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id_tag = "researchdesk1";
-	name = "Research Desk Shutters"
-	},
 /obj/machinery/door/window/classic/normal,
 /obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "researchdesk1";
+	name = "Research and Development Front Desk Shutters"
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/rnd)
 "nyH" = (
@@ -80506,7 +80504,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 1;
 	id_tag = "researchdesk1";
-	name = "Research Desk Shutters"
+	name = "Research and Development Front Desk Shutters"
 	},
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "rnd"
@@ -83495,6 +83493,9 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
+"sRE" = (
+/turf/simulated/wall/r_wall,
+/area/station/science/rnd)
 "sRR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -86066,8 +86067,10 @@
 /obj/effect/mapping_helpers/airlock/polarized{
 	id = "rnd"
 	},
-/turf/simulated/floor/plasteel/white,
-/area/station/science/robotics/chargebay)
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
+	},
+/area/station/science/rnd)
 "ugz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -86225,7 +86228,7 @@
 "ujF" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall,
-/area/station/science/robotics/chargebay)
+/area/station/science/rnd)
 "ujH" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/decal/cleanable/dirt,
@@ -89073,8 +89076,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/research/glass,
 /obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/machinery/door/airlock/research,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/robotics/chargebay)
 "vPo" = (
@@ -92810,15 +92813,8 @@
 	},
 /area/station/maintenance/fsmaint)
 "xKX" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/wrench,
-/obj/item/clothing/glasses/welding,
 /obj/machinery/newscaster/directional/north,
+/obj/structure/machine_frame,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurplecorner"
@@ -130506,13 +130502,13 @@ cZx
 cKF
 dbY
 cRg
+sRE
 dfo
 dfo
-dfp
 dfo
 vPd
 gfI
-dfp
+dfo
 dfo
 dqp
 dql
@@ -130763,7 +130759,7 @@ cTR
 anF
 egF
 ddC
-dfo
+sRE
 dim
 doU
 dmf
@@ -131020,7 +131016,7 @@ cZs
 daI
 dca
 ddj
-dfo
+sRE
 din
 doV
 dnx
@@ -131290,7 +131286,7 @@ dsL
 dvl
 dug
 dvn
-dui
+ihx
 dyR
 dEX
 jTj
@@ -131528,7 +131524,7 @@ ewj
 xKn
 cTR
 cVu
-cWY
+cZA
 daJ
 daJ
 daK
@@ -132048,7 +132044,7 @@ daJ
 daJ
 daJ
 ddF
-dfo
+sRE
 rmU
 doX
 lqj
@@ -132305,7 +132301,7 @@ ddr
 daM
 dcc
 ddH
-dfo
+sRE
 dis
 djS
 cDI
@@ -132562,7 +132558,7 @@ cTR
 cVz
 lyp
 cVz
-dfo
+sRE
 dit
 iaD
 hYh
@@ -132819,7 +132815,7 @@ cTQ
 daN
 dce
 ddJ
-dfo
+sRE
 dfo
 dfo
 dnB

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -1862,12 +1862,6 @@
 /area/station/maintenance/fore2)
 "anF" = (
 /obj/structure/table/reinforced,
-/obj/item/folder,
-/obj/item/pen,
-/obj/machinery/door/window/classic/normal{
-	dir = 8;
-	name = "Research Lab Desk"
-	},
 /obj/machinery/door/window/classic/normal{
 	dir = 4;
 	name = "Research Lab Desk"
@@ -1876,6 +1870,12 @@
 /obj/effect/mapping_helpers/airlock/windoor/access/any/science/research{
 	dir = 4
 	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/mapping_helpers/airlock/windoor/autoname/desk{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/rnd)
 "anJ" = (
@@ -8617,6 +8617,16 @@
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/abandoned_garden)
+"aHt" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkyellow"
+	},
+/area/station/science/robotics/chargebay)
 "aHv" = (
 /obj/structure/table,
 /obj/item/crowbar,
@@ -39878,10 +39888,12 @@
 /area/station/engineering/control)
 "cDI" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics/chargebay)
 "cDJ" = (
 /obj/item/kirbyplants/large,
@@ -41520,19 +41532,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics/chargebay)
 "cIq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics/chargebay)
 "cIr" = (
 /obj/structure/table/reinforced,
@@ -41812,10 +41825,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/science/robotics/chargebay)
 "cJz" = (
 /turf/simulated/floor/plasteel{
@@ -42058,12 +42070,12 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/toxins/mixing)
 "cKw" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
 /obj/structure/sign/poster/official/science{
 	pixel_x = -32
 	},
+/obj/structure/table/glass,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurplecorner"
@@ -42129,7 +42141,6 @@
 	},
 /area/station/science/lobby)
 "cKH" = (
-/obj/structure/table,
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/glasses/science,
 /obj/item/assembly/timer{
@@ -42138,6 +42149,7 @@
 	},
 /obj/item/assembly/igniter,
 /obj/item/stack/cable_coil/random,
+/obj/structure/table/glass,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurplecorner"
@@ -42317,8 +42329,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics/chargebay)
 "cLx" = (
 /obj/machinery/atmospherics/unary/portables_connector,
@@ -42457,15 +42470,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/port2)
 "cMd" = (
-/obj/structure/table,
-/obj/item/folder/white{
-	pixel_y = 12
-	},
-/obj/machinery/cell_charger{
-	pixel_x = -4
-	},
-/obj/item/stock_parts/cell/high,
 /obj/machinery/alarm/directional/west,
+/obj/structure/table/glass,
+/obj/item/stock_parts/cell/high,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurplecorner"
@@ -42522,7 +42529,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
 "cMm" = (
@@ -42754,7 +42762,6 @@
 	dir = 4
 	},
 /obj/structure/table/glass,
-/obj/item/stock_parts/cell/high,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -42798,7 +42805,6 @@
 	dir = 8
 	},
 /obj/structure/table/glass,
-/obj/item/paicard,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -42806,6 +42812,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/item/paicard,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -43320,6 +43327,9 @@
 	dir = 4
 	},
 /obj/structure/table/glass,
+/obj/item/folder/white{
+	pixel_y = 12
+	},
 /obj/item/gps,
 /obj/item/flash{
 	pixel_x = -5
@@ -43342,7 +43352,9 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/item/paper_bin,
 /obj/structure/table/glass,
+/obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -44105,7 +44117,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/xenobiology)
 "cSm" = (
-/obj/structure/table,
 /obj/item/clipboard,
 /obj/item/airlock_electronics,
 /obj/item/stack/sheet/glass,
@@ -44115,6 +44126,7 @@
 	name = "south bump";
 	pixel_y = -28
 	},
+/obj/structure/table/glass,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurplecorner"
@@ -44179,7 +44191,6 @@
 /turf/simulated/floor/grass,
 /area/station/science/lobby)
 "cSv" = (
-/obj/structure/table,
 /obj/machinery/light,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty{
@@ -44187,6 +44198,7 @@
 	pixel_y = 5
 	},
 /obj/item/stack/package_wrap,
+/obj/structure/table/glass,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplecorner"
 	},
@@ -44542,7 +44554,9 @@
 	id_tag = "robodesk";
 	name = "Robotics Desk Shutters"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "robo"
+	},
 /turf/simulated/floor/plating,
 /area/station/science/robotics)
 "cTQ" = (
@@ -44562,12 +44576,14 @@
 	},
 /area/station/hallway/primary/aft/south)
 "cTT" = (
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "rnd"
+	},
 /obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
+	dir = 1;
 	id_tag = "researchdesk1";
 	name = "Research Desk Shutters"
 	},
-/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/station/science/rnd)
 "cTU" = (
@@ -44913,6 +44929,9 @@
 /obj/machinery/computer/guestpass{
 	pixel_x = -28
 	},
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurplecorner"
@@ -44988,6 +45007,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/science/research)
 "cVt" = (
+/obj/machinery/alarm/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurplecorner"
@@ -44995,9 +45015,6 @@
 /area/station/science/rnd)
 "cVu" = (
 /obj/item/kirbyplants/large,
-/obj/machinery/status_display{
-	pixel_y = 32
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -45032,9 +45049,11 @@
 "cVz" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id_tag = "researchdesk2";
-	name = "Research Desk Shutters"
+	name = "Research and Development Lab Shutters"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "rnd"
+	},
 /turf/simulated/floor/plating,
 /area/station/science/rnd)
 "cVA" = (
@@ -45310,9 +45329,6 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
 "cWL" = (
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
 /obj/machinery/camera{
 	c_tag = "Research Lobby";
 	dir = 1;
@@ -45324,7 +45340,6 @@
 /area/station/science/lobby)
 "cWM" = (
 /obj/structure/table/reinforced,
-/obj/machinery/alarm/directional/west,
 /obj/item/stock_parts/matter_bin{
 	pixel_x = 3;
 	pixel_y = 3
@@ -45334,6 +45349,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/power/apc/directional/west,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -45354,15 +45373,16 @@
 /turf/simulated/floor/plasteel,
 /area/station/science/rnd)
 "cWS" = (
-/obj/machinery/ai_status_display{
-	pixel_x = 32
-	},
 /obj/machinery/r_n_d/protolathe,
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
+	},
+/obj/item/radio/intercom{
+	name = "east bump";
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/rnd)
@@ -45404,6 +45424,9 @@
 /area/station/science/xenobiology)
 "cWY" = (
 /obj/effect/landmark/start/scientist,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/rnd)
 "cXa" = (
@@ -45607,10 +45630,6 @@
 /area/station/science/research)
 "cYm" = (
 /obj/structure/table/reinforced,
-/obj/item/radio/intercom{
-	name = "west bump";
-	pixel_x = -28
-	},
 /obj/item/stack/cable_coil/random,
 /obj/item/stack/cable_coil/random,
 /obj/item/stock_parts/scanning_module,
@@ -45620,6 +45639,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	name = "west bump";
+	pixel_x = -30
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -45644,10 +45667,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/requests_console/directional/east,
 /turf/simulated/floor/plasteel,
 /area/station/science/rnd)
 "cYy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/rnd)
 "cYD" = (
@@ -45841,19 +45868,14 @@
 /area/station/maintenance/electrical)
 "cZs" = (
 /obj/structure/table/reinforced,
-/obj/machinery/power/apc/directional/west,
-/obj/item/folder/white,
-/obj/item/stock_parts/cell/high,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurple"
@@ -45881,10 +45903,10 @@
 /area/station/science/rnd)
 "cZB" = (
 /obj/machinery/hologram/holopad,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/rnd)
 "cZC" = (
@@ -46123,7 +46145,10 @@
 	},
 /area/station/science/research)
 "dav" = (
-/turf/simulated/floor/plasteel/white,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkpurplecorners"
+	},
 /area/station/science/robotics)
 "daw" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -46231,6 +46256,7 @@
 "daN" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
+/obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
 	},
@@ -46822,12 +46848,12 @@
 /area/station/maintenance/port)
 "ddj" = (
 /obj/structure/table/reinforced,
-/obj/machinery/firealarm/directional/south,
 /obj/machinery/cell_charger,
 /obj/machinery/light,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/item/stock_parts/cell/high,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurplecorner"
@@ -46872,7 +46898,11 @@
 	dir = 8;
 	network = list("Research","SS13")
 	},
-/obj/machinery/requests_console/directional/east,
+/obj/machinery/button/windowtint{
+	id = "rnd";
+	pixel_x = 24;
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplecorner"
 	},
@@ -46939,9 +46969,6 @@
 /area/station/science/rnd)
 "ddE" = (
 /obj/structure/table/reinforced,
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/stack/cable_coil/random,
@@ -46956,10 +46983,6 @@
 /area/station/science/rnd)
 "ddF" = (
 /obj/structure/table/reinforced,
-/obj/structure/extinguisher_cabinet{
-	name = "south bump";
-	pixel_y = -30
-	},
 /obj/item/folder/white,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/glass/beaker,
@@ -46967,6 +46990,18 @@
 /obj/item/reagent_containers/dropper,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/machinery/door_control{
+	id = "researchdesk1";
+	name = "Primary Research Shutters";
+	pixel_x = -8;
+	pixel_y = -26
+	},
+/obj/machinery/door_control{
+	id = "researchdesk2";
+	name = "Secondary Research Shutters";
+	pixel_x = 8;
+	pixel_y = -26
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplecorner"
@@ -46988,18 +47023,6 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/light,
-/obj/machinery/door_control{
-	id = "researchdesk2";
-	name = "Secondary Research Shutters";
-	pixel_x = 8;
-	pixel_y = -26
-	},
-/obj/machinery/door_control{
-	id = "researchdesk1";
-	name = "Primary Research Shutters";
-	pixel_x = -8;
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -48005,29 +48028,27 @@
 	},
 /area/station/maintenance/apmaint)
 "dim" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/machinery/alarm/directional/west,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel/white,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "darkyellow"
+	},
 /area/station/science/robotics/chargebay)
 "din" = (
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/machinery/alarm/directional/north,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkyellow"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/science/robotics/chargebay)
 "dio" = (
 /obj/machinery/computer/mech_bay_power_console{
@@ -48042,10 +48063,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkyellow"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/science/robotics/chargebay)
 "dir" = (
 /obj/structure/cable{
@@ -48054,39 +48075,44 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/stripes/line,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/science/robotics/chargebay)
 "dis" = (
-/obj/machinery/power/apc/directional/north,
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/machinery/computer/cryopod/robot{
+	pixel_y = 32
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkyellow"
+	},
 /area/station/science/robotics/chargebay)
 "dit" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 32
 	},
 /obj/machinery/cryopod/robot,
-/obj/machinery/computer/cryopod/robot{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel/white,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "darkyellow"
+	},
 /area/station/science/robotics/chargebay)
 "diu" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway South 2";
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -48452,22 +48478,21 @@
 	},
 /area/station/science/research)
 "djQ" = (
-/turf/simulated/floor/bluegrid,
-/area/station/science/robotics/chargebay)
-"djR" = (
-/obj/machinery/mech_bay_recharge_port{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 1
 	},
-/turf/simulated/floor/bluegrid,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "darkyellow"
+	},
 /area/station/science/robotics/chargebay)
 "djS" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics/chargebay)
 "djZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -48783,7 +48808,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics/chargebay)
 "dlb" = (
 /obj/machinery/hologram/holopad,
@@ -48791,7 +48818,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/roboticist,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics/chargebay)
 "dld" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -48982,16 +49011,21 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/command/office/rd)
 "dmf" = (
-/obj/effect/turf_decal/delivery/hollow,
-/obj/machinery/light_switch{
-	dir = 4;
+/obj/item/radio/intercom{
 	name = "west bump";
-	pixel_x = -24
+	pixel_x = -28
 	},
-/turf/simulated/floor/plasteel/white,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkyellow";
+	dir = 8
+	},
 /area/station/science/robotics/chargebay)
 "dmg" = (
-/turf/simulated/floor/greengrid,
+/obj/effect/turf_decal/stripes/line,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "darkyellow"
+	},
 /area/station/science/robotics/chargebay)
 "dmh" = (
 /obj/item/radio/intercom{
@@ -49279,49 +49313,46 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/science/robotics/chargebay)
 "dny" = (
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics/chargebay)
 "dnz" = (
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/robotics/chargebay)
-"dnA" = (
-/obj/machinery/computer/mech_bay_power_console{
-	dir = 8
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/turf/simulated/floor/greengrid,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics/chargebay)
 "dnB" = (
-/obj/machinery/door/poddoor/shutters{
-	id_tag = "roboticsshutters";
-	name = "Mech Bay Shutters"
-	},
 /obj/machinery/door_control{
 	id = "roboticsshutters";
 	name = "Mech Bay Door Control";
 	pixel_y = 24;
 	req_access = list(29)
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters{
+	id_tag = "roboticsshutters";
+	name = "Mech Bay Shutters"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plasteel/white,
 /area/station/science/robotics/chargebay)
 "dnC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/primary/aft/north)
 "dnD" = (
 /obj/structure/disposalpipe/segment,
@@ -49452,11 +49483,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel/white,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics/chargebay)
 "doz" = (
 /obj/structure/table/reinforced,
@@ -49535,57 +49567,52 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/xenobiology)
 "doR" = (
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters{
 	id_tag = "roboticsshutters";
 	name = "Mech Bay Shutters"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/white,
 /area/station/science/robotics/chargebay)
 "doS" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/north)
 "doT" = (
-/obj/machinery/status_display{
-	pixel_x = -32
+/turf/simulated/floor/plasteel{
+	icon_state = "darkyellow";
+	dir = 8
 	},
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel/white,
 /area/station/science/robotics/chargebay)
 "doU" = (
 /obj/machinery/recharge_station,
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel/white,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkyellow";
+	dir = 8
+	},
 /area/station/science/robotics/chargebay)
 "doV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/cyborg,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/science/robotics/chargebay)
 "doW" = (
-/obj/effect/turf_decal/delivery/hollow,
 /obj/effect/landmark/start/cyborg,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics/chargebay)
 "doX" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/simulated/floor/greengrid,
+/turf/simulated/floor/bluegrid,
 /area/station/science/robotics/chargebay)
 "doY" = (
 /turf/simulated/floor/plasteel{
@@ -49778,27 +49805,33 @@
 	},
 /area/station/science/genetics)
 "dqj" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/extinguisher_cabinet{
 	name = "west bump";
 	pixel_x = -30
 	},
-/obj/item/stack/package_wrap,
-/obj/item/hand_labeler,
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel/white,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -3;
+	pixel_y = 10
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/obj/machinery/light,
+/obj/item/crowbar/large,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "darkyellow"
+	},
 /area/station/science/robotics/chargebay)
 "dqk" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/turf/simulated/floor/plasteel{
+	icon_state = "darkyellow"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/science/robotics/chargebay)
 "dql" = (
 /turf/simulated/wall,
@@ -49809,19 +49842,22 @@
 	id_tag = "robodesk";
 	name = "Robotics Desk Shutters"
 	},
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "robo"
+	},
 /turf/simulated/floor/plating,
 /area/station/science/robotics)
 "dqn" = (
-/obj/structure/sign/science,
+/obj/machinery/status_display,
 /turf/simulated/wall/r_wall,
 /area/station/science/robotics)
 "dqo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkyellow"
+	},
 /area/station/science/robotics/chargebay)
 "dqp" = (
 /turf/simulated/wall/r_wall,
@@ -50068,23 +50104,30 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/simulated/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics/chargebay)
 "drE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkyellow"
+	},
 /area/station/science/robotics/chargebay)
 "drF" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel/white,
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "darkyellow"
+	},
 /area/station/science/robotics/chargebay)
 "drH" = (
 /turf/simulated/floor/plasteel{
@@ -50268,8 +50311,6 @@
 /obj/item/stack/sheet/metal{
 	amount = 50
 	},
-/obj/machinery/requests_console/directional/north,
-/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/light_switch{
 	dir = 4;
 	name = "west bump";
@@ -50295,12 +50336,19 @@
 	pixel_x = -3;
 	pixel_y = 6
 	},
-/turf/simulated/floor/plasteel/white,
+/obj/item/stack/sheet/plasteel{
+	amount = 10;
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil/random,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "darkpurple"
+	},
 /area/station/science/robotics)
 "dsK" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
 /obj/item/assembly/prox_sensor,
 /obj/item/assembly/prox_sensor,
 /obj/item/assembly/prox_sensor,
@@ -50308,13 +50356,23 @@
 /obj/item/healthanalyzer,
 /obj/item/healthanalyzer,
 /obj/item/healthanalyzer,
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel/white,
+/obj/item/storage/firstaid/regular/empty,
+/obj/item/storage/firstaid/regular/empty,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/requests_console/directional/north,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkpurple"
+	},
 /area/station/science/robotics)
 "dsL" = (
-/obj/effect/turf_decal/delivery,
 /obj/machinery/mecha_part_fabricator/station,
-/turf/simulated/floor/plasteel/white,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkpurple"
+	},
 /area/station/science/robotics)
 "dsM" = (
 /obj/structure/rack,
@@ -50323,11 +50381,12 @@
 	},
 /obj/item/book/manual/wiki/robotics_cyborgs,
 /obj/item/book/manual/ripley_build_and_repair,
-/obj/item/storage/belt/utility/full,
 /obj/item/circuitboard/mecha/ripley/main,
 /obj/item/circuitboard/mecha/ripley/peripherals,
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel/white,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkpurple"
+	},
 /area/station/science/robotics)
 "dsO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -50495,7 +50554,10 @@
 /area/station/maintenance/port2)
 "dtN" = (
 /obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel/white,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "darkpurple"
+	},
 /area/station/science/robotics)
 "dtO" = (
 /obj/structure/rack,
@@ -50577,64 +50639,94 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/command/office/rd)
-"due" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/robotics)
 "duf" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/toy/figure/crew/roboticist,
 /obj/machinery/door_control{
 	id = "robodesk";
-	name = "Robotics Desk Shutters";
-	pixel_x = 24;
+	name = "Robotics Privacy Shutters";
+	pixel_x = 10;
+	pixel_y = 24
+	},
+/obj/item/paper_bin{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/item/pen{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/obj/item/flash,
+/obj/item/flash,
+/obj/item/flash,
+/obj/item/flash,
+/obj/item/flash{
+	pixel_x = -5
+	},
+/obj/item/flash{
+	pixel_x = -5
+	},
+/obj/item/flash{
+	pixel_x = -5
+	},
+/obj/item/flash{
+	pixel_x = -5
+	},
+/obj/structure/table,
+/obj/machinery/button/windowtint{
+	id = "robo";
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
 	name = "custom placement";
-	pixel_x = 24;
-	pixel_y = 36
+	pixel_x = -8;
+	pixel_y = 24
 	},
-/obj/item/flash,
-/obj/item/flash,
-/obj/item/flash,
-/obj/item/flash,
-/turf/simulated/floor/plasteel/white,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "darkpurple"
+	},
 /area/station/science/robotics)
 "dug" = (
 /obj/item/robot_parts/robot_suit,
 /obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics)
 "dui" = (
 /obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics)
 "duj" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/west,
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
-/obj/item/wrench,
-/obj/item/clothing/glasses/welding,
 /obj/item/clothing/glasses/hud/diagnostic{
-	pixel_x = 2;
-	pixel_y = 5
+	pixel_x = 6;
+	pixel_y = 11
+	},
+/obj/item/multitool{
+	pixel_x = -9;
+	pixel_y = 9
+	},
+/obj/item/multitool{
+	pixel_x = -9;
+	pixel_y = 1
 	},
 /obj/item/clothing/glasses/hud/diagnostic{
-	pixel_x = 2;
-	pixel_y = 5
+	pixel_x = 4;
+	pixel_y = 8
 	},
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel/white,
+/obj/item/robotanalyzer,
+/obj/item/robotanalyzer{
+	pixel_y = -4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkpurple"
+	},
 /area/station/science/robotics)
 "duk" = (
 /turf/simulated/wall,
@@ -50786,49 +50878,65 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/science/robotics)
 "dvl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/loading_area,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/science/robotics)
 "dvm" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/science/robotics)
 "dvn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/station/science/robotics)
-"dvo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/science/robotics)
+"dvo" = (
 /obj/effect/landmark/start/roboticist,
-/obj/effect/turf_decal/stripes/corner,
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkpurplecorners"
+	},
 /area/station/science/robotics)
 "dvp" = (
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
 	id = "RoboSurgery"
 	},
-/turf/simulated/floor/plasteel/white,
+/obj/item/toy/figure/crew/roboticist{
+	pixel_x = 13;
+	pixel_y = -6
+	},
+/obj/structure/filingcabinet/filingcabinet,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "darkpurple"
+	},
 /area/station/science/robotics)
 "dvq" = (
 /obj/structure/mirror{
@@ -50838,17 +50946,20 @@
 	dir = 4;
 	pixel_x = 12
 	},
-/turf/simulated/floor/plasteel/white,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "darkpurple"
+	},
 /area/station/science/robotics)
 "dvr" = (
 /obj/structure/chair/office/light{
 	dir = 4
 	},
 /obj/effect/landmark/start/roboticist,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkpurple"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/science/robotics)
 "dvs" = (
 /obj/structure/morgue,
@@ -50948,27 +51059,30 @@
 /turf/simulated/floor/plating,
 /area/station/science/robotics)
 "dwq" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/cable_coil/random,
-/obj/item/flash,
-/obj/item/flash,
-/obj/item/robotanalyzer,
-/obj/item/mmi/robotic_brain,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/shelf/science,
+/obj/item/storage/belt/utility/full,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/glasses/welding,
 /obj/item/mecha_parts/core,
-/turf/simulated/floor/plasteel/white,
+/obj/item/paicard,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkpurple"
+	},
 /area/station/science/robotics)
 "dwr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/science/robotics)
 "dws" = (
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics)
 "dwt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -51147,13 +51261,6 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/science/research)
-"dxz" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/science/robotics)
 "dxA" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /mob/living/simple_animal/chick{
@@ -51193,19 +51300,18 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment/corner{
 	dir = 2
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics)
 "dxH" = (
 /obj/structure/disposalpipe/segment{
@@ -51301,40 +51407,36 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/science/research)
 "dyM" = (
-/obj/structure/rack,
-/obj/item/storage/firstaid/regular/empty,
-/obj/item/storage/firstaid/regular/empty,
-/obj/item/paicard,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/robotics)
-"dyN" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkpurple"
 	},
+/area/station/science/robotics)
+"dyO" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkpurple"
 	},
-/turf/simulated/floor/plasteel,
-/area/station/science/robotics)
-"dyO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
 /area/station/science/robotics)
 "dyR" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel/white,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics)
 "dyS" = (
 /obj/effect/landmark/start/roboticist,
-/turf/simulated/floor/plasteel/white,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics)
 "dyW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -51459,40 +51561,25 @@
 	},
 /area/station/science/research)
 "dzV" = (
-/obj/machinery/power/apc/directional/west,
 /obj/machinery/disposal,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/robotics)
-"dzW" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/newscaster/directional/west,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkpurple"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/simulated/floor/plasteel,
-/area/station/science/robotics)
-"dzX" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/simulated/floor/plasteel,
 /area/station/science/robotics)
 "dzY" = (
 /obj/machinery/computer/operating{
 	dir = 1;
 	name = "Robotics Operating Computer"
 	},
-/turf/simulated/floor/plasteel/white,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkpurple"
+	},
 /area/station/science/robotics)
 "dzZ" = (
 /obj/machinery/optable{
@@ -51501,13 +51588,9 @@
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
-/turf/simulated/floor/plasteel/white,
-/area/station/science/robotics)
-"dAa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/turf/simulated/floor/plasteel{
+	icon_state = "darkpurple"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/science/robotics)
 "dAx" = (
 /turf/simulated/wall,
@@ -51804,7 +51887,10 @@
 /obj/item/storage/firstaid/machine,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/robotanalyzer,
-/turf/simulated/floor/plasteel/white,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "darkpurple"
+	},
 /area/station/science/robotics)
 "dBP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -51997,13 +52083,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "dCW" = (
@@ -52046,18 +52132,15 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "dCZ" = (
-/obj/structure/rack,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/electrical,
-/obj/item/screwdriver,
-/obj/item/multitool,
-/obj/item/clothing/head/welding,
-/obj/machinery/newscaster/directional/west,
 /obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel/white,
+/obj/structure/closet/secure_closet/roboticist,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkpurple"
+	},
 /area/station/science/robotics)
 "dDb" = (
 /obj/structure/cable{
@@ -52364,8 +52447,14 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics)
 "dEo" = (
 /turf/simulated/wall,
@@ -52463,17 +52552,14 @@
 /turf/simulated/floor/carpet,
 /area/station/hallway/primary/aft/south)
 "dEX" = (
-/obj/structure/table,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/storage/box/bodybags,
-/obj/item/borg/upgrade/rename,
-/obj/item/stock_parts/cell/high,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel/white,
+/obj/structure/table,
+/obj/item/mmi/robotic_brain,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics)
 "dEZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -52571,7 +52657,10 @@
 /obj/item/mmi,
 /obj/effect/turf_decal/delivery/hollow,
 /obj/item/mmi,
-/turf/simulated/floor/plasteel/white,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkpurple"
+	},
 /area/station/science/robotics)
 "dFx" = (
 /obj/structure/chair/comfy/brown{
@@ -52587,7 +52676,14 @@
 	},
 /obj/effect/turf_decal/delivery/hollow,
 /obj/item/storage/surgical_tray,
-/turf/simulated/floor/plasteel/white,
+/obj/item/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 13
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkpurple"
+	},
 /area/station/science/robotics)
 "dFA" = (
 /obj/machinery/firealarm/directional/east,
@@ -52693,7 +52789,14 @@
 	},
 /obj/structure/closet/secure_closet/roboticist,
 /obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel/white,
+/obj/machinery/power/apc/directional/west,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "darkpurple"
+	},
 /area/station/science/robotics)
 "dGo" = (
 /obj/structure/disposalpipe/segment,
@@ -52951,21 +53054,23 @@
 /area/station/hallway/primary/aft/south)
 "dHR" = (
 /obj/structure/table/reinforced,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/item/storage/box/bodybags{
+	pixel_x = -2;
+	pixel_y = 16
+	},
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
 	id = "RoboSurgery"
 	},
-/obj/effect/turf_decal/delivery/hollow,
-/obj/item/storage/box/bodybags{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/storage/box/masks,
-/obj/item/storage/box/gloves{
-	pixel_x = 4;
+/obj/item/storage/box/masks{
+	pixel_x = 2;
 	pixel_y = 4
 	},
-/turf/simulated/floor/plasteel/white,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "darkpurple"
+	},
 /area/station/science/robotics)
 "dHT" = (
 /turf/simulated/floor/plasteel,
@@ -53087,8 +53192,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/simulated/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkyellow"
+	},
 /area/station/science/robotics/chargebay)
 "dJr" = (
 /obj/structure/sink{
@@ -53840,14 +53949,9 @@
 /obj/structure/window/reinforced/polarized{
 	id = "RoboSurgery"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "darkpurple"
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/computer/rdconsole/core{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
 /area/station/science/robotics)
 "dOd" = (
 /turf/simulated/floor/plasteel{
@@ -53939,15 +54043,15 @@
 	},
 /area/station/science/toxins/mixing)
 "dOD" = (
-/obj/machinery/r_n_d/circuit_imprinter,
+/obj/machinery/computer/rdconsole/core{
+	dir = 1
+	},
 /obj/structure/window/reinforced/polarized{
 	id = "RoboSurgery"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "darkpurple"
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/simulated/floor/plasteel,
 /area/station/science/robotics)
 "dOF" = (
 /obj/structure/lattice/catwalk,
@@ -54373,7 +54477,10 @@
 /obj/effect/turf_decal/delivery/hollow,
 /obj/item/tank/internals/anesthetic,
 /obj/item/clothing/mask/breath/medical,
-/turf/simulated/floor/plasteel/white,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "darkpurple"
+	},
 /area/station/science/robotics)
 "dQr" = (
 /obj/machinery/power/apc/directional/east,
@@ -55226,6 +55333,13 @@
 	icon_state = "red"
 	},
 /area/station/hallway/secondary/exit)
+"dTL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/science/rnd)
 "dTV" = (
 /obj/machinery/power/solar{
 	name = "Aft Starboard Solar Panel"
@@ -55847,17 +55961,14 @@
 	dir = 8;
 	network = list("Research","SS13")
 	},
-/obj/structure/filingcabinet/chestdrawer,
 /obj/structure/window/reinforced/polarized{
 	id = "RoboSurgery"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/r_n_d/circuit_imprinter,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "darkpurple"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel,
 /area/station/science/robotics)
 "dXs" = (
 /obj/structure/grille/broken,
@@ -56936,6 +57047,17 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central/se)
+"epW" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/science/robotics)
 "eqq" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -60280,6 +60402,18 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
+"gfC" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/science/robotics)
+"gfI" = (
+/obj/machinery/ai_status_display,
+/turf/simulated/wall/r_wall,
+/area/station/science/robotics/chargebay)
 "gfR" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -61131,6 +61265,13 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/carpet/black,
 /area/station/security/detective)
+"gGU" = (
+/obj/machinery/economy/vending/robodrobe,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkpurple"
+	},
+/area/station/science/robotics)
 "gHk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -61544,6 +61685,13 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/legal/courtroom/gallery)
+"gRO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery/partial{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint)
 "gTw" = (
 /obj/structure/table/wood,
 /obj/item/folder/white,
@@ -63071,16 +63219,19 @@
 /turf/simulated/floor/carpet/black,
 /area/station/security/detective)
 "hPC" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Robotics Maintenance"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/science/robotics,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
-/turf/simulated/floor/plasteel,
+/obj/machinery/door/airlock/maintenance{
+	name = "Robotics Maintenance"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/maintenance/apmaint)
 "hPM" = (
 /obj/structure/closet/l3closet/virology,
@@ -63134,7 +63285,9 @@
 /obj/effect/mapping_helpers/airlock/windoor/access/any/science/robotics{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel/white,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics)
 "hQV" = (
 /obj/machinery/door/poddoor{
@@ -63368,6 +63521,14 @@
 	icon_state = "darkgreen"
 	},
 /area/station/medical/virology)
+"hYh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/science/robotics/chargebay)
 "hYv" = (
 /obj/structure/table,
 /obj/item/toy/figure/crew/scientist,
@@ -63488,8 +63649,13 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/arrows{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics/chargebay)
 "iaU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -64554,6 +64720,14 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/public/fitness)
+"iFd" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/science/robotics/chargebay)
 "iFl" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/wood,
@@ -66680,9 +66854,18 @@
 	dir = 4
 	},
 /obj/machinery/alarm/directional/south,
-/obj/machinery/economy/vending/robodrobe,
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel/white,
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -3;
+	pixel_y = 10
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkpurple"
+	},
 /area/station/science/robotics)
 "jTm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -68994,6 +69177,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"lkR" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/science/robotics/chargebay)
 "llc" = (
 /obj/structure/table,
 /obj/item/storage/bag/dice,
@@ -69176,6 +69367,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/security/detective)
+"lqj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "darkyellow"
+	},
+/area/station/science/robotics/chargebay)
 "lqk" = (
 /obj/structure/table,
 /obj/item/instrument/harmonica,
@@ -69548,24 +69748,28 @@
 /area/station/maintenance/fore2)
 "lyp" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/classic/normal{
-	dir = 8;
-	name = "Research Lab Desk"
-	},
-/obj/machinery/door/window/classic/normal{
-	dir = 4;
-	name = "Research Lab Desk"
-	},
-/obj/item/folder,
-/obj/item/pen,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id_tag = "researchdesk2";
-	name = "Research Desk Shutters"
-	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/airlock/windoor/access/any/science/research{
 	dir = 8
 	},
+/obj/item/desk_bell{
+	pixel_y = 9;
+	pixel_x = -4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "rnd"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id_tag = "researchdesk2";
+	name = "Research and Development Lab Shutters"
+	},
+/obj/machinery/door/window/classic/normal{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/windoor/autoname/desk{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
 	},
@@ -69585,6 +69789,17 @@
 	icon_state = "darkred"
 	},
 /area/station/security/prisonershuttle)
+"lzQ" = (
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "rnd"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	name = s;
+	id_tag = "researchdesk2"
+	},
+/turf/simulated/floor/plating,
+/area/station/science/robotics/chargebay)
 "lzY" = (
 /obj/structure/table/wood,
 /obj/machinery/alarm/directional/east,
@@ -73016,16 +73231,6 @@
 /area/station/security/storage)
 "nxX" = (
 /obj/structure/table/reinforced,
-/obj/item/folder,
-/obj/item/pen,
-/obj/machinery/door/window/classic/normal{
-	name = "Research Lab Desk"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "researchdesk1";
-	name = "Research Desk Shutters"
-	},
 /obj/effect/turf_decal/delivery,
 /obj/item/desk_bell{
 	anchored = 1;
@@ -73033,10 +73238,17 @@
 	pixel_y = 3
 	},
 /obj/effect/mapping_helpers/airlock/windoor/access/any/science/research,
-/obj/machinery/door/window/classic/normal{
-	dir = 1;
-	name = "Research Lab Desk"
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "rnd"
 	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "researchdesk1";
+	name = "Research Desk Shutters"
+	},
+/obj/machinery/door/window/classic/normal,
+/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/rnd)
 "nyH" = (
@@ -73417,8 +73629,9 @@
 	dir = 4;
 	sort_type_txt = "14"
 	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel/white,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics)
 "nIC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
@@ -73604,6 +73817,12 @@
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/wood,
 /area/station/maintenance/library)
+"nQv" = (
+/obj/effect/turf_decal/loading_area,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/science/robotics/chargebay)
 "nQF" = (
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/reception)
@@ -79945,6 +80164,17 @@
 	icon_state = "black"
 	},
 /area/station/security/permabrig)
+"rmU" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/power/apc/directional/north,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkyellow"
+	},
+/area/station/science/robotics/chargebay)
 "rnb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80201,6 +80431,12 @@
 	icon_state = "darkredfull"
 	},
 /area/station/command/office/hos)
+"rtT" = (
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkpurple"
+	},
+/area/station/science/robotics)
 "rtU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos/glass{
@@ -80266,6 +80502,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
+"rwm" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "researchdesk1";
+	name = "Research Desk Shutters"
+	},
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "rnd"
+	},
+/turf/simulated/floor/plating,
+/area/station/science/rnd)
 "rwD" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Head of Personnel Bedroom"
@@ -80561,7 +80808,6 @@
 "rEc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/item/folder,
 /obj/machinery/door/window/classic/normal{
 	dir = 8;
 	name = "Robotics Desk"
@@ -80574,11 +80820,16 @@
 	name = "Robotics Desk Shutters"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/classic/normal{
-	dir = 4;
-	name = "Robotics Desk"
+/obj/item/desk_bell{
+	pixel_y = 9;
+	pixel_x = -4
 	},
-/turf/simulated/floor/plasteel,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "robo"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics)
 "rEg" = (
 /obj/structure/extinguisher_cabinet{
@@ -81578,6 +81829,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
+"sdO" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "darkyellow"
+	},
+/area/station/science/robotics/chargebay)
 "sdP" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -81763,6 +82021,14 @@
 	icon_state = "darkblue"
 	},
 /area/station/ai_monitored/storage/eva)
+"sie" = (
+/obj/machinery/mecha_part_fabricator/station,
+/obj/machinery/firealarm/directional/north,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkpurple"
+	},
+/area/station/science/robotics)
 "siG" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -82065,7 +82331,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel/white,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "robo"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics)
 "soV" = (
 /obj/structure/cable{
@@ -82552,11 +82823,10 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/airlock/access/all/science/research,
-/turf/simulated/floor/plasteel/white,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics/chargebay)
 "sAB" = (
 /turf/simulated/floor/plasteel{
@@ -83300,6 +83570,17 @@
 	icon_state = "neutral"
 	},
 /area/station/legal/courtroom/gallery)
+"sTp" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkyellow"
+	},
+/area/station/science/robotics/chargebay)
 "sTq" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -85782,6 +86063,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/research,
 /obj/machinery/door/airlock/research/glass,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "rnd"
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/robotics/chargebay)
 "ugz" = (
@@ -85938,6 +86222,10 @@
 	icon_state = "cafeteria"
 	},
 /area/station/security/permabrig)
+"ujF" = (
+/obj/machinery/status_display,
+/turf/simulated/wall/r_wall,
+/area/station/science/robotics/chargebay)
 "ujH" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/decal/cleanable/dirt,
@@ -89430,6 +89718,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/maintenance/incinerator)
+"wfs" = (
+/obj/machinery/ai_status_display,
+/turf/simulated/wall,
+/area/station/science/rnd)
 "wfv" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -89934,6 +90226,10 @@
 	icon_state = "darkred"
 	},
 /area/station/security/prisonershuttle)
+"wtg" = (
+/obj/effect/turf_decal/delivery/partial,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint)
 "wts" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -92718,7 +93014,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel/white,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/science/robotics)
 "xQW" = (
 /obj/machinery/light/small{
@@ -92987,7 +93285,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "yal" = (
-/turf/simulated/floor/plasteel,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/primary/aft/north)
 "yaM" = (
 /obj/structure/chair/stool{
@@ -129960,8 +130263,8 @@ cSt
 cSt
 dvj
 dgv
-rWL
 cSt
+rWL
 dzU
 cSt
 jEZ
@@ -130208,7 +130511,7 @@ dfo
 dfp
 dfo
 vPd
-dfo
+gfI
 dfp
 dfo
 dqp
@@ -130479,7 +130782,7 @@ dCZ
 dGn
 dql
 dGf
-dCU
+gRO
 dEi
 dES
 dCU
@@ -130725,14 +131028,14 @@ cIp
 dnx
 doV
 dqk
-dqm
+dqp
 dsK
 dvk
 dwr
 dxD
-dyN
-dzW
-dEn
+epW
+epW
+epW
 dEn
 hPC
 cMk
@@ -130966,15 +131269,15 @@ ncs
 xBJ
 kWO
 xKn
-cTT
+cTR
 cVt
-daJ
-daJ
 cZA
+daJ
+daJ
 daJ
 cvT
 ddD
-dfp
+lzQ
 diq
 doW
 dny
@@ -130988,7 +131291,7 @@ dvl
 dug
 dvn
 dui
-dzX
+dyR
 dEX
 jTj
 dql
@@ -131227,29 +131530,29 @@ cTR
 cVu
 cWY
 daJ
-cZA
+daJ
 daK
 cvT
 ddE
-dfo
-diq
+ujF
+aHt
 dio
 djQ
 cIq
 dmg
-dnA
+dio
 dIL
 dqn
 dsM
-dvl
+gfC
 dws
 dvo
 dyO
-dAa
-dtN
+dyR
+rtT
 dtN
 mxK
-dBC
+wtg
 dbB
 dfu
 dET
@@ -131482,7 +131785,7 @@ ckI
 xKn
 cTT
 cVv
-cYy
+dTL
 cYy
 cZB
 daL
@@ -131491,13 +131794,13 @@ ddG
 ugy
 dir
 dip
-djQ
+iFd
 dlb
-dmg
+nQv
 dip
-dqo
-dqm
-dsL
+sTp
+dqp
+sie
 dvl
 dui
 dOc
@@ -131507,7 +131810,7 @@ dFw
 dHR
 dql
 dGf
-dBT
+dHL
 dfu
 dEU
 dFv
@@ -131746,20 +132049,20 @@ daJ
 daJ
 ddF
 dfo
-diq
-djR
-djQ
+rmU
+doX
+lqj
 cIq
-dmg
+sdO
 doX
 drD
 soA
-due
+dwr
 dvm
-dws
+dyR
 dOD
-dav
-dav
+gGU
+dyR
 dyR
 dzY
 dql
@@ -131994,7 +132297,7 @@ cNK
 cPu
 ffi
 xKn
-cTT
+rwm
 cVx
 cWR
 cYq
@@ -132007,13 +132310,13 @@ dis
 djS
 cDI
 cJq
-djS
+lkR
 djS
 drE
-dqm
+dqp
 duf
 dvr
-dxz
+rtT
 dXr
 dvq
 dav
@@ -132262,16 +132565,16 @@ cVz
 dfo
 dit
 iaD
-dnz
-dnz
-dnz
+hYh
+hYh
+hYh
 dnz
 drF
 dqp
 cTP
 rEc
 cTP
-cTP
+dql
 dql
 dBO
 dFy
@@ -132509,9 +132812,9 @@ cPw
 cIW
 sZs
 cTR
-cVz
+wfs
 cTR
-cVz
+cTR
 cTQ
 daN
 dce


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes a lot of decal spam.

Adds electrochromic windows to R&D and Robotics.

Replaces some windows with walls.

Gives Robotics a shelf, tidies up the items so they're much better organized.

Adds a second locker to Robotics.

The Mech Bay shutters now start in the open position.

Replaces a table in R&D with a machine frame.

Tables in the science lobby are now made of glass.

Gives robotics Hi Cap+ cells as with other stations.

Repaints Robotics and Mech Bay floors black.

Adds toolboxes and a large crowbar to the Mech Bay.

Adds desk bells.

Removes all walbump conflicts from the edited areas.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Nicer areas are good.

Also having all the equipment that other stations has is good too.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/user-attachments/assets/5a195c9d-e904-41e1-9468-aa4ecf886aa4)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Inspected the locations.
Checked that all the electrochromic windows functioned correctly.
Checked the shutters functioned correctly.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
add: Adds an extra machine analyzer, electrical toolbox, multitool, and flashes to Delta Robotics.
add: Adds tools to the Delta Mech Bay.
del: Removes the cyborg reclassification board from Delta Robotics.
tweak: Rearranged the items in Delta robotics, replaced the high capacity cells with high capacity cell+s
tweak: Delta RnD and Robotics now have electrochromic windows facing the public and mech bay.
tweak: The Delta Mech Bay starts open to the public.
tweak: Reduced the window count at RnD, Robotics, and Mech Bay on Delta.
tweak: Repainted the floors of Delta Robotics and Mech Bay.
tweak: Delta Science Lobby now has all glass tables.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
