### PR TITLE
[DNM] Temporary Revert of "Makes APCs Less Annoying to Construct/Deconstruct"

### DIFF
--- a/code/__DEFINES/apc_defines.dm
+++ b/code/__DEFINES/apc_defines.dm
@@ -16,6 +16,7 @@
 //electronics_state
 #define APC_ELECTRONICS_NONE 0
 #define APC_ELECTRONICS_INSTALLED 1
+#define APC_ELECTRONICS_SECURED 2
 
 /// Power channel is off, anything connected to it is not powered, cannot be set manually by players
 #define APC_CHANNEL_SETTING_OFF 0

--- a/code/modules/power/apc/apc.dm
+++ b/code/modules/power/apc/apc.dm
@@ -181,7 +181,7 @@
 		GLOB.apcs = sortAtom(GLOB.apcs)
 		return
 
-	electronics_state = APC_ELECTRONICS_INSTALLED
+	electronics_state = APC_ELECTRONICS_SECURED
 	// is starting with a power cell installed, create it and set its charge level
 	if(cell_type)
 		cell = new /obj/item/stock_parts/cell/upgraded(src)
@@ -328,8 +328,6 @@
 				electronics_state = APC_ELECTRONICS_INSTALLED
 				locked = FALSE
 				to_chat(user, "<span class='notice'>You place [used] inside the frame.</span>")
-				stat &= ~MAINT
-				update_icon()
 				qdel(used)
 
 		return ITEM_INTERACT_COMPLETE

--- a/code/modules/power/apc/apc_construction.dm
+++ b/code/modules/power/apc/apc_construction.dm
@@ -10,110 +10,98 @@
 		if(opened != APC_COVER_OFF)
 			opened = APC_COVER_OFF
 			coverlocked = FALSE
-			visible_message(
-				"<span class='warning'>The APC cover falls off!</span>",
-				"<span class='warning'>You hear a small flat object falling to the floor!</span>"
-				)
+			visible_message("<span class='warning'>The APC cover is knocked down!</span>")
 			update_icon()
+
 
 /obj/machinery/power/apc/crowbar_act(mob/living/user, obj/item/I)
 	. = TRUE
 	if(!I.tool_start_check(src, user, 0))
 		return
-
 	if(opened) // a) on open apc
 		if(electronics_state == APC_ELECTRONICS_INSTALLED)
 			if(terminal)
 				to_chat(user, "<span class='warning'>Disconnect the wires first!</span>")
 				return
-
 			to_chat(user, "<span class='notice'>You start trying to remove the APC electronics...</span>" )
 			if(I.use_tool(src, user, 50, volume = I.tool_volume))
 				if(has_electronics())
 					electronics_state = APC_ELECTRONICS_NONE
 					if(stat & BROKEN)
-						user.visible_message(
-							"<span class='notice'>[user.name] rips out the broken the APC electronics inside [name]!</span>",
+						user.visible_message(\
+							"[user.name] has broken the APC electronics inside [name]!",
 							"<span class='notice'>You break the charred APC electronics and remove the remains.</span>",
-							"<span class='warning'>You hear metallic levering and a crack.</span>")
-						stat |= MAINT
-						update_icon()
+							"<span class='italics'>You hear a crack.</span>")
 						return
-
 						//SSticker.mode:apcs-- //XSI said no and I agreed. -rastaf0
-					if(emagged) // We emag board, not APC's frame
+					else if(emagged) // We emag board, not APC's frame
 						emagged = FALSE
 						user.visible_message(
-							"<span class='notice'>[user.name] has discarded the shorted APC electronics from [name]!</span>",
-							"<span class='notice'>You discarded the shorted board.</span>",
-							"<span class='warning'>You hear metallic levering.</span>"
-							)
-						stat |= MAINT
-						update_icon()
+							"[user.name] has discarded the shorted APC electronics from [name]!",
+							"<span class='notice'>You discarded the shorted board.</span>")
 						return
-
-					if(malfhack) // AI hacks board, not APC's frame
+					else if(malfhack) // AI hacks board, not APC's frame
 						user.visible_message(\
-							"<span class='notice'>[user.name] has discarded the strangely programmed APC electronics from [name]!</span>",
-							"<span class='notice'>You discarded the strangely programmed board.</span>",
-							"<span class='warning'>You hear metallic levering.</span>"
-							)
+							"[user.name] has discarded the strangely programmed APC electronics from [name]!",
+							"<span class='notice'>You discarded the strangely programmed board.</span>")
 						malfai = null
 						malfhack = FALSE
-						stat |= MAINT
-						update_icon()
 						return
-
-					user.visible_message(\
-						"<span class='notice'>[user.name] has removed the APC electronics from [name]!</span>",
-						"<span class='notice'>You remove the APC electronics.</span>",
-						"<span class='warning'>You hear metallic levering.</span>"
-						)
-					new /obj/item/apc_electronics(loc)
-					stat |= MAINT
-					update_icon()
-					return
-
-		if(opened != APC_COVER_OFF) //cover isn't removed
+					else
+						user.visible_message(\
+							"[user.name] has removed the APC electronics from [name]!",
+							"<span class='notice'>You remove the APC electronics.</span>")
+						new /obj/item/apc_electronics(loc)
+						return
+		else if(opened != APC_COVER_OFF) //cover isn't removed
 			opened = APC_CLOSED
 			coverlocked = TRUE //closing cover relocks it
 			update_icon()
 			return
-
-	if(!(stat & BROKEN)) // b) on closed and not broken APC
+	else if(!(stat & BROKEN)) // b) on closed and not broken APC
 		if(coverlocked && !(stat & MAINT)) // locked...
 			to_chat(user, "<span class='warning'>The cover is locked and cannot be opened!</span>")
 			return
-
-		if(panel_open) // wires are exposed
+		else if(panel_open) // wires are exposed
 			to_chat(user, "<span class='warning'>Exposed wires prevents you from opening it!</span>")
 			return
-
-		opened = APC_OPENED
-		update_icon()
+		else
+			opened = APC_OPENED
+			update_icon()
 
 /obj/machinery/power/apc/screwdriver_act(mob/living/user, obj/item/I)
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-
-	if(opened)
-		to_chat(user, "<span class='warning'>Close the APC first!</span>") //Less hints more mystery!
-		return
-
-	if(emagged)
+	else if(opened)
+		if(cell && !(stat & MAINT))
+			to_chat(user, "<span class='warning'>Close the APC first!</span>") //Less hints more mystery!
+			return
+		else
+			if(electronics_state == APC_ELECTRONICS_INSTALLED)
+				electronics_state = APC_ELECTRONICS_SECURED
+				stat &= ~MAINT
+				to_chat(user, "<span class='notice'>You screw the circuit electronics into place.</span>")
+			else if(electronics_state == APC_ELECTRONICS_SECURED)
+				electronics_state = APC_ELECTRONICS_INSTALLED
+				stat |= MAINT
+				to_chat(user, "<span class='notice'>You unfasten the electronics.</span>")
+			else
+				to_chat(user, "<span class='warning'>There is nothing to secure!</span>")
+				return
+			update_icon()
+	else if(emagged)
 		to_chat(user, "<span class='warning'>The interface is broken!</span>")
-		return
+	else
+		panel_open = !panel_open
+		to_chat(user, "The wires have been [panel_open ? "exposed" : "unexposed"]")
+		update_icon()
 
-	panel_open = !panel_open
-	to_chat(user, "<span class='notice'>The wires have been [panel_open ? "exposed" : "unexposed"]</span>")
-	update_icon()
 
 /obj/machinery/power/apc/wirecutter_act(mob/living/user, obj/item/I)
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-
 	if(panel_open && !opened)
 		wires.Interact(user)
 	else if(terminal && opened)
@@ -123,32 +111,25 @@
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-
 	if(panel_open && !opened)
 		wires.Interact(user)
 
 /obj/machinery/power/apc/welder_act(mob/user, obj/item/I)
 	if(!opened || has_electronics() || terminal)
 		return
-
 	. = TRUE
 	if(!I.tool_use_check(user, 3))
 		return
-
 	WELDER_ATTEMPT_SLICING_MESSAGE
 	if(I.use_tool(src, user, 50, amount = 3, volume = I.tool_volume))
 		if((stat & BROKEN) || opened == APC_COVER_OFF)
 			new /obj/item/stack/sheet/metal(loc)
 			user.visible_message(\
-				"<span class='notice'>[user.name] has cut [src] apart with [I].</span>",
-				"<span class='notice'>You disassembled the broken APC frame.</span>",
-				"<span class='warning'>You hear welding.</span>"
-				)
+				"[user.name] has cut [src] apart with [I].",\
+				"<span class='notice'>You disassembled the broken APC frame.</span>")
 		else
 			new /obj/item/mounted/frame/apc_frame(loc)
 			user.visible_message(\
-				"<span class='notice'>[user.name] has cut [src] from the wall with [I].</span>",
-				"<span class='notice'>You cut the APC frame from the wall.</span>",
-				"<span class='warning'>You hear welding.</span>"
-				)
+				"[user.name] has cut [src] from the wall with [I].",\
+				"<span class='notice'>You cut the APC frame from the wall.</span>")
 		qdel(src)


### PR DESCRIPTION
Reverts ParadiseSS13/Paradise#28602

Issues with construction of APCs after a cell is added. You are not able to close the panel. Panel state incorrect on examination (shows closed when open).