### PR TITLE
remove unused constants define file

### DIFF
--- a/code/__HELPERS/constants.dm
+++ b/code/__HELPERS/constants.dm
@@ -1,2 +1,0 @@
-#define TICKS_IN_DAY 864000
-#define TICKS_IN_SECOND 10

--- a/paradise.dme
+++ b/paradise.dme
@@ -176,7 +176,6 @@
 #include "code\__HELPERS\bitflag_lists.dm"
 #include "code\__HELPERS\cmp.dm"
 #include "code\__HELPERS\colour_helpers.dm"
-#include "code\__HELPERS\constants.dm"
 #include "code\__HELPERS\debugger.dm"
 #include "code\__HELPERS\files.dm"
 #include "code\__HELPERS\filters.dm"


### PR DESCRIPTION
## What Does This PR Do
This PR removes an unused two line file of macro defines.
## Why It's Good For The Game
Dead code bad.
## Testing
Built and ran CI.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
NPFC
