### PR TITLE
[S] Fixes mindflayer grapple having a lower cooldown than it should

### DIFF
--- a/code/modules/antagonists/mind_flayer/powers/flayer_weapon_powers.dm
+++ b/code/modules/antagonists/mind_flayer/powers/flayer_weapon_powers.dm
@@ -188,7 +188,7 @@
 
 /datum/spell/flayer/self/weapon/grapple_arm/on_apply()
 	..()
-	cooldown_handler.recharge_duration = initial(cooldown_handler.recharge_duration) - 10 SECONDS * level
+	cooldown_handler.recharge_duration = initial(cooldown_handler.recharge_duration) - 10 SECONDS * level - 1
 
 /*
  * A slightly slower (5 seconds) version of the basic access tuner

--- a/code/modules/antagonists/mind_flayer/powers/flayer_weapon_powers.dm
+++ b/code/modules/antagonists/mind_flayer/powers/flayer_weapon_powers.dm
@@ -188,7 +188,7 @@
 
 /datum/spell/flayer/self/weapon/grapple_arm/on_apply()
 	..()
-	cooldown_handler.recharge_duration = initial(cooldown_handler.recharge_duration) - 10 SECONDS * level - 1
+	cooldown_handler.recharge_duration = base_cooldown - 10 SECONDS * level //Level 1: 15 seconds, level 2: 5 seconds, level 3: No cooldown, just limited by travel time
 
 /*
  * A slightly slower (5 seconds) version of the basic access tuner


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Title
## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This is a pretty egregious bug, whoops

## Testing

<!-- How did you test the PR, if at all? -->
Fired a level 1, level 2, and level 3 grappling hooks. They all had the correct cooldowns
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
