### PR TITLE
Cleanup AI subsystem names

### DIFF
--- a/code/controllers/subsystem/SSai_controllers.dm
+++ b/code/controllers/subsystem/SSai_controllers.dm
@@ -1,6 +1,6 @@
 /// The subsystem used to tick [/datum/ai_controllers] instances. Handling the re-checking of plans.
 SUBSYSTEM_DEF(ai_controllers)
-	name = "AI Controller Ticker"
+	name = "AI Controller"
 	flags = SS_POST_FIRE_TIMING|SS_BACKGROUND
 	priority = FIRE_PRIORITY_NPC
 	init_order = INIT_ORDER_AI_CONTROLLERS

--- a/code/controllers/subsystem/movement/SSai_movement.dm
+++ b/code/controllers/subsystem/movement/SSai_movement.dm
@@ -1,6 +1,6 @@
 /// The subsystem used to tick [/datum/ai_movement] instances. Handling the movement of individual AI instances
 MOVEMENT_SUBSYSTEM_DEF(ai_movement)
-	name = "AI movement"
+	name = "AI Movement"
 	flags = SS_BACKGROUND|SS_TICKER
 	priority = FIRE_PRIORITY_NPC_MOVEMENT
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME

--- a/code/controllers/subsystem/processing/SSai_behaviors.dm
+++ b/code/controllers/subsystem/processing/SSai_behaviors.dm
@@ -1,7 +1,7 @@
 /// The subsystem used to tick [/datum/ai_behavior] instances.
 /// Handling the individual actions an AI can take like punching someone in the fucking NUTS
 PROCESSING_SUBSYSTEM_DEF(ai_behaviors)
-	name = "AI Behavior Ticker"
+	name = "AI Behavior"
 	flags = SS_POST_FIRE_TIMING|SS_BACKGROUND
 	priority = FIRE_PRIORITY_NPC_ACTIONS
 	runlevels = RUNLEVEL_GAME|RUNLEVEL_POSTGAME


### PR DESCRIPTION
## What Does This PR Do
This PR cleans up the names of some AI-related subsystems.
## Why It's Good For The Game
Consistency, looks nicer.
## Images of changes
### Before
![2025_03_03__14_03_25__Paradise Station 13](https://github.com/user-attachments/assets/0432a822-ea66-483c-b505-b71736f203ce)

### After
![2025_03_03__14_05_17__Paradise Station 13](https://github.com/user-attachments/assets/39053325-4bff-4fad-8d48-823a83a55565)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Visual Inspection
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: The names of AI-related subsystems have been cleaned up.
/:cl:
