### PR TITLE
Makes APCs Less Annoying to Construct/Deconstruct

### DIFF
--- a/code/__DEFINES/apc_defines.dm
+++ b/code/__DEFINES/apc_defines.dm
@@ -16,7 +16,6 @@
 //electronics_state
 #define APC_ELECTRONICS_NONE 0
 #define APC_ELECTRONICS_INSTALLED 1
-#define APC_ELECTRONICS_SECURED 2
 
 /// Power channel is off, anything connected to it is not powered, cannot be set manually by players
 #define APC_CHANNEL_SETTING_OFF 0

--- a/code/modules/power/apc/apc.dm
+++ b/code/modules/power/apc/apc.dm
@@ -181,7 +181,7 @@
 		GLOB.apcs = sortAtom(GLOB.apcs)
 		return
 
-	electronics_state = APC_ELECTRONICS_SECURED
+	electronics_state = APC_ELECTRONICS_INSTALLED
 	// is starting with a power cell installed, create it and set its charge level
 	if(cell_type)
 		cell = new /obj/item/stock_parts/cell/upgraded(src)
@@ -328,6 +328,8 @@
 				electronics_state = APC_ELECTRONICS_INSTALLED
 				locked = FALSE
 				to_chat(user, "<span class='notice'>You place [used] inside the frame.</span>")
+				stat &= ~MAINT
+				update_icon()
 				qdel(used)
 
 		return ITEM_INTERACT_COMPLETE

--- a/code/modules/power/apc/apc_construction.dm
+++ b/code/modules/power/apc/apc_construction.dm
@@ -13,16 +13,17 @@
 			visible_message("<span class='warning'>The APC cover is knocked down!</span>")
 			update_icon()
 
-
 /obj/machinery/power/apc/crowbar_act(mob/living/user, obj/item/I)
 	. = TRUE
 	if(!I.tool_start_check(src, user, 0))
 		return
+
 	if(opened) // a) on open apc
 		if(electronics_state == APC_ELECTRONICS_INSTALLED)
 			if(terminal)
 				to_chat(user, "<span class='warning'>Disconnect the wires first!</span>")
 				return
+
 			to_chat(user, "<span class='notice'>You start trying to remove the APC electronics...</span>" )
 			if(I.use_tool(src, user, 50, volume = I.tool_volume))
 				if(has_electronics())
@@ -32,70 +33,73 @@
 							"[user.name] has broken the APC electronics inside [name]!",
 							"<span class='notice'>You break the charred APC electronics and remove the remains.</span>",
 							"<span class='italics'>You hear a crack.</span>")
+						stat |= MAINT
+						update_icon()
 						return
+
 						//SSticker.mode:apcs-- //XSI said no and I agreed. -rastaf0
-					else if(emagged) // We emag board, not APC's frame
+					if(emagged) // We emag board, not APC's frame
 						emagged = FALSE
 						user.visible_message(
 							"[user.name] has discarded the shorted APC electronics from [name]!",
 							"<span class='notice'>You discarded the shorted board.</span>")
+						stat |= MAINT
+						update_icon()
 						return
-					else if(malfhack) // AI hacks board, not APC's frame
+
+					if(malfhack) // AI hacks board, not APC's frame
 						user.visible_message(\
 							"[user.name] has discarded the strangely programmed APC electronics from [name]!",
 							"<span class='notice'>You discarded the strangely programmed board.</span>")
 						malfai = null
 						malfhack = FALSE
+						stat |= MAINT
+						update_icon()
 						return
-					else
-						user.visible_message(\
-							"[user.name] has removed the APC electronics from [name]!",
-							"<span class='notice'>You remove the APC electronics.</span>")
-						new /obj/item/apc_electronics(loc)
-						return
-		else if(opened != APC_COVER_OFF) //cover isn't removed
+
+					user.visible_message(\
+						"[user.name] has removed the APC electronics from [name]!",
+						"<span class='notice'>You remove the APC electronics.</span>")
+					new /obj/item/apc_electronics(loc)
+					stat |= MAINT
+					update_icon()
+					return
+
+		if(opened != APC_COVER_OFF) //cover isn't removed
 			opened = APC_CLOSED
 			coverlocked = TRUE //closing cover relocks it
 			update_icon()
 			return
-	else if(!(stat & BROKEN)) // b) on closed and not broken APC
+
+	if(!(stat & BROKEN)) // b) on closed and not broken APC
 		if(coverlocked && !(stat & MAINT)) // locked...
 			to_chat(user, "<span class='warning'>The cover is locked and cannot be opened!</span>")
 			return
-		else if(panel_open) // wires are exposed
+
+		if(panel_open) // wires are exposed
 			to_chat(user, "<span class='warning'>Exposed wires prevents you from opening it!</span>")
 			return
-		else
-			opened = APC_OPENED
-			update_icon()
+
+		opened = APC_OPENED
+		update_icon()
 
 /obj/machinery/power/apc/screwdriver_act(mob/living/user, obj/item/I)
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	else if(opened)
+
+	if(opened)
 		if(cell && !(stat & MAINT))
 			to_chat(user, "<span class='warning'>Close the APC first!</span>") //Less hints more mystery!
 			return
-		else
-			if(electronics_state == APC_ELECTRONICS_INSTALLED)
-				electronics_state = APC_ELECTRONICS_SECURED
-				stat &= ~MAINT
-				to_chat(user, "<span class='notice'>You screw the circuit electronics into place.</span>")
-			else if(electronics_state == APC_ELECTRONICS_SECURED)
-				electronics_state = APC_ELECTRONICS_INSTALLED
-				stat |= MAINT
-				to_chat(user, "<span class='notice'>You unfasten the electronics.</span>")
-			else
-				to_chat(user, "<span class='warning'>There is nothing to secure!</span>")
-				return
-			update_icon()
-	else if(emagged)
+
+	if(emagged)
 		to_chat(user, "<span class='warning'>The interface is broken!</span>")
-	else
-		panel_open = !panel_open
-		to_chat(user, "The wires have been [panel_open ? "exposed" : "unexposed"]")
-		update_icon()
+		return
+
+	panel_open = !panel_open
+	to_chat(user, "The wires have been [panel_open ? "exposed" : "unexposed"]")
+	update_icon()
 
 
 /obj/machinery/power/apc/wirecutter_act(mob/living/user, obj/item/I)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the requirement to screw/unscrew the APC's electronics to the frame. Nanotrasen has realized that screwless connectors (as used by literally all its other devices) are the future!

This also removes a silly condition where wiring the APC electronics before screwing them in will brick the APC construction process until the wires are removed.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
APCs are to my knowledge the only machine where the circuitry needs to be screwed in. It makes it more tedious than it needs to be, especially when you need to rebuild two dozen of them.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Loaded test_tiny and fully constructed and deconstructed an APC, verified its function. Smashed the APC, emagged the APC. All was good.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: APCs no longer need to have their electronics screwed/unscrewed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
