### PR TITLE
[Fix] Body type isn't random anymore.

### DIFF
--- a/code/modules/surgery/organs/organ_icon.dm
+++ b/code/modules/surgery/organs/organ_icon.dm
@@ -155,7 +155,7 @@
 		new_icon_state = "[icon_name][gendered_icon ? "_f" : ""]"
 	else
 		if(gendered_icon)
-			switch(dna.GetUITriState(DNA_UI_BODY_TYPE))
+			switch(dna.GetUIState(DNA_UI_BODY_TYPE))
 				if(DNA_GENDER_FEMALE)
 					body = "f"
 				else


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #27847
Fixes #25421
Changes `GetUITriState` to `GetUIState`. I assume it was getting jumbled with TriState since there's only 2 body types and TriState expects 3, but I haven't delved deep into DNA code. That caused it to randomly revert the body types of every species upon being created.

Reports came from slime players cause their body types are the most noticeable, due to their eyes.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Getting your body type and visuals inverted for an entire round sucks

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/user-attachments/assets/faca86b8-bbbf-47c5-88a0-0d4925dc5217)
Row 1
Gender - Female
Body Type - Feminine

Row 2
Gender - Male
Body Type - Feminine

Row 3
Gender - Female
Body Type - Masculine

Row 4
Gender - Male
Body Type - Masculine
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
On image, spawned 36 slimes with various combinations of settings. Also tested humans and IPCs. All get the correct body type to the setting.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Characters won't flip their body type anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
