### PR TITLE
fix luxury capsule windows blocking movement

### DIFF
--- a/_maps/map_files/templates/shelter_2.dmm
+++ b/_maps/map_files/templates/shelter_2.dmm
@@ -79,7 +79,8 @@
 /area/survivalpod)
 "o" = (
 /obj/structure/window/reinforced/survival_pod{
-	dir = 8
+	dir = 8;
+	pixel_y = -8
 	},
 /obj/machinery/door/window/survival_pod{
 	dir = 1
@@ -88,13 +89,8 @@
 /area/survivalpod)
 "p" = (
 /obj/structure/window/reinforced/survival_pod{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/black,
-/area/survivalpod)
-"q" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 9
+	dir = 8;
+	pixel_y = -8
 	},
 /turf/simulated/floor/carpet/black,
 /area/survivalpod)
@@ -120,7 +116,6 @@
 	dir = 1
 	},
 /obj/structure/displaycase{
-	alert = 0;
 	desc = "A display case containing an expensive forgery, probably.";
 	pixel_y = -4;
 	start_showpiece_type = /obj/item/fakeartefact;
@@ -231,7 +226,7 @@ a
 n
 o
 p
-q
+r
 r
 a
 "}


### PR DESCRIPTION
## What Does This PR Do
This PR removes a tiny corner window in the luxury capsule which was preventing movement through the shelter, pixel shifting two nearby windows to take up the space. The windows were overlapping a nearby door anyway so the change is basically unnoticeable. This is basically the only instance of a corner window being used like this and the movement code, keyed to the dir of the atom, is all scuffed and there's no reason to spend time fixing it when this is the only time it's a problem, as evidenced by the available icon states:
![2025_03_10__19_40_18__icons_obj_lavaland_survival_pod dmi - Paradise (Workspace) - Visual Studio Code](https://github.com/user-attachments/assets/089088d6-6111-4e1f-bdd2-8c4f1b949915)
## Why It's Good For The Game
Movement shouldn't be stopped by something this unnecessary.
## Images of changes
### Before
![2025_03_10__19_37_52__paradise dme  shelter_2 dmm  - StrongDMM](https://github.com/user-attachments/assets/338da9b7-9664-4b80-924f-b6b30a070a10)
### After
![2025_03_10__19_37_43__paradise dme  shelter_2 dmm  - StrongDMM](https://github.com/user-attachments/assets/8662a3dd-948d-48de-ab34-ee6f109ca2b2)
## Testing
Spawned luxury capsule, walked around.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Players can now properly move about the interior of luxury shelter capsules.
/:cl: