### PR TITLE
Allow putting items into a janicart's trashbag

### DIFF
--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -58,6 +58,11 @@
 	if(istype(used, /obj/item/reagent_containers))
 		return ITEM_INTERACT_SKIP_TO_AFTER_ATTACK
 
+	if(my_bag)
+		if(my_bag.can_be_inserted(used))
+			my_bag.handle_item_insertion(used, user)
+		return ITEM_INTERACT_COMPLETE
+
 	return ..()
 
 /obj/structure/janitorialcart/proc/handle_janitorial_equipment(mob/living/user, obj/item/used)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds an interaction for stuffing things into the bag for the janicart. It is at the very end of the item interaction chain, so you can't end up stuffing equipment or reagent containers in it unless you remove the bag first. Everything else is handled by the bag's own procs.

## Why It's Good For The Game
Fixes #28636

## Images of changes
![Monke](https://github.com/user-attachments/assets/edbeffb1-6831-4d92-8380-40c0dbf80568)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Spawned as a ~~monke~~ janitor and started interacting with a trashbag, either on its own or in the cart.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Items can be put into a trashbag attached to a janicart
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
