### PR TITLE
Remove exponential rad wave decay

### DIFF
--- a/code/__DEFINES/radiation_defines.dm
+++ b/code/__DEFINES/radiation_defines.dm
@@ -68,11 +68,6 @@ Ask ninjanomnom if they're around
 /// The portion of a radiation wave that acts on the source tile.
 #define RAD_SOURCE_WEIGHT 0.25
 
-/// The point in steps at which radiation waves start to decay
-#define RAD_DECAY_POINT 10
-/// This multiplies the intensity of the radiation wave each step after reaching the decay point.
-#define RAD_DECAY_RATE 0.7943 // 1% after 20 tiles
-
 #define ALPHA_RAD 1
 #define BETA_RAD 2
 #define GAMMA_RAD 3

--- a/code/datums/radiation_wave.dm
+++ b/code/datums/radiation_wave.dm
@@ -80,9 +80,6 @@
 			offset += 2 * (steps - 1)
 
 	weights = new_weights
-	// With the spread each step being linear waves can spread very far. This limits the distance for performace reasons
-	if(steps > RAD_DECAY_POINT)
-		intensity *= RAD_DECAY_RATE
 
 /// Calls rad act on each relevant atom in the turf and returns the resulting weight for that tile after reduction by insulation
 /datum/radiation_wave/proc/radiate(atom/source, turf/current_turf, weight, emission_type)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes exponential decay of radiation waves past a certain distance.
In the utter majority of situations players won't know the difference, but for things like the singulo that can move about in a big enclosure it can make for some inconsistencies.
Extremely powerful SM setups in the millions of EER can now potentially leak a small amount of radiation into other areas.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This was intended purely as a performance feature, but the loss of performance I observed before adding it was a result of my testing rather than rad waves being too slow. upon retesting, there doesn't seem to be any TIDI even with something impossible like a 100,000,000,000 EER engine that irradiates the entire station.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
- Ran the server separately through dream daemon this time
- Var edited the SM to 100,000,000,000 EER and placed windows all over the place to make sure it's really irradiating very far
- Tested with a 5,000,000 EER engine to make sure it isn't irradiating too far away
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Radiation waves no longer exponentially decay past a certain distance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
