### PR TITLE
Makes check_grep2.py 10x faster

### DIFF
--- a/tools/ci/check_grep2.py
+++ b/tools/ci/check_grep2.py
@@ -4,7 +4,7 @@ import os
 import sys
 import time
 from collections import namedtuple
-
+from concurrent.futures import ProcessPoolExecutor
 Failure = namedtuple("Failure", ["filename", "lineno", "message"])
 
 RED = "\033[0;31m"
@@ -212,6 +212,27 @@ CODE_CHECKS = [
     check_uid_parameters,
 ]
 
+def lint_file(code_filepath: str) -> list[Failure]:
+    all_failures = []
+    with open(code_filepath, encoding="UTF-8") as code:
+        filename = code_filepath.split(os.path.sep)[-1]
+
+        extra_checks = []
+        if filename != IGNORE_515_PROC_MARKER_FILENAME:
+            extra_checks.append(check_515_proc_syntax)
+        if filename != IGNORE_ATOM_ICON_FILE:
+            extra_checks.append(check_manual_icon_updates)
+
+        last_line = None
+        for idx, line in enumerate(code):
+            for check in CODE_CHECKS + extra_checks:
+                if failures := check(idx, line):
+                    all_failures += [Failure(code_filepath, lineno, message) for lineno, message in failures]
+            last_line = line
+
+        if last_line and last_line[-1] != '\n':
+            all_failures.append(Failure(code_filepath, idx + 1, "Missing a trailing newline"))
+    return all_failures
 
 if __name__ == "__main__":
     print("check_grep2 started")
@@ -225,26 +246,9 @@ if __name__ == "__main__":
         dm_files = [sys.argv[1]]
 
     all_failures = []
-
-    for code_filepath in dm_files:
-        with open(code_filepath, encoding="UTF-8") as code:
-            filename = code_filepath.split(os.path.sep)[-1]
-
-            extra_checks = []
-            if filename != IGNORE_515_PROC_MARKER_FILENAME:
-                extra_checks.append(check_515_proc_syntax)
-            if filename != IGNORE_ATOM_ICON_FILE:
-                extra_checks.append(check_manual_icon_updates)
-
-            last_line = None
-            for idx, line in enumerate(code):
-                for check in CODE_CHECKS + extra_checks:
-                    if failures := check(idx, line):
-                        all_failures += [Failure(code_filepath, lineno, message) for lineno, message in failures]
-                last_line = line
-
-            if last_line and last_line[-1] != '\n':
-                all_failures.append(Failure(code_filepath, idx + 1, "Missing a trailing newline"))
+    with ProcessPoolExecutor() as executor:
+        for failures in executor.map(lint_file, dm_files):
+            all_failures += failures
 
     if all_failures:
         exit_code = 1


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Since check_grep2 is just iterating through a bunch of files and running some regexes on each line, most of the current slowness is due to file IO overhead. 

ProcessPoolExecutor is Python's high level API for splitting tasks across concurrent process forks. By splitting it over several processes, the program isn't stuck waiting on file operations the whole time. Instead, _several_ programs are stuck waiting on file operations the whole time. This is much more efficient.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
I am a very impatient person. I do not like waiting for a several second lint to complete. This thing _zooms_ (at least a 10x speedup or more) on my laptop's 8 core Intel CPU. This makes running lints frequently during development much more tolerable.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
<!-- How did you test the PR, if at all? -->
CI examples:

Old:
https://github.com/ParadiseSS13/Paradise/actions/runs/13619495168/job/38066905532
`check_grep2 tests completed in 5.26s`

New:
https://github.com/chuga-git/Paradise/actions/runs/13619417271/job/38068521366
` check_grep2 tests completed in 2.37s`

Note that the action runners are virtual machines with at most 4 cores. I have a feeling that not all of the cores are available at this stage in the lint workflow, so an only 50% speedup is still pretty sweet. 
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
