### PR TITLE
Makes oxygen grenades printable in Protolathe and Increase amount of oxygen grenades in Cargo Emergency Equipment Crate

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -1267,6 +1267,15 @@
 	new /obj/item/storage/lockbox/medal/hardmode_box(src)
 	new /obj/item/paper/hardmode(src)
 
+/obj/item/storage/box/oxygen_grenades
+	name = "oxygen grenades box"
+	desc = "A box full of oxygen grenades."
+	icon_state = "flashbang_box"
+
+/obj/item/storage/box/oxygen_grenades/populate_contents()
+	for(var/I in 1 to 7)
+		new /obj/item/grenade/gas/oxygen(src)
+
 /obj/item/storage/box/foam_grenades
 	name = "foam grenades box"
 	desc = "A box full of foam grenades."

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -124,7 +124,7 @@
 
 /datum/design/emergency_oxygen
 	name = "Empty Emergency Oxygen Tank"
-	desc = "Used for emergencies. Onl contains very little oxygen once filled up."
+	desc = "Used for emergencies. Only contains very little oxygen once filled up."
 	id = "emergencyoxygen"
 	req_tech = list("toxins" = 3)
 	build_type = PROTOLATHE
@@ -160,4 +160,14 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL=3000, MAT_GLASS=500)
 	build_path = /obj/item/tank/internals/oxygen/empty
+	category = list("Miscellaneous")
+
+/datum/design/oxygen_grenade
+	name = "Oxygen Grenade"
+	desc = "When triggered, releases a stream of pure O2 gas from the grenade."
+	id = "oxygen_Grenade"
+	req_tech = list("combat" = 3, "engineering" = 4, "toxins" = 4)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 3000, MAT_GLASS = 500) //Same as Advanced Release Grenade
+	build_path = /obj/item/grenade/gas/oxygen
 	category = list("Miscellaneous")

--- a/code/modules/supply/supply_packs/pack_emergency.dm
+++ b/code/modules/supply/supply_packs/pack_emergency.dm
@@ -20,8 +20,8 @@
 					/obj/item/clothing/mask/gas,
 					/obj/item/clothing/mask/gas,
 					/obj/item/clothing/mask/gas,
-					/obj/item/grenade/gas/oxygen,
-					/obj/item/grenade/gas/oxygen)
+					/obj/item/storage/box/oxygen_grenades,
+					/obj/item/storage/box/oxygen_grenades)
 	cost = 400
 	containertype = /obj/structure/closet/crate/internals
 	containername = "emergency crate"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Oxygen grenades are now printable in the Protolathe, costing 3000 metal and 500 glass. Locked behind Combat 3, Engineering 4 and Toxins 4.

Emergency Equipment Crates in Cargo now has 2 full boxes of oxygen grenades (14 grenades total) instead of 2 oxygen nades. Cost remains unchanged.

## Why It's Good For The Game

With the vacuum of space becoming more dangerous thanks to MILLA, Engineering needs more tools to refill areas with low air pump coverage (Such as maintenance) or to quickly refill an area with air.

More oxygen grenades in the Emergency Equipment Crate would allow Engineering to have an easier time for early round breaches (And make the Crate much more palatable to buy), while the printable oxygen grenades will require RnD to actually do some work, giving the oft-neglected Toxins Research some fun toys to play with. Once they are researched though, they can be loaded into a disk to be printed in Engineering Autolathe.

## Images of changes

![Screenshot 2025-03-07 112111](https://github.com/user-attachments/assets/c40e6278-e16e-406b-a92d-a4f5bccdc8bb)
![Screenshot 2025-03-07 112228](https://github.com/user-attachments/assets/8ea8dc74-e81c-48d2-8fbc-eea780ee5e50)
![Screenshot 2025-03-07 134401](https://github.com/user-attachments/assets/5f538963-17b1-4034-9b99-a3638068f851)

## Testing

Booted up local server, maxed research levels in RnD, try and print some oxygen grenades and was able to.
Loaded the oxygen grenade design into a design disk, imported it into an autolathe and managed to print a oxygen grenade.
Ordered an Emergency Equipment Crate, and once it arrived saw it had two boxes of oxygen grenades.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

![Screenshot 2025-03-07 143624](https://github.com/user-attachments/assets/8e163d56-a692-4a57-a410-ebffe5de0298)

## Changelog

:cl:
tweak: Oxygen grenades can now be printed in the Protolathe
tweak: Cargo Emergency Equipment Crate now has 2 boxes of oxygen grenades
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
