### PR TITLE
Looping External Infection Treatment plus Progress Text

### DIFF
--- a/code/modules/surgery/external_infection_treatment.dm
+++ b/code/modules/surgery/external_infection_treatment.dm
@@ -14,3 +14,8 @@
 		TOOL_WELDER = 30,
 		/obj/item/flamethrower = 1
 	)
+
+	preop_sound = 'sound/surgery/cautery1.ogg'
+	success_sound = 'sound/surgery/cautery2.ogg'
+	failure_sound = 'sound/items/welder.ogg'
+	time = 2.4 SECONDS

--- a/code/modules/surgery/external_infection_treatment.dm
+++ b/code/modules/surgery/external_infection_treatment.dm
@@ -78,7 +78,7 @@
 	germ_healed += germ_amount_healed
 	affected.germ_level = max(affected.germ_level - germ_amount_healed, 0)
 
-	self_msg += get_progress(user, target, germ_healed)
+	self_msg += get_progress(user, target, target_zone, germ_healed)
 
 	if(COOLDOWN_FINISHED(src, success_message_spam_cooldown))
 		user.visible_message(
@@ -87,7 +87,7 @@
 			chat_message_type = MESSAGE_TYPE_COMBAT
 		)
 
-		COOLDOWN_START(src, success_message_spam_cooldown, 10 SECONDS)
+		COOLDOWN_START(src, success_message_spam_cooldown, 7 SECONDS)
 
 	// retry ad nauseum; can_repeat should handle anything else.
 	if(affected.germ_level > 0)
@@ -105,7 +105,7 @@
 	target.apply_damage(3, BURN, affected)
 	return SURGERY_STEP_RETRY
 
-/datum/surgery_step/heal_infection/brute/get_progress(mob/user, mob/living/carbon/target, target_zone, germ_healed)
+/datum/surgery_step/heal_infection/get_progress(mob/user, mob/living/carbon/target, target_zone, germ_healed)
 	if(!germ_healed)
 		return
 
@@ -120,7 +120,7 @@
 		if(INFECTION_LEVEL_ONE + 200 to INFECTION_LEVEL_ONE + 300)
 			progress_text = ", continuing to eliminate the spots of infection"
 		if(INFECTION_LEVEL_ONE + 300 to INFECTION_LEVEL_ONE + 400)
-			progress_text = ", still counting some moderate spots of"
+			progress_text = ", still counting some moderate spots of infection"
 		if(INFECTION_LEVEL_TWO to INFECTION_LEVEL_TWO + 200)
 			progress_text = ", steadying yourself for the long surgery ahead"
 		if(INFECTION_LEVEL_TWO + 200 to INFECTION_LEVEL_TWO + 300)

--- a/code/modules/surgery/external_infection_treatment.dm
+++ b/code/modules/surgery/external_infection_treatment.dm
@@ -4,3 +4,13 @@
 	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD, BODY_ZONE_PRECISE_GROIN, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT)
 
 /datum/surgery_step/heal_infection
+	name = "tend infection"
+
+	allowed_tools = list(
+		/obj/item/scalpel/laser = 100,
+		TOOL_CAUTERY = 100,
+		/obj/item/clothing/mask/cigarette = 90,
+		/obj/item/lighter = 60,
+		TOOL_WELDER = 30,
+		/obj/item/flamethrower = 1
+	)

--- a/code/modules/surgery/external_infection_treatment.dm
+++ b/code/modules/surgery/external_infection_treatment.dm
@@ -26,11 +26,11 @@
 	time = 2.4 SECONDS
 	repeatable = TRUE
 
-var/shown_starting_message_already = FALSE
+	var/shown_starting_message_already = FALSE
 
-COOLDOWN_DECLARE(success_message_spam_cooldown)
+	COOLDOWN_DECLARE(success_message_spam_cooldown)
 
-var/germ_amount_healed = 50
+	var/germ_amount_healed = 50
 
 /// Get a message indicating how the surgery is going.
 /datum/surgery_step/heal_infection/proc/get_progress(mob/user, mob/living/carbon/target, germ_healed)

--- a/code/modules/surgery/external_infection_treatment.dm
+++ b/code/modules/surgery/external_infection_treatment.dm
@@ -52,3 +52,5 @@ COOLDOWN_DECLARE(success_message_spam_cooldown)
 			chat_message_type = MESSAGE_TYPE_COMBAT
 		)
 	affected.custom_pain("Something in your [affected.name] is causing you a lot of pain!")
+
+	return ..()

--- a/code/modules/surgery/external_infection_treatment.dm
+++ b/code/modules/surgery/external_infection_treatment.dm
@@ -94,3 +94,29 @@ var/germ_amount_healed = 50
 	)
 	target.apply_damage(3, BURN, affected)
 	return SURGERY_STEP_RETRY
+
+/datum/surgery_step/heal_infection/brute/get_progress(mob/user, mob/living/carbon/target, brute_healed, burn_healed)
+	if(!brute_healed)
+		return
+
+	var/progress_text
+
+	switch(target.germ_level)
+		if(1 to INFECTION_LEVEL_ONE - 1)
+			progress_text = ", removing the last traces of the infection"
+		if(INFECTION_LEVEL_ONE to INFECTION_LEVEL_ONE + 200)
+			progress_text = ", counting down the small bits of infection"
+		if(INFECTION_LEVEL_ONE + 200 to INFECTION_LEVEL_ONE + 300)
+			progress_text = ", continuing to eliminate the spots of infection"
+		if(INFECTION_LEVEL_ONE + 300 to INFECTION_LEVEL_ONE + 400)
+			progress_text = ", still counting some moderate spots of"
+		if(INFECTION_LEVEL_TWO to INFECTION_LEVEL_TWO + 200)
+			progress_text = ", steadying yourself for the long surgery ahead"
+		if(INFECTION_LEVEL_TWO + 200 to INFECTION_LEVEL_TWO + 300)
+			progress_text = ", burning through some of the severe spots of infection"
+		if(INFECTION_LEVEL_TWO + 300 to INFECTION_LEVEL_TWO + 400)
+			progress_text = ", though [target.p_their()] limb still look[target.p_s()] more like infection than limb"
+		if(INFECTION_LEVEL_THREE to INFINITY)
+			progress_text = ", though you feel like you're barely making a dent in [target.p_their()] septic limb"
+
+	return progress_text

--- a/code/modules/surgery/external_infection_treatment.dm
+++ b/code/modules/surgery/external_infection_treatment.dm
@@ -26,23 +26,23 @@ var/shown_starting_message_already = FALSE
 COOLDOWN_DECLARE(success_message_spam_cooldown)
 
 /// Get a message indicating how the surgery is going.
-/datum/surgery_step/heal/proc/get_progress(mob/user, mob/living/carbon/target, brute_healed, burn_healed)
+/datum/surgery_step/heal_infection/proc/get_progress(mob/user, mob/living/carbon/target, germ_healed)
 	return
 
-/datum/surgery_step/heal/proc/can_be_healed(mob/living/user, mob/living/carbon/target, target_zone)
-	if(germ_healed == 0)
+/datum/surgery_step/heal_infection/proc/can_be_healed(mob/living/user, mob/living/carbon/target, target_zone)
+	if(germ_amount_healed == 0)
 		stack_trace("A healing surgery was given no healing values.")
 		return FALSE
 
-	return (germ_healed && target.germ_level)
+	return (germ_amount_healed && target.germ_level)
 
-/datum/surgery_step/heal/can_repeat(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+/datum/surgery_step/heal_infection/can_repeat(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(!can_be_healed(user, target, target_zone))
 		to_chat(user, "<span class='notice'>It doesn't look like [target] has any remaining infection.</span>")
 		return FALSE
 	return TRUE
 
-/datum/surgery_step/heal/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
+/datum/surgery_step/heal_infection/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(!shown_starting_message_already)
 		shown_starting_message_already = TRUE
@@ -54,3 +54,27 @@ COOLDOWN_DECLARE(success_message_spam_cooldown)
 	affected.custom_pain("Something in your [affected.name] is causing you a lot of pain!")
 
 	return ..()
+
+/datum/surgery_step/heal_infection/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
+
+	if(!can_be_healed(user, target, target_zone))
+		to_chat(user, "<span class='notice'>It doesn't look like [target] has any remaining infection.</span>")
+		return SURGERY_STEP_CONTINUE
+
+	var/outer_msg = "[user] succeeds in fixing some of [target]'s infection"
+	var/self_msg = "You successfully manage to remove some of [target]'s infection"
+
+	var/germ_healed = germ_amount_healed
+
+	germ_healed += 50
+	affected.germ_level = max(affected.germ_level - 50, 0)
+
+/datum/surgery_step/heal_infection/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message(
+		"<span class='warning'>[user]'s hand slips, leaving a small burn on [target]'s [affected.name] with \the [tool]!</span>",
+		"<span class='warning'>Your hand slips, leaving a small burn on [target]'s [affected.name] with \the [tool]!</span>",
+		chat_message_type = MESSAGE_TYPE_COMBAT
+	)
+	target.apply_damage(3, BURN, affected)
+	return SURGERY_STEP_RETRY

--- a/code/modules/surgery/external_infection_treatment.dm
+++ b/code/modules/surgery/external_infection_treatment.dm
@@ -41,7 +41,8 @@
 		stack_trace("A healing surgery was given no healing values.")
 		return FALSE
 
-	return (germ_amount_healed && target.germ_level)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	return (germ_amount_healed && affected.germ_level)
 
 /datum/surgery_step/heal_infection/can_repeat(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(!can_be_healed(user, target, target_zone))
@@ -109,8 +110,9 @@
 		return
 
 	var/progress_text
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
-	switch(target.germ_level)
+	switch(affected.germ_level)
 		if(1 to INFECTION_LEVEL_ONE - 1)
 			progress_text = ", removing the last traces of the infection"
 		if(INFECTION_LEVEL_ONE to INFECTION_LEVEL_ONE + 200)

--- a/code/modules/surgery/external_infection_treatment.dm
+++ b/code/modules/surgery/external_infection_treatment.dm
@@ -1,11 +1,12 @@
 /datum/surgery/infection
 	name = "External Infection Treatment"
+	desc = "Gradually remove infected from an affected limb"
 	steps = list(/datum/surgery_step/generic/cut_open, /datum/surgery_step/heal_infection, /datum/surgery_step/generic/cauterize)
 	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD, BODY_ZONE_PRECISE_GROIN, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT)
 
-/datum/surgery/infection/New(atom/surgery_target, surgery_location, surgery_bodypart)
+/* /datum/surgery/infection/New(atom/surgery_target, surgery_location, surgery_bodypart)
 	name = "External Infection Treatment"
-	steps = list(/datum/surgery_step/generic/cut_open, /datum/surgery_step/heal_infection, /datum/surgery_step/generic/cauterize)
+	steps = list(/datum/surgery_step/generic/cut_open, /datum/surgery_step/heal_infection, /datum/surgery_step/generic/cauterize) */
 
 /datum/surgery_step/heal_infection
 	name = "tend infection"

--- a/code/modules/surgery/external_infection_treatment.dm
+++ b/code/modules/surgery/external_infection_treatment.dm
@@ -19,3 +19,36 @@
 	success_sound = 'sound/surgery/cautery2.ogg'
 	failure_sound = 'sound/items/welder.ogg'
 	time = 2.4 SECONDS
+	repeatable = TRUE
+
+var/shown_starting_message_already = FALSE
+
+COOLDOWN_DECLARE(success_message_spam_cooldown)
+
+/// Get a message indicating how the surgery is going.
+/datum/surgery_step/heal/proc/get_progress(mob/user, mob/living/carbon/target, brute_healed, burn_healed)
+	return
+
+/datum/surgery_step/heal/proc/can_be_healed(mob/living/user, mob/living/carbon/target, target_zone)
+	if(germ_healed == 0)
+		stack_trace("A healing surgery was given no healing values.")
+		return FALSE
+
+	return (germ_healed && target.germ_level)
+
+/datum/surgery_step/heal/can_repeat(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	if(!can_be_healed(user, target, target_zone))
+		to_chat(user, "<span class='notice'>It doesn't look like [target] has any remaining infection.</span>")
+		return FALSE
+	return TRUE
+
+/datum/surgery_step/heal/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	if(!shown_starting_message_already)
+		shown_starting_message_already = TRUE
+		user.visible_message(
+			"[user] starts to remove some of the infection on [target]'s [affected.name] with [tool].",
+			"You start to remove some of the infection on [target]'s [affected.name] with [tool].",
+			chat_message_type = MESSAGE_TYPE_COMBAT
+		)
+	affected.custom_pain("Something in your [affected.name] is causing you a lot of pain!")

--- a/code/modules/surgery/external_infection_treatment.dm
+++ b/code/modules/surgery/external_infection_treatment.dm
@@ -3,6 +3,10 @@
 	steps = list(/datum/surgery_step/generic/cut_open, /datum/surgery_step/heal_infection, /datum/surgery_step/generic/cauterize)
 	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD, BODY_ZONE_PRECISE_GROIN, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT)
 
+/datum/surgery/infection/New(atom/surgery_target, surgery_location, surgery_bodypart)
+	name = "External Infection Treatment"
+	steps = list(/datum/surgery_step/generic/cut_open, /datum/surgery_step/heal_infection, /datum/surgery_step/generic/cauterize)
+
 /datum/surgery_step/heal_infection
 	name = "tend infection"
 
@@ -120,3 +124,24 @@ var/germ_amount_healed = 50
 			progress_text = ", though you feel like you're barely making a dent in [target.p_their()] septic limb"
 
 	return progress_text
+
+/* /datum/surgery/intermediate/heal_infection
+	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD, BODY_ZONE_PRECISE_GROIN, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT)
+
+/datum/surgery/intermediate/heal_infection
+	name = "Tend Infection (abstract)"
+	desc = "An intermediate surgery to tend to a patient's infection while they're undergoing another procedure."
+	steps = list(
+		/datum/surgery_step/heal_infection
+	)
+
+/datum/surgery/intermediate/heal_infection/can_start(mob/user, mob/living/carbon/target)
+	. = ..()
+	if(!.)
+		return
+	if(target.getBruteLoss() == 0)
+		to_chat(user, "<span class='warning'>[target] doesn't even have a trace of infection on that limb, there's nothing to treat.</span>")
+		return FALSE
+	return TRUE
+	// Normally, adding to_chat to can_start is poor practice since this gets called when listing surgery steps.
+	// It's alright for intermediate surgeries, though, since they never get listed out */

--- a/code/modules/surgery/external_infection_treatment.dm
+++ b/code/modules/surgery/external_infection_treatment.dm
@@ -89,7 +89,10 @@
 		COOLDOWN_START(src, success_message_spam_cooldown, 10 SECONDS)
 
 	// retry ad nauseum; can_repeat should handle anything else.
-	return SURGERY_STEP_RETRY
+	if(affected.germ_level > 0)
+		return SURGERY_STEP_RETRY
+	else
+		return SURGERY_STEP_CONTINUE
 
 /datum/surgery_step/heal_infection/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -101,8 +104,8 @@
 	target.apply_damage(3, BURN, affected)
 	return SURGERY_STEP_RETRY
 
-/datum/surgery_step/heal_infection/brute/get_progress(mob/user, mob/living/carbon/target, brute_healed, burn_healed)
-	if(!brute_healed)
+/datum/surgery_step/heal_infection/brute/get_progress(mob/user, mob/living/carbon/target, target_zone, germ_healed)
+	if(!germ_healed)
 		return
 
 	var/progress_text
@@ -126,24 +129,3 @@
 			progress_text = ", though you feel like you're barely making a dent in [target.p_their()] septic limb"
 
 	return progress_text
-
-/* /datum/surgery/intermediate/heal_infection
-	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD, BODY_ZONE_PRECISE_GROIN, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT)
-
-/datum/surgery/intermediate/heal_infection
-	name = "Tend Infection (abstract)"
-	desc = "An intermediate surgery to tend to a patient's infection while they're undergoing another procedure."
-	steps = list(
-		/datum/surgery_step/heal_infection
-	)
-
-/datum/surgery/intermediate/heal_infection/can_start(mob/user, mob/living/carbon/target)
-	. = ..()
-	if(!.)
-		return
-	if(target.getBruteLoss() == 0)
-		to_chat(user, "<span class='warning'>[target] doesn't even have a trace of infection on that limb, there's nothing to treat.</span>")
-		return FALSE
-	return TRUE
-	// Normally, adding to_chat to can_start is poor practice since this gets called when listing surgery steps.
-	// It's alright for intermediate surgeries, though, since they never get listed out */

--- a/code/modules/surgery/external_infection_treatment.dm
+++ b/code/modules/surgery/external_infection_treatment.dm
@@ -1,0 +1,6 @@
+/datum/surgery/infection
+	name = "External Infection Treatment"
+	steps = list(/datum/surgery_step/generic/cut_open, /datum/surgery_step/heal_infection, /datum/surgery_step/generic/cauterize)
+	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD, BODY_ZONE_PRECISE_GROIN, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT)
+
+/datum/surgery_step/heal_infection

--- a/code/modules/surgery/external_infection_treatment.dm
+++ b/code/modules/surgery/external_infection_treatment.dm
@@ -72,6 +72,7 @@ var/germ_amount_healed = 50
 	var/self_msg = "You successfully manage to remove some of [target]'s infection"
 
 	var/germ_healed = germ_amount_healed
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
 	germ_healed += germ_amount_healed
 	affected.germ_level = max(affected.germ_level - germ_amount_healed, 0)

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -3,11 +3,6 @@
 //					INTERNAL WOUND PATCHING						//
 //////////////////////////////////////////////////////////////////
 
-/datum/surgery/infection
-	name = "External Infection Treatment"
-	steps = list(/datum/surgery_step/generic/cut_open, /datum/surgery_step/generic/cauterize)
-	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD, BODY_ZONE_PRECISE_GROIN, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT)
-
 /datum/surgery/bleeding
 	name = "Internal Bleeding"
 	steps = list(

--- a/paradise.dme
+++ b/paradise.dme
@@ -2947,6 +2947,7 @@
 #include "code\modules\surgery\core_removal.dm"
 #include "code\modules\surgery\dental_implant.dm"
 #include "code\modules\surgery\encased.dm"
+#include "code\modules\surgery\external_infection_treatment.dm"
 #include "code\modules\surgery\generic.dm"
 #include "code\modules\surgery\limb_augmentation.dm"
 #include "code\modules\surgery\limb_reattach.dm"


### PR DESCRIPTION
## What Does This PR Do

Moves the External Infection Treatment into its own file due to changes being larger than reasonable for a file of multiple surgeries. Makes it so External Infection Treatment loops the cautery step automatically with progress text as the germ level decreases, also adds a "pull skin" step after the first cautery step due to not being able to complete the surgery without just cancelling it otherwise.

## Why It's Good For The Game

Currently, the External Infection Treatment surgery appears useless and feels tedious. This would give the user an idea as to how the surgery is progressing and make it not tedious to utilise.

## Testing

Spawned in as a Drask Medical Doctor, spawned in surgical equipment, spawned in operating table and console as well as a sink, spawned in sterile mask and nitrile gloves, spawned in spray bottle filled with sterilizine, removed germ_level from myself and spawned items on the ground by spraying sterilizine, spawned in human and buckled them to the operating table, set their left arm's germ level to 1010, went through surgery until the cautery stage confirming that console showed steps correctly, began cautery stage seeing correct progress text as germ_level decreased and the step looped, cautery step automatically stopped once germ_level of target limb reached 0, tried cauterising again and received chat message informing me germ_level of target limb was 0, pulled incision closed, cauterised to finish surgery, surgery was complete and target limb's germ_level was 0.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl:
tweak: External Infection Treatment now loops with progress text, similar to Tend Wounds/Burns, and now requires a retractor after the first cautery step.
/:cl:
