### PR TITLE
[AFD] Planet of the Apes

### DIFF
--- a/code/controllers/subsystem/non_firing/SSlate_mapping.dm
+++ b/code/controllers/subsystem/non_firing/SSlate_mapping.dm
@@ -28,6 +28,7 @@ SUBSYSTEM_DEF(late_mapping)
 		log_startup_progress("Generated [mgcount] mazes in [duration]s")
 
 	maintenance_mice()
+	planet_of_the_apes()
 
 	GLOB.spawn_pool_manager.process_pools()
 
@@ -61,3 +62,12 @@ SUBSYSTEM_DEF(late_mapping)
 			new /mob/living/simple_animal/mouse(pick_n_take(maintenance_turfs))
 
 	log_debug("Spawned [mice_number] mice over in [stop_watch(watch)]s")
+
+/**
+ * Return to monke, some monkeys will evolve
+ */
+/datum/controller/subsystem/late_mapping/proc/planet_of_the_apes()
+	log_startup_progress("Ook, ook... OOK!")
+	for(var/mob/living/carbon/human/monkey/M in GLOB.carbon_list)
+		if(prob(15))
+			M.gorillize()

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -152,6 +152,10 @@
 
 /mob/living/carbon/human/monkey/Initialize(mapload)
 	. = ..(mapload, /datum/species/monkey)
+	if(mapload)
+		return
+	if(prob(10))
+		addtimer(CALLBACK(src, PROC_REF(gorillize), prob(5)), 3 SECONDS) // OH SHIT
 
 /mob/living/carbon/human/farwa/Initialize(mapload)
 	. = ..(mapload, /datum/species/monkey/tajaran)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it so monkeys have a chance to turn into gorillas. Mapload gorillas can't be rampaging, and their step is separate from the monkey init just so pets don't wind up runtiming. We might be returning to monke, but that doesn't mean I'm banging rocks together here, gotta keep it clean.

## Why It's Good For The Game
![gorilla](https://github.com/user-attachments/assets/03370dd0-24e2-425e-b30c-1d449f1da4ea)

## Images of changes
![MangilaGorilla](https://github.com/user-attachments/assets/fe9ef029-2ede-4fbd-86c7-f6d74e928b44)

## Testing
Started an instance and looked around for gorillas, then started spawning monkeys.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: It's time for the apes to reclaim the station
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
