### PR TITLE
Decrease megafauna melee attack delay after ability

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -145,7 +145,7 @@
 			adjustBruteLoss(50)
 
 /mob/living/simple_animal/hostile/megafauna/proc/SetRecoveryTime(buffer_time)
-	recovery_time = world.time + buffer_time
+	recovery_time = world.time + 2.5 DECISECONDS
 	ranged_cooldown = world.time + buffer_time
 
 /// This proc is called by the HRD-MDE grenade to enrage the megafauna. This should increase the megafaunas attack speed if possible, give it new moves, or disable weak moves. This should be reverseable, and reverses on zlvl change.


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Changes megafauna melee attack delay from dynamic (1-8 seconds) to static (0.25 seconds). This is only used after performing an ability (Ash drake swoops, bubblegum charges etc.)

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

A delay of 8 seconds resulted in Ash Drake being harmless after his swoop, and you could just stand next to him for this amount of time. He couldn't do anything except of chasing you.

This will make megafauna a little bit more "active", so they won't just do nothing and receive hit by hit from miners.

This might sound like a huge change, but it's not really. You are still able to hit fauna while they perform the ability attack, so there is not much of a change in "difficulty". It's just about megafauna being not that stupid.

The only thing i was unable to fix - Ash Drake, after his swoop, stays for around 1-2 seconds and does nothing. No idea how to fix it. But it's still less than 8 seconds, so that is an improvement for sure.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Testing on [downstream](https://github.com/ss220club/Paradise-SS220/pull/1813) currently. Not a single issue for almost 2 weeks.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Dynamic (1-8 seconds) melee attack delay for megafauna is now static (2.5 deciseconds).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
