### PR TITLE
fix pill and patch activate in-hand

### DIFF
--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -16,6 +16,12 @@
 	apply(target, user)
 	return ITEM_INTERACT_COMPLETE
 
+/obj/item/reagent_containers/patch/activate_self(mob/user)
+	if(..())
+		return FINISH_ATTACK
+
+	apply(user, user)
+
 /obj/item/reagent_containers/patch/proc/apply(mob/living/carbon/C, mob/user)
 	if(!istype(C))
 		return

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -18,6 +18,12 @@
 	if(!icon_state)
 		icon_state = "pill[rand(1, 20)]"
 
+/obj/item/reagent_containers/pill/activate_self(mob/user)
+	if(..())
+		return FINISH_ATTACK
+
+	apply(user, user)
+
 /obj/item/reagent_containers/pill/proc/apply(mob/living/carbon/C, mob/user)
 	if(!istype(C))
 		return FALSE

--- a/code/tests/attack_chain/test_attack_chain_reagent_containers.dm
+++ b/code/tests/attack_chain/test_attack_chain_reagent_containers.dm
@@ -204,6 +204,9 @@
 	pill = player.spawn_obj_in_hand(/obj/item/reagent_containers/pill/salicylic)
 	player.click_on(beaker)
 	TEST_ASSERT_LAST_CHATLOG(player, "You dissolve [pill] in [beaker].")
+	pill = player.spawn_obj_in_hand(/obj/item/reagent_containers/pill/salicylic)
+	player.use_item_in_hand()
+	TEST_ASSERT_LAST_CHATLOG(player, "You swallow [pill].")
 
 	// Patches
 	var/obj/item/reagent_containers/patch/patch = player.spawn_obj_in_hand(/obj/item/reagent_containers/patch/silver_sulf)


### PR DESCRIPTION
## What Does This PR Do
This PR fixes not being able to activate pills and patches in hand to ingest or apply them.
## Why It's Good For The Game
Bugfix.
## Testing
Manual and test suite addition.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl:
fix: Patches and pills are properly applied and ingested when used in-hand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
