### PR TITLE
Removes the Pulse Demon event from rotation

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -209,6 +209,7 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Shadow Demon", 		/datum/event/spawn_slaughter/shadow,	20, 	is_one_shot = TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Immovable Rod",		/datum/event/immovable_rod,				0,		list(ASSIGNMENT_ENGINEER = 10), TRUE)
 		//new /datum/event_meta(EVENT_LEVEL_MAJOR, "Floor Cluwne",	/datum/event/spawn_floor_cluwne,	15, is_one_shot = TRUE)
+		//new /datum/event_meta(EVENT_LEVEL_MAJOR, "Pulse Demon Infiltration",	/datum/event/spawn_pulsedemon,	20,	is_one_shot = TRUE)
 	)
 
 

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -207,7 +207,6 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Terror Spiders",		/datum/event/spider_terror, 	15,		list(ASSIGNMENT_SECURITY = 3), TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Slaughter Demon",		/datum/event/spawn_slaughter,	20,  	is_one_shot = TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Shadow Demon", 		/datum/event/spawn_slaughter/shadow,	20, 	is_one_shot = TRUE),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Pulse Demon Infiltration",	/datum/event/spawn_pulsedemon,	20,	is_one_shot = TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Immovable Rod",		/datum/event/immovable_rod,				0,		list(ASSIGNMENT_ENGINEER = 10), TRUE)
 		//new /datum/event_meta(EVENT_LEVEL_MAJOR, "Floor Cluwne",	/datum/event/spawn_floor_cluwne,	15, is_one_shot = TRUE)
 	)


### PR DESCRIPTION
## What Does This PR Do

Title.

Does not affect pulse demon itself or remove any of its code.

## Why It's Good For The Game
Pulse demon is one of the most hated midround antagonists in our lineup. It's unfun to fight, can become godly powerful in a few minutes at the supermatter buffet, and the only ways to kill it are to cut power to the entire station or use ions, which themselves may kill more people than the demon. Plus, its console explosion ability can blow holes in the station, which is extremely lethal with MILLA.

While I understand that this may lead to Pulse becoming deprecated content in the future, better that than leaving a terrible antagonist in the game to steal the show from more enjoyable midrounds.

## Testing

- entered game
- checked admin event panel
- no more pulse demon event

<hr>

### Declaration
![Screenshot 2025-03-16 161032](https://github.com/user-attachments/assets/f5f76f82-a077-4d68-bb92-38b7035d2276)

![Screenshot 2025-03-16 163543](https://github.com/user-attachments/assets/0cddd974-b944-45d2-aa3d-fbd92b9813fd)

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  
<hr>

## Changelog

:cl:
tweak: Removes pulse demon from event rotation.
/:cl:


