### PR TITLE
Fire alarms now eventually stop blaring

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -341,7 +341,7 @@
 			F.update_icon()
 			GLOB.firealarm_soundloop.start(F)
 		if(!firealarm_sound_stop_timer)
-			firealarm_sound_stop_timer = addtimer(CALLBACK(src, PROC_REF(stop_alarm_sounds)), 4 MINUTES, TIMER_STOPPABLE || TIMER_UNIQUE)
+			firealarm_sound_stop_timer = addtimer(CALLBACK(src, PROC_REF(stop_alarm_sounds)), 4 MINUTES, TIMER_STOPPABLE | TIMER_UNIQUE)
 
 	for(var/thing in cameras)
 		var/obj/machinery/camera/C = locateUID(thing)
@@ -353,8 +353,7 @@
 	START_PROCESSING(SSobj, src)
 
 /area/proc/stop_alarm_sounds()
-	for(var/item in firealarms)
-		var/obj/machinery/firealarm/F = item
+	for(var/obj/machinery/firealarm/F in firealarms)
 		F.update_icon()
 		GLOB.firealarm_soundloop.stop(F)
 /**

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -342,8 +342,7 @@
 			GLOB.firealarm_soundloop.start(F)
 		if(!firealarm_sound_stop_timer)
 			firealarm_sound_stop_timer = addtimer(CALLBACK(src, PROC_REF(stop_alarm_sounds)), 4 MINUTES, TIMER_STOPPABLE || TIMER_UNIQUE)
-		else(deltimer(firealarm_sound_stop_timer))
-		
+
 	for(var/thing in cameras)
 		var/obj/machinery/camera/C = locateUID(thing)
 		if(!QDELETED(C))
@@ -372,6 +371,7 @@
 		ModifyFiredoors(TRUE)
 		if(firealarm_sound_stop_timer)
 			deltimer(firealarm_sound_stop_timer)
+			firealarm_sound_stop_timer = null
 		for(var/item in firealarms)
 			var/obj/machinery/firealarm/F = item
 			F.update_icon()

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -341,7 +341,7 @@
 			F.update_icon()
 			GLOB.firealarm_soundloop.start(F)
 		if(!firealarm_sound_stop_timer)
-			firealarm_sound_stop_timer = addtimer(CALLBACK(src, PROC_REF(stop_alarm_sounds)), 1 MINUTES, TIMER_STOPPABLE || TIMER_UNIQUE)
+			firealarm_sound_stop_timer = addtimer(CALLBACK(src, PROC_REF(stop_alarm_sounds)), 4 MINUTES, TIMER_STOPPABLE || TIMER_UNIQUE)
 		else(deltimer(firealarm_sound_stop_timer))
 		
 	for(var/thing in cameras)

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -61,6 +61,8 @@
 	var/list/firealarms
 	var/firedoors_last_closed_on = 0
 
+	/// Timer to stop ongoing fire alarm sounds
+	var/firealarm_sound_stop_timer = null
 	/// The air alarms present in this area.
 	var/list/air_alarms = list()
 	/// The list of vents in our area.
@@ -338,7 +340,10 @@
 			var/obj/machinery/firealarm/F = item
 			F.update_icon()
 			GLOB.firealarm_soundloop.start(F)
-
+		if(!firealarm_sound_stop_timer)
+			firealarm_sound_stop_timer = addtimer(CALLBACK(src, PROC_REF(stop_alarm_sounds)), 1 MINUTES, TIMER_STOPPABLE || TIMER_UNIQUE)
+		else(deltimer(firealarm_sound_stop_timer))
+		
 	for(var/thing in cameras)
 		var/obj/machinery/camera/C = locateUID(thing)
 		if(!QDELETED(C))
@@ -348,6 +353,11 @@
 
 	START_PROCESSING(SSobj, src)
 
+/area/proc/stop_alarm_sounds()
+	for(var/item in firealarms)
+		var/obj/machinery/firealarm/F = item
+		F.update_icon()
+		GLOB.firealarm_soundloop.stop(F)
 /**
   * Reset the firealarm alert for this area
   *
@@ -360,6 +370,8 @@
 	if(fire)
 		unset_fire_alarm_effects()
 		ModifyFiredoors(TRUE)
+		if(firealarm_sound_stop_timer)
+			deltimer(firealarm_sound_stop_timer)
 		for(var/item in firealarms)
 			var/obj/machinery/firealarm/F = item
 			F.update_icon()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This makes fire alarms stop the racket after 4 minutes.
They still do all the other fire alarm stuff after that, just not the noise.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The sound is really grating and carries across half the station, and the immersive effect wears thin a bit after hearing it for ages when atmos hazards haven't been repaired. It's good for a bit, but after a while of being on it's just a nuisance to anyone in a huge radius, who has to hear it or mess with their volume until engi fixes whatever caused the alarm.

I think 4 minutes is a good amount of time to alert everyone and get engi called, without being too painfully long, but I can change it if need be.

Also, the silence is nice and thematic when things have really gone to hell on the station after a plasmaflood or huge explosion.
Between this and #28517, hopefully we can get an eerily quiet, dark environment when the station is falling apart.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Turned on an alarm, waited for it to stop making sounds.
Turned it off and on again quickly to make sure it kept making sounds again the second time and didn't get interrupted for the full cooldown.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Fire alarms eventually stop making noise
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
