### PR TITLE
Revenants haunted items ability can now hit stuff that aren't humanoid mobs

### DIFF
--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -388,10 +388,12 @@
 /datum/spell/aoe/revenant/haunt_object/proc/attack__legacy__attackchain(mob/living/simple_animal/possessed_object/possessed_object, mob/living/simple_animal/revenant/user)
 	var/list/potential_victims = list()
 	for(var/turf/turf_to_search in spiral_range_turfs(aoe_range, get_turf(possessed_object)))
-		for(var/mob/living/carbon/potential_victim in turf_to_search)
+		for(var/mob/living/potential_victim in turf_to_search)
 			if(QDELETED(possessed_object) || !can_see(possessed_object, potential_victim, aoe_range)) // You can't see me
 				continue
 			if(potential_victim.stat != CONSCIOUS) // Don't kill our precious essence-filled sleepy mobs
+				continue
+			if(istype(potential_victim, user) || istype(potential_victim, possessed_object))
 				continue
 			potential_victims.Add(potential_victim)
 
@@ -402,7 +404,7 @@
 		set_outline(possessed_object)
 		return
 
-	var/mob/living/carbon/victim = pick(potential_victims)
+	var/mob/living/victim = pick(potential_victims)
 	possessed_object.throw_at(victim, aoe_range, 2, user, dodgeable = FALSE)
 
 /// Sets the glow on the haunted object, scales up based on throwforce


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it so the haunted items ability can attack things that aren't humanoid(as well as humanoids)
example some of what they can now attack;
Borgs/ai
Ian the corgi
Terror spiders
blob naughts/spores

Basically if they're a simple mob, or carbon they'll be attacked. The only things that they wont attack, are revenants, and other possessed items.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Theres little reason why the haunted items ability only targets humanoid mobs, If lets say, the revenant had the objective "Help the crew in critical situations, but take your payments in souls." and terror spiders rolled. All the rev could do, is spam light shock, But if the terrors break the apc, now the rev is unable to help the crew in any meaningful way, outside of report where terrors are. 
Ontop of that, stuff like cyborgs that dont get stunned in one malfunction ability anymore, are suddenly as powerful, if not more powerful than crew with holy weapons, as you have no real way of dealing with them. out side of using your malfunction ability 8-11 times on the one borg. (to my knowledge the light shock doesn't target borgs)
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned various items, and mobs(human, borg, terror spider), haunted the items, watched them attack the mobs i spawned
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
![Discord_idZIJJ8kem](https://github.com/user-attachments/assets/18ea65f1-6136-4ea8-8e81-d02b7d2afef2)

<hr>

## Changelog

:cl:
tweak: The "Haunt objects" ability revenant has will now target all mobs, not just humanoids
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
