### PR TITLE
interaction fixes for IV bags, chem bags, and syringes

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -94,6 +94,9 @@
 		return FINISH_ATTACK
 
 /obj/attack_by(obj/item/attacking, mob/user, params)
+	if(!attacking.new_attack_chain)
+		return attackby__legacy__attackchain(attacking, user, params)
+
 	. = ..()
 
 	if(.)

--- a/code/_onclick/item_attack_legacy.dm
+++ b/code/_onclick/item_attack_legacy.dm
@@ -62,7 +62,9 @@
 	user.changeNext_move(CLICK_CD_MELEE)
 	user.do_attack_animation(O)
 
-	if(!O.new_attack_chain)
+	if(O.new_attack_chain)
+		O.attacked_by(src, user)
+	else
 		O.attacked_by__legacy__attackchain(src, user)
 
 /**

--- a/code/modules/reagents/reagent_containers/iv_bag.dm
+++ b/code/modules/reagents/reagent_containers/iv_bag.dm
@@ -91,11 +91,12 @@
 			update_icon(UPDATE_OVERLAYS)
 
 /obj/item/reagent_containers/iv_bag/mob_act(mob/target, mob/living/user)
+	. = TRUE
 	if(!target.reagents)
-		return
+		return FALSE
 
-	if(isliving(target))
-		var/mob/living/L = target
+	var/mob/living/L = target
+	if(istype(L))
 		if(injection_target) // Removing the needle
 			if(L != injection_target)
 				to_chat(user, "<span class='notice'>[src] is already inserted into [injection_target]'s arm!")
@@ -123,7 +124,12 @@
 									"<span class='userdanger'>[user] inserts [src]'s needle into [L]'s arm!</span>")
 			begin_processing(L)
 
-	else if(target.is_refillable() && is_drainable()) // Transferring from IV bag to other containers
+/obj/item/reagent_containers/iv_bag/normal_act(atom/target, mob/living/user)
+	. = TRUE
+	if(!target.reagents)
+		return FALSE
+
+	if(target.is_refillable() && is_drainable()) // Transferring from IV bag to other containers
 		if(!reagents.total_volume)
 			to_chat(user, "<span class='warning'>[src] is empty.</span>")
 			return

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -13,16 +13,16 @@
 	var/needs_to_apply_reagents = TRUE
 
 /obj/item/reagent_containers/patch/mob_act(mob/target, mob/living/user)
-	if(!apply(target, user))
-		return ITEM_INTERACT_COMPLETE
+	apply(target, user)
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/reagent_containers/patch/proc/apply(mob/living/carbon/C, mob/user)
 	if(!istype(C))
-		return FALSE
+		return
 
 	if(ismachineperson(C))
 		to_chat(user, "<span class='warning'>[user == C ? "You" : C] can't use [src]!</span>")
-		return FALSE
+		return
 
 	if(user == C)
 		to_chat(user, "<span class='notice'>You apply [src].</span>")
@@ -30,7 +30,7 @@
 		if(!instant_application)
 			C.visible_message("<span class='warning'>[user] attempts to force [C] to apply [src].</span>")
 			if(!do_after(user, 3 SECONDS, TRUE, C, TRUE))
-				return FALSE
+				return
 
 		C.forceFedAttackLog(src, user)
 		C.visible_message("<span class='warning'>[user] forces [C] to apply [src].</span>")
@@ -39,7 +39,7 @@
 		user.drop_item() // Only drop if they're holding the patch directly
 	forceMove(C)
 	LAZYADD(C.processing_patches, src)
-	return TRUE
+	return
 
 /obj/item/reagent_containers/patch/styptic
 	name = "brute patch"

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -23,6 +23,9 @@
 	. = ..()
 	ADD_TRAIT(src, TRAIT_CAN_POINT_WITH, ROUNDSTART_TRAIT)
 
+/obj/item/reagent_containers/spray/ranged_interact_with_atom(atom/target, mob/living/user, list/modifiers)
+	return interact_with_atom(target, user, modifiers)
+
 /obj/item/reagent_containers/spray/normal_act(atom/A, mob/living/user)
 	. = TRUE
 	if(isstorage(A) || ismodcontrol(A) || istype(A, /obj/structure/table) || istype(A, /obj/structure/rack) || istype(A, /obj/structure/closet) \
@@ -128,13 +131,6 @@
 	spray_currentrange = 2
 	amount_per_transfer_from_this = 10
 	list_reagents = list("cleaner" = 250)
-
-/obj/item/reagent_containers/spray/cleaner/activate_self(mob/user)
-	if(..())
-		return
-	amount_per_transfer_from_this = (amount_per_transfer_from_this == 5 ? 10 : 5)
-	spray_currentrange = (spray_currentrange == 1 ? spray_maxrange : 1)
-	to_chat(user, "<span class='notice'>You [amount_per_transfer_from_this == 5 ? "remove" : "fix"] the nozzle. You'll now use [amount_per_transfer_from_this] units per spray.</span>")
 
 /obj/item/reagent_containers/spray/cleaner/advanced
 	name = "advanced space cleaner"

--- a/code/tests/attack_chain/test_attack_chain_reagent_containers.dm
+++ b/code/tests/attack_chain/test_attack_chain_reagent_containers.dm
@@ -192,7 +192,38 @@
 	var/datum/test_puppeteer/player = new(src)
 	var/datum/test_puppeteer/target = player.spawn_puppet_nearby()
 
-	// Syringes
+	// Pills
+	var/obj/pill = player.spawn_obj_in_hand(/obj/item/reagent_containers/pill/salicylic)
+	player.click_on_self()
+	TEST_ASSERT_LAST_CHATLOG(player, "You swallow [pill].")
+	var/obj/beaker = player.spawn_obj_nearby(/obj/item/reagent_containers/glass/beaker)
+	player.puppet.swap_hand()
+	pill = player.spawn_obj_in_hand(/obj/item/reagent_containers/pill/salicylic)
+	player.click_on(beaker)
+	TEST_ASSERT_LAST_CHATLOG(player, "You break open [pill] in [beaker].")
+	pill = player.spawn_obj_in_hand(/obj/item/reagent_containers/pill/salicylic)
+	player.click_on(beaker)
+	TEST_ASSERT_LAST_CHATLOG(player, "You dissolve [pill] in [beaker].")
+
+	// Patches
+	var/obj/item/reagent_containers/patch/patch = player.spawn_obj_in_hand(/obj/item/reagent_containers/patch/silver_sulf)
+	player.click_on_self()
+	TEST_ASSERT_LAST_CHATLOG(player, "You apply [patch].")
+	patch = player.spawn_obj_in_hand(/obj/item/reagent_containers/patch/silver_sulf)
+	patch.instant_application = TRUE
+	player.click_on(target)
+	TEST_ASSERT_LAST_CHATLOG(player, "[player.puppet] forces [target.puppet] to apply [patch].")
+
+	// Beakers
+	beaker = player.spawn_obj_in_hand(/obj/item/reagent_containers/glass/beaker)
+	var/obj/structure/table/table = player.spawn_obj_nearby(/obj/structure/table)
+	player.click_on(table)
+	TEST_ASSERT(beaker in get_turf(table), "beaker not placed on table")
+
+/datum/game_test/attack_chain_syringes/Run()
+	var/datum/test_puppeteer/player = new(src)
+	var/datum/test_puppeteer/target = player.spawn_puppet_nearby()
+
 	var/obj/item/reagent_containers/syringe/syringe = player.spawn_obj_in_hand(/obj/item/reagent_containers/syringe)
 	var/obj/beaker = player.spawn_obj_nearby(/obj/item/reagent_containers/glass/beaker)
 	beaker.reagents.add_reagent("plasma_dust", 10)
@@ -212,14 +243,19 @@
 	var/obj/slime_extract = player.spawn_obj_nearby(/obj/item/slime_extract/grey)
 	player.click_on(slime_extract)
 	TEST_ASSERT_ANY_CHATLOG(player, "the used slime extract's power is consumed in the reaction")
-	player.put_away(syringe)
 
-	// IV Bags
+	player.click_on(beaker)
+	TEST_ASSERT_LAST_CHATLOG(player, "You inject 5 units of the solution")
+
+/datum/game_test/attack_chain_iv_bags/Run()
+	var/datum/test_puppeteer/player = new(src)
+	var/datum/test_puppeteer/target = player.spawn_puppet_nearby()
+
 	var/obj/machinery/iv_drip/iv_drip = player.spawn_obj_nearby(/obj/machinery/iv_drip)
 	var/obj/blood_bag = player.spawn_obj_in_hand(/obj/item/reagent_containers/iv_bag)
 	player.click_on(iv_drip)
 	TEST_ASSERT_LAST_CHATLOG(player, "You attach [blood_bag] to [iv_drip].")
-	beaker = player.spawn_obj_in_hand(/obj/item/reagent_containers/glass/beaker/cryoxadone)
+	var/obj/beaker = player.spawn_obj_in_hand(/obj/item/reagent_containers/glass/beaker/cryoxadone)
 	player.click_on(iv_drip)
 	TEST_ASSERT_LAST_CHATLOG(player, "You transfer 10 units of the solution to [blood_bag].")
 	player.put_away(beaker)
@@ -227,30 +263,36 @@
 	iv_drip.drag_drop_onto(target.puppet, player.puppet)
 	TEST_ASSERT_LAST_CHATLOG(player, "[player.puppet] inserts [blood_bag]'s needle into [target.puppet]'s arm")
 
-	// Pills
-	var/obj/pill = player.spawn_obj_in_hand(/obj/item/reagent_containers/pill/salicylic)
-	player.click_on_self()
-	TEST_ASSERT_LAST_CHATLOG(player, "You swallow [pill].")
-	player.retrieve(beaker)
+	blood_bag = player.spawn_obj_in_hand(/obj/item/reagent_containers/iv_bag)
 	player.puppet.swap_hand()
-	pill = player.spawn_obj_in_hand(/obj/item/reagent_containers/pill/salicylic)
+	player.retrieve(beaker)
+	player.click_on(blood_bag)
+	TEST_ASSERT_LAST_CHATLOG(player, "You transfer 10 units of the solution to [blood_bag]")
+
+	player.puppet.swap_hand()
 	player.click_on(beaker)
-	TEST_ASSERT_LAST_CHATLOG(player, "You dissolve [pill] in [beaker].")
+	TEST_ASSERT_LAST_CHATLOG(player, "You transfer 1 units of the solution to [beaker]")
 
-	// Patches
-	var/obj/item/reagent_containers/patch/patch = player.spawn_obj_in_hand(/obj/item/reagent_containers/patch/silver_sulf)
-	player.click_on_self()
-	TEST_ASSERT_LAST_CHATLOG(player, "You apply [patch].")
-	patch = player.spawn_obj_in_hand(/obj/item/reagent_containers/patch/silver_sulf)
-	patch.instant_application = TRUE
-	player.click_on(target)
-	TEST_ASSERT_LAST_CHATLOG(player, "[player.puppet] forces [target.puppet] to apply [patch].")
+/datum/game_test/attack_chain_chemistry_bags/Run()
+	var/datum/test_puppeteer/player = new(src)
 
-	// Beakers
-	beaker = player.spawn_obj_in_hand(/obj/item/reagent_containers/glass/beaker)
-	var/obj/structure/table/table = player.spawn_obj_nearby(/obj/structure/table)
-	player.click_on(table)
-	TEST_ASSERT(beaker in get_turf(table), "beaker not placed on table")
+	var/obj/table = player.spawn_obj_nearby(/obj/structure/table)
+	var/turf/T = get_turf(table)
+	var/obj/last_patch
+	for(var/i in 1 to 5)
+		last_patch = new /obj/item/reagent_containers/patch/styptic(T)
+	var/obj/chem_bag = player.spawn_obj_in_hand(/obj/item/storage/bag/chemistry)
+	player.click_on(last_patch)
+	TEST_ASSERT_EQUAL(length(chem_bag.contents), 5, "chem bag failed to pick up patches")
+
+	var/obj/chem_fridge = player.spawn_obj_nearby(/obj/machinery/smartfridge/medbay)
+	player.click_on(chem_fridge)
+	TEST_ASSERT_LAST_CHATLOG(player, "You load [chem_fridge] with [chem_bag]")
+
+	player.puppet.swap_hand()
+	var/obj/patch = player.spawn_obj_in_hand(/obj/item/reagent_containers/patch/styptic)
+	player.click_on(chem_bag)
+	TEST_ASSERT_LAST_CHATLOG(player, "You put [patch] into [chem_bag]")
 
 /datum/game_test/attack_chain_rags/Run()
 	var/datum/test_puppeteer/player = new(src)


### PR DESCRIPTION
## What Does This PR Do
This PR fixes and adds tests for:
- Chemistry bags not picking up all reagent containers with one click on a tile
- Chemistry bags not emptying into chem fridges
- Chemistry bag not accepting items placed directly inside them
- IV bags not being filled from other containers
- Syringes not emptying into containers on inject
- Fixes spray cleaners adjusting their nozzle flow twice on use
- Fixes spray cleaners not being able to spray a distant tile

Chem bags were a new code path for the attack chain and needed a few call sites added in negotiating between chains. The issue is still that /obj/item/attackby is still the only place where the main behavior of using storage on other items sits, and up until now, to the best of my knowledge, nothing else has been migrated that is auto-picked up by a storage. The rest of the test suite still passes, though.

Fixes #28761. Fixes #28762. The last point on the latter issue, that the effects of laz reagent on a corpse weren't occurring, is unrelated to the attack chain migration. Once the patch has been applied and the reagents are in the mob's system, the attack chain interactions have been completed.
## Why It's Good For The Game
More bugfixes.
## Testing
Manual testing and additions to test suite.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Pills/patches on a tile should now properly be added to a chem bag when clicked on.
fix: Chemistry bags should properly empty into fridges.
fix: Chemistry bags should properly accept items being placed directly into them.
fix: IV bags should properly receive reagents transferred from other containers.
fix: Syringes should properly inject reagents into other containers.
fix: Spray cleaner bottles will not instantly switch back their nozzle flow rate on use.
fix: Spray cleaner bottles will properly work when clicking on a distant object.
/:cl:
