### PR TITLE
refactor map size CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,10 @@ jobs:
           python tools/ci/illegal_dme_files.py ${GITHUB_WORKSPACE}
           python tools/ci/define_sanity.py
           python tools/ci/restrict_file_types.py
-          python tools/ci/check_map_sizes.py
           python tools/ci/verify_sql_version.py
           python tools/ci/no_duplicate_definitions.py
           python tools/ci/check_icons.py
+          python -m tools.ci.check_map_sizes
           python -m tools.ci.check_legacy_attack_chain
           python -m tools.maplint.source --github
 

--- a/tools/ci/check_map_sizes.py
+++ b/tools/ci/check_map_sizes.py
@@ -1,91 +1,64 @@
-import glob
 import os
 import sys
-import subprocess
-import platform
-import json
+from pathlib import Path
 import time
 
-parent_directory = "_maps/**/*.dmm"
+from avulto import DMM
+
+CODE_ROOT = Path(".")
 
 MAX_X_SIZE = 255
 MAX_Y_SIZE = 255
 MAX_Z_SIZE = 1
+FIX_MESSAGE = f"Please make sure maps are <= {MAX_X_SIZE}x{MAX_Y_SIZE}x{MAX_Z_SIZE}."
 
-how_to_fix_message = f"Please make sure maps are <= {MAX_X_SIZE}x{MAX_Y_SIZE}x{MAX_Z_SIZE}."
-
-def green(text):
-    return "\033[32m" + str(text) + "\033[0m"
 
 def red(text):
     return "\033[31m" + str(text) + "\033[0m"
 
-def blue(text):
-    return "\033[34m" + str(text) + "\033[0m"
 
-def post_error(file, map_data, github_error_style):
+def post_error(filepath: str, size, github_error_style: bool):
+    msg = f" is >{MAX_X_SIZE}x{MAX_Y_SIZE}x{MAX_Z_SIZE} (Found: {size.x},{size.y},{size.z})"
     if github_error_style:
-        print(f"::error file={file},title=Map Size::{file} is >{MAX_X_SIZE}x{MAX_Y_SIZE}x{MAX_Z_SIZE} (Found: {map_data['x']},{map_data['y']},{map_data['z']})!")
+        print(f"::error file={filepath},title=Map Size::{filepath}{msg}")
     else:
-        print(f"- Failure: {red(file)} is is >{MAX_X_SIZE}x{MAX_Y_SIZE}x{MAX_Z_SIZE} (Found: {map_data['x']},{map_data['y']},{map_data['z']})")
+        print(f"- Failure: {red(filepath)}{msg}")
 
-def do_dmmtools_call(file):
-    # Windows - hopefully local
-    exec_path = None
-    if platform.system() == 'Windows':
-        exec_path = "dmm-tools.exe"
-    # Linux - CI
-    else:
-        exec_path = "tools/github-actions/nanomap-renderer"
-
-    exec_args = f"{exec_path} map-info \"{file}\""
-    result = subprocess.run(exec_args, shell=True, capture_output=True, text=True)
-
-    res_obj = json.loads(result.stdout)
-
-    return_obj = {
-        "x": res_obj[file]["size"][0],
-        "y": res_obj[file]["size"][1],
-        "z": res_obj[file]["size"][2]
-    }
-
-    return return_obj
 
 def main():
+    print("check_map_sizes started")
+    exit_code = 0
     start = time.time()
     # simple way to check if we're running on github actions, or on a local machine
     on_github = os.getenv("GITHUB_ACTIONS") == "true"
 
-    maps_greater_than_allowed = []
-
+    failures = []
     map_count = 0
 
-    for map_file in glob.glob(parent_directory, recursive=True):
+    for map_file in (CODE_ROOT / "_maps/map_files").glob("**/*.dmm"):
         map_count += 1
-        # Open the map in the nanomap dmm tools - it works
-        map_data = do_dmmtools_call(map_file)
+        dmm = DMM.from_file(map_file)
 
-        if map_data["x"] > MAX_X_SIZE or map_data["y"] > MAX_Y_SIZE or map_data["z"] > MAX_Z_SIZE:
-            maps_greater_than_allowed.append((map_file, map_data))
+        if (
+            dmm.size.x > MAX_X_SIZE
+            or dmm.size.y > MAX_Y_SIZE
+            or dmm.size.z > MAX_Z_SIZE
+        ):
+            failures.append((map_file.relative_to(CODE_ROOT), dmm.size))
 
-    if len(maps_greater_than_allowed):
-        for error in maps_greater_than_allowed:
+    if failures:
+        exit_code = 1
+
+        for error in failures:
             post_error(error[0], error[1], on_github)
 
-        print(red(how_to_fix_message))
-
-        end = time.time()
-        print(f"\ncheck_map_sizes.py completed in {(end - start):.2f}s\n")
-
-        sys.exit(1)
-
-    else:
-        print(green(f"No oversized maps found (checked {map_count} maps)."))
+        print(red(FIX_MESSAGE))
 
     end = time.time()
-    print(f"\ncheck_map_sizes.py completed in {(end - start):.2f}s\n")
+    print(f"check_map_sizes.py completed in {(end - start):.2f}s")
+
+    sys.exit(exit_code)
+
 
 if __name__ == "__main__":
     main()
-
-

--- a/tools/ci/check_map_sizes.py
+++ b/tools/ci/check_map_sizes.py
@@ -55,7 +55,7 @@ def main():
         print(red(FIX_MESSAGE))
 
     end = time.time()
-    print(f"check_map_sizes.py completed in {(end - start):.2f}s")
+    print(f"check_map_sizes.py checked {map_count} maps in {(end - start):.2f}s")
 
     sys.exit(exit_code)
 


### PR DESCRIPTION
## What Does This PR Do
This PR refactors the map size check CI. The current check looked up map size by running nanomap-renderer with special args to print out map metadata, requiring looking up the system platform to run the right windows/linux executable, parsing STDOUT, etc. I don't know if this is necessarily faster but it's much less complicated and much more in line with the expected style and output of the rest of our CI checks.
## Why It's Good For The Game
Less complicated Python scripts.
## Testing
sample run:
![2025_03_20__10_16_24__Open](https://github.com/user-attachments/assets/83fd9549-ed33-4ba6-9d4c-52cb87d90cac)
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
NPFC
