### PR TITLE
[READY] RUSTG Update

### DIFF
--- a/_build_dependencies.sh
+++ b/_build_dependencies.sh
@@ -14,4 +14,4 @@ export BETA_BYOND_MINOR=1648
 # Python version for mapmerge and other tools
 export PYTHON_VERSION=3.11.6
 # RUSTG version
-export RUSTG_VERSION=v3.4.0-P
+export RUSTG_VERSION=v3.7.0-P

--- a/code/__DEFINES/_versions.dm
+++ b/code/__DEFINES/_versions.dm
@@ -1,2 +1,2 @@
 /// Version of RUST-G that this codebase wants
-#define RUST_G_VERSION "3.4.0-P"
+#define RUST_G_VERSION "3.7.0-P"

--- a/code/controllers/subsystem/SSredis.dm
+++ b/code/controllers/subsystem/SSredis.dm
@@ -91,7 +91,7 @@ SUBSYSTEM_DEF(redis)
 	try // Did you know byond had try catch?
 		usable_data = json_decode(raw_data)
 	catch
-		message_admins("Failed to deserialise a redis message | Please inform the server host IMMEDIATELY BECAUSE IT MEANS THAT I BROKE A LIBRARY UPDATE.")
+		message_admins("Failed to deserialise a redis message | Please inform the server host.")
 		log_debug("Redis raw data: [raw_data]")
 		return
 
@@ -104,7 +104,7 @@ SUBSYSTEM_DEF(redis)
 			else
 				error_str = redis_error_data
 
-			message_admins("Redis error: [error_str] | Please inform the server host IMMEDIATELY BECAUSE IT MEANS THAT I BROKE A LIBRARY UPDATE.") // uh oh
+			message_admins("Redis error: [error_str] | Please inform the server host.") // uh oh
 			log_game("Redis error: [error_str]")
 			continue
 		// Check its an actual channel

--- a/code/controllers/subsystem/SSredis.dm
+++ b/code/controllers/subsystem/SSredis.dm
@@ -91,7 +91,7 @@ SUBSYSTEM_DEF(redis)
 	try // Did you know byond had try catch?
 		usable_data = json_decode(raw_data)
 	catch
-		message_admins("Failed to deserialise a redis message | Please inform the server host.")
+		message_admins("Failed to deserialise a redis message | Please inform the server host IMMEDIATELY BECAUSE IT MEANS THAT I BROKE A LIBRARY UPDATE.")
 		log_debug("Redis raw data: [raw_data]")
 		return
 
@@ -104,7 +104,7 @@ SUBSYSTEM_DEF(redis)
 			else
 				error_str = redis_error_data
 
-			message_admins("Redis error: [error_str] | Please inform the server host.") // uh oh
+			message_admins("Redis error: [error_str] | Please inform the server host IMMEDIATELY BECAUSE IT MEANS THAT I BROKE A LIBRARY UPDATE.") // uh oh
 			log_game("Redis error: [error_str]")
 			continue
 		// Check its an actual channel

--- a/tools/ci/install_rustg.sh
+++ b/tools/ci/install_rustg.sh
@@ -4,8 +4,6 @@ set -euo pipefail
 source _build_dependencies.sh
 
 mkdir -p ~/.byond/bin
-#wget -O ~/.byond/bin/librust_g.so "https://github.com/ParadiseSS13/rust-g/releases/download/$RUSTG_VERSION/librust_g.so"
-# TEMP
-cp tools/ci/librust_g_ci_temp.so ~/.byond/bin/librust_g.so
+wget -O ~/.byond/bin/librust_g.so "https://github.com/ParadiseSS13/rust-g/releases/download/$RUSTG_VERSION/librust_g.so"
 chmod +x ~/.byond/bin/librust_g.so
 ldd ~/.byond/bin/librust_g.so

--- a/tools/ci/install_rustg.sh
+++ b/tools/ci/install_rustg.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 source _build_dependencies.sh
 
 mkdir -p ~/.byond/bin
-wget -O ~/.byond/bin/librust_g.so "https://github.com/ParadiseSS13/rust-g/releases/download/$RUSTG_VERSION/librust_g.so"
+#wget -O ~/.byond/bin/librust_g.so "https://github.com/ParadiseSS13/rust-g/releases/download/$RUSTG_VERSION/librust_g.so"
+# TEMP
+cp tools/ci/librust_g_ci_temp.so ~/.byond/bin/librust_g.so
 chmod +x ~/.byond/bin/librust_g.so
 ldd ~/.byond/bin/librust_g.so


### PR DESCRIPTION
## What Does This PR Do
Bumps rustg from 3.4.0-P to 3.7.0-P. Has new features for iconforge shenanigans and a soundfile length thing. No idea if we will use either but nice to have.

TM because updating this has a tendency to make redis just stop working. Im not pushing a new release to our rust repo till we know this works, so the CI library is in repo for a bit. Purists be damned.

## Why It's Good For The Game
Updates good

## Testing
Started server, redis connected, SQL connected, verified that logs are the right format.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl: AffectedArc07
experiment: Updated the rust helper library that handles logging and DB stuff
/:cl:
