### PR TITLE
Adds basic healing supplies to the nanomed in stardard shelters, and givesthe luxury shelter a standard nanomed 

### DIFF
--- a/_maps/map_files/templates/shelter_1.dmm
+++ b/_maps/map_files/templates/shelter_1.dmm
@@ -28,7 +28,7 @@
 /area/survivalpod)
 "g" = (
 /obj/machinery/sleeper/survival_pod,
-/obj/machinery/economy/vending/wallmed/directional/west,
+/obj/machinery/economy/vending/wallmed/survival_pod/directional/west,
 /turf/simulated/floor/pod,
 /area/survivalpod)
 "h" = (

--- a/_maps/map_files/templates/shelter_1.dmm
+++ b/_maps/map_files/templates/shelter_1.dmm
@@ -28,7 +28,7 @@
 /area/survivalpod)
 "g" = (
 /obj/machinery/sleeper/survival_pod,
-/obj/machinery/economy/vending/wallmed/survival_pod/directional/west,
+/obj/machinery/economy/vending/wallmed/directional/west,
 /turf/simulated/floor/pod,
 /area/survivalpod)
 "h" = (

--- a/_maps/map_files/templates/shelter_2.dmm
+++ b/_maps/map_files/templates/shelter_2.dmm
@@ -37,7 +37,7 @@
 /area/survivalpod)
 "i" = (
 /obj/machinery/sleeper/survival_pod,
-/obj/machinery/economy/vending/wallmed/survival_pod/directional/west,
+/obj/machinery/economy/vending/wallmed/directional/west,
 /turf/simulated/floor/pod,
 /area/survivalpod)
 "j" = (

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -194,6 +194,7 @@
 				/obj/item/stack/medical/ointment = 1,
 				/obj/item/reagent_containers/syringe/charcoal = 1,
 				/obj/item/reagent_containers/hypospray/autoinjector/epinephrine = 2,
+				/obj/item/stack/medical/splint = 1,
 	)
 	contraband = list()
 

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -185,6 +185,20 @@
 	component_parts += new /obj/item/stack/cable_coil(null, 1)
 	RefreshParts()
 
+//NanoMed
+/obj/machinery/economy/vending/wallmed/survival_pod
+	name = "survival pod emergency medical supply"
+	desc = "Wall-mounted Medical Equipment dispenser. This one seems just a tiny bit smaller."
+
+	products = list(/obj/item/stack/medical/bruise_pack = 1,
+				/obj/item/stack/medical/ointment = 1,
+				/obj/item/reagent_containers/syringe/charcoal = 1,
+				/obj/item/reagent_containers/hypospray/autoinjector/epinephrine = 2,
+)
+	contraband = list()
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/economy/vending/wallmed/survival_pod, 32, 32)
+
 //Computer
 /obj/item/gps/computer
 	name = "pod computer"

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -194,7 +194,7 @@
 				/obj/item/stack/medical/ointment = 1,
 				/obj/item/reagent_containers/syringe/charcoal = 1,
 				/obj/item/reagent_containers/hypospray/autoinjector/epinephrine = 2,
-)
+	)
 	contraband = list()
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/economy/vending/wallmed/survival_pod, 32, 32)

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -185,17 +185,6 @@
 	component_parts += new /obj/item/stack/cable_coil(null, 1)
 	RefreshParts()
 
-//NanoMed
-/obj/machinery/economy/vending/wallmed/survival_pod
-	name = "survival pod medical supply"
-	desc = "Wall-mounted Medical Equipment dispenser. This one seems just a tiny bit smaller."
-	req_access = list()
-
-	products = list(/obj/item/stack/medical/splint = 2)
-	contraband = list()
-
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/economy/vending/wallmed/survival_pod, 32, 32)
-
 //Computer
 /obj/item/gps/computer
 	name = "pod computer"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
changes the vender in the emergency standard shelter to include 1 stack of splints 1 stack of gauze 1 stack of ointment 1 charcoal syringe 2 and epipens.
Also changes the luxury vender to a normal station nanomed 
also adds "emergency" to the name of the standard shelters vender 
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The nano med that the survival pods have currently are hilariously useless, as you rarely ever need splints, since legion cores, and it lacks anything else

This changes that so over healing 0
you can heal a maximum of 60 brute/burn with 15u of charcoal
Plus the weak donks i the shelter storage, however they heal such a low amount you're unlikely to get any good use out of them in an emergency

Point being, its an emergency shelter, that lacks proper medical supplies. It just doesn't make sense to me why a shelter thats meant to save your life.. can't? outside of hunger, and ash storms. While yes it has a sleeper, you need 2 people to operate it, and the best thing you can get is saline and salbu, while the salbutamol helps alot in crit, you're still facing the minimal brute healing from saline and weak omni.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![dreamseeker_SKkvp0zL3v](https://github.com/user-attachments/assets/9fbc37af-bb71-45a2-a4e5-e22849ebf7ad)

![ApplicationFrameHost_01MVNVhmFJ](https://github.com/user-attachments/assets/fcc567a2-6ec6-4b7d-bc73-1a43a50798dc)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
seee above
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
Not sec/antag changes/content from what i understand you dont need pre-approval
<hr>

## Changelog

:cl:
tweak: The standard shelter has gotten basic medical supplies, and a name tweak
tweak: The luxury survival shelters now comes with proper nano med
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
