### PR TITLE
Fixes some bugs with changeling's Augmented Eyesight

### DIFF
--- a/code/modules/antagonists/changeling/powers/augmented_eyesight.dm
+++ b/code/modules/antagonists/changeling/powers/augmented_eyesight.dm
@@ -27,7 +27,6 @@
 		return
 	var/obj/item/organ/internal/eyes/E = user.get_organ_slot("eyes")
 	if(E)
-		if(active)
 		E.vision_flags = initial(E.vision_flags)
 		E.flash_protect = initial(E.flash_protect)
 		user.update_sight()

--- a/code/modules/antagonists/changeling/powers/augmented_eyesight.dm
+++ b/code/modules/antagonists/changeling/powers/augmented_eyesight.dm
@@ -12,36 +12,15 @@
 /datum/action/changeling/augmented_eyesight/on_purchase(mob/user, /datum/antagonist/changeling/C) //The ability starts inactive, so we should be protected from flashes.
 	if(!..())
 		return
-	var/obj/item/organ/internal/eyes/E = user.get_organ_slot("eyes")
-	if(E)
-		E.flash_protect = FLASH_PROTECTION_WELDER //Adjust the user's eyes' flash protection
-		to_chat(user, "<span class='notice'>We adjust our eyes to protect them from bright lights.</span>")
-	else
-		to_chat(user, "<span class='warning'>We can't adjust our eyes if we don't have any!</span>")
+	update_eyes(user)
 
 /datum/action/changeling/augmented_eyesight/sting_action(mob/living/carbon/user)
 	if(!istype(user))
 		return FALSE
 	..()
-	var/obj/item/organ/internal/eyes/E = user.get_organ_slot("eyes")
-	if(E)
-		if(!active)
-			E.vision_flags |= SEE_MOBS | SEE_OBJS | SEE_TURFS //Add sight flags to the user's eyes
-			E.flash_protect = FLASH_PROTECTION_SENSITIVE //Adjust the user's eyes' flash protection
-			E.lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
-			to_chat(user, "<span class='notice'>We adjust our eyes to sense prey through walls.</span>")
-			active = TRUE
-		else
-			E.vision_flags ^= SEE_MOBS | SEE_OBJS | SEE_TURFS //Remove sight flags from the user's eyes
-			E.flash_protect = FLASH_PROTECTION_WELDER //Adjust the user's eyes' flash protection
-			E.lighting_alpha = LIGHTING_PLANE_ALPHA_VISIBLE
-			to_chat(user, "<span class='notice'>We adjust our eyes to protect them from bright lights.</span>")
-			active = FALSE
-		user.update_sight()
-	else
-		to_chat(user, "<span class='warning'>We can't adjust our eyes if we don't have any!</span>")
+	active = !active
+	update_eyes(user)
 	return TRUE
-
 
 /datum/action/changeling/augmented_eyesight/Remove(mob/user) //Get rid of x-ray vision and flash protection when the user refunds this ability
 	if(!istype(user))
@@ -49,8 +28,24 @@
 	var/obj/item/organ/internal/eyes/E = user.get_organ_slot("eyes")
 	if(E)
 		if(active)
-			E.vision_flags ^= SEE_MOBS | SEE_OBJS | SEE_TURFS
-		else
-			E.flash_protect = FLASH_PROTECTION_NONE
+		E.vision_flags = initial(E.vision_flags)
+		E.flash_protect = initial(E.flash_protect)
 		user.update_sight()
 	..()
+
+/datum/action/changeling/augmented_eyesight/proc/update_eyes(mob/user)
+	var/obj/item/organ/internal/eyes/E = user.get_organ_slot("eyes")
+	if(!E)
+		to_chat(user, "<span class='warning'>We can't adjust our eyes if we don't have any!</span>")
+		return
+	if(active)
+		E.vision_flags |= SEE_MOBS | SEE_OBJS | SEE_TURFS //Add sight flags to the user's eyes
+		E.flash_protect = FLASH_PROTECTION_SENSITIVE //Adjust the user's eyes' flash protection
+		E.lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
+		to_chat(user, "<span class='notice'>We adjust our eyes to sense prey through walls.</span>")
+	else
+		E.vision_flags = initial(E.vision_flags) //Remove sight flags from the user's eyes
+		E.flash_protect = FLASH_PROTECTION_WELDER //Adjust the user's eyes' flash protection
+		E.lighting_alpha = LIGHTING_PLANE_ALPHA_VISIBLE
+		to_chat(user, "<span class='notice'>We adjust our eyes to protect them from bright lights.</span>")
+	user.update_sight()

--- a/code/modules/antagonists/changeling/powers/transform.dm
+++ b/code/modules/antagonists/changeling/powers/transform.dm
@@ -25,5 +25,7 @@
 		user.handcuffed = keep_cuffs
 		user.update_handcuffed()
 	cling.update_languages()
+	var/datum/action/changeling/augmented_eyesight/eyesight = locate() in user.actions
+	eyesight.update_eyes(user)
 	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]"))
 	return TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes some bugs with changeling's Augmented Eyesight, including giving you the wrong eyesight flags post-transforming.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bugs bad

## Testing

<!-- How did you test the PR, if at all? -->
Yep, it works correctly.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Changeling's Augmented Eyesight stays active after a transformation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
