### PR TITLE
Emergency lights turn off after 2 minutes again

### DIFF
--- a/code/modules/power/apc/apc.dm
+++ b/code/modules/power/apc/apc.dm
@@ -477,7 +477,7 @@
 		machine_powernet.set_power_channel(PW_CHANNEL_LIGHTING, (lighting_channel > APC_CHANNEL_SETTING_AUTO_OFF))
 		machine_powernet.set_power_channel(PW_CHANNEL_EQUIPMENT, (equipment_channel > APC_CHANNEL_SETTING_AUTO_OFF))
 		machine_powernet.set_power_channel(PW_CHANNEL_ENVIRONMENT, (environment_channel > APC_CHANNEL_SETTING_AUTO_OFF))
-		if(lighting_channel > 1)
+		if(lighting_channel > APC_CHANNEL_SETTING_AUTO_OFF)
 			emergency_power = TRUE
 			if(emergency_power_timer)
 				deltimer(emergency_power_timer)

--- a/code/modules/power/apc/apc.dm
+++ b/code/modules/power/apc/apc.dm
@@ -477,18 +477,20 @@
 		machine_powernet.set_power_channel(PW_CHANNEL_LIGHTING, (lighting_channel > APC_CHANNEL_SETTING_AUTO_OFF))
 		machine_powernet.set_power_channel(PW_CHANNEL_EQUIPMENT, (equipment_channel > APC_CHANNEL_SETTING_AUTO_OFF))
 		machine_powernet.set_power_channel(PW_CHANNEL_ENVIRONMENT, (environment_channel > APC_CHANNEL_SETTING_AUTO_OFF))
-		if(lighting_channel)
+		if(lighting_channel > 1)
 			emergency_power = TRUE
 			if(emergency_power_timer)
 				deltimer(emergency_power_timer)
 				emergency_power_timer = null
 		else
-			emergency_power_timer = addtimer(CALLBACK(src, PROC_REF(turn_emergency_power_off)), 2 MINUTES, TIMER_UNIQUE|TIMER_STOPPABLE)
+			if(!emergency_power_timer)
+				emergency_power_timer = addtimer(CALLBACK(src, PROC_REF(turn_emergency_power_off)), 2 MINUTES, TIMER_UNIQUE|TIMER_STOPPABLE)
 	else
 		machine_powernet.set_power_channel(PW_CHANNEL_LIGHTING, FALSE)
 		machine_powernet.set_power_channel(PW_CHANNEL_EQUIPMENT, FALSE)
 		machine_powernet.set_power_channel(PW_CHANNEL_ENVIRONMENT, FALSE)
-		emergency_power_timer = addtimer(CALLBACK(src, PROC_REF(turn_emergency_power_off)), 2 MINUTES, TIMER_UNIQUE|TIMER_STOPPABLE)
+		if(!emergency_power_timer)
+			emergency_power_timer = addtimer(CALLBACK(src, PROC_REF(turn_emergency_power_off)), 2 MINUTES, TIMER_UNIQUE|TIMER_STOPPABLE)
 	machine_powernet.power_change()
 
 /obj/machinery/power/apc/proc/can_use(mob/user, loud = 0) //used by attack_hand() and Topic()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This makes emergency lighting turn off after 2 minutes, which they were intended to but don't because of a bug.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Apart from the infinite emergency power being a bug, I think it's good for losing power to lights to (eventually) mean no lights.

The total lack of darkness on the station even in blackouts is a bit of a detriment to the atmosphere of the game, I think, and more or less relegates torches, flares and light sources to situations where antags intentionally created darkness.

Between this and #28518, hopefully we can get an eerily quiet, dark environment when the station is falling apart.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
VV'd an APC to see the timer. 
Waited 2 minutes to see if the lights turned off.
Restored power to make sure the timer reset.
Turned APC power off while unpowered to make sure emergency power didn't come back.
Tried using a fire alarm while power was broken, lights didn't come on.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Emergency power now runs out again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
