### PR TITLE
dropper, patch and pill fixes

### DIFF
--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -40,6 +40,7 @@
 	var/originalname = "condiment" //Can't use initial(name) for this. This stores the name set by condimasters.
 
 /obj/item/reagent_containers/condiment/mob_act(mob/target, mob/living/user)
+	. = TRUE
 	if(!reagents || !reagents.total_volume)
 		to_chat(user, "<span class='warning'>None of [src] left, oh no!</span>")
 		return

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -18,6 +18,7 @@
 
 /obj/item/reagent_containers/interact_with_atom(atom/target, mob/living/user, list/modifiers)
 	if(isliving(target) && mob_act(target, user))
+		user.changeNext_move(CLICK_CD_MELEE)
 		return ITEM_INTERACT_COMPLETE
 	if(normal_act(target, user))
 		return ITEM_INTERACT_COMPLETE

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -17,9 +17,10 @@
 	new_attack_chain = TRUE
 
 /obj/item/reagent_containers/interact_with_atom(atom/target, mob/living/user, list/modifiers)
-	if(isliving(target) && mob_act(target, user))
+	if(isliving(target))
 		user.changeNext_move(CLICK_CD_MELEE)
-		return ITEM_INTERACT_COMPLETE
+		if(mob_act(target, user))
+			return ITEM_INTERACT_COMPLETE
 	if(normal_act(target, user))
 		return ITEM_INTERACT_COMPLETE
 	return ..()

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -11,6 +11,8 @@
 	amount_per_transfer_from_this = 1
 	possible_transfer_amounts = list(1, 2, 3, 4, 5)
 	volume = 5
+	/// How long it takes to drip the contents into someone's eyes.
+	var/mob_drip_delay = 3 SECONDS
 
 /obj/item/reagent_containers/dropper/on_reagent_change()
 	if(!reagents.total_volume)
@@ -19,6 +21,7 @@
 		icon_state = "[initial(icon_state)]1"
 
 /obj/item/reagent_containers/dropper/mob_act(mob/target, mob/living/user)
+	. = TRUE
 	var/to_transfer = 0
 	if(iscarbon(target))
 		var/mob/living/carbon/C = target
@@ -26,7 +29,7 @@
 			return
 		if(user != C)
 			visible_message("<span class='danger'>[user] begins to drip something into [C]'s eyes!</span>")
-			if(!do_mob(user, C, 30))
+			if(!do_mob(user, C, mob_drip_delay))
 				return
 		if(ishuman(target))
 			var/mob/living/carbon/human/H = target
@@ -63,7 +66,6 @@
 		to_chat(user, "<span class='notice'>You transfer [to_transfer] units of the solution.</span>")
 
 /obj/item/reagent_containers/dropper/normal_act(atom/target, mob/living/user)
-	. = FALSE
 	var/to_transfer = 0
 	if(!target.reagents)
 		return

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -28,6 +28,7 @@
 	. += "<span class='notice'>[src] can hold up to [reagents.maximum_volume] units.</span>"
 
 /obj/item/reagent_containers/glass/mob_act(mob/target, mob/living/user)
+	. = TRUE
 	if(!is_open_container())
 		return
 

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -12,6 +12,12 @@
 	var/instant_application = FALSE
 	var/needs_to_apply_reagents = TRUE
 
+/obj/item/reagent_containers/patch/interact_with_atom(atom/target, mob/living/user, list/modifiers)
+	if(isnull(target.reagents))
+		return
+
+	return ..()
+
 /obj/item/reagent_containers/patch/mob_act(mob/target, mob/living/user)
 	apply(target, user)
 	return ITEM_INTERACT_COMPLETE

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -53,6 +53,12 @@
 	qdel(src)
 	return TRUE
 
+/obj/item/reagent_containers/pill/interact_with_atom(atom/target, mob/living/user, list/modifiers)
+	if(isnull(target.reagents))
+		return
+
+	return ..()
+
 /obj/item/reagent_containers/pill/mob_act(mob/target, mob/living/user)
 	apply(target, user)
 	return TRUE

--- a/code/tests/attack_chain/test_attack_chain_reagent_containers.dm
+++ b/code/tests/attack_chain/test_attack_chain_reagent_containers.dm
@@ -192,6 +192,8 @@
 	var/datum/test_puppeteer/player = new(src)
 	var/datum/test_puppeteer/target = player.spawn_puppet_nearby()
 
+	var/obj/structure/table/table = player.spawn_obj_nearby(/obj/structure/table)
+
 	// Pills
 	var/obj/pill = player.spawn_obj_in_hand(/obj/item/reagent_containers/pill/salicylic)
 	player.click_on_self()
@@ -207,6 +209,9 @@
 	pill = player.spawn_obj_in_hand(/obj/item/reagent_containers/pill/salicylic)
 	player.use_item_in_hand()
 	TEST_ASSERT_LAST_CHATLOG(player, "You swallow [pill].")
+	pill = player.spawn_obj_in_hand(/obj/item/reagent_containers/pill/salicylic)
+	player.click_on(table)
+	TEST_ASSERT(pill in get_turf(table), "pill not placed on table")
 
 	// Patches
 	var/obj/item/reagent_containers/patch/patch = player.spawn_obj_in_hand(/obj/item/reagent_containers/patch/silver_sulf)
@@ -223,9 +228,15 @@
 	beaker.reagents.add_reagent("sanguine_reagent", 10)
 	player.click_on(clonepod)
 	TEST_ASSERT_LAST_CHATLOG(player, "You transfer 10 units of the solution to [clonepod].")
-	var/obj/structure/table/table = player.spawn_obj_nearby(/obj/structure/table)
 	player.click_on(table)
 	TEST_ASSERT(beaker in get_turf(table), "beaker not placed on table")
+
+	// Pill bottles
+	var/obj/pill_bottle = player.spawn_obj_in_hand(/obj/item/storage/pill_bottle)
+	player.puppet.swap_hand()
+	pill = player.spawn_obj_in_hand(/obj/item/reagent_containers/pill/salicylic)
+	player.click_on(pill_bottle)
+	TEST_ASSERT_LAST_CHATLOG(player, "You put [pill] into [pill_bottle].")
 
 /datum/game_test/attack_chain_syringes/Run()
 	var/datum/test_puppeteer/player = new(src)
@@ -326,3 +337,15 @@
 	autoinjector = player.spawn_obj_in_hand(/obj/item/reagent_containers/hypospray/autoinjector/stimpack)
 	player.click_on(target)
 	TEST_ASSERT_ANY_CHATLOG(player, "You inject [target] with [autoinjector]")
+
+/datum/game_test/attack_chain_droppers/Run()
+	var/datum/test_puppeteer/player = new(src)
+	var/datum/test_puppeteer/target = player.spawn_puppet_nearby()
+	var/obj/item/reagent_containers/dropper/dropper = player.spawn_obj_in_hand(/obj/item/reagent_containers/dropper)
+	dropper.mob_drip_delay = 0
+	var/obj/item/beaker = player.spawn_obj_nearby(/obj/item/reagent_containers/glass/beaker/waterbottle)
+	player.click_on(beaker)
+	TEST_ASSERT_LAST_CHATLOG(player, "You fill [dropper] with 1 units of the solution.")
+	player.click_on(target)
+	TEST_ASSERT_ANY_CHATLOG(player, "[player.puppet] drips something into [target.puppet]'s eyes")
+	TEST_ASSERT_NOT_CHATLOG(player, "You cannot directly remove reagents from [target.puppet]")


### PR DESCRIPTION
## What Does This PR Do
This PR fixes:
- Incorrect messages appearing in chat when using a dropper on mobs
- Attack animations occurring when drinking from or feeding a mob from glass bottles
- Being unable to insert pills into a bottle by hand
- Lack of click cooldown in certain situations (not mentioned in changelog for reasons)
## Why It's Good For The Game
Bugfixes.
## Testing
Manual testing, especially for attack animation stuff since we don't have a good test harness for that yet, and test suites for everything else.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog

:cl:
fix: Messages about drawing reagents from people will no longer appear when using an eye dropper on them.
fix: Attack animations will no longer occur when drinking from or feeding a mob from glass bottles.
fix: Pills can properly be inserted into and picked up by pill bottles.
/:cl:
