### PR TITLE
reword shadow crawl ability description

### DIFF
--- a/code/datums/spells/bloodcrawl.dm
+++ b/code/datums/spells/bloodcrawl.dm
@@ -268,7 +268,7 @@
 
 /datum/spell/bloodcrawl/shadow_crawl
 	name = "Shadow Crawl"
-	desc = "Fade into the shadows, increasing your speed and making you incomprehensible. Will not work in brightened terrane."
+	desc = "Fade into the shadows, increasing your speed and making you incomprehensible. Will not work in lit areas."
 	allowed_type = /turf
 	action_background_icon_state = "shadow_demon_bg"
 	action_icon_state = "shadow_crawl"


### PR DESCRIPTION
## What Does This PR Do
This PR simplifies the description of the shadow crawl power. Rather than just change the spelling of "terrane" to "terrain", I just used smaller words. I'm not even sure if "incomprehensible" is also the intended word usage here. Like, they probably just mean invisible right? It could literally mean "unable to be comprehended (with the senses)" but that feels kind of overwrought when they could just say "invisible". Whatever.
## Why It's Good For The Game
Easier to read.
## Testing
Visual inspection.

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Reworded the description of the shadow crawl ability to be clearer.
/:cl:
