### PR TITLE
Implants, implanted items and other bodypart contents no longer get deleted on species change

### DIFF
--- a/code/game/dna/mutations/monkey_mutation.dm
+++ b/code/game/dna/mutations/monkey_mutation.dm
@@ -14,8 +14,17 @@
 		return
 	if(issmall(H))
 		return
+
+	var/list/implants = list()
+
+	for(var/obj/item/organ/external/body_part in H.bodyparts)
+		implants += body_part.hidden
+		for(var/obj/item/I in body_part.contents)
+			if(!istype(I, /obj/item/organ))
+				implants += I
+
 	for(var/obj/item/W in H)
-		if(istype(W, /obj/item/bio_chip))
+		if(istype(W, /obj/item/bio_chip) || (W in implants))
 			continue
 		H.drop_item_to_ground(W)
 
@@ -46,10 +55,19 @@
 		return
 	if(!issmall(H))
 		return
+
+	var/list/implants = list()
+
+	for(var/obj/item/organ/external/body_part in H.bodyparts)
+		implants += body_part.hidden
+		for(var/obj/item/I in body_part.contents)
+			if(!istype(I, /obj/item/organ))
+				implants += I
+
 	for(var/obj/item/W in H)
 		if(W == H.w_uniform) // will be torn
 			continue
-		if(istype(W, /obj/item/bio_chip))
+		if(istype(W, /obj/item/bio_chip) || (W in implants))
 			continue
 		H.drop_item_to_ground(W)
 	H.regenerate_icons()

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -221,8 +221,48 @@
  * Arguments:
  * * H: The human to create organs inside of
  * * bodyparts_to_omit: Any bodyparts in this list (and organs within them) should not be added.
+ * * transfer_contents: Whether or not to transfer the contents of the old organs to the new ones
  */
-/datum/species/proc/create_organs(mob/living/carbon/human/H, list/bodyparts_to_omit) //Handles creation of mob organs.
+/datum/species/proc/create_organs(mob/living/carbon/human/H, list/bodyparts_to_omit, transfer_contents = TRUE) //Handles creation of mob organs.
+	var/list/transfer_list = list()
+	for(var/limb_name in has_limbs)
+		var/obj/item/organ/external/body_part = H.bodyparts_by_name[limb_name]
+		if(!body_part)
+			continue
+		// If we don't transfer the content or make a new organ in place of the old one, drop the contents on the ground
+		if(!transfer_contents || (bodyparts_to_omit && (limb_name in bodyparts_to_omit)))
+			// Drop cavity implant
+			if(body_part.hidden)
+				body_part.hidden.forceMove(get_turf(H))
+				body_part.hidden = null // null ref so it doesn't get deleted with the bodypart
+			// Drop general contents of bodypart
+			for(var/atom/movable/thing in body_part.contents)
+				thing.forceMove(get_turf(H))
+			body_part.contents = list() // empty ref list so the contents don't get deleted with the bodypart
+
+			// Drop all cyber implants
+			for(var/obj/item/organ/internal/internal_organ in body_part.internal_organs)
+				if(istype(internal_organ, /obj/item/organ/internal/cyberimp))
+					internal_organ.forceMove(get_turf(H))
+					body_part.internal_organs -= internal_organ // remove ref so it doesn't get deleted with the bodypart
+		else
+			// Transfer cavity implant
+			transfer_list += list("[limb_name]" = list("hidden" = null, "contents" = list(), "cyber_implants" = list()))
+			if(body_part.hidden)
+				transfer_list[limb_name]["hidden"] = body_part.hidden
+				body_part.hidden = null // null ref so it doesn't get deleted with the bodypart
+			// Transfer contents
+			if(length(body_part.contents))
+				transfer_list[limb_name]["contents"] = body_part.contents
+				body_part.contents = list() // empty ref list so the contents don't get deleted with the bodypart
+			// Transfer Cyber Implants
+			if(length(body_part.internal_organs))
+				for(var/obj/item/organ/internal/internal_organ in body_part.internal_organs) // Drop all cyber implants
+					if(istype(internal_organ, /obj/item/organ/internal/cyberimp))
+						transfer_list[limb_name]["cyber_implants"] += internal_organ
+						body_part.internal_organs -= internal_organ // remove ref so it doesn't get deleted with the bodypart
+
+
 	QDEL_LIST_CONTENTS(H.internal_organs)
 	QDEL_LIST_CONTENTS(H.bodyparts)
 
@@ -238,6 +278,12 @@
 		var/limb_path = organ_data["path"]
 		var/obj/item/organ/O = new limb_path(H)
 		organ_data["descriptor"] = O.name
+		if(istype(O, /obj/item/organ/external) && transfer_list[limb_name])
+			var/obj/item/organ/external/external_organ = O
+			external_organ.hidden = transfer_list[limb_name]["hidden"]
+			external_organ.contents = transfer_list[limb_name]["contents"]
+			external_organ.internal_organs = transfer_list[limb_name]["cyber_implants"]
+			H.internal_organs += external_organ.internal_organs
 
 	for(var/index in has_organ)
 		var/obj/item/organ/internal/organ_path = has_organ[index]

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -229,6 +229,11 @@
 		var/obj/item/organ/external/body_part = H.bodyparts_by_name[limb_name]
 		if(!body_part)
 			continue
+		// Always expel all cyber implants
+		for(var/obj/item/organ/internal/cyberimp/internal_organ in body_part.internal_organs)
+			internal_organ.remove(H)
+			internal_organ.forceMove(get_turf(H))
+
 		// If we don't transfer the content or make a new organ in place of the old one, drop the contents on the ground
 		if(!transfer_contents || (bodyparts_to_omit && (limb_name in bodyparts_to_omit)))
 			// Drop cavity implant
@@ -240,14 +245,9 @@
 				thing.forceMove(get_turf(H))
 			body_part.contents = list() // empty ref list so the contents don't get deleted with the bodypart
 
-			// Drop all cyber implants
-			for(var/obj/item/organ/internal/internal_organ in body_part.internal_organs)
-				if(istype(internal_organ, /obj/item/organ/internal/cyberimp))
-					internal_organ.forceMove(get_turf(H))
-					body_part.internal_organs -= internal_organ // remove ref so it doesn't get deleted with the bodypart
 		else
 			// Transfer cavity implant
-			transfer_list += list("[limb_name]" = list("hidden" = null, "contents" = list(), "cyber_implants" = list()))
+			transfer_list += list("[limb_name]" = list("hidden" = null, "contents" = list()))
 			if(body_part.hidden)
 				transfer_list[limb_name]["hidden"] = body_part.hidden
 				body_part.hidden = null // null ref so it doesn't get deleted with the bodypart
@@ -255,13 +255,6 @@
 			if(length(body_part.contents))
 				transfer_list[limb_name]["contents"] = body_part.contents
 				body_part.contents = list() // empty ref list so the contents don't get deleted with the bodypart
-			// Transfer Cyber Implants
-			if(length(body_part.internal_organs))
-				for(var/obj/item/organ/internal/internal_organ in body_part.internal_organs) // Drop all cyber implants
-					if(istype(internal_organ, /obj/item/organ/internal/cyberimp))
-						transfer_list[limb_name]["cyber_implants"] += internal_organ
-						body_part.internal_organs -= internal_organ // remove ref so it doesn't get deleted with the bodypart
-
 
 	QDEL_LIST_CONTENTS(H.internal_organs)
 	QDEL_LIST_CONTENTS(H.bodyparts)
@@ -278,12 +271,23 @@
 		var/limb_path = organ_data["path"]
 		var/obj/item/organ/O = new limb_path(H)
 		organ_data["descriptor"] = O.name
+		// Transfer things from the old organ to the new
 		if(istype(O, /obj/item/organ/external) && transfer_list[limb_name])
 			var/obj/item/organ/external/external_organ = O
 			external_organ.hidden = transfer_list[limb_name]["hidden"]
 			external_organ.contents = transfer_list[limb_name]["contents"]
-			external_organ.internal_organs = transfer_list[limb_name]["cyber_implants"]
-			H.internal_organs += external_organ.internal_organs
+
+			transfer_list -= transfer_list[limb_name]
+
+	// Anything we still didn't transfer for whatever reason we drop on the ground
+	for(var/list/remaining in transfer_list)
+		if(remaining["hidden"])
+			var/atom/movable/thing = remaining["hidden"]
+			thing.forceMove(get_turf(H))
+		if(length(remaining["contents"]))
+			for(var/atom/movable/thing in remaining["contents"])
+				thing.forceMove(get_turf(H))
+
 
 	for(var/index in has_organ)
 		var/obj/item/organ/internal/organ_path = has_organ[index]


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Stops items that are inside a mob's bodyparts from getting deleted when it changes species. 
- cybernetic implants drop on the floor
- cavity implanted items and other contents are transferred 
- If the analogue of the original organ is missing the relevant items will get dropped
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Species change shouldn't delete random items
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
- Implanted stuff in and changed species on a bunch of people and monkeys. Used CMA, mutadone and changeling ability
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: cybernetic implants now drop on species change
fix: items inside a mob no longer get deleted on species change
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
