### PR TITLE
[AFD] remove mindshield restriction from antags

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -6,7 +6,14 @@ GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","E
 	name = "changeling"
 	config_tag = "changeling"
 	restricted_jobs = list("AI", "Cyborg")
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Nanotrasen Representative", "Magistrate", "Internal Affairs Agent", "Nanotrasen Career Trainer", "Nanotrasen Navy Officer", "Special Operations Officer", "Syndicate Officer", "Trans-Solar Federation General", "Nanotrasen Career Trainer", "Research Director", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Quartermaster")
+	protected_jobs = list(
+		"Nanotrasen Career Trainer",
+		"Nanotrasen Navy Officer",
+		"Special Operations Officer",
+		"Syndicate Officer",
+		"Trans-Solar Federation General",
+		"Nanotrasen Career Trainer",
+	)
 	species_to_mindflayer = list("Machine")
 	required_players = 15
 	required_enemies = 1

--- a/code/game/gamemodes/dynamic/antag_rulesets.dm
+++ b/code/game/gamemodes/dynamic/antag_rulesets.dm
@@ -21,24 +21,10 @@
 	var/list/banned_jobs = list("Cyborg")
 	/// These roles can't be antagonists because mindshielding or are command staff (this can be disabled via config)
 	var/list/protected_jobs = list(
-		"Security Officer",
-		"Warden",
-		"Detective",
-		"Head of Security",
-		"Captain",
-		"Blueshield",
-		"Nanotrasen Representative",
-		"Magistrate",
-		"Internal Affairs Agent",
 		"Nanotrasen Career Trainer",
 		"Nanotrasen Navy Officer",
 		"Special Operations Officer",
 		"Trans-Solar Federation General",
-		"Research Director",
-		"Head of Personnel",
-		"Chief Medical Officer",
-		"Chief Engineer",
-		"Quartermaster"
 	)
 	/// Applies the mind roll to assigned_role, preventing them from rolling a normal job. Good for wizards and nuclear operatives.
 	var/assign_job_role = FALSE

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -2,7 +2,13 @@
 	name = "traitor"
 	config_tag = "traitor"
 	restricted_jobs = list("Cyborg")//They are part of the AI if he is traitor so are they, they use to get double chances
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Nanotrasen Representative", "Magistrate", "Internal Affairs Agent", "Nanotrasen Navy Officer", "Special Operations Officer", "Syndicate Officer", "Trans-Solar Federation General", "Nanotrasen Career Trainer", "Research Director", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Quartermaster")
+	protected_jobs = list(
+		"Nanotrasen Navy Officer",
+		"Special Operations Officer",
+		"Syndicate Officer",
+		"Trans-Solar Federation General",
+		"Nanotrasen Career Trainer",
+	)
 	required_players = 0
 	required_enemies = 1
 	recommended_enemies = 4

--- a/code/game/gamemodes/trifecta/trifecta.dm
+++ b/code/game/gamemodes/trifecta/trifecta.dm
@@ -6,7 +6,13 @@
 /datum/game_mode/trifecta
 	name = "Trifecta"
 	config_tag = "trifecta"
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Nanotrasen Representative", "Magistrate", "Internal Affairs Agent", "Nanotrasen Career Trainer", "Nanotrasen Navy Officer", "Special Operations Officer", "Trans-Solar Federation General", "Nanotrasen Career Trainer", "Research Director", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Quartermaster")
+	protected_jobs = list(
+		"Nanotrasen Career Trainer",
+		"Nanotrasen Navy Officer",
+		"Special Operations Officer",
+		"Trans-Solar Federation General",
+		"Nanotrasen Career Trainer",
+	)
 	restricted_jobs = list("Cyborg")
 	secondary_restricted_jobs = list("AI")
 	required_players = 25

--- a/code/game/gamemodes/vampire/traitor_vamp.dm
+++ b/code/game/gamemodes/vampire/traitor_vamp.dm
@@ -2,7 +2,13 @@
 	name = "traitor_vampire"
 	config_tag = "traitorvamp"
 	traitors_possible = 3 //hard limit on traitors if scaling is turned off
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Nanotrasen Representative", "Magistrate", "Internal Affairs Agent", "Nanotrasen Career Trainer", "Nanotrasen Navy Officer", "Special Operations Officer", "Trans-Solar Federation General",  "Research Director", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Quartermaster")
+	protected_jobs = list(
+		"Internal Affairs Agent",
+		"Nanotrasen Career Trainer",
+		"Nanotrasen Navy Officer",
+		"Special Operations Officer",
+		"Trans-Solar Federation General",
+	)
 	restricted_jobs = list("Cyborg")
 	secondary_restricted_jobs = list("AI", "Chaplain")
 	required_players = 10

--- a/code/game/gamemodes/vampire/vampire_chan.dm
+++ b/code/game/gamemodes/vampire/vampire_chan.dm
@@ -2,7 +2,13 @@
 	name = "vampire_changeling"
 	config_tag = "vampchan"
 	restricted_jobs = list("AI", "Cyborg")
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Nanotrasen Representative", "Magistrate", "Chaplain", "Internal Affairs Agent", "Nanotrasen Career Trainer", "Nanotrasen Navy Officer", "Special Operations Officer", "Syndicate Officer", "Solar Federation General", "Research Director", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Quartermaster")
+	protected_jobs = list(
+		"Internal Affairs Agent",
+		"Nanotrasen Career Trainer",
+		"Nanotrasen Navy Officer",
+		"Special Operations Officer",
+		"Trans-Solar Federation General",
+	)
 	species_to_mindflayer = list("Machine")
 	required_players = 15
 	required_enemies = 1

--- a/code/game/gamemodes/vampire/vampire_gamemode.dm
+++ b/code/game/gamemodes/vampire/vampire_gamemode.dm
@@ -2,7 +2,13 @@
 	name = "vampire"
 	config_tag = "vampire"
 	restricted_jobs = list("AI", "Cyborg")
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Nanotrasen Representative", "Magistrate", "Chaplain", "Internal Affairs Agent", "Nanotrasen Career Trainer", "Nanotrasen Navy Officer", "Special Operations Officer", "Syndicate Officer", "Trans-Solar Federation General", "Nanotrasen Career Trainer",  "Research Director", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Quartermaster")
+	protected_jobs = list(
+		"Internal Affairs Agent",
+		"Nanotrasen Career Trainer",
+		"Nanotrasen Navy Officer",
+		"Special Operations Officer",
+		"Trans-Solar Federation General",
+	)
 	species_to_mindflayer = list("Machine")
 	required_players = 15
 	required_enemies = 1


### PR DESCRIPTION
## What Does This PR Do
This PR removes all command, procedure, dignitary, and mindshielded roles from the default antag restriction lists. I know there's a config option to do this for dynamic but a non-config PR is easier to deal with for the purposes of AFD.
## Why It's Good For The Game
If this game's about paranoia it's time to stop being such little bitches about it
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: All standard on-station roles may now roll antag.
/:cl:
