### PR TITLE
reagent container interaction fixes

### DIFF
--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -97,13 +97,16 @@
 
 		var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this)
 		to_chat(user, "<span class='notice'>You fill [src] with [trans] unit\s of the contents of [target].</span>")
-
+		return
 	else if(reagents.total_volume)
 		if(user.a_intent == INTENT_HARM)
 			user.visible_message("<span class='danger'>[user] splashes the contents of [src] onto [target]!</span>", \
 								"<span class='notice'>You splash the contents of [src] onto [target].</span>")
 			reagents.reaction(target, REAGENT_TOUCH)
 			reagents.clear_reagents()
+			return
+
+	return FALSE
 
 /obj/item/reagent_containers/glass/item_interaction(mob/living/user, obj/item/used, list/modifiers)
 	if(is_pen(used))

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -50,6 +50,107 @@
 	..()
 	update_icon()
 
+/obj/item/reagent_containers/syringe/proc/mob_inject(mob/living/L, mob/living/user)
+	. = TRUE
+
+	if(!reagents.total_volume)
+		to_chat(user, "<span class='notice'>[src] is empty.</span>")
+		return
+
+	if(!L && !L.is_injectable(user)) //only checks on non-living mobs, due to how can_inject() handles
+		to_chat(user, "<span class='warning'>You cannot directly fill [L]!</span>")
+		return
+
+	if(L.reagents.total_volume >= L.reagents.maximum_volume)
+		to_chat(user, "<span class='notice'>[L] is full.</span>")
+		return
+
+	if(L) //living mob
+		if(!L.can_inject(user, TRUE, penetrate_thick = penetrates_thick))
+			return
+		if(L != user)
+			L.visible_message("<span class='danger'>[user] is trying to inject [L]!</span>", \
+									"<span class='userdanger'>[user] is trying to inject you!</span>")
+			if(!do_mob(user, L))
+				return
+			if(!reagents.total_volume)
+				return
+			if(L.reagents.total_volume >= L.reagents.maximum_volume)
+				return
+			L.visible_message("<span class='danger'>[user] injects [L] with the syringe!", \
+							"<span class='userdanger'>[user] injects [L] with the syringe!")
+
+		var/list/rinject = list()
+		for(var/datum/reagent/R in reagents.reagent_list)
+			rinject += R.name
+		var/contained = english_list(rinject)
+
+		add_attack_logs(user, L, "Injected with [name] containing [contained], transfered [amount_per_transfer_from_this] units", reagents.harmless_helper() ? ATKLOG_ALMOSTALL : null)
+
+/obj/item/reagent_containers/syringe/proc/mob_draw(mob/living/L, mob/living/user)
+	. = TRUE
+
+	var/drawn_amount = reagents.maximum_volume - reagents.total_volume
+	if(L != user)
+		L.visible_message("<span class='danger'>[user] is trying to take a blood sample from [L]!</span>", \
+						"<span class='userdanger'>[user] is trying to take a blood sample from [L]!</span>")
+		busy = TRUE
+		if(!do_mob(user, L, syringe_draw_time))
+			busy = FALSE
+			return
+		if(reagents.holder_full())
+			return
+	busy = FALSE
+	if(L.transfer_blood_to(src, drawn_amount))
+		user.visible_message("<span class='notice'>[user] takes a blood sample from [L].</span>")
+	else
+		to_chat(user, "<span class='warning'>You are unable to draw any blood from [L]!</span>")
+
+	if(reagents.holder_full())
+		mode = !mode
+		update_icon()
+
+/obj/item/reagent_containers/syringe/proc/normal_draw(atom/target, mob/living/user)
+	. = TRUE
+	if(!target.reagents.total_volume)
+		to_chat(user, "<span class='warning'>[target] is empty!</span>")
+		return
+
+	if(!target.is_drawable(user))
+		to_chat(user, "<span class='warning'>You cannot directly remove reagents from [target]!</span>")
+		return
+
+	var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this) // transfer from, transfer to - who cares?
+	to_chat(user, "<span class='notice'>You fill [src] with [trans] units of the solution. It now contains [reagents.total_volume] units.</span>")
+
+	if(reagents.holder_full())
+		mode = !mode
+		update_icon()
+
+/obj/item/reagent_containers/syringe/proc/normal_inject(atom/target, mob/living/user)
+	. = TRUE
+
+	if(isfood(target))
+		var/list/chemicals = list()
+		for(var/datum/reagent/chem in reagents.reagent_list)
+			chemicals += chem.name
+		var/contained_chemicals = english_list(chemicals)
+		add_attack_logs(user, target, "Injected [amount_per_transfer_from_this]u [contained_chemicals] into food item")
+		finish_injection(target, user)
+
+/obj/item/reagent_containers/syringe/normal_act(atom/target, mob/living/user)
+	. = TRUE
+	if(!target.reagents)
+		return
+
+	switch(mode)
+		if(SYRINGE_DRAW)
+			return normal_draw(target, user)
+		if(SYRINGE_INJECT)
+			. = normal_inject(target, user)
+			if(.)
+				finish_injection(target, user)
+
 /obj/item/reagent_containers/syringe/mob_act(mob/target, mob/living/user)
 	. = TRUE
 	if(!target.reagents)
@@ -63,95 +164,26 @@
 
 	switch(mode)
 		if(SYRINGE_DRAW)
-
 			if(reagents.holder_full())
 				to_chat(user, "<span class='notice'>The syringe is full.</span>")
 				return
 
-			if(L) //living mob
-				var/drawn_amount = reagents.maximum_volume - reagents.total_volume
-				if(target != user)
-					target.visible_message("<span class='danger'>[user] is trying to take a blood sample from [target]!</span>", \
-									"<span class='userdanger'>[user] is trying to take a blood sample from [target]!</span>")
-					busy = TRUE
-					if(!do_mob(user, target, syringe_draw_time))
-						busy = FALSE
-						return
-					if(reagents.holder_full())
-						return
-				busy = FALSE
-				if(L.transfer_blood_to(src, drawn_amount))
-					user.visible_message("<span class='notice'>[user] takes a blood sample from [L].</span>")
-				else
-					to_chat(user, "<span class='warning'>You are unable to draw any blood from [L]!</span>")
-
-			else //if not mob
-				if(!target.reagents.total_volume)
-					to_chat(user, "<span class='warning'>[target] is empty!</span>")
-					return
-
-				if(!target.is_drawable(user))
-					to_chat(user, "<span class='warning'>You cannot directly remove reagents from [target]!</span>")
-					return
-
-				var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this) // transfer from, transfer to - who cares?
-
-				to_chat(user, "<span class='notice'>You fill [src] with [trans] units of the solution. It now contains [reagents.total_volume] units.</span>")
-			if(reagents.holder_full())
-				mode = !mode
-				update_icon()
-
+			// still one check here because we're not sure from the above logic
+			if(istype(L))
+				return mob_draw(L, user)
 		if(SYRINGE_INJECT)
-			if(!reagents.total_volume)
-				to_chat(user, "<span class='notice'>[src] is empty.</span>")
-				return
+			. = mob_inject(L, user)
+			if(.)
+				finish_injection(target, user)
 
-			if(!L && !target.is_injectable(user)) //only checks on non-living mobs, due to how can_inject() handles
-				to_chat(user, "<span class='warning'>You cannot directly fill [target]!</span>")
-				return
-
-			if(target.reagents.total_volume >= target.reagents.maximum_volume)
-				to_chat(user, "<span class='notice'>[target] is full.</span>")
-				return
-
-			if(L) //living mob
-				if(!L.can_inject(user, TRUE, penetrate_thick = penetrates_thick))
-					return
-				if(L != user)
-					L.visible_message("<span class='danger'>[user] is trying to inject [L]!</span>", \
-											"<span class='userdanger'>[user] is trying to inject you!</span>")
-					if(!do_mob(user, L))
-						return
-					if(!reagents.total_volume)
-						return
-					if(L.reagents.total_volume >= L.reagents.maximum_volume)
-						return
-					L.visible_message("<span class='danger'>[user] injects [L] with the syringe!", \
-									"<span class='userdanger'>[user] injects [L] with the syringe!")
-
-				var/list/rinject = list()
-				for(var/datum/reagent/R in reagents.reagent_list)
-					rinject += R.name
-				var/contained = english_list(rinject)
-
-				add_attack_logs(user, L, "Injected with [name] containing [contained], transfered [amount_per_transfer_from_this] units", reagents.harmless_helper() ? ATKLOG_ALMOSTALL : null)
-
-			if(isfood(target))
-
-				var/list/chemicals = list()
-				for(var/datum/reagent/chem in reagents.reagent_list)
-					chemicals += chem.name
-				var/contained_chemicals = english_list(chemicals)
-
-				add_attack_logs(user, target, "Injected [amount_per_transfer_from_this]u [contained_chemicals] into food item")
-
-			var/fraction = min(amount_per_transfer_from_this / reagents.total_volume, 1)
-			reagents.reaction(L, REAGENT_INGEST, fraction)
-			reagents.trans_to(target, amount_per_transfer_from_this)
-			to_chat(user, "<span class='notice'>You inject [amount_per_transfer_from_this] units of the solution. The syringe now contains [reagents.total_volume] units.</span>")
-			if(reagents.total_volume <= 0 && mode == SYRINGE_INJECT)
-				mode = SYRINGE_DRAW
-				update_icon()
+/obj/item/reagent_containers/syringe/proc/finish_injection(atom/target, mob/living/user)
+	var/fraction = min(amount_per_transfer_from_this / reagents.total_volume, 1)
+	reagents.reaction(target, REAGENT_INGEST, fraction)
+	reagents.trans_to(target, amount_per_transfer_from_this)
+	to_chat(user, "<span class='notice'>You inject [amount_per_transfer_from_this] units of the solution. The syringe now contains [reagents.total_volume] units.</span>")
+	if(reagents.total_volume <= 0 && mode == SYRINGE_INJECT)
+		mode = SYRINGE_DRAW
+		update_icon()
 
 /obj/item/reagent_containers/syringe/update_icon_state()
 	var/rounded_vol

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -141,7 +141,7 @@
 /obj/item/reagent_containers/syringe/normal_act(atom/target, mob/living/user)
 	. = TRUE
 	if(!target.reagents)
-		return
+		return FALSE
 
 	switch(mode)
 		if(SYRINGE_DRAW)

--- a/code/tests/attack_chain/test_attack_chain_reagent_containers.dm
+++ b/code/tests/attack_chain/test_attack_chain_reagent_containers.dm
@@ -194,9 +194,24 @@
 
 	// Syringes
 	var/obj/item/reagent_containers/syringe/syringe = player.spawn_obj_in_hand(/obj/item/reagent_containers/syringe)
-	syringe.syringe_draw_time = 0
+	var/obj/beaker = player.spawn_obj_nearby(/obj/item/reagent_containers/glass/beaker)
+	beaker.reagents.add_reagent("plasma_dust", 10)
+	player.click_on(beaker)
+	TEST_ASSERT_LAST_CHATLOG(player, "You fill the syringe with 5 units of the solution.")
+	qdel(syringe)
+
+	syringe = player.spawn_obj_in_hand(/obj/item/reagent_containers/syringe)
 	player.click_on(target)
-	TEST_ASSERT_LAST_CHATLOG(player, "[player.puppet] takes a blood sample")
+	TEST_ASSERT_LAST_CHATLOG(player, "[player.puppet] takes a blood sample from [target.puppet]")
+	qdel(syringe)
+
+	syringe = player.spawn_obj_in_hand(/obj/item/reagent_containers/syringe)
+	syringe.syringe_draw_time = 0
+	player.click_on_self()
+	TEST_ASSERT_LAST_CHATLOG(player, "[player.puppet] takes a blood sample from [player.puppet]")
+	var/obj/slime_extract = player.spawn_obj_nearby(/obj/item/slime_extract/grey)
+	player.click_on(slime_extract)
+	TEST_ASSERT_ANY_CHATLOG(player, "the used slime extract's power is consumed in the reaction")
 	player.put_away(syringe)
 
 	// IV Bags
@@ -204,7 +219,7 @@
 	var/obj/blood_bag = player.spawn_obj_in_hand(/obj/item/reagent_containers/iv_bag)
 	player.click_on(iv_drip)
 	TEST_ASSERT_LAST_CHATLOG(player, "You attach [blood_bag] to [iv_drip].")
-	var/obj/beaker = player.spawn_obj_in_hand(/obj/item/reagent_containers/glass/beaker/cryoxadone)
+	beaker = player.spawn_obj_in_hand(/obj/item/reagent_containers/glass/beaker/cryoxadone)
 	player.click_on(iv_drip)
 	TEST_ASSERT_LAST_CHATLOG(player, "You transfer 10 units of the solution to [blood_bag].")
 	player.put_away(beaker)
@@ -230,6 +245,12 @@
 	patch.instant_application = TRUE
 	player.click_on(target)
 	TEST_ASSERT_LAST_CHATLOG(player, "[player.puppet] forces [target.puppet] to apply [patch].")
+
+	// Beakers
+	beaker = player.spawn_obj_in_hand(/obj/item/reagent_containers/glass/beaker)
+	var/obj/structure/table/table = player.spawn_obj_nearby(/obj/structure/table)
+	player.click_on(table)
+	TEST_ASSERT(beaker in get_turf(table), "beaker not placed on table")
 
 /datum/game_test/attack_chain_rags/Run()
 	var/datum/test_puppeteer/player = new(src)


### PR DESCRIPTION
## What Does This PR Do
This PR fixes two issues found with the reagent containers attack chain migration: not being able to place beakers on tables, and various interaction problems with syringes.
## Why It's Good For The Game
Bugfixes.
## Testing
See newly added tests.

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Beakers and other such containers can properly be placed on tables and in backpacks.
fix: Syringes can now properly draw from beakers and inject into other items like slime extracts.
/:cl:
