### PR TITLE
New mapmanip function: map orientation.

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/abandoned_engi_sat.jsonc
+++ b/_maps/map_files/RandomRuins/SpaceRuins/abandoned_engi_sat.jsonc
@@ -1,0 +1,5 @@
+[
+	{
+		"type": "RandomOrientation"
+	}
+]

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroid1.jsonc
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroid1.jsonc
@@ -1,0 +1,5 @@
+[
+	{
+		"type": "RandomOrientation"
+	}
+]

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroid2.jsonc
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroid2.jsonc
@@ -1,0 +1,5 @@
+[
+	{
+		"type": "RandomOrientation"
+	}
+]

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroid3.jsonc
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroid3.jsonc
@@ -1,0 +1,5 @@
+[
+	{
+		"type": "RandomOrientation"
+	}
+]

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroid4.jsonc
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroid4.jsonc
@@ -1,0 +1,5 @@
+[
+	{
+		"type": "RandomOrientation"
+	}
+]

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroid5.jsonc
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroid5.jsonc
@@ -1,0 +1,5 @@
+[
+	{
+		"type": "RandomOrientation"
+	}
+]

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict1.jsonc
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict1.jsonc
@@ -1,0 +1,5 @@
+[
+	{
+		"type": "RandomOrientation"
+	}
+]

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict3.jsonc
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict3.jsonc
@@ -1,0 +1,5 @@
+[
+	{
+		"type": "RandomOrientation"
+	}
+]

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict4.jsonc
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict4.jsonc
@@ -1,0 +1,5 @@
+[
+	{
+		"type": "RandomOrientation"
+	}
+]

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict5.jsonc
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict5.jsonc
@@ -1,0 +1,5 @@
+[
+	{
+		"type": "RandomOrientation"
+	}
+]

--- a/_maps/map_files/RandomRuins/SpaceRuins/druglab.jsonc
+++ b/_maps/map_files/RandomRuins/SpaceRuins/druglab.jsonc
@@ -1,0 +1,5 @@
+[
+	{
+		"type": "RandomOrientation"
+	}
+]

--- a/_maps/map_files/RandomRuins/SpaceRuins/rocky_motel.jsonc
+++ b/_maps/map_files/RandomRuins/SpaceRuins/rocky_motel.jsonc
@@ -9,6 +9,8 @@
 		"marker_extract": "/obj/effect/map_effect/marker/mapmanip/submap/extract/space_ruin/rocky_motel/drunk_accident",
 		"marker_insert": "/obj/effect/map_effect/marker/mapmanip/submap/insert/space_ruin/rocky_motel/drunk_accident",
 		"submaps_can_repeat": true // doesn't matter, as there's only one insert marker
+	},
+	{
+		"type": "RandomOrientation"
 	}
-
 ]

--- a/_maps/map_files/RandomRuins/SpaceRuins/turretedoutpost.jsonc
+++ b/_maps/map_files/RandomRuins/SpaceRuins/turretedoutpost.jsonc
@@ -1,0 +1,5 @@
+[
+	{
+		"type": "RandomOrientation"
+	}
+]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -944,6 +944,7 @@ dependencies = [
  "chrono",
  "diff",
  "dmm-tools",
+ "dreammaker",
  "eyre",
  "fxhash",
  "itertools",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -19,6 +19,7 @@ thread-priority = "1.1.0"
 
 # spacemandmm, also used by strongmandmm
 dmmtools = { git = "https://github.com/SpaceManiac/SpacemanDMM", rev = "6c5a751516ae0e8add4b2aa4388a1e84e96e7082", package = "dmm-tools" }
+dreammaker = { git = "https://github.com/SpaceManiac/SpacemanDMM", rev = "6c5a751516ae0e8add4b2aa4388a1e84e96e7082", package = "dreammaker" }
 # diffs between two strings/texts/files, used in tests
 diff = "0.1"
 # general utility lib for iterator operations

--- a/rust/src/mapmanip/mod.rs
+++ b/rust/src/mapmanip/mod.rs
@@ -1,13 +1,19 @@
 use core::map_to_string;
 use core::to_grid_map;
 use core::GridMap;
+use core::TileGrid;
 
 use byondapi::byond_string;
 use byondapi::value::ByondValue;
+use dmmtools::dmi::Dir;
+use dmmtools::dmm::Coord3;
+use dreammaker::constants::Constant;
 use eyre::Context;
 use eyre::ContextCompat;
 use itertools::Itertools;
 use rand::prelude::IteratorRandom;
+use rand::seq::SliceRandom;
+use rand::thread_rng;
 use serde::{Deserialize, Serialize};
 use tools::extract_submap;
 use tools::insert_submap;
@@ -34,6 +40,15 @@ pub enum MapManipulation {
         marker_insert: String,
         submaps_can_repeat: bool,
     },
+    RandomOrientation,
+}
+
+#[derive(Debug)]
+enum MapRotation {
+    None,
+    Clockwise90,
+    Clockwise180,
+    Clockwise270,
 }
 
 pub fn mapmanip_config_parse(config_path: &std::path::Path) -> eyre::Result<Vec<MapManipulation>> {
@@ -93,6 +108,8 @@ pub fn mapmanip(
 					submaps path: {submaps_dmm:?};
 					markers: {marker_extract}, {marker_insert};"
             )),
+            MapManipulation::RandomOrientation => mapmanip_orientation_randomize(&mut map)
+                .wrap_err(format!("randomize orientation fail")),
         }
         .wrap_err(format!("mapmanip fail; manip n is: {n}/{config_len}"))?;
     }
@@ -165,6 +182,209 @@ fn mapmanip_submap_extract_insert(
             .wrap_err(format!("submap insertion failed; at {insert_coord}"))?;
     }
 
+    Ok(())
+}
+
+fn rotate_direction(dir_i: i32, rotation: &MapRotation) -> i32 {
+    let dir = Dir::from_int(dir_i).unwrap_or(Dir::South);
+    match rotation {
+        MapRotation::None => dir_i,
+        MapRotation::Clockwise90 => dir.clockwise_90().to_int(),
+        MapRotation::Clockwise180 => dir.flip_ns().to_int(),
+        MapRotation::Clockwise270 => dir.counterclockwise_90().to_int(),
+    }
+}
+
+fn rotate_cable(dir_i: i32, rotation: &MapRotation) -> i32 {
+    if dir_i == 0 {
+        return 0;
+    }
+    let dir = Dir::from_int(dir_i).unwrap_or(Dir::South);
+    match rotation {
+        MapRotation::None => dir_i,
+        MapRotation::Clockwise90 => dir.clockwise_90().to_int(),
+        MapRotation::Clockwise180 => dir.flip_ns().to_int(),
+        MapRotation::Clockwise270 => dir.counterclockwise_90().to_int(),
+    }
+}
+
+fn directional_mapper_rotate(path: String, rotation: &MapRotation) -> String {
+    match rotation {
+        MapRotation::None => path,
+        MapRotation::Clockwise90 => {
+            if path.ends_with("/directional/north") {
+                path.replace("/directional/north", "/directional/east")
+            } else if path.ends_with("/directional/south") {
+                path.replace("/directional/south", "/directional/west")
+            } else if path.ends_with("/directional/east") {
+                path.replace("/directional/east", "/directional/south")
+            } else {
+                path.replace("/directional/west", "/directional/north")
+            }
+        }
+        MapRotation::Clockwise180 => {
+            if path.ends_with("/directional/north") {
+                path.replace("/directional/north", "/directional/south")
+            } else {
+                path.replace("/directional/south", "/directional/north")
+            }
+        }
+        MapRotation::Clockwise270 => {
+            if path.ends_with("/directional/north") {
+                path.replace("/directional/north", "/directional/west")
+            } else if path.ends_with("/directional/south") {
+                path.replace("/directional/south", "/directional/east")
+            } else if path.ends_with("/directional/east") {
+                path.replace("/directional/east", "/directional/north")
+            } else {
+                path.replace("/directional/west", "/directional/south")
+            }
+        }
+    }
+}
+
+fn rotation_radians(rotation: &MapRotation) -> f32 {
+    match rotation {
+        MapRotation::None => 0f32.to_radians(),
+        MapRotation::Clockwise90 => 90f32.to_radians(),
+        MapRotation::Clockwise180 => 180f32.to_radians(),
+        MapRotation::Clockwise270 => 270f32.to_radians(),
+    }
+}
+
+fn rotation_coords(coord: Coord3, map_size: &Coord3, rotation: &MapRotation) -> Coord3 {
+    match rotation {
+        MapRotation::None => coord,
+        MapRotation::Clockwise90 => Coord3 {
+            x: coord.y,
+            y: map_size.x - coord.x + 1,
+            z: coord.z,
+        },
+        MapRotation::Clockwise180 => Coord3 {
+            x: coord.x,
+            y: map_size.y - coord.y + 1,
+            z: coord.z,
+        },
+        MapRotation::Clockwise270 => Coord3 {
+            x: map_size.y - coord.y + 1,
+            y: coord.x,
+            z: coord.z,
+        },
+    }
+}
+
+fn rotation_size(size: Coord3, rotation: &MapRotation) -> Coord3 {
+    match rotation {
+        MapRotation::None => size,
+        MapRotation::Clockwise90 => Coord3 {
+            x: size.y,
+            y: size.x,
+            z: size.z,
+        },
+        MapRotation::Clockwise180 => size,
+        MapRotation::Clockwise270 => Coord3 {
+            x: size.y,
+            y: size.x,
+            z: size.z,
+        },
+    }
+}
+
+fn mapmanip_orientation_randomize(map: &mut GridMap) -> eyre::Result<()> {
+    let rotation = [
+        MapRotation::None,
+        MapRotation::Clockwise90,
+        MapRotation::Clockwise180,
+        MapRotation::Clockwise270,
+    ]
+    .choose(&mut rand::thread_rng())
+    .unwrap();
+
+    if let MapRotation::None = rotation {
+        return Ok(());
+    }
+
+    let new_coord = rotation_size(map.size, rotation);
+    let mut new_map: GridMap = GridMap {
+        size: new_coord,
+        grid: TileGrid::new(new_coord.x, new_coord.y, new_coord.z),
+    };
+
+    for t in map.grid.values_mut() {
+        t.prefabs.iter_mut().for_each(|f| {
+            if f.path.contains("/directional/") {
+                f.path = directional_mapper_rotate(f.path.to_string(), rotation);
+            } else if f.path.starts_with("/obj/structure/cable") {
+                let cable_dirs = f
+                    .vars
+                    .get("icon_state")
+                    .unwrap_or(&Constant::String("0-1".into()))
+                    .to_string()
+                    .replace('"', "")
+                    .split('-')
+                    .map(|f| {
+                        f.to_string()
+                            .parse::<i32>()
+                            .unwrap_or_else(|_| panic!("Ugh: {}", f))
+                    })
+                    .map(|f| rotate_cable(f, rotation))
+                    .sorted()
+                    .join("-");
+                f.vars.insert(
+                    "icon_state".to_string(),
+                    Constant::String(cable_dirs.into()),
+                );
+            } else {
+                let dir = f
+                    .vars
+                    .get("dir")
+                    .unwrap_or(&Constant::Float(2.0f32))
+                    .to_int()
+                    .unwrap();
+                f.vars.insert(
+                    "dir".to_string(),
+                    Constant::Float(rotate_direction(dir, rotation) as f32),
+                );
+
+                let pixel_x = f
+                    .vars
+                    .get("pixel_x")
+                    .unwrap_or(&Constant::Float(0f32))
+                    .to_int()
+                    .unwrap();
+                let pixel_y = f
+                    .vars
+                    .get("pixel_y")
+                    .unwrap_or(&Constant::Float(0f32))
+                    .to_int()
+                    .unwrap();
+                if pixel_x != 0 || pixel_y != 0 {
+                    let rads = rotation_radians(rotation);
+                    f.vars.insert(
+                        "pixel_x".to_string(),
+                        Constant::Float(
+                            ((pixel_x as f32) * rads.cos() + (pixel_y as f32) * rads.sin()).round(),
+                        ),
+                    );
+                    f.vars.insert(
+                        "pixel_y".to_string(),
+                        Constant::Float(
+                            ((-pixel_x as f32) * rads.sin() + (pixel_y as f32) * rads.cos())
+                                .round(),
+                        ),
+                    );
+                }
+            }
+        });
+    }
+
+    for (coord, tile) in map.grid.iter() {
+        new_map
+            .grid
+            .insert(&rotation_coords(coord, &map.size, rotation), tile.clone());
+    }
+
+    *map = new_map;
     Ok(())
 }
 


### PR DESCRIPTION
## What Does This PR Do
This PR adds a new mapmanip function, 'RandomOrientation', which will rotate the input map 0, 90, 180, or 270 degrees. This is very dependent on the objects on the map to work properly. Many things will not work as expected, such as airlock generators, multi-tile objects that are made up of multiple atoms (such as the cyberiad statue), floor tiles that expect a specific orientation to look right (such as station name tile decorations), multi-tile airlocks and blast doors/pod doors, and so on, but it does work well enough for simple maps such as ruins.

Several ruins have had the function added to their mapmanip configurations.

## Why It's Good For The Game
Shakes things up a bit.
## Images of changes
Sample output:

![2025_02_28__18_10_48__paradise dme  turretedoutpost mapmanipout dmm  - StrongDMM](https://github.com/user-attachments/assets/ccb7473d-903b-442f-9518-1754e335dc5f)
![2025_02_28__18_12_22__paradise dme  turretedoutpost mapmanipout dmm  - StrongDMM](https://github.com/user-attachments/assets/77efd512-3091-46d8-a975-0f9699b3d25b)
![2025_02_28__18_14_53__paradise dme  druglab mapmanipout dmm  - StrongDMM](https://github.com/user-attachments/assets/a3c7d342-ff9b-43a8-8ca6-b1845de81ce7)
![2025_02_28__18_15_15__paradise dme  druglab mapmanipout dmm  - StrongDMM](https://github.com/user-attachments/assets/0e0c58e7-40ab-47a4-b6fa-20a231370c54)
![2025_02_28__18_21_34__paradise dme  abandoned_engi_sat mapmanipout dmm  - StrongDMM](https://github.com/user-attachments/assets/7bdea752-0fc0-4128-bbcb-d82fc891aa80)



## Testing
In progress.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
add: Some ruins have a chance of spawning 90, 180, or 270 degrees from their normal orientation.
/:cl:
