### PR TITLE
Edge cases broadcast examine

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -672,7 +672,7 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 
 	// Only ones who can see both examining mob and examined item
 	var/list/can_see_examine = viewers(examined) & viewers(2, src)
-	if(can_see_examine.len <= 1)
+	if(length(can_see_examine) <= 1)
 		return
 
 	// If TRUE, the usr's view() for the examined object too

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -740,12 +740,9 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 
 /mob/living/silicon/ai/broadcast_examine(atom/examined)
 	var/mob/living/silicon/ai/ai = src
-	// Should prevent AI in camera form from triggering proc
+	// Only show the AI's examines if they're in a holopad
 	if(istype(ai.current, /obj/machinery/hologram/holopad))
-		// return call(mob::broadcast_examine, examined)
 		return call(ai, /mob::broadcast_examine())(examined)
-
-	return // AI is not spying on you
 
 
 /mob/proc/ret_grab(obj/effect/list_container/mobl/L as obj, flag)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -672,8 +672,6 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 
 	// Only ones who can see both examining mob and examined item
 	var/list/can_see_examine = viewers(examined) & viewers(2, src)
-	if(length(can_see_examine) <= 1)
-		return
 
 	// If TRUE, the usr's view() for the examined object too
 	var/examining_worn_item = FALSE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -742,7 +742,7 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	var/mob/living/silicon/ai/ai = src
 	// Only show the AI's examines if they're in a holopad
 	if(istype(ai.current, /obj/machinery/hologram/holopad))
-		return call(ai, /mob::broadcast_examine())(examined)
+		return ..()
 
 
 /mob/proc/ret_grab(obj/effect/list_container/mobl/L as obj, flag)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -742,7 +742,8 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	var/mob/living/silicon/ai/ai = src
 	// Should prevent AI in camera form from triggering proc
 	if(istype(ai.current, /obj/machinery/hologram/holopad))
-		return ..()
+		// return call(mob::broadcast_examine, examined)
+		return call(ai, /mob::broadcast_examine())(examined)
 
 	return // AI is not spying on you
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -670,6 +670,11 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	if(examined == src)
 		return
 
+	// Only ones who can see both examining mob and examined item
+	var/list/can_see_examine = viewers(examined) & viewers(2, src)
+	if(can_see_examine.len <= 1)
+		return
+
 	// If TRUE, the usr's view() for the examined object too
 	var/examining_worn_item = FALSE
 	var/loc_str = "at something off in the distance."
@@ -697,12 +702,11 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 
 	var/cannot_see_str = "<span class='subtle'>\The [src] looks [loc_str]</span>"
 
-	var/list/can_see_target = viewers(examined)
-	for(var/mob/M as anything in viewers(2, src))
+	for(var/mob/M as anything in can_see_examine)
 		if(!M.client || M.stat != CONSCIOUS ||HAS_TRAIT(M, TRAIT_BLIND))
 			continue
 
-		if(examining_worn_item || (M == src) || (M in can_see_target))
+		if(examining_worn_item || (M == src))
 			to_chat(M, can_see_str)
 		else
 			to_chat(M, cannot_see_str)
@@ -733,6 +737,15 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 
 /mob/dead/broadcast_examine(atom/examined)
 	return //Observers arent real the government is lying to you
+
+/mob/living/silicon/ai/broadcast_examine(atom/examined)
+	var/mob/living/silicon/ai/ai = src
+	// Should prevent AI in camera form from triggering proc
+	if(istype(ai.current, /obj/machinery/hologram/holopad))
+		return ..()
+
+	return // AI is not spying on you
+
 
 /mob/proc/ret_grab(obj/effect/list_container/mobl/L as obj, flag)
 	if((!istype(l_hand, /obj/item/grab) && !istype(r_hand, /obj/item/grab)))


### PR DESCRIPTION
## What Does This PR Do

1) Prevents glance messages for AI when in camera mod
( fix for https://github.com/ParadiseSS13/Paradise/issues/28453)
2) Prevents appearance for users in case no one else can see the interaction

## Why It's Good For The Game
AI should be able to spy undetected. GLORY TO MY IMMORTAL OVERLORD!!!

## Testing
localhost, all good.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: You will not get a message in chat when ai examine something close to you.
/:cl: