### PR TITLE
Updates pride mirror's code

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -138,7 +138,8 @@
 				AC.flags = APPEARANCE_ALL
 				AC.whitelist = race_list
 				ui_users[user] = AC
-			AC.ui_interact(user)
+			if(user.Adjacent(src))
+				AC.ui_interact(user)
 
 		if("Voice")
 			var/voice_choice = tgui_input_list(user, "Perhaps...", "Voice effects", list("Comic Sans", "Wingdings", "Swedish", "Chav", "Mute"))

--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -305,13 +305,6 @@
 /turf/simulated/floor/chasm/CanPass(atom/movable/mover, border_dir)
 	return TRUE
 
-/turf/simulated/floor/chasm/pride/Initialize(mapload)
-	. = ..()
-	drop_x = x
-	drop_y = y
-	var/list/target_z = levels_by_trait(SPAWN_RUINS)
-	drop_z = pick(target_z)
-
 /turf/simulated/floor/chasm/space_ruin
 	/// Used to keep count of how many times we checked if our target turf was valid.
 	var/times_turfs_checked = 0

--- a/code/modules/ruins/lavalandruin_code/sin_ruins.dm
+++ b/code/modules/ruins/lavalandruin_code/sin_ruins.dm
@@ -161,25 +161,22 @@
 	icon_state = "magic_mirror"
 
 /obj/structure/mirror/magic/pride/curse(mob/user)
-	user.visible_message("<span class='danger'><B>The ground splits beneath [user] as [user.p_their()] hand leaves the mirror!</B></span>", \
+	user.visible_message("<span class='danger'><b>The ground splits beneath [user] as [user.p_their()] hand leaves the mirror!</b></span>", \
 	"<span class='notice'>Perfect. Much better! Now <i>nobody</i> will be able to resist yo-</span>")
 
 	var/turf/T = get_turf(user)
-	var/list/levels = GLOB.space_manager.z_list.Copy()
-	for(var/level in levels)
-		if(!is_teleport_allowed(level))
-			levels -= level
-	if(user.z != 3) //if you somehow manage to bloody get out of lavaland without closing the UI
-		var/turf/return_turf = locate(user.x, user.y, 3) //return to sender
+	if(!user.Adjacent(src)) // Trying to escape?
+		var/turf/return_turf = locate(src.x, src.y-1, src.z) // You will never
 		var/mob/living/carbon/human/fool = user
 		if(return_turf && fool)
-			to_chat(fool, "<span class='danger'><B>You dare try to play me for a fool?</B></span>")
+			to_chat(fool, "<span class='colossus'><b>You dare try to play me for a fool?</b></span>")
 			fool.monkeyize()
 			fool.forceMove(return_turf)
 			return
-	T.ChangeTurf(/turf/simulated/floor/chasm/pride)
-	var/turf/simulated/floor/chasm/C = T
-	C.drop(user)
+	T.ChangeTurf(/turf/simulated/floor/chasm/space_ruin)
+	if(user.Adjacent(src))
+		var/turf/simulated/floor/chasm/space_ruin/C = T
+		C.drop(user)
 
 // Envy
 /// Envy's knife: Found in the Envy ruin. Attackers take on the appearance of whoever they strike.

--- a/code/modules/ruins/lavalandruin_code/sin_ruins.dm
+++ b/code/modules/ruins/lavalandruin_code/sin_ruins.dm
@@ -166,7 +166,7 @@
 
 	var/turf/T = get_turf(user)
 	if(!user.Adjacent(src)) // Trying to escape?
-		var/turf/return_turf = locate(src.x, src.y-1, src.z) // You will never
+		var/turf/return_turf = locate(x, y - 1, z) // To the south one to account for the fact the mirror is on a wall
 		var/mob/living/carbon/human/fool = user
 		if(return_turf && fool)
 			to_chat(fool, "<span class='colossus'><b>You dare try to play me for a fool?</b></span>")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

There is no more dumb z lvl check, instead, whenever you try to use mirror not being next to it - you will get cursed.
Changes span class from tiny `danger` to `colossus`, making it more visible and stylish.
Fixed unintended double `drop()`, removed unused code.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Unused code is useless. This z lvl check also caused the mirror to fuck up the whole idea on downstream, because its Lavaland is located on lvl 4, not 3. Also you are now able to put this mirror anywhere, not only Lavaland. The mirror should be only located to the north of player, tho.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Tested everything i changed. It's working properly.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: You can't fool pride mirror's anymore.
tweak: Message for trying to fool a pride mirror is now more noticable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
