### PR TITLE
[s] Prevents telegun from spawning inside surplus crates

### DIFF
--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -234,6 +234,7 @@
 	cost = 50
 	job = list("Scientist")
 	hijack_only = TRUE
+	surplus = 0
 
 //Roboticist
 /datum/uplink_item/jobspecific/syndiemmi


### PR DESCRIPTION
## What Does This PR Do
Stops telegun from spawning when surplus crates are purchased.

## Why It's Good For The Game
Fixes an oversight

## Testing
Compiled

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl:
fix: Fixed an oversight where telegun could spawn in surplus crates.
/:cl: