### PR TITLE
Fix cogbar appearing with thief gloves

### DIFF
--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -75,7 +75,8 @@
 /// Start the equipping process. This is the proc you should yield in.
 /// Returns TRUE/FALSE depending on if it is allowed.
 /datum/strippable_item/proc/start_equip(atom/source, obj/item/equipping, mob/user)
-	if(!in_thief_mode(user))
+	var/thief_mode = in_thief_mode(user)
+	if(!thief_mode)
 		source.visible_message(
 			"<span class='notice'>[user] tries to put [equipping] on [source].</span>",
 			"<span class='notice'>[user] tries to put [equipping] on you.</span>",
@@ -85,7 +86,7 @@
 			if(!victim_human.has_vision())
 				to_chat(victim_human, "<span class='userdanger'>You feel someone trying to put something on you.</span>")
 
-	if(!do_mob(user, source, equipping.put_on_delay))
+	if(!do_mob(user, source, equipping.put_on_delay, hidden = thief_mode))
 		return FALSE
 
 	if(QDELETED(equipping) || !user.Adjacent(source) || (equipping.flags & NODROP))
@@ -127,7 +128,8 @@
 	add_attack_logs(user, source, "Attempting stripping of [item]")
 	item.add_fingerprint(user)
 
-	if(!in_thief_mode(user))
+	var/thief_mode = in_thief_mode(user)
+	if(!thief_mode)
 		source.visible_message(
 			"<span class='warning'>[user] tries to remove [source]'s [item.name].</span>",
 			"<span class='userdanger'>[user] tries to remove your [item.name].</span>",
@@ -138,7 +140,7 @@
 			if(!victim_human.has_vision())
 				to_chat(source, "<span class='userdanger'>You feel someone fumble with your belongings.</span>")
 
-	return start_unequip_mob(get_item(source), source, user)
+	return start_unequip_mob(get_item(source), source, user, hidden = thief_mode)
 
 /// The proc that unequips the item from the source. This should not yield.
 /datum/strippable_item/proc/finish_unequip(atom/source, mob/user)
@@ -255,10 +257,10 @@
 	return equipping.put_on_delay
 
 /// A utility function for `/datum/strippable_item`s to start unequipping an item from a mob.
-/proc/start_unequip_mob(obj/item/item, mob/source, mob/user, strip_delay)
+/proc/start_unequip_mob(obj/item/item, mob/source, mob/user, strip_delay, hidden = FALSE)
 	if(!strip_delay)
 		strip_delay = item.strip_delay
-	if(!do_mob(user, source, strip_delay))
+	if(!do_mob(user, source, strip_delay, hidden = hidden))
 		return FALSE
 
 	return TRUE

--- a/code/modules/mob/living/carbon/carbon_stripping.dm
+++ b/code/modules/mob/living/carbon/carbon_stripping.dm
@@ -36,17 +36,20 @@
 /datum/strippable_item/mob_item_slot/mask/alternate_action(atom/source, mob/user, action_key)
 	if(!..())
 		return
+
+	var/thief_mode = in_thief_mode(user)
+
 	// Headpocket dislodging
 	if(action_key == "dislodge_headpocket")
 		var/mob/living/carbon/human/H = source
 		var/obj/item/organ/internal/headpocket/pocket = H.get_int_organ(/obj/item/organ/internal/headpocket)
 		if(!pocket.held_item)
 			return
-		if(!in_thief_mode(user))
+		if(!thief_mode)
 			user.visible_message("<span class='danger'>[user] is trying to remove something from [source]'s head!</span>",
 								"<span class='danger'>You start to dislodge whatever's inside [source]'s headpocket!</span>")
-		if(do_mob(user, source, POCKET_STRIP_DELAY))
-			if(!in_thief_mode(user))
+		if(do_mob(user, source, POCKET_STRIP_DELAY, hidden = thief_mode))
+			if(!thief_mode)
 				user.visible_message("<span class='danger'>[user] has dislodged something from [source]'s head!</span>",
 									"<span class='danger'>You have dislodged everything from [source]'s headpocket!</span>")
 			pocket.empty_contents()
@@ -63,10 +66,10 @@
 		to_chat(user, "You lack the ability to manipulate the lock.")
 		return
 
-	if(!in_thief_mode(user))
+	if(!thief_mode)
 		muzzle.visible_message("<span class='danger'>[user] tries to [muzzle.locked ? "unlock" : "lock"] [source]'s [muzzle.name].</span>", \
 						"<span class='userdanger'>[user] tries to [muzzle.locked ? "unlock" : "lock"] [source]'s [muzzle.name].</span>")
-	if(!do_mob(user, source, POCKET_STRIP_DELAY))
+	if(!do_mob(user, source, POCKET_STRIP_DELAY, hidden = thief_mode))
 		return
 
 	var/success = FALSE
@@ -77,7 +80,7 @@
 
 	if(!success)
 		return
-	if(!in_thief_mode(user))
+	if(!thief_mode)
 		muzzle.visible_message("<span class='danger'>[user] [muzzle.locked ? "locks" : "unlocks"] [source]'s [muzzle.name].</span>", \
 						"<span class='userdanger'>[user] [muzzle.locked ? "locks" : "unlocks"] [source]'s [muzzle.name].</span>")
 

--- a/code/modules/mob/living/carbon/human/human_stripping.dm
+++ b/code/modules/mob/living/carbon/human/human_stripping.dm
@@ -59,16 +59,17 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 	if(!length(jumpsuit.accessories))
 		return
 	var/obj/item/clothing/accessory/A = jumpsuit.accessories[1]
-	if(!in_thief_mode(user))
+	var/thief_mode = in_thief_mode(user)
+	if(!thief_mode)
 		user.visible_message("<span class='danger'>[user] starts to take off [A] from [source]'s [jumpsuit]!</span>", \
 							"<span class='danger'>You start to take off [A] from [source]'s [jumpsuit]!</span>")
 
-	if(!do_mob(user, source, POCKET_STRIP_DELAY))
+	if(!do_mob(user, source, POCKET_STRIP_DELAY, hidden = thief_mode))
 		return
 	if(QDELETED(A) || !(A in jumpsuit.accessories))
 		return
 
-	if(!in_thief_mode(user))
+	if(!thief_mode)
 		user.visible_message("<span class='danger'>[user] takes [A] off of [source]'s [jumpsuit]!</span>", \
 							"<span class='danger'>You take [A] off of [source]'s [jumpsuit]!</span>")
 	jumpsuit.detach_accessory(A, user)
@@ -157,9 +158,10 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 	add_attack_logs(user, source, "Attempting pickpocketing of [item]")
 	item.add_fingerprint(user)
 
-	var/result = start_unequip_mob(item, source, user, POCKET_STRIP_DELAY)
+	var/thief_mode = in_thief_mode(user)
+	var/result = start_unequip_mob(item, source, user, POCKET_STRIP_DELAY, thief_mode)
 
-	if(!result && !in_thief_mode(user))
+	if(!result && !thief_mode)
 		warn_owner(source)
 
 	return result


### PR DESCRIPTION
## What Does This PR Do
Makes thief gloves stealthy again. Fixes all cases of cogbars appearing on in_thief_mode() check.
Fixes #28598 
Fixes #28615

## Why It's Good For The Game
Oversight fix

## Testing
Joined a local server with two clients, spawned thief gloves, and stripped the item from one of the clients

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog

:cl:
fix: Fixed cogbars appearing with thief gloves
/:cl:
