### PR TITLE
Makes Space Heaters Into Constructable Machines and Slightly Improves Them

### DIFF
--- a/code/game/machinery/machine_frame.dm
+++ b/code/game/machinery/machine_frame.dm
@@ -420,6 +420,17 @@ to destroy them and players will be able to make replacements.
 							/obj/item/stack/cable_coil = 1,
 							/obj/item/stack/sheet/glass = 1)
 
+/obj/item/circuitboard/space_heater
+	board_name = "Space Heater"
+	icon_state = "engineering"
+	build_path = /obj/machinery/space_heater
+	board_type = "machine"
+	origin_tech = "programming=3;plasmatech=3"
+	req_components = list(
+							/obj/item/stock_parts/micro_laser = 1,
+							/obj/item/stock_parts/capacitor = 1,
+							/obj/item/stock_parts/cell = 1)
+
 /obj/item/circuitboard/recharger
 	board_name = "Recharger"
 	icon_state = "security"

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -1,15 +1,14 @@
 /obj/machinery/space_heater
-	anchored = FALSE
-	density = TRUE
-	icon = 'icons/obj/atmos.dmi'
-	icon_state = "sheater0"
 	name = "space heater"
 	desc = "Made by Space Amish using traditional space techniques, this heater is guaranteed not to set the station on fire."
+	icon = 'icons/obj/atmos.dmi'
+	icon_state = "sheater0"
+	anchored = FALSE
+	density = TRUE
 	max_integrity = 250
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, RAD = 100, FIRE = 80, ACID = 10)
 	var/obj/item/stock_parts/cell/cell
 	var/on = FALSE
-	var/open = FALSE
 	var/set_temperature = 50		// in celcius, add T0C for kelvin
 	var/heating_power = 40000
 
@@ -18,9 +17,25 @@
 
 /obj/machinery/space_heater/Initialize(mapload)
 	. = ..()
-	cell = new /obj/item/stock_parts/cell(src)
+	component_parts = list()
+	component_parts += new /obj/item/circuitboard/space_heater(null)
+	component_parts += new /obj/item/stock_parts/capacitor(null)
+	component_parts += new /obj/item/stock_parts/micro_laser(null)
+	component_parts += new /obj/item/stock_parts/cell(null)
+	RefreshParts()
 	update_icon()
 	return
+
+/obj/machinery/space_heater/RefreshParts()
+	cell = null
+	for(var/obj/item/stock_parts/cell/P in component_parts)
+		cell = P
+
+/obj/machinery/space_heater/deconstruct(disassembled)
+	if(cell)
+		cell.forceMove(loc)
+		cell = null
+	return ..()
 
 /obj/machinery/space_heater/Destroy()
 	QDEL_NULL(cell)
@@ -31,13 +46,13 @@
 
 /obj/machinery/space_heater/update_overlays()
 	. = ..()
-	if(open)
+	if(panel_open)
 		. += "sheater-open"
 
 /obj/machinery/space_heater/examine(mob/user)
 	. = ..()
-	. += "The heater is [on ? "on" : "off"] and the hatch is [open ? "open" : "closed"]."
-	if(open)
+	. += "The heater is [on ? "on" : "off"] and the hatch is [panel_open ? "open" : "closed"]."
+	if(panel_open)
 		. += "The power cell is [cell ? "installed" : "missing"]."
 	else
 		. += "The charge meter reads [cell ? round(cell.percent(),1) : 0]%"
@@ -54,42 +69,60 @@
 	if(!istype(used, /obj/item/stock_parts/cell))
 		return ..()
 
-	if(!open)
+	if(!panel_open)
 		to_chat(user, "The hatch must be open to insert a power cell.")
 		return ITEM_INTERACT_COMPLETE
 
 	if(cell)
 		to_chat(user, "There is already a power cell inside.")
 		return ITEM_INTERACT_COMPLETE
-	else
-		// insert cell
-		var/obj/item/stock_parts/cell/C = user.get_active_hand()
-		C.add_fingerprint(user)
-		user.visible_message("<span class='notice'>[user] inserts a power cell into [src].</span>",\
-			"<span class='notice'>You insert the power cell into [src].</span>")
 
+	// insert cell
+	var/obj/item/stock_parts/cell/C = used
+	if(!user.drop_item())
+		to_chat(user, "<span class='warning'>[used] is stuck to your hand!</span>")
 		return ITEM_INTERACT_COMPLETE
 
-/obj/machinery/space_heater/screwdriver_act(mob/user, obj/item/I)
+	component_parts += C
+	RefreshParts()
+	cell.forceMove(src)
+	C.add_fingerprint(user)
+	user.visible_message(
+		"<span class='notice'>[user] inserts a power cell into [src].</span>",
+		"<span class='notice'>You insert the power cell into [src].</span>"
+		)
+	return ITEM_INTERACT_COMPLETE
+
+/obj/machinery/space_heater/screwdriver_act(mob/living/user, obj/item/I)
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	open = !open
-	if(open)
+
+	panel_open = !panel_open
+	if(panel_open)
 		SCREWDRIVER_OPEN_PANEL_MESSAGE
+		on = FALSE
 	else
 		SCREWDRIVER_CLOSE_PANEL_MESSAGE
 	update_icon()
-	if(!open && user.machine == src)
+	if(!panel_open && user.machine == src)
 		user << browse(null, "window=spaceheater")
 		user.unset_machine()
+
+/obj/machinery/space_heater/crowbar_act(mob/living/user, obj/item/I)
+	if(panel_open && !on && default_deconstruction_crowbar(user, I))
+		return TRUE
+
+/obj/machinery/space_heater/wrench_act(mob/living/user, obj/item/I)
+	default_unfasten_wrench(user, I, 0)
+	return TRUE	
 
 /obj/machinery/space_heater/attack_hand(mob/user as mob)
 	src.add_fingerprint(user)
 	interact(user)
 
 /obj/machinery/space_heater/interact(mob/user as mob)
-	if(open)
+	if(panel_open)
 		var/dat
 		dat = "Power cell: "
 		if(cell)
@@ -116,10 +149,10 @@
 		update_icon()
 	return
 
-
 /obj/machinery/space_heater/Topic(href, href_list)
 	if(..())
-		return 1
+		return TRUE
+
 	if((in_range(src, usr) && isturf(src.loc)) || (issilicon(usr)))
 		usr.set_machine(src)
 
@@ -132,34 +165,43 @@
 				set_temperature = dd_range(0, 90, set_temperature + value)
 
 			if("cellremove")
-				if(open && cell && !usr.get_active_hand())
+				if(panel_open && cell && !usr.get_active_hand())
 					cell.update_icon()
 					cell.forceMove(loc)
 					if(Adjacent(usr) && !issilicon(usr))
 						usr.put_in_hands(cell)
 					cell.add_fingerprint(usr)
-					cell = null
-					usr.visible_message("<span class='notice'>[usr] removes the power cell from [src].</span>", "<span class='notice'>You remove the power cell from [src].</span>")
-
+				for(var/obj/item/stock_parts/cell/C in component_parts)
+					component_parts -= C
+				cell = null
+				RefreshParts()
+				usr.visible_message(
+					"<span class='notice'>[usr] removes the power cell from [src].</span>",
+					"<span class='notice'>You remove the power cell from [src].</span>"
+					)
 
 			if("cellinstall")
-				if(open && !cell)
+				if(panel_open && !cell)
 					var/obj/item/stock_parts/cell/C = usr.get_active_hand()
 					if(istype(C))
-						usr.drop_item()
-						cell = C
-						C.loc = src
-						C.add_fingerprint(usr)
+						if(usr.drop_item())
+							component_parts += C
+							RefreshParts()
+							C.forceMove(src)
+							C.add_fingerprint(usr)
 
-						usr.visible_message("<span class='notice'>[usr] inserts a power cell into [src].</span>", "<span class='notice'>You insert the power cell into [src].</span>")
+							usr.visible_message(
+								"<span class='notice'>[usr] inserts a power cell into [src].</span>",
+								"<span class='notice'>You insert the power cell into [src].</span>"
+								)
+						else
+							to_chat(usr, "<span class='warning'>[C] is stuck to your hand!</span>")
 
 		updateDialog()
 	else
 		usr << browse(null, "window=spaceheater")
 		usr.unset_machine()
 	return
-
-
 
 /obj/machinery/space_heater/process()
 	var/datum/milla_safe/space_heater_process/milla = new()

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -12,6 +12,16 @@
 	build_path = /obj/item/circuitboard/thermomachine
 	category = list ("Engineering Machinery")
 
+/datum/design/space_heater
+	name = "Machine Board (Space Heater)"
+	desc = "The circuit board for a space heater"
+	id = "space_heater"
+	req_tech = list("programming" = 3, "plasmatech" = 3)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 1000)
+	build_path = /obj/item/circuitboard/space_heater
+	category = list ("Engineering Machinery")
+
 /datum/design/recharger
 	name = "Machine Board (Weapon Recharger)"
 	desc = "The circuit board for a weapon recharger."


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Nanotrasen has finally reverse-engineered the traditional techniques of the Space Amish used to make the Space Heater. Space Heater circuits can now be printed at the circuit imprinter. The machine itself requires 1 power cell, 1 micro laser, and one capacitor to construct.

The space heater can now be wrenched to the floor to avoid it getting pushed around by space heaters, space men, or other space phenomena.

Unscrewing the heater immediately turns it off.

I have not touched the crusty old webUI interface of the space heater because it scares me.

Currently higher tier parts do nothing for the machine except for the cell.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
We can finally build heaters instead of relying purely whether or not mappers decided to add them to particular areas.

If space heaters are destroyed, they can be replaced.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Printed off the parts needed to build a space heater at RND.
Turned it on and off.
Unscrewed it, checked that doing so turned it off.
Removed the cell. Replaced it using both the `item_interaction()` and webUI.
Deconstructed it with and without an installed cell.
Repeated all the above but as a cyborg.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
add: Added the ability to build space heaters (1 power cell, 1 capacitor, 1 micro laser). Higher tier parts currently have no effect besides the cell.
tweak: Space Heaters can now be wrenched.
tweak: Space Heaters are now constructable/deconstructable machines.
tweak: Space Heaters turn off when unscrewed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
