### PR TITLE
fix spray container interactions with tables

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -30,7 +30,7 @@
 	. = TRUE
 	if(isstorage(A) || ismodcontrol(A) || istype(A, /obj/structure/table) || istype(A, /obj/structure/rack) || istype(A, /obj/structure/closet) \
 	|| istype(A, /obj/item/reagent_containers) || istype(A, /obj/structure/sink) || istype(A, /obj/structure/janitorialcart) || istype(A, /obj/machinery/hydroponics))
-		return
+		return FALSE
 
 	if(loc != user)
 		return

--- a/code/tests/attack_chain/test_attack_chain_reagent_containers.dm
+++ b/code/tests/attack_chain/test_attack_chain_reagent_containers.dm
@@ -356,3 +356,10 @@
 	player.click_on(target)
 	TEST_ASSERT_ANY_CHATLOG(player, "[player.puppet] drips something into [target.puppet]'s eyes")
 	TEST_ASSERT_NOT_CHATLOG(player, "You cannot directly remove reagents from [target.puppet]")
+
+/datum/game_test/attack_chain_spray/Run()
+	var/datum/test_puppeteer/player = new(src)
+	var/obj/item/reagent_containers/spray/spray = player.spawn_obj_in_hand(/obj/item/reagent_containers/spray)
+	var/obj/structure/table = player.spawn_obj_nearby(/obj/structure/table)
+	player.click_on(table)
+	TEST_ASSERT(spray in get_turf(table), "spray bottle not placed on table")


### PR DESCRIPTION
## What Does This PR Do
This PR fixes spray containers not being interactable with certain objects like tables. Fixes #28787.
## Why It's Good For The Game
Bugfix.
## Testing
Manual testing and added game test.
![2025_03_25__06_14_35__Paradise Station 13](https://github.com/user-attachments/assets/5ac443bd-60dd-4d11-81aa-1bb2ec6dc767)

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog

:cl:
fix: Spray bottles can properly be placed on tables, racks, and other structures.
/:cl:
