### PR TITLE
Buffs the EmeraldStation Emitter Chamber, Also Adds Garbage Can

### DIFF
--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -4277,6 +4277,12 @@
 /obj/structure/closet/cardboard,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fpmaint)
+"aTE" = (
+/obj/structure/girder,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "aTF" = (
 /obj/item/target/syndicate,
 /turf/simulated/floor/plasteel{
@@ -7486,7 +7492,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/closet/firecloset,
+/obj/structure/closet/crate/can,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine)
 "bzh" = (
@@ -10644,6 +10650,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/warehouse)
+"ccA" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/engine)
 "ccY" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -14310,6 +14322,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/fore)
+"cPV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/engine)
 "cPY" = (
 /turf/simulated/wall,
 /area/station/hallway/secondary/entry/west)
@@ -15838,10 +15862,15 @@
 	},
 /area/station/security/armory/secure)
 "dgY" = (
-/obj/structure/sign/electricshock{
-	pixel_x = -32
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine)
 "dhi" = (
@@ -17603,6 +17632,17 @@
 	icon_state = "darkredcorners"
 	},
 /area/station/security/brig)
+"dyI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "dyQ" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel,
@@ -18523,11 +18563,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "dHR" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -20269,6 +20306,17 @@
 	icon_state = "bluecorner"
 	},
 /area/station/engineering/ai_transit_tube)
+"ecs" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "ecx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/oil/maybe,
@@ -21168,6 +21216,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
+"emc" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "emd" = (
 /obj/machinery/light,
 /obj/structure/sign/poster/official/random{
@@ -21642,6 +21701,19 @@
 "eqW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
+"erg" = (
+/obj/item/radio/intercom{
+	name = "south bump";
+	pixel_y = -28
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -23337,14 +23409,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/hallway/primary/starboard)
-"eIp" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "eIv" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -23973,16 +24037,7 @@
 /turf/simulated/floor/carpet/royalblue,
 /area/station/command/office/captain)
 "eOV" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -25233,14 +25288,7 @@
 /turf/simulated/floor/engine/airless/nodecay,
 /area/station/engineering/atmos/asteroid_filtering)
 "fbi" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	name = "south bump";
-	pixel_y = -28
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -25990,6 +26038,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint2)
+"fif" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "fih" = (
 /obj/machinery/light{
 	dir = 8
@@ -27535,6 +27591,13 @@
 "fwH" = (
 /turf/simulated/wall,
 /area/station/maintenance/dorms/port)
+"fwM" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "fwN" = (
 /obj/structure/chair/sofa/bench/left,
 /obj/effect/landmark/start/security_officer,
@@ -27646,9 +27709,9 @@
 /turf/simulated/floor/plating,
 /area/station/security/prisonershuttle)
 "fxM" = (
-/obj/structure/rack,
-/obj/item/crowbar,
-/obj/item/flashlight,
+/obj/structure/table/reinforced,
+/obj/item/weldingtool,
+/obj/item/clothing/head/welding,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -27999,13 +28062,13 @@
 /turf/simulated/floor/plating,
 /area/station/science/break_room)
 "fBH" = (
-/obj/structure/table,
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil{
 	pixel_x = -3;
 	pixel_y = 3
 	},
 /obj/item/multitool,
+/obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -29545,6 +29608,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
+"fQl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "fQq" = (
 /obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/plasteel{
@@ -36210,6 +36281,15 @@
 	icon_state = "purplecorner"
 	},
 /area/station/hallway/primary/starboard/south)
+"hiW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "hja" = (
 /obj/structure/closet/secure_closet/evidence,
 /obj/item/radio/intercom/department/security{
@@ -37868,6 +37948,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/hallway/secondary/exit)
+"hyy" = (
+/obj/structure/table/reinforced,
+/obj/item/crowbar,
+/obj/item/wrench,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "hyB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -39198,6 +39286,13 @@
 /obj/item/storage/fancy/donut_box,
 /turf/simulated/floor/wood,
 /area/station/service/library)
+"hLB" = (
+/obj/item/rpd,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "hLU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -39271,11 +39366,12 @@
 /area/station/maintenance/security/fore)
 "hMP" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
+/turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "hMT" = (
 /obj/structure/barricade/wooden/crude,
@@ -39549,7 +39645,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/effect/turf_decal/stripes/line,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/engineering/engine)
 "hQt" = (
 /obj/structure/table/wood,
@@ -39662,10 +39761,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/wood,
 /area/station/service/bar)
-"hSo" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/station/engineering/engine)
 "hSv" = (
 /obj/effect/spawner/window/reinforced/polarized/grilled{
 	id = "NTR"
@@ -39749,10 +39844,10 @@
 /turf/simulated/wall,
 /area/station/supply/office)
 "hTt" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
+/turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "hTw" = (
 /obj/effect/landmark/start/scientist,
@@ -39798,12 +39893,6 @@
 	icon_state = "browncorner"
 	},
 /area/station/supply/storage)
-"hUu" = (
-/obj/structure/sign/electricshock{
-	pixel_x = -32
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/engine)
 "hUy" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -40372,13 +40461,13 @@
 /turf/simulated/floor/wood,
 /area/station/command/office/ntrep)
 "iag" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/red{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/meter,
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 6
+	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine)
 "iak" = (
@@ -42598,9 +42687,11 @@
 /turf/simulated/floor/plating,
 /area/station/service/kitchen)
 "ixn" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	dir = 4
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine)
@@ -44137,7 +44228,6 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/binary/valve/digital/open{
-	dir = 4;
 	name = "Output Release"
 	},
 /turf/simulated/floor/engine,
@@ -45725,10 +45815,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
 "jbr" = (
-/obj/structure/rack,
-/obj/item/wrench,
-/obj/item/weldingtool,
-/obj/item/clothing/head/welding,
+/obj/structure/table/reinforced,
+/obj/item/flashlight{
+	pixel_x = -2;
+	pixel_y = 7
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -46281,6 +46372,9 @@
 /obj/item/radio/intercom{
 	name = "west bump";
 	pixel_x = -28
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 5
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine)
@@ -47614,6 +47708,14 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/maintenance/dorms/port)
+"jwb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/stripes/line,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "jwc" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/stripes/line,
@@ -52838,6 +52940,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/abandoned_garden)
+"kxw" = (
+/obj/machinery/atmospherics/unary/outlet_injector/on{
+	autolink_id = "engine-waste_out";
+	name = "engine outlet injector";
+	volume_rate = 200
+	},
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
 "kxA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -53575,6 +53685,11 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/public/toilet/unisex)
+"kGW" = (
+/obj/effect/spawner/window/reinforced/plasma/grilled,
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor/plating,
+/area/station/engineering/engine)
 "kGX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
@@ -55920,6 +56035,18 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/supermatter)
+"lfw" = (
+/obj/item/radio/intercom{
+	name = "north bump";
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "lfB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -56764,13 +56891,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8;
-	initialize_directions = 11
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "loU" = (
 /obj/machinery/camera{
@@ -73415,6 +73537,14 @@
 	},
 /turf/simulated/floor/engine/airless,
 /area/station/engineering/atmos)
+"oDL" = (
+/obj/structure/cable,
+/obj/machinery/power/emitter{
+	anchored = 1;
+	state = 2
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/engine)
 "oDM" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
@@ -76560,6 +76690,17 @@
 /obj/structure/lattice/catwalk/mining,
 /turf/simulated/floor/lava/plasma/fuming,
 /area/station/engineering/atmos/asteroid_core)
+"pgI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "pgK" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/secure/briefcase,
@@ -77714,6 +77855,10 @@
 	icon_state = "dark"
 	},
 /area/station/ai_monitored/storage/eva)
+"psz" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/engine,
+/area/station/engineering/engine)
 "psR" = (
 /obj/structure/table,
 /obj/structure/decorative_structures/flammable/lava_land_display{
@@ -78761,18 +78906,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/blueshield)
-"pED" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "pEJ" = (
 /obj/structure/table,
 /obj/item/dest_tagger{
@@ -81611,20 +81744,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/storage/secondary)
-"qiJ" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "qiO" = (
 /obj/machinery/bodyscanner,
 /obj/structure/extinguisher_cabinet{
@@ -84669,17 +84788,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
-"qQB" = (
-/obj/machinery/power/emitter{
-	anchored = 1;
-	dir = 1;
-	state = 2
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/engine)
 "qQE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -85040,13 +85148,6 @@
 /obj/machinery/alarm/directional/east,
 /turf/simulated/floor/carpet/grimey,
 /area/station/service/chapel/office)
-"qUP" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
-/obj/effect/spawner/window/reinforced/plasma/grilled,
-/turf/simulated/floor/plating,
-/area/station/engineering/engine)
 "qUR" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plasteel{
@@ -85139,6 +85240,14 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/misc_lab)
+"qVK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "qVN" = (
 /obj/machinery/atmospherics/binary/valve,
 /obj/structure/cable{
@@ -85873,6 +85982,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard)
+"rcB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "rcE" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/black,
@@ -87970,12 +88090,6 @@
 	icon_state = "caution"
 	},
 /area/station/public/fitness)
-"rxQ" = (
-/obj/machinery/power/emitter,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "rxR" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/simulated/floor/plasteel{
@@ -96913,15 +97027,6 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
-"tja" = (
-/obj/item/radio/intercom{
-	name = "north bump";
-	pixel_y = 28
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "tjl" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
@@ -97508,6 +97613,12 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/atmos/asteroid_filtering)
+"toc" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/engineering/engine)
 "tod" = (
 /obj/machinery/suit_storage_unit/industrial/ce/secure,
 /turf/simulated/floor/plasteel{
@@ -98838,14 +98949,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "tCV" = (
-/obj/structure/table,
-/obj/item/rpd,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -99147,7 +99252,10 @@
 /area/station/medical/medbay)
 "tFC" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
@@ -99441,15 +99549,6 @@
 "tJp" = (
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/supermatter)
-"tJq" = (
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 4;
-	autolink_id = "engine-waste_out";
-	name = "engine outlet injector";
-	volume_rate = 200
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/engineering/engine)
 "tJz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -100163,6 +100262,14 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"tRh" = (
+/obj/structure/reflector/single{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "tRi" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -101643,6 +101750,9 @@
 	network = list("SS13","engine")
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -102569,6 +102679,17 @@
 	icon_state = "darkredcorners"
 	},
 /area/station/security/brig)
+"upA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "upI" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -105456,14 +105577,6 @@
 	icon_state = "darkpurplecorners"
 	},
 /area/station/science/genetics)
-"uSJ" = (
-/obj/machinery/power/emitter{
-	anchored = 1;
-	state = 2
-	},
-/obj/structure/cable,
-/turf/simulated/floor/plating,
-/area/station/engineering/engine)
 "uSL" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -110705,15 +110818,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "vUy" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+	dir = 8;
+	initialize_directions = 11
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/closet/radiation,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine)
 "vUH" = (
@@ -113056,6 +113169,15 @@
 /obj/structure/flora/rock/jungle,
 /turf/simulated/floor/grass,
 /area/station/hallway/secondary/exit)
+"wtb" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "wti" = (
 /obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/plasteel{
@@ -113369,6 +113491,11 @@
 	icon_state = "vault"
 	},
 /area/station/security/armory/secure)
+"wwz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/station/engineering/engine)
 "wwG" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/cyan,
 /turf/simulated/floor/plasteel,
@@ -114078,7 +114205,7 @@
 	name = "west bump";
 	pixel_x = -28
 	},
-/obj/structure/closet/radiation,
+/obj/structure/closet/firecloset,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine)
 "wFV" = (
@@ -117284,9 +117411,9 @@
 	},
 /area/station/security/permabrig)
 "xod" = (
-/obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/t_scanner,
+/obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -118780,6 +118907,11 @@
 /obj/machinery/atmospherics/binary/valve/digital/open,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/asteroid_filtering)
+"xCx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/station/engineering/engine)
 "xCz" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
@@ -119420,6 +119552,17 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/public/toilet/unisex)
+"xJO" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 1;
+	state = 2
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/engine)
 "xJP" = (
 /obj/machinery/power/apc/critical/directional/north,
 /obj/structure/cable{
@@ -120271,12 +120414,10 @@
 /turf/simulated/floor/light/disco,
 /area/station/maintenance/apmaint2)
 "xTC" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "xTF" = (
 /obj/structure/railing{
@@ -120680,6 +120821,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"xWZ" = (
+/obj/structure/reflector/double,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "xXa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -129680,7 +129827,7 @@ gDq
 jnP
 jnP
 jnP
-jnP
+orn
 orn
 orn
 orn
@@ -129694,7 +129841,7 @@ orn
 orn
 orn
 orn
-jnP
+orn
 aZS
 jnP
 jnP
@@ -129937,8 +130084,8 @@ gDq
 aZS
 aZS
 aZS
-aZS
 orn
+hyy
 fxM
 jbr
 orn
@@ -129950,8 +130097,8 @@ orn
 orn
 xod
 fBH
+hLB
 orn
-jnP
 aZS
 jnP
 jnP
@@ -130194,21 +130341,21 @@ gDq
 jnP
 jnP
 aZS
-jnP
 orn
-pHq
 jMN
-pED
+hiW
+wwz
+loR
 ueP
 kPu
 kPu
 kPu
-kPu
+jwb
 loR
-kPu
+xCx
 tCV
+pgI
 orn
-aZS
 aZS
 aZS
 jnP
@@ -130451,21 +130598,21 @@ gDq
 aZS
 aZS
 aZS
-jnP
 orn
-tja
+lfw
+fNu
 xTC
-fNu
-pHq
-pHq
-kqr
-pHq
-pHq
-fNu
+tVC
+ecs
+tRh
+aTE
+wYR
+fwM
+xJO
 hTt
 fbi
+erg
 orn
-jnP
 jnP
 jnP
 jnP
@@ -130708,21 +130855,21 @@ gDq
 jnP
 jnP
 aZS
-jnP
 orn
-eIp
+qVK
+kqr
 hMP
-tVC
-kEj
+oDL
+fQl
 pHq
-rxQ
+eJQ
 pHq
-kEj
-tNa
+cdv
+xJO
 tFC
-qiJ
+kqr
+upA
 orn
-jnP
 jnP
 jnP
 jnP
@@ -130965,21 +131112,21 @@ gDq
 jnP
 aZS
 aZS
-aZS
 orn
+fif
 dHR
 hMP
 tVC
-kEj
+ecs
 pHq
-wYR
 pHq
-kEj
-qQB
+pHq
+fwM
+tNa
 tFC
 eOV
+dyI
 orn
-aZS
 aZS
 jnP
 jnP
@@ -131222,21 +131369,21 @@ gDq
 jnP
 jnP
 jnP
-tJq
 orn
-dHR
-hMP
-uSJ
-hQm
+pHq
+pHq
+ccA
+kEj
+emc
 pHq
 eJQ
-pHq
+xWZ
 hQm
-qQB
-tFC
-eOV
+kEj
+cPV
+wtb
+rcB
 orn
-jnP
 jnP
 jnP
 jnP
@@ -131479,19 +131626,19 @@ gDq
 aZS
 aZS
 orn
-qUP
 orn
+orn
+wDW
 iBX
+wDW
 orn
-hSo
+wDW
+wDW
+wDW
 orn
-hSo
-hSo
-hSo
-orn
-hSo
-orn
+wDW
 vPm
+wDW
 orn
 orn
 orn
@@ -131734,24 +131881,24 @@ gDq
 hcP
 gDq
 jnP
-jnP
-orn
+kxw
+kGW
 iLV
 jhb
+toc
 sJB
-hUu
 xFh
 xFh
 vSq
 evI
 oYa
 xFh
-xFh
+psz
 dgY
 vUy
 wFS
 byY
-orn
+vIo
 jnP
 vru
 pXr
@@ -132250,7 +132397,7 @@ gDq
 jnP
 jnP
 vIo
-nIh
+pMe
 daX
 nsG
 wMb
@@ -132507,7 +132654,7 @@ aZS
 jnP
 jnP
 vIo
-pMe
+nIh
 exT
 mDM
 bgZ


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Increases the width of the Emerald SM emitter chamber by 2 tiles, adds an additional reflector box and reflector, removes an excess emitter, redoes the room's vents and wiring, adds a garbage can to the engine room. Changes the tables in the emitter room to plasteel. Adds some hazard warnings to the floor and otherwise slightly adjusts the feng shui.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
2 emitter boxes is standard across most stations, having somewhere to dispose of garbage is good (box has one). The room in my subjective opinion looks a little better now.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/user-attachments/assets/682abd5e-6d9b-45f5-b6fd-32ef8706b6a0)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Visual confirmation of changes.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
add: Adds a garbage can to the Emerald SM engine room.
add: Adds an extra emitter box and reflector to the Emerald SM emitter chamber.
del: Removes an excess emitter from the emitter chamber.
tweak: Increases the width of the emitter chamber by 2 tiles and turns the tables into plasteel.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
