### PR TITLE
fix disposal pipe draw layer

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -841,7 +841,7 @@
 	damage_deflection = 10
 	flags_2 = RAD_PROTECT_CONTENTS_2 | RAD_NO_CONTAMINATE_2
 	plane = FLOOR_PLANE
-	layer = CLOSED_TURF_LAYER				// slightly lower than wires and other pipes
+	layer = DISPOSAL_PIPE_LAYER				// slightly lower than wires and other pipes
 	base_icon_state	// initial icon state on map
 	/// The last time a sound was played from this
 	var/last_sound


### PR DESCRIPTION
## What Does This PR Do
This PR fixes disposal pipes rendering above other underfloor atoms like pipes. I changed this in #28544, probably for debugging purposes, but forgot to change it back. Fixes #28701.
## Why It's Good For The Game
Regression fix.
## Images of changes
### Before
![2025_03_19__14_24_31__paradise dme  boxstation dmm  - StrongDMM](https://github.com/user-attachments/assets/27953820-9bbf-4872-8e23-28cb1a4e164d)
### After
![2025_03_19__14_24_46__paradise dme  boxstation dmm  - StrongDMM](https://github.com/user-attachments/assets/1934f2a7-5c55-4f77-b93b-26a7cfd0306b)
## Testing
Visual inspection.
<hr>

### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Disposals pipes will properly render under atmos pipes under flooring.
/:cl:
