### PR TITLE
refactor: speed up emergency light change

### DIFF
--- a/code/modules/power/lights.dm
+++ b/code/modules/power/lights.dm
@@ -766,13 +766,12 @@
 
 // attempts to set emergency lights
 /obj/machinery/light/proc/set_emergency_lights()
-	var/area/current_area = get_area(src)
-	var/obj/machinery/power/apc/current_apc = current_area.get_apc()
+	var/obj/machinery/power/apc/current_apc = machine_powernet?.powernet_apc
 	if(status != LIGHT_OK || !current_apc || flickering || no_emergency)
-		emergency_lights_off(current_area, current_apc)
+		emergency_lights_off(current_apc)
 		return
 	if(current_apc.emergency_lights || !current_apc.emergency_power)
-		emergency_lights_off(current_area, current_apc)
+		emergency_lights_off(current_apc)
 		return
 	if(fire_mode)
 		set_light(nightshift_light_range, nightshift_light_power, bulb_emergency_colour)
@@ -783,7 +782,7 @@
 	update_icon()
 	RegisterSignal(machine_powernet, COMSIG_POWERNET_POWER_CHANGE, PROC_REF(update), override = TRUE)
 
-/obj/machinery/light/proc/emergency_lights_off(area/current_area, obj/machinery/power/apc/current_apc)
+/obj/machinery/light/proc/emergency_lights_off(obj/machinery/power/apc/current_apc)
 	set_light(0, 0, 0) //you, sir, are off!
 	if(current_apc)
 		RegisterSignal(machine_powernet, COMSIG_POWERNET_POWER_CHANGE, PROC_REF(update), override = TRUE)


### PR DESCRIPTION
## What Does This PR Do
This PR changes how lights lookup their managing APC when being set to emergency lights. Previously, on every power change which required emergency lighting, every light would receive a signal and perform a `/area/proc/get_apc()` call on its area, which iterates over every APC in the world before returning the relevant one, instead of just checking the APC in the light's powernet, which has to be the same one, because every area can only have one APC.
## Why It's Good For The Game
Tiny tiny performance improvement.
## Testing
Turned off light channel on APCs on station, ensured emergency lights still worked. Added a light to the druglab ruin, spawned multiple drug lab ruins, and ensured that turning the power off on one of them did not effect the lights on the other one.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
NPFC
