### PR TITLE
Fixes items being vended into cyborg hands

### DIFF
--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -903,7 +903,7 @@
 //override this proc to add handling for what to do with the vended product when you have a inserted item and remember to include a parent call for this generic handling
 /obj/machinery/economy/vending/proc/do_vend(datum/data/vending_product/R, mob/user, put_in_hands = TRUE)
 	var/vended = R.vend(loc)
-	if(put_in_hands && isliving(user) && istype(vended, /obj/item) && Adjacent(user))
+	if(put_in_hands && isliving(user) && istype(vended, /obj/item) && Adjacent(user) && !issilicon(user))
 		// Try the active hand first, then the inactive hand, and leave it here if both fail
 		if(!user.put_in_active_hand(vended))
 			user.put_in_inactive_hand(vended)

--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -903,7 +903,7 @@
 //override this proc to add handling for what to do with the vended product when you have a inserted item and remember to include a parent call for this generic handling
 /obj/machinery/economy/vending/proc/do_vend(datum/data/vending_product/R, mob/user, put_in_hands = TRUE)
 	var/vended = R.vend(loc)
-	if(put_in_hands && isliving(user) && istype(vended, /obj/item) && Adjacent(user) && !issilicon(user))
+	if(put_in_hands && isliving(user) && istype(vended, /obj/item) && Adjacent(user))
 		// Try the active hand first, then the inactive hand, and leave it here if both fail
 		if(!user.put_in_active_hand(vended))
 			user.put_in_inactive_hand(vended)

--- a/code/modules/mob/living/silicon/silicon_mob.dm
+++ b/code/modules/mob/living/silicon/silicon_mob.dm
@@ -222,6 +222,12 @@
 /mob/living/silicon/drop_item()
 	return
 
+/mob/living/silicon/put_in_l_hand(obj/item/W, skip_blocked_hands_check)
+	return
+
+/mob/living/silicon/put_in_r_hand(obj/item/W, skip_blocked_hands_check)
+	return
+
 /mob/living/silicon/electrocute_act(shock_damage, source, siemens_coeff = 1, flags = NONE)
 	return FALSE //So borgs they don't die trying to fix wiring
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #28546
Fixes #28381
overrides silicon put_in_hand_ procs.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
bug
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
vended 12 items
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Items vended by borgs no longer go in their hands
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
