### PR TITLE
Shift planes and layers to prevent overlap with conflicting displayed elements

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -112,49 +112,49 @@
 #define EMISSIVE_RENDER_TARGET "*EMISSIVE_PLANE"
 
 #define POINT_PLANE 14
-#define COGBAR_PLANE 14
+#define COGBAR_PLANE 15
 
-#define LIGHTING_PLANE 15
-#define LIGHTING_LAYER 15
+#define LIGHTING_PLANE 16
+#define LIGHTING_LAYER 16
 
-#define LIGHTING_LAMPS_GLARE 16 // Light glare (optional setting)
-#define LIGHTING_EXPOSURE_PLANE 17 // Light sources "cones"
-#define LIGHTING_LAMPS_SELFGLOW 18 // Light sources glow (lamps, doors overlay, etc.)
-#define LIGHTING_LAMPS_PLANE 19 // Light sources themselves (lamps, screens, etc.)
+#define LIGHTING_LAMPS_GLARE 17 // Light glare (optional setting)
+#define LIGHTING_EXPOSURE_PLANE 18 // Light sources "cones"
+#define LIGHTING_LAMPS_SELFGLOW 19 // Light sources glow (lamps, doors overlay, etc.)
+#define LIGHTING_LAMPS_PLANE 20 // Light sources themselves (lamps, screens, etc.)
 
 #define LIGHTING_LAMPS_RENDER_TARGET "*LIGHTING_LAMPS_RENDER_TARGET"
 
-#define RAD_TEXT_LAYER 19.1
+#define RAD_TEXT_LAYER 20.1
 
-#define ABOVE_LIGHTING_PLANE 20
-#define ABOVE_LIGHTING_LAYER 20
+#define ABOVE_LIGHTING_PLANE 21
+#define ABOVE_LIGHTING_LAYER 21
 
-#define FLOOR_OPENSPACE_PLANE 21
-#define OPENSPACE_LAYER 21
+#define FLOOR_OPENSPACE_PLANE 22
+#define OPENSPACE_LAYER 22
 
-#define BYOND_LIGHTING_PLANE 22
-#define BYOND_LIGHTING_LAYER 22
+#define BYOND_LIGHTING_PLANE 24
+#define BYOND_LIGHTING_LAYER 24
 
-#define CAMERA_STATIC_PLANE 23
-#define CAMERA_STATIC_LAYER 23
+#define CAMERA_STATIC_PLANE 24
+#define CAMERA_STATIC_LAYER 24
 
 //HUD layer defines
 
-#define FULLSCREEN_PLANE 24
-#define FLASH_LAYER 24
-#define FULLSCREEN_LAYER 24.1
-#define UI_DAMAGE_LAYER 24.2
-#define BLIND_LAYER 24.3
-#define CRIT_LAYER 24.4
-#define CURSE_LAYER 24.5
+#define FULLSCREEN_PLANE 25
+#define FLASH_LAYER 25
+#define FULLSCREEN_LAYER 25.1
+#define UI_DAMAGE_LAYER 25.2
+#define BLIND_LAYER 25.3
+#define CRIT_LAYER 25.4
+#define CURSE_LAYER 25.5
 
-#define HUD_PLANE 25
-#define HUD_LAYER 25
-#define ABOVE_HUD_PLANE 26
-#define ABOVE_HUD_LAYER 26
+#define HUD_PLANE 26
+#define HUD_LAYER 26
+#define ABOVE_HUD_PLANE 27
+#define ABOVE_HUD_LAYER 27
 
-#define SPLASHSCREEN_LAYER 27
-#define SPLASHSCREEN_PLANE 27
+#define SPLASHSCREEN_LAYER 28
+#define SPLASHSCREEN_PLANE 28
 
 #define HUD_PLANE_BUILDMODE 30
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Shifts the defined planes and layers so that cogs and thought bubbles aren't overlapping. I can't just shift cogs since it's a plane and those do not support floats like layers, so everything has to be moved up.

Otherwise, the cog plane ends up taking over the bubble plane, which makes the preference runtime since it's looking for a screen element that does not exist.

## Why It's Good For The Game
Fixes #28612

## Images of changes
https://github.com/user-attachments/assets/fdad3665-a0be-4241-87a7-5bbfbba55a5d

## Testing
Looked around in general to make sure nothing was broken with general lighting and UI elements. Toggled both thought bubbles and cogs on a player separately from each other.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Fix cogs setting conflicting with thought bubbles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
