### PR TITLE
Gives ghosts the ability to see the power on cables 

### DIFF
--- a/code/modules/power/cables/cable.dm
+++ b/code/modules/power/cables/cable.dm
@@ -60,6 +60,13 @@ By design, d1 is the smallest direction and d2 is the highest
 	if(level == 1)
 		hide(T.intact)
 
+/obj/structure/cable/examine(mob/user)
+	. = ..()
+	if(isobserver(user))
+		. += "<span class='notice'>Total power: [DisplayPower(powernet.available_power)]</span>"
+		. += "<span class='notice'>Load: [DisplayPower(powernet.power_demand)]</span>"
+		. += "<span class='notice'>Excess power: [DisplayPower(get_surplus())]</span>"
+
 /obj/structure/cable/Destroy()
 	if(powernet)
 		cut_cable_from_powernet()		// update the powernets


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Ghosts now have the ability to inspect power cables and see the same details as if they were to click it with a multi tool.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Observers observe. Not being able to easily figure out the power of, lets say the supermatter kinda sucks, so i wanted to change that 
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
as ghost
![dreamseeker_xBtArJbuoC](https://github.com/user-attachments/assets/55440cfd-6e9b-440e-87e6-8c2b99a16323)

as living
![dreamseeker_rOnVlA8EqS](https://github.com/user-attachments/assets/ddd9945f-c6e2-4433-aceb-3286c5150dee)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
see above
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
add: Ghosts now have the powers of a multitool, and as such, can see the same information as one if they inspect a cable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
