### PR TITLE
Fix Cogbar Appearing Over Cyborgs/AI When Bolting/Shocking Doors

### DIFF
--- a/code/_onclick/ai_onclick.dm
+++ b/code/_onclick/ai_onclick.dm
@@ -15,9 +15,9 @@
 		// But we return here since we don't want to do regular dblclick handling
 		return
 
-	if(control_disabled || stat) 
+	if(control_disabled || stat)
 		return
-	if(ismecha(loc)) 
+	if(ismecha(loc))
 		return
 
 	if(ismob(A))
@@ -227,7 +227,7 @@
 /obj/machinery/door/airlock/AICtrlClick(mob/living/silicon/user) // Bolts doors
 	if(!ai_control_check(user))
 		return
-	if(ispulsedemon(user) || user.can_instant_lockdown() || do_after_once(user, 3 SECONDS, needhand = FALSE, target = src, allow_moving = TRUE, attempt_cancel_message = "Bolting [src] cancelled.", special_identifier = "Bolt"))
+	if(ispulsedemon(user) || user.can_instant_lockdown() || do_after_once(user, 3 SECONDS, needhand = FALSE, target = src, allow_moving = TRUE, attempt_cancel_message = "Bolting [src] cancelled.", special_identifier = "Bolt", hidden = TRUE))
 		toggle_bolt(user)
 
 
@@ -239,7 +239,7 @@
 	if(isElectrified())
 		electrify(0, user, TRUE) // un-shock
 	else
-		if(ispulsedemon(user) || user.can_instant_lockdown() || do_after_once(user, 3 SECONDS, target = src, allow_moving = TRUE, attempt_cancel_message = "Shocking [src] cancelled.", special_identifier = "Shock"))
+		if(ispulsedemon(user) || user.can_instant_lockdown() || do_after_once(user, 3 SECONDS, target = src, allow_moving = TRUE, attempt_cancel_message = "Shocking [src] cancelled.", special_identifier = "Shock", hidden = TRUE))
 			electrify(-1, user, TRUE) // permanent shock + audio cue
 			playsound(loc, "sparks", 100, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 


### PR DESCRIPTION
Fix Cogbar Appearing Over Cyborgs When Bolting/Shocking Doors
## What Does This PR Do
Fixes Cogbar Appearing Over Cyborgs/AI When Bolting/Shocking Doors
Fixes #28625

## Why It's Good For The Game
Oversight fix

## Testing
Tried to bolt airlock as cyborg, no cogbar on other client.

<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl:
fix: Fixed сogbar appearing over cyborgs/AI when bolting/shocking doors
/:cl: