### PR TITLE
Gives Poly Some More Lines

### DIFF
--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -682,7 +682,7 @@
 		"Check the crystal, you chucklefucks!",
 		"STOP HOT-WIRING THE ENGINE, FUCKING CHRIST!",
 		"Wire the solars, you lazy bums!",
-		"WHO TOOK THE DAMN MODSUITS?",
+		"WHO TOOK THE DAMN HARDSUITS?",
 		"OH GOD ITS ABOUT TO DELAMINATE CALL THE SHUTTLE",
 		"Why are there so many atmos alerts?",
 		"OH GOD WHY WOULD YOU PUT PLASMA IN THE SM?",
@@ -706,10 +706,11 @@
 		"Checked that everything is connected as it should be?",
 		"If you push the SM too far we'll have to abandon station!",
 		"SOS, save our supermatter!",
-		"Is that a terror spider in the SM?",
-		"Remember those mesons, or you'll be seeing terror spiders in the SM!",
+		"Is that a spider in the SM?",
+		"Remember those mesons, or you'll be seeing spiders in the SM!",
 		"Check the air alarm is set properly!",
 		"Is the station goal done yet?",
+		"WHO TOOK THE DAMN MODSUITS?",
 		)
 	unique_pet = TRUE
 	gold_core_spawnable = NO_SPAWN

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -715,6 +715,8 @@
 		"THE BSH IS SPAWNING HORRIFIC THINGS, YOU PUT IT TOO HIGH!",
 		"It's an excellent idea to aim the BSA at the shuttle",
 		"Nitrogen is an awful gas if you need to power a BSH!",
+		"There's a hole in the shield coverage!",
+		"The shields aren't up and meteors are inbound!",
 		)
 	unique_pet = TRUE
 	gold_core_spawnable = NO_SPAWN

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -699,6 +699,9 @@
 		"Chief Engineers are the SM's natural diet.",
 		"Don't eat the forbidden nacho!",
 		"Is the engine meant to be making that noise?",
+		"THE TESLA IS LOOSE CALL THE SHUTTLE",
+		"Go fix the chewed wires, you lazy bums!",
+		"Go fix that breach, or we'll end up with no air!",
 		)
 	unique_pet = TRUE
 	gold_core_spawnable = NO_SPAWN

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -708,6 +708,8 @@
 		"SOS, save our supermatter!",
 		"Is that a terror spider in the SM?",
 		"Remember those mesons, or you'll be seeing terror spiders in the SM!",
+		"Check the air alarm is set properly!",
+		"Is the station goal done yet?",
 		)
 	unique_pet = TRUE
 	gold_core_spawnable = NO_SPAWN

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -713,11 +713,11 @@
 		"WHO TOOK THE DAMN MODSUITS?",
 		"Don't wire the Bluespace Harvester to the Grid, or the station will be powerless!",
 		"THE BSH IS SPAWNING HORRIFIC THINGS, YOU PUT IT TOO HIGH!",
-		"It's an excellent idea to aim the BSA at the shuttle",
+		"It's an excellent idea to aim the BSA at the shuttle.",
 		"Nitrogen is an awful gas if you need to power a BSH!",
 		"There's a hole in the shield coverage!",
 		"The shields aren't up and meteors are inbound!",
-		"The leading cause of death among engineering is due to deactivated magboots, whether that's due to unwrenching a pressurised pipe or being pulled into the embrace of the SM, it means turn on your magboots!",
+		"The leading cause of death among engineers is due to deactivated magboots, whether that's due to unwrenching a pressurised pipe or being pulled into the embrace of the SM, it means turn on your magboots!",
 		)
 	unique_pet = TRUE
 	gold_core_spawnable = NO_SPAWN

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -717,7 +717,7 @@
 		"Nitrogen is an awful gas if you need to power a BSH!",
 		"There's a hole in the shield coverage!",
 		"The shields aren't up and meteors are inbound!",
-		"The leading cause of death among engineers is due to deactivated magboots, whether that's due to unwrenching a pressurised pipe or being pulled into the embrace of the SM, it means turn on your magboots!",
+		"The leading cause of death among engineers is due to deactivated magboots, whether that's due to unwrenching a pressurized pipe or being pulled into the embrace of the SM, it means turn on your magboots!",
 		)
 	unique_pet = TRUE
 	gold_core_spawnable = NO_SPAWN

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -714,6 +714,7 @@
 		"Don't wire the Bluespace Harvester to the Grid, or the station will be powerless!",
 		"THE BSH IS SPAWNING HORRIFIC THINGS, YOU PUT IT TOO HIGH!",
 		"It's an excellent idea to aim the BSA at the shuttle",
+		"Nitrogen is an awful gas if you need to power a BSH!",
 		)
 	unique_pet = TRUE
 	gold_core_spawnable = NO_SPAWN

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -701,7 +701,13 @@
 		"Is the engine meant to be making that noise?",
 		"THE TESLA IS LOOSE CALL THE SHUTTLE",
 		"Go fix the chewed wires, you lazy bums!",
-		"Go fix that breach, or we'll end up with no air!",
+		"Go fix that breach, or we'll all suffocate!",
+		"Why is the engine failing?",
+		"Checked that everything is connected as it should be?",
+		"If you push the SM too far we'll have to abandon station!",
+		"SOS, save our supermatter!",
+		"Is that a terror spider in the SM?",
+		"Remember those mesons, or you'll be seeing terror spiders in the SM!",
 		)
 	unique_pet = TRUE
 	gold_core_spawnable = NO_SPAWN

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -717,7 +717,7 @@
 		"Nitrogen is an awful gas if you need to power a BSH!",
 		"There's a hole in the shield coverage!",
 		"The shields aren't up and meteors are inbound!",
-		"The leading cause of death is due to deactivated magboots, whether that's due to unwrenching a pressurised pipe or being pulled into the embrace of the SM, it means turn on your magboots!",
+		"The leading cause of death among engineering is due to deactivated magboots, whether that's due to unwrenching a pressurised pipe or being pulled into the embrace of the SM, it means turn on your magboots!",
 		)
 	unique_pet = TRUE
 	gold_core_spawnable = NO_SPAWN

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -711,6 +711,9 @@
 		"Check the air alarm is set properly!",
 		"Is the station goal done yet?",
 		"WHO TOOK THE DAMN MODSUITS?",
+		"Don't wire the Bluespace Harvester to the Grid, or the station will be powerless!",
+		"THE BSH IS SPAWNING HORRIFIC THINGS, YOU PUT IT TOO HIGH!",
+		"It's an excellent idea to aim the BSA at the shuttle",
 		)
 	unique_pet = TRUE
 	gold_core_spawnable = NO_SPAWN

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -717,6 +717,7 @@
 		"Nitrogen is an awful gas if you need to power a BSH!",
 		"There's a hole in the shield coverage!",
 		"The shields aren't up and meteors are inbound!",
+		"The leading cause of death is due to deactivated magboots, whether that's due to unwrenching a pressurised pipe or being pulled into the embrace of the SM, it means turn on your magboots!",
 		)
 	unique_pet = TRUE
 	gold_core_spawnable = NO_SPAWN

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -682,7 +682,7 @@
 		"Check the crystal, you chucklefucks!",
 		"STOP HOT-WIRING THE ENGINE, FUCKING CHRIST!",
 		"Wire the solars, you lazy bums!",
-		"WHO TOOK THE DAMN HARDSUITS?",
+		"WHO TOOK THE DAMN MODSUITS?",
 		"OH GOD ITS ABOUT TO DELAMINATE CALL THE SHUTTLE",
 		"Why are there so many atmos alerts?",
 		"OH GOD WHY WOULD YOU PUT PLASMA IN THE SM?",


### PR DESCRIPTION
## What Does This PR Do

Gives Poly some more lines and adds one line that is the 'WHO TOOK THE DAMN HARDSUITS?' but 'MODSUITS' instead of 'HARDSUITS'.

## Why It's Good For The Game

Poly seems too constrained by the limited lines. Engineering doesn't use hardsuits anymore.

## Testing

Just changed and added some text lines, I feel that testing wouldn't be needed in _this_ case.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl:
add: Adds 19 lines to Poly
/:cl:
