### PR TITLE
[AFD] Slippery Clowns

### DIFF
--- a/code/modules/mob/living/living_status_procs.dm
+++ b/code/modules/mob/living/living_status_procs.dm
@@ -124,6 +124,9 @@ STATUS EFFECTS
 	set_density(FALSE)
 	set_lying_angle(pick(90, 270))
 
+	if(job == "Clown")
+		AddComponent(/datum/component/slippery, src, 4 SECONDS, 100, 0, FALSE)
+
 /mob/living/proc/on_standing_up()
 	if(layer == LYING_MOB_LAYER || HAS_TRAIT(src, TRAIT_CONTORTED_BODY))
 		layer = initial(layer)
@@ -132,6 +135,9 @@ STATUS EFFECTS
 	UnregisterSignal(src, COMSIG_ATOM_DIR_CHANGE)
 	set_lying_angle(0)
 	pixel_y = 0
+
+	if(job == "Clown")
+		DeleteComponent(/datum/component/slippery)
 
 /* makes sure the crawlers head is pointing in the direction they crawl
  * effectively splits dirs down the middle.


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Clowns become slippery when horizontal. They can't just crawl under people to make them slip, though, that's just lazy.

## Why It's Good For The Game
If you somehow lose the tools of the trade, use your own body.

## Images of changes
![Slippery](https://github.com/user-attachments/assets/442d611e-e223-4e24-99d8-c3db7444fe40)


## Testing
Lied on the floor as a clown, had a poor sod step over me.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
add: Clowns are slippery when they're lying down. Or slipped.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
