### PR TITLE
add miscellanous engineering boards to maint loots table

### DIFF
--- a/code/_globalvars/lists/maint_loot_tables.dm
+++ b/code/_globalvars/lists/maint_loot_tables.dm
@@ -2,9 +2,10 @@ GLOBAL_LIST_INIT(maintenance_loot_tier_0, list(
 	list(
 		// Tools
 		/obj/effect/spawner/random/engineering/tools = 4,
-
 		// Materials
 		/obj/effect/spawner/random/engineering/materials = 4,
+		// Misc eng supplies
+		/obj/effect/spawner/random/engineering/misc = 1,
 		// Plushies
 		/obj/effect/spawner/random/plushies = 1,
 	) = 6,

--- a/code/game/objects/effects/spawners/random/engineering_spawners.dm
+++ b/code/game/objects/effects/spawners/random/engineering_spawners.dm
@@ -3,6 +3,17 @@
 	icon_state = "wrench"
 	record_spawn = TRUE
 
+/obj/effect/spawner/random/engineering/misc
+	name = "miscellaneous engineering supplies spawner"
+	loot = list(
+		/obj/item/airlock_electronics,
+		/obj/item/firelock_electronics,
+		/obj/item/firealarm_electronics,
+		/obj/item/apc_electronics,
+		/obj/item/airalarm_electronics,
+		/obj/item/camera_assembly,
+	)
+
 /obj/effect/spawner/random/engineering/tools
 	name = "Tool spawner"
 	loot = list(


### PR DESCRIPTION
## What Does This PR Do
This PR adds common engineering electronics to the maintenance loot tables, specifically
- airlock electronics
- firelock electronics
- firealarm electronics
- apc electronics
- air alarm electronics
- and camera assemblies.

They have a 1% chance in the 66% chance loot tier of the tier 0 table, so reasonably rare. They won't start flooding maints.
## Why It's Good For The Game
More variety in maint loot table, more emergent scenarios if one of these is needed in a pinch. It honestly feels like an oversight these weren't included because of the amount of other shit like stock parts, tools, and materials.
## Testing
Visual inspection.

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
add: Common engineering electronics may now be found in maintenance loot spawners.
/:cl:
