### PR TITLE
[AFD] Child-proofed pill bottles and patch packs

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -349,7 +349,7 @@
 
 /obj/item/storage/pill_bottle/try_opening(mob/user)
 	if(HAS_TRAIT(user, TRAIT_CLUMSY))
-		to_chat(user, "<span class='warning'>Try as much as you want, the child-proof cap twarts your attempts to open [src]!</span>")
+		to_chat(user, "<span class='warning'>Try as much as you want, the child-proof cap thwarts your attempts to open [src]!</span>")
 		return FALSE
 
 	to_chat(user, "<span class='notice'>You start fiddling with the child-proof cap on [src]...</span>")

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -396,6 +396,14 @@
 	rapid_post_instake_message = "stamps the entire contents of the patch pack all over their entire body!"
 	wrapper_state = "patch_pack_wrap"
 
+/obj/item/storage/pill_bottle/try_opening(mob/user)
+	if(HAS_TRAIT(user, TRAIT_CLUMSY))
+		to_chat(user, "<span class='warning'>Try as much as you want, the child-proof lid twarts your attempts to open [src]!</span>")
+		return FALSE
+
+	to_chat(user, "<span class='notice'>You start fiddling with the child-proof lid on [src]...</span>")
+	return do_after(user, rand(2 SECONDS, 5 SECONDS), target = src, allow_moving = TRUE)
+
 /obj/item/storage/pill_bottle/charcoal
 	name = "Pill bottle (Charcoal)"
 	desc = "Contains pills used to counter toxins."

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -396,7 +396,7 @@
 	rapid_post_instake_message = "stamps the entire contents of the patch pack all over their entire body!"
 	wrapper_state = "patch_pack_wrap"
 
-/obj/item/storage/pill_bottle/try_opening(mob/user)
+/obj/item/storage/pill_bottle/patch_pack/try_opening(mob/user)
 	if(HAS_TRAIT(user, TRAIT_CLUMSY))
 		to_chat(user, "<span class='warning'>Try as much as you want, the child-proof lid twarts your attempts to open [src]!</span>")
 		return FALSE

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -347,12 +347,22 @@
 		new /obj/item/reagent_containers/pill/lazarus_reagent(src)
 		new /obj/item/reagent_containers/pill/rezadone(src)
 
+/obj/item/storage/pill_bottle/try_opening(mob/user)
+	if(HAS_TRAIT(user, TRAIT_CLUMSY))
+		to_chat(user, "<span class='warning'>Try as much as you want, the child-proof cap twarts your attempts to open [src]!</span>")
+		return FALSE
+
+	to_chat(user, "<span class='notice'>You start fiddling with the child-proof cap on [src]...</span>")
+	return do_after(user, rand(2 SECONDS, 5 SECONDS), target = src, allow_moving = TRUE)
+	
 /obj/item/storage/pill_bottle/MouseDrop(obj/over_object) // Best utilized if you're a cantankerous doctor with a Vicodin habit.
 	if(iscarbon(over_object))
 		var/mob/living/carbon/C = over_object
 		if(loc == C && src == C.get_active_hand())
 			if(!length(contents))
 				to_chat(C, "<span class='notice'>There is nothing in [src]!</span>")
+				return
+			if(!try_opening(C))
 				return
 			C.visible_message("<span class='danger'>[C] [rapid_intake_message]</span>")
 			if(do_mob(C, C, 100)) // 10 seconds

--- a/code/game/objects/items/weapons/storage/storage_base.dm
+++ b/code/game/objects/items/weapons/storage/storage_base.dm
@@ -250,6 +250,8 @@
 	if(isobserver(user))
 		show_to(user)
 		return
+	if(!try_opening(user))
+		return
 	if(use_sound && isliving(user))
 		playsound(loc, use_sound, 50, TRUE, -5)
 
@@ -587,6 +589,9 @@
 	else
 		..()
 	add_fingerprint(user)
+
+/obj/item/storage/proc/try_opening(mob/user)
+	return TRUE
 
 /obj/item/storage/equipped(mob/user, slot, initial)
 	. = ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
After numerous complaints about irresponsible crewmembers getting access to medication, it is time to make the medbay's inventory safer. Adds child-proof caps to pill bottles and lids to patch packs.

## Why It's Good For The Game
THINK OF THE ~~CLOWNS~~ CHILDREN! 

## Images of changes
![Pills](https://github.com/user-attachments/assets/688609bf-e06f-48bd-890e-9ddf236d3424)

## Testing
Spawned a pill bottle, and tried to get the candies inside. Also tried other storage. 10/10, would curse those safety advocates.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Pill bottles now are child-friendly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
