### PR TITLE
Moves eyes to the eye slot

### DIFF
--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -3,7 +3,7 @@
 	icon_state = "eyes"
 	gender = PLURAL
 	organ_tag = "eyes"
-	parent_organ = "head"
+	parent_organ = "eyes"
 	slot = "eyes"
 	var/eye_color = "#000000" // Should never be null
 	var/list/colourmatrix = null


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Changes the `parent_organ` of eyes from the head to the eyes meaning that your eyes are now located within the eye slot... bit confusing yes but what this means is you don't need to do head organ manipulation to get at someone's eyes, it's under eye organ manipulation.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

It makes little to no sense that the eyes are located within someone's head/skull.

You do not need to saw through the top of someone's head to remove their eyes even in real life.

Other servers have already set their code up to have the eye slot as the parent organ for eyes, this will bring us in line with them and just logically makes more sense.

## Testing

In game, did a bunch of surgery to make sure the eyes still functioned.

Made sure all the eyes+hud implants still fit in the eye slot.

Made sure you still go blind when your eyes are removed and vice versa.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Eyes are now located within the eye slot instead of the head.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
