### PR TITLE
remove unnecessary proc get_roletext

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -302,7 +302,6 @@
 	return null
 
 /proc/get_candidates(be_special_type, afk_bracket=3000, override_age=0, override_jobban=0)
-	var/roletext = get_roletext(be_special_type)
 	var/list/candidates = list()
 	// Keep looping until we find a non-afk candidate within the time bracket (we limit the bracket to 10 minutes (6000))
 	while(!length(candidates) && afk_bracket < 6000)
@@ -310,7 +309,7 @@
 			if(G.client != null)
 				if(!(G.mind && G.mind.current && G.mind.current.stat != DEAD))
 					if(!G.client.is_afk(afk_bracket) && (be_special_type in G.client.prefs.be_special))
-						if(!override_jobban || (!jobban_isbanned(G, roletext) && !jobban_isbanned(G, ROLE_SYNDICATE)))
+						if(!override_jobban || (!jobban_isbanned(G, be_special_type) && !jobban_isbanned(G, ROLE_SYNDICATE)))
 							if(override_age || player_old_enough_antag(G.client,be_special_type))
 								candidates += G.client
 		afk_bracket += 600 // Add a minute to the bracket, for every attempt
@@ -318,7 +317,6 @@
 	return candidates
 
 /proc/get_candidate_ghosts(be_special_type, afk_bracket=3000, override_age=0, override_jobban=0)
-	var/roletext = get_roletext(be_special_type)
 	var/list/candidates = list()
 	// Keep looping until we find a non-afk candidate within the time bracket (we limit the bracket to 10 minutes (6000))
 	while(!length(candidates) && afk_bracket < 6000)
@@ -326,7 +324,7 @@
 			if(G.client != null)
 				if(!(G.mind && G.mind.current && G.mind.current.stat != DEAD))
 					if(!G.client.is_afk(afk_bracket) && (be_special_type in G.client.prefs.be_special))
-						if(!override_jobban || (!jobban_isbanned(G, roletext) && !jobban_isbanned(G, ROLE_SYNDICATE)))
+						if(!override_jobban || (!jobban_isbanned(G, be_special_type) && !jobban_isbanned(G, ROLE_SYNDICATE)))
 							if(override_age || player_old_enough_antag(G.client,be_special_type))
 								candidates += G
 		afk_bracket += 600 // Add a minute to the bracket, for every attempt

--- a/code/controllers/subsystem/SSghost_spawns.dm
+++ b/code/controllers/subsystem/SSghost_spawns.dm
@@ -44,7 +44,7 @@ SUBSYSTEM_DEF(ghost_spawns)
   * * role_cleanname - The name override to display to clients
   */
 /datum/controller/subsystem/ghost_spawns/proc/poll_candidates(question = "Would you like to play a special role?", role, antag_age_check = FALSE, poll_time = 30 SECONDS, ignore_respawnability = FALSE, min_hours = 0, flash_window = TRUE, check_antaghud = TRUE, source, role_cleanname, reason, dont_play_notice_sound = FALSE)
-	log_debug("Polling candidates [role ? "for [role_cleanname || get_roletext(role)]" : "\"[question]\""] for [poll_time / 10] seconds")
+	log_debug("Polling candidates [role ? "for [role_cleanname || role]" : "\"[question]\""] for [poll_time / 10] seconds")
 
 	// Start firing
 	polls_active = TRUE
@@ -132,7 +132,7 @@ SUBSYSTEM_DEF(ghost_spawns)
 		if(isatom(source))
 			act_jump = "<a href='byond://?src=[M.UID()];jump=\ref[source]'>\[Teleport]</a>"
 		var/act_signup = "<a href='byond://?src=[A.UID()];signup=1'>\[Sign Up]</a>"
-		to_chat(M, "<big><span class='boldnotice'>Now looking for candidates [role ? "to play as \an [role_cleanname || get_roletext(role)]" : "\"[question]\""]. [act_jump] [act_signup] [reason ? "<i>\nReason: [sanitize(reason)]</i>" : ""]</span></big>", MESSAGE_TYPE_DEADCHAT)
+		to_chat(M, "<big><span class='boldnotice'>Now looking for candidates [role ? "to play as \an [role_cleanname || role]" : "\"[question]\""]. [act_jump] [act_signup] [reason ? "<i>\nReason: [sanitize(reason)]</i>" : ""]</span></big>", MESSAGE_TYPE_DEADCHAT)
 
 		// Start processing it so it updates visually the timer
 		START_PROCESSING(SSprocessing, A)
@@ -196,7 +196,7 @@ SUBSYSTEM_DEF(ghost_spawns)
 	// Trim players who aren't eligible anymore
 	var/len_pre_trim = length(P.signed_up)
 	P.trim_candidates()
-	log_debug("Candidate poll [P.role ? "for [get_roletext(P.role)]" : "\"[P.question]\""] finished. [len_pre_trim] players signed up, [length(P.signed_up)] after trimming")
+	log_debug("Candidate poll [P.role ? "for [P.role]" : "\"[P.question]\""] finished. [len_pre_trim] players signed up, [length(P.signed_up)] after trimming")
 
 	P.finished = TRUE
 	currently_polling -= P

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -280,17 +280,15 @@
 	var/list/players = list()
 	var/list/candidates = list()
 
-	var/roletext = get_roletext(role)
-
 	// Assemble a list of active players without jobbans.
 	for(var/mob/new_player/player in GLOB.player_list)
 		if(player.client && player.ready)
-			if(!jobban_isbanned(player, ROLE_SYNDICATE) && !jobban_isbanned(player, roletext))
+			if(!jobban_isbanned(player, ROLE_SYNDICATE) && !jobban_isbanned(player, role))
 				if(player_old_enough_antag(player.client,role))
 					players += player
 
 	for(var/mob/living/carbon/human/player in GLOB.player_list)
-		if(jobban_isbanned(player, ROLE_SYNDICATE) || jobban_isbanned(player, roletext))
+		if(jobban_isbanned(player, ROLE_SYNDICATE) || jobban_isbanned(player, role))
 			continue
 		if(player_old_enough_antag(player.client, role))
 			players += player
@@ -303,7 +301,7 @@
 			if(species_exclusive && (eligible_player.client.prefs.active_character.species != species_exclusive))
 				continue
 			if(role in eligible_player.client.prefs.be_special)
-				player_draft_log += "[eligible_player.key] had [roletext] enabled, so we are drafting them."
+				player_draft_log += "[eligible_player.key] had [role] enabled, so we are drafting them."
 				candidates += eligible_player.mind
 				players -= eligible_player
 
@@ -327,13 +325,11 @@
 	var/list/players = list()
 	var/list/candidates = list()
 
-	var/roletext = get_roletext(role)
-
 	// Assemble a list of active players without jobbans.
 	for(var/mob/living/carbon/human/player in GLOB.player_list)
 		if(!player.client || (locate(player) in SSafk.afk_players))
 			continue
-		if(!jobban_isbanned(player, ROLE_SYNDICATE) && !jobban_isbanned(player, roletext))
+		if(!jobban_isbanned(player, ROLE_SYNDICATE) && !jobban_isbanned(player, role))
 			players += player
 
 	// Shuffle the players list so that it becomes ping-independent.
@@ -347,7 +343,7 @@
 		if(!(role in player.client.prefs.be_special) || (player.client.prefs.active_character.species in species_to_mindflayer))
 			continue
 
-		player_draft_log += "[player.key] had [roletext] enabled, so we are drafting them."
+		player_draft_log += "[player.key] had [role] enabled, so we are drafting them."
 		candidates += player.mind
 		players -= player
 
@@ -490,9 +486,6 @@
 		and before taking extreme actions, please try to also contact the administration! \
 		Think through your actions and make the roleplay immersive! <b>Please remember all \
 		rules aside from those without explicit exceptions apply to antagonists.</b>")
-
-/proc/get_roletext(role)
-	return role
 
 /proc/get_nuke_code()
 	var/nukecode = "ERROR"


### PR DESCRIPTION
## What Does This PR Do
This PR removes `/proc/get_roletext(role)`, a proc that does nothing but return its argument. It used to do something back when special roles were bitflags (#3025) but is no longer necessary.
## Why It's Good For The Game
Code cleanup.
## Testing
Ran CI.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog
NPFC
