### PR TITLE
Buffs the Pencil Shuttle

### DIFF
--- a/_maps/map_files/shuttles/emergency_cramped.dmm
+++ b/_maps/map_files/shuttles/emergency_cramped.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/space,
+/turf/simulated/wall/mineral/titanium,
 /area/space)
 "b" = (
 /turf/simulated/wall/mineral/titanium,
@@ -10,12 +10,24 @@
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "f" = (
-/obj/machinery/computer/emergency_shuttle,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/light/spot{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
+"h" = (
+/turf/template_noop,
+/area/template_noop)
 "i" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law/black,
+/obj/machinery/door/airlock/titanium/glass{
+	name = "Shuttle Hatch";
+	id_tag = "s_docking_airlock";
+	hackProof = 1;
+	aiControlDisabled = 1
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "j" = (
@@ -25,16 +37,17 @@
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "k" = (
-/obj/structure/table,
-/obj/item/gps,
-/turf/simulated/floor/plating,
+/obj/machinery/door/window/reinforced/normal{
+	dir = 8;
+	name = "Brig"
+	},
+/turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "l" = (
-/obj/machinery/door/airlock/titanium{
-	aiControlDisabled = 1;
-	hackProof = 1;
-	id_tag = "s_docking_airlock";
-	name = "Shuttle Hatch"
+/obj/structure/table,
+/obj/item/gps,
+/obj/machinery/light/spot{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
@@ -42,48 +55,34 @@
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "n" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
+/obj/machinery/computer/emergency_shuttle,
 /turf/simulated/floor/plating,
-/area/shuttle/escape)
+/area/space)
 "o" = (
-/obj/machinery/door/window/classic/normal{
-	dir = 1
-	},
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "p" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/closet/emcloset,
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "q" = (
-/obj/machinery/door/airlock/titanium{
-	aiControlDisabled = 1;
-	hackProof = 1;
-	id_tag = "s_docking_airlock";
-	name = "Shuttle Hatch"
+/obj/machinery/door/airlock/titanium/glass{
+	name = "Cockpit"
 	},
-/obj/docking_port/mobile/emergency{
-	name = "Secure Transport Vessel 5";
-	timid = 1
-	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "r" = (
-/obj/effect/turf_decal/delivery/hollow,
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance,
 /obj/machinery/light/spot{
 	dir = 4
 	},
+/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "s" = (
@@ -102,6 +101,16 @@
 /obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/crate,
 /turf/simulated/floor/plating,
+/area/shuttle/escape)
+"x" = (
+/obj/structure/window/plastitanium{
+	dir = 1
+	},
+/obj/structure/window/plastitanium{
+	dir = 8
+	},
+/obj/structure/chair/comfy/shuttle,
+/turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "y" = (
 /obj/structure/closet/emcloset,
@@ -128,49 +137,81 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/escape)
+"D" = (
+/obj/docking_port/mobile/emergency{
+	name = "Secure Transport Vessel 5";
+	timid = 1
+	},
+/obj/machinery/door/airlock/titanium/glass{
+	name = "Shuttle Hatch";
+	id_tag = "s_docking_airlock";
+	hackProof = 1;
+	aiControlDisabled = 1
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/escape)
+"I" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law/black,
+/obj/item/storage/firstaid/regular,
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/escape)
+"V" = (
+/obj/effect/spawner/window/shuttle,
+/turf/simulated/floor/plating,
+/area/space)
 
 (1,1,1) = {"
+h
+a
 a
 b
+i
 b
-l
-b
-q
+D
 b
 c
 c
 c
 b
-l
+i
 b
-l
+i
+b
 b
 b
 "}
 (2,1,1) = {"
-b
-b
-i
+a
+a
+I
 m
-n
+m
+c
+m
+f
+s
+s
+s
+s
+m
+f
 m
 s
-s
-s
-s
-s
-m
-s
-m
 z
 B
 "}
 (3,1,1) = {"
-c
-f
+V
+n
 j
 m
-o
+m
+q
+m
 m
 m
 m
@@ -184,37 +225,41 @@ z
 C
 "}
 (4,1,1) = {"
-b
-b
+a
+a
+l
+x
 k
-m
-p
-r
+c
+y
 r
 u
+u
+p
 w
-w
-r
-r
-r
+u
+u
+o
 y
 z
 C
 "}
 (5,1,1) = {"
+h
+a
 a
 b
+c
 b
-b
-b
-b
+c
 b
 c
 c
 c
 b
+c
 b
-b
+c
 b
 b
 b

--- a/_maps/map_files/shuttles/emergency_cramped.dmm
+++ b/_maps/map_files/shuttles/emergency_cramped.dmm
@@ -1,7 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/turf/simulated/wall/mineral/titanium,
-/area/space)
 "b" = (
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/escape)
@@ -15,6 +12,16 @@
 	},
 /obj/machinery/light/spot{
 	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/escape)
+"g" = (
+/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance,
+/obj/item/radio/intercom{
+	name = "east bump";
+	pixel_x = 28
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
@@ -41,14 +48,35 @@
 	dir = 8;
 	name = "Brig"
 	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig{
+	dir = 8
+	},
 /turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "l" = (
-/obj/structure/table,
-/obj/item/gps,
-/obj/machinery/light/spot{
-	dir = 4
+/obj/item/book/manual/wiki/security_space_law/black{
+	pixel_x = 7;
+	pixel_y = 4
 	},
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 19
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 37
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 28
+	},
+/obj/item/radio/intercom{
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/table/reinforced,
+/obj/item/restraints/handcuffs{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/flash,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "m" = (
@@ -57,16 +85,11 @@
 "n" = (
 /obj/machinery/computer/emergency_shuttle,
 /turf/simulated/floor/plating,
-/area/space)
+/area/shuttle/escape)
 "o" = (
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/delivery/hollow,
 /obj/effect/spawner/random/maintenance,
-/turf/simulated/floor/plating,
-/area/shuttle/escape)
-"p" = (
-/obj/structure/closet/crate,
-/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "q" = (
@@ -100,6 +123,10 @@
 "w" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance,
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_x = 28
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "x" = (
@@ -110,10 +137,14 @@
 	dir = 8
 	},
 /obj/structure/chair/comfy/shuttle,
+/obj/structure/sign/poster/official/obey{
+	pixel_x = 32
+	},
 /turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "y" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/firecloset/full,
+/obj/machinery/economy/vending/wallmed/directional/east,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "z" = (
@@ -150,45 +181,79 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
-"I" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law/black,
-/obj/item/storage/firstaid/regular,
-/obj/machinery/light/spot{
-	dir = 8
+"F" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_x = -28
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
-"V" = (
-/obj/effect/spawner/window/shuttle,
+"G" = (
+/turf/simulated/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"I" = (
+/obj/item/storage/firstaid/regular{
+	pixel_x = -5
+	},
+/obj/item/gps{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_y = 28
+	},
+/obj/structure/extinguisher_cabinet{
+	name = "west bump";
+	pixel_x = -27
+	},
+/obj/structure/table/reinforced,
 /turf/simulated/floor/plating,
-/area/space)
+/area/shuttle/escape)
+"M" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/economy/vending/wallmed/directional/west,
+/turf/simulated/floor/plating,
+/area/shuttle/escape)
+"P" = (
+/obj/structure/closet/fireaxecabinet{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/escape)
+"U" = (
+/obj/structure/closet/firecloset/full,
+/turf/simulated/floor/plating,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 h
-a
-a
 b
+G
+G
 i
-b
+G
 D
-b
+G
 c
 c
 c
-b
+G
 i
-b
+G
 i
-b
-b
-b
+G
+G
+h
 "}
 (2,1,1) = {"
-a
-a
+b
+G
 I
-m
+P
 m
 c
 m
@@ -196,16 +261,16 @@ f
 s
 s
 s
-s
+F
 m
 f
 m
-s
+M
 z
 B
 "}
 (3,1,1) = {"
-V
+c
 n
 j
 m
@@ -225,20 +290,20 @@ z
 C
 "}
 (4,1,1) = {"
-a
-a
+b
+G
 l
 x
 k
 c
-y
+U
 r
 u
 u
-p
+o
 w
 u
-u
+g
 o
 y
 z
@@ -246,21 +311,21 @@ C
 "}
 (5,1,1) = {"
 h
-a
-a
 b
+G
+G
 c
-b
+G
 c
-b
+G
 c
 c
 c
-b
+G
 c
-b
+G
 c
-b
-b
-b
+G
+G
+h
 "}


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Alters the pencil shuttle in the following ways:
- The bridge now has AN ENTIRE ONE (1) EXTRA TILE of floor space.
- Adds a 1x2 tile brig. Living antagonists with successful double kill objectives can now be redtexted. This reduces security bloodlust pressure (slightly).
- The partition between the cockpit and the rest of the ship is now made of full-tile windows and airlocks. The amount of floor space in the crew section has not been changed.
- There are now 2 wall-mounted O2 lockers in the crew section, and 1 in the cockpit.
- There are now 2 wall-mounted first aid vendors to allow rudimentary healthcare.
- The freestanding O2 lockers have been replaced with fire lockers.
- There are now intercoms in the crew and cockpit sections.
- There are now 3 wall-mounted gun chargers in the cockpit (to bring it up to par with other shuttles' charger counts).
- There is now a fire axe in the cockpit.
- There is now a fire extinguisher in the cockpit.
- There is now a single pair of handcuffs and a flash in the cockpit.
- Added 2 maint loot spawners into the crates that lacked them.
- The two tables are now made of plastitanium.
- The cockpit now requires basic brig access as with other shuttles.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The amenities in the pencil shuttle don't suck so much. All the gear and the full windows and the brig make the shuttle feel more cramped despite technically being larger, thus objectively improving the shuttle in every aspect.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/user-attachments/assets/0ba6a863-ea06-4c76-8098-8583d4e78195)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Spawned the pencil shuttle in. Flew it. Murdered a skrell with the axe.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Remapped the pencil shuttle. It now includes wall mounted lockers, fire axe, gun chargers, a brig, and other amenities.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
