### PR TITLE
Fix Legion megafauna being able to `enrage()` for more than 1 time and remove `/datum/nothing`

### DIFF
--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -81,6 +81,3 @@
 
 	for(var/target in signal_procs)
 		UnregisterSignal(target, signal_procs[target])
-
-/datum/nothing
-	// Placeholder object, used for ispath checks. Has to be defined to prevent errors, but shouldn't ever be created.

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -57,19 +57,22 @@ Difficulty: Medium
 	transform *= 2
 
 /mob/living/simple_animal/hostile/megafauna/legion/enrage()
+	if(enraged || ((health / maxHealth) * 100 <= 80))
+		return
+	enraged = TRUE
 	health = 1250
 	maxHealth = 1250
 	transform /= 1.5
-	loot = list(/datum/nothing)
-	crusher_loot = list(/datum/nothing)
+	loot = list()
+	crusher_loot = list()
 	var/mob/living/simple_animal/hostile/megafauna/legion/legiontwo = new /mob/living/simple_animal/hostile/megafauna/legion(get_turf(src))
-	legiontwo.transform /= 1.5
-	legiontwo.loot = list(/datum/nothing)
-	legiontwo.crusher_loot = list(/datum/nothing)
+	legiontwo.enraged = TRUE
 	legiontwo.health = 1250
 	legiontwo.maxHealth = 1250
-	legiontwo.enraged = TRUE
-
+	legiontwo.transform /= 1.5
+	legiontwo.loot = list()
+	legiontwo.crusher_loot = list()
+	
 /mob/living/simple_animal/hostile/megafauna/legion/unrage()
 	. = ..()
 	for(var/mob/living/simple_animal/hostile/megafauna/legion/other in GLOB.mob_list)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes a case when you could throw 2+ hardmode grenades at Legion and he would enrage for more than one time, which resulted in 4+ half-sized Legions and 2+ staffs of storms.

Also moved code around for the constistency.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Bug fix. I doubt that you should be able to get 10 staffs of storms as well as fighting 20 half-sized Legions.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Local server, tried to enrage him with 3 different hardmode nades - he only enraged one time and i had to deal with just 2 half-sized Legions instead of 6.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Legion megafauna can't be enraged for more than one time now, which prevents getting 2+ staffs of storms.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
