### PR TITLE
make detective closet contents consistent across stations

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -10264,8 +10264,6 @@
 /area/station/hallway/primary/fore)
 "aKB" = (
 /obj/structure/closet/secure_closet/detective,
-/obj/item/restraints/handcuffs,
-/obj/item/flash,
 /turf/simulated/floor/carpet/grimey,
 /area/station/security/detective)
 "aKC" = (

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -13242,8 +13242,6 @@
 /area/station/engineering/smes)
 "bPO" = (
 /obj/structure/closet/secure_closet/detective,
-/obj/item/flash,
-/obj/item/restraints/handcuffs,
 /obj/item/radio/intercom{
 	name = "east bump";
 	pixel_x = 28

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -101066,9 +101066,6 @@
 /area/station/maintenance/starboard)
 "tYT" = (
 /obj/structure/closet/secure_closet/detective,
-/obj/item/restraints/handcuffs,
-/obj/item/flash,
-/obj/item/clothing/gloves/color/latex,
 /obj/machinery/alarm/directional/north,
 /turf/simulated/floor/carpet,
 /area/station/security/detective)

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -546,10 +546,7 @@
 /area/station/engineering/solar/fore_port)
 "agY" = (
 /obj/structure/closet/secure_closet/detective,
-/obj/item/restraints/handcuffs,
-/obj/item/flash,
 /obj/machinery/alarm/directional/south,
-/obj/item/reagent_containers/drinks/flask/detflask,
 /turf/simulated/floor/carpet/grimey,
 /area/station/security/detective)
 "ahd" = (

--- a/code/game/objects/structures/crates_lockers/closets/secure/security_lockers.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security_lockers.dm
@@ -189,19 +189,23 @@
 	close_sound = 'sound/machines/wooden_closet_close.ogg'
 
 /obj/structure/closet/secure_closet/detective/populate_contents()
+	new /obj/effect/spawner/detgun(src)
+	new /obj/item/ammo_box/magazine/detective/speedcharger(src)
+	new /obj/item/ammo_box/magazine/detective/speedcharger(src)
+	new /obj/item/clipboard(src)
+	new /obj/item/clothing/gloves/color/latex(src)
+	new /obj/item/detective_scanner(src)
+	new /obj/item/flash(src)
+	new /obj/item/flashlight/seclite(src)
+	new /obj/item/holosign_creator/detective(src)
+	new /obj/item/radio/headset/headset_sec/alt(src)
+	new /obj/item/reagent_containers/drinks/flask/detflask(src)
+	new /obj/item/restraints/handcuffs(src)
 	new /obj/item/storage/bag/garment/detective(src)
 	new /obj/item/storage/belt/security(src)
 	new /obj/item/storage/box/evidence(src)
-	new /obj/item/clipboard(src)
-	new /obj/item/radio/headset/headset_sec/alt(src)
-	new /obj/item/detective_scanner(src)
-	new /obj/item/ammo_box/magazine/detective/speedcharger(src)
-	new /obj/item/ammo_box/magazine/detective/speedcharger(src)
-	new /obj/effect/spawner/detgun(src)
-	new /obj/item/flashlight/seclite(src)
-	new /obj/item/holosign_creator/detective(src)
-	new /obj/item/taperecorder(src)
 	new /obj/item/storage/box/tapes(src)
+	new /obj/item/taperecorder(src)
 
 /obj/structure/closet/secure_closet/injection
 	name = "lethal injections locker"


### PR DESCRIPTION
## What Does This PR Do
This PR removes all the arbitrary contents added on top of the hardcoded items added to detective closets across all stations and adds them to the hardcoded list.
## Why It's Good For The Game
Mapping consistency.
## Testing
Visual inspection.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog

:cl:
fix: Detective closets across all stations, if they didn't have them already, will now have a flash, an extra flask, a pair of handcuffs, a and a pair of latex gloves.
/:cl: