### PR TITLE
Fixes certain atmos devices appearing wrong when unwrenched

### DIFF
--- a/code/game/machinery/pipe/pipe_construction.dm
+++ b/code/game/machinery/pipe/pipe_construction.dm
@@ -109,10 +109,10 @@ GLOBAL_LIST_INIT(pipe_path2type, list(
 		// If our path is in the list use the list
 		if(makes_type in GLOB.pipe_path2type)
 			pipe_type = GLOB.pipe_path2type[makes_type] + is_bent
-		// If our path isn't exactly in the list(e.g /obj/machinery/atmospherics/binary/pump/on) try and find and ancestor there
+		// If our path isn't exactly in the list (e.g /obj/machinery/atmospherics/binary/pump/on) try and find an ancestor there
 		else
 			for(var/type_path in GLOB.pipe_path2type)
-				if(findtext("[makes_type]", "[type_path]"))
+				if(ispath(makes_type, type_path))
 					pipe_type = GLOB.pipe_path2type[type_path] + is_bent
 					break
 

--- a/code/game/machinery/pipe/pipe_construction.dm
+++ b/code/game/machinery/pipe/pipe_construction.dm
@@ -106,7 +106,15 @@ GLOBAL_LIST_INIT(pipe_path2type, list(
 		if(make_from.initialize_directions in list(NORTH|WEST, NORTH|EAST, SOUTH|WEST, SOUTH|EAST))
 			is_bent = TRUE
 
-		pipe_type = GLOB.pipe_path2type[makes_type] + is_bent
+		// If our path is in the list use the list
+		if(makes_type in GLOB.pipe_path2type)
+			pipe_type = GLOB.pipe_path2type[makes_type] + is_bent
+		// If our path isn't exactly in the list(e.g /obj/machinery/atmospherics/binary/pump/on) try and find and ancestor there
+		else
+			for(var/type_path in GLOB.pipe_path2type)
+				if(findtext("[makes_type]", "[type_path]"))
+					pipe_type = GLOB.pipe_path2type[type_path] + is_bent
+					break
 
 		switch(pipe_type)
 			if(PIPE_SUPPLY_STRAIGHT, PIPE_SUPPLY_BENT, PIPE_SUPPLY_MANIFOLD, PIPE_SUPPLY_MANIFOLD4W, PIPE_SUPPLY_CAP)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes #28740 
fixes #28206
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
less bug more good
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
- unwrenched pumps that are on by default and flipped filters
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Certain pipe types no longer look wrong when unwrenched
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
