### PR TITLE
[s] Fixes an issue with the smart hopper

### DIFF
--- a/code/__DEFINES/dcs/atom_signals.dm
+++ b/code/__DEFINES/dcs/atom_signals.dm
@@ -149,5 +149,3 @@
 #define COMSIG_LENS_ATTACH "lens_attach"
 /// When using an insert on an item that can accept an insert
 #define COMSIG_INSERT_ATTACH "insert_attach"
-/// When a magma crucible is destroyed
-#define COMSIG_CRUCIBLE_DESTROYED "crucible_destroy"

--- a/code/__DEFINES/dcs/atom_signals.dm
+++ b/code/__DEFINES/dcs/atom_signals.dm
@@ -149,3 +149,5 @@
 #define COMSIG_LENS_ATTACH "lens_attach"
 /// When using an insert on an item that can accept an insert
 #define COMSIG_INSERT_ATTACH "insert_attach"
+/// When a magma crucible is destroyed
+#define COMSIG_CRUCIBLE_DESTROYED "crucible_destroy"

--- a/code/game/machinery/smith_machines.dm
+++ b/code/game/machinery/smith_machines.dm
@@ -306,6 +306,7 @@
 		if(istype(machine, /obj/machinery/smithing/casting_basin))
 			var/obj/machinery/smithing/casting_basin/basin = machine
 			basin.linked_crucible = null
+	linked_machines.Cut()
 	return ..()
 
 /obj/machinery/magma_crucible/power_change()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes an issue with the smart hopper.

## Why It's Good For The Game

Issues are bad.

## Testing

Spawned in, did things, issue ceased to be.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Fixed an issue with the Smart Hopper
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
