### PR TITLE
Atomized APC Construction Update

### DIFF
--- a/code/modules/power/apc/apc.dm
+++ b/code/modules/power/apc/apc.dm
@@ -308,7 +308,7 @@
 			"<span class='notice'>You start adding cables to [src]...</span>"
 			)
 		playsound(loc, 'sound/items/deconstruct.ogg', 50, TRUE)
-		if(do_after(user, 2 SECONDS, target = src))
+		if(do_after(user, 5 SECONDS, target = src))
 			if(C.get_amount() < 10 || !C)
 				return ITEM_INTERACT_COMPLETE
 

--- a/code/modules/power/apc/apc.dm
+++ b/code/modules/power/apc/apc.dm
@@ -336,16 +336,18 @@
 			return ITEM_INTERACT_COMPLETE
 
 		if(!has_electronics())
-			user.visible_message(
-				"<span class='notice'>[user] installs [used] into [src]...</span>",
-				"<span class='notice'>You install [used] into [src]...</span>"
-				)
-			playsound(loc, 'sound/items/deconstruct.ogg', 50, TRUE)
-			electronics_state = APC_ELECTRONICS_INSTALLED
-			locked = FALSE
-			stat &= ~MAINT
-			update_icon()
-			qdel(used)
+			to_chat(user, "<span class='notice'>You start to add [used] to [src].</span>")
+			if(do_after(user, 1 SECONDS, target = src))
+				user.visible_message(
+					"<span class='notice'>[user] installs [used] into [src]...</span>",
+					"<span class='notice'>You install [used] into [src]...</span>"
+					)
+				playsound(loc, 'sound/items/deconstruct.ogg', 50, TRUE)
+				electronics_state = APC_ELECTRONICS_INSTALLED
+				locked = FALSE
+				stat &= ~MAINT
+				update_icon()
+				qdel(used)
 
 		return ITEM_INTERACT_COMPLETE
 

--- a/code/modules/power/apc/apc.dm
+++ b/code/modules/power/apc/apc.dm
@@ -257,7 +257,10 @@
 
 		used.forceMove(src)
 		cell = used
-
+		user.visible_message(
+			"<span class='notice'>[user] inserts [used] into [src].</span>",
+			"<span class='notice'>You insert [used] into [src].</span>"
+			)
 		for(var/mob/living/simple_animal/demon/pulse_demon/demon in cell)
 			demon.forceMove(src)
 			demon.current_power = src
@@ -265,11 +268,6 @@
 				demon.try_hijack_apc(src)
 		if(being_hijacked)
 			cell.rigged = FALSE // Do not explode the demon.
-
-		user.visible_message(
-			"<span class='notice'>[user] inserts [used] into [src].</span>",
-			"<span class='notice'>You insert [used] into [src].</span>"
-			)
 		chargecount = 0
 		update_icon()
 		return ITEM_INTERACT_COMPLETE

--- a/code/modules/power/apc/apc.dm
+++ b/code/modules/power/apc/apc.dm
@@ -287,7 +287,7 @@
 			return ITEM_INTERACT_COMPLETE
 
 		if(host_turf.intact)
-			to_chat(user, "<span class='warning'>You must expode the floor plating in front of [src] first!</span>")
+			to_chat(user, "<span class='warning'>You must expose the floor plating in front of [src] first!</span>")
 			return ITEM_INTERACT_COMPLETE
 
 		if(terminal)

--- a/code/modules/power/apc/apc.dm
+++ b/code/modules/power/apc/apc.dm
@@ -308,7 +308,7 @@
 			"<span class='notice'>You start adding cables to [src]...</span>"
 			)
 		playsound(loc, 'sound/items/deconstruct.ogg', 50, TRUE)
-		if(do_after(user, 5 SECONDS, target = src))
+		if(do_after(user, 2 SECONDS, target = src))
 			if(C.get_amount() < 10 || !C)
 				return ITEM_INTERACT_COMPLETE
 

--- a/code/modules/power/apc/apc.dm
+++ b/code/modules/power/apc/apc.dm
@@ -337,18 +337,19 @@
 
 		if(!has_electronics())
 			to_chat(user, "<span class='notice'>You start to add [used] to [src].</span>")
-			if(do_after(user, 1 SECONDS, target = src))
-				user.visible_message(
-					"<span class='notice'>[user] installs [used] into [src]...</span>",
-					"<span class='notice'>You install [used] into [src]...</span>"
-					)
-				playsound(loc, 'sound/items/deconstruct.ogg', 50, TRUE)
-				electronics_state = APC_ELECTRONICS_INSTALLED
-				locked = FALSE
-				stat &= ~MAINT
-				update_icon()
-				qdel(used)
+			if(!do_after(user, 1 SECONDS, target = src))
+				return ITEM_INTERACT_COMPLETE
 
+			user.visible_message(
+				"<span class='notice'>[user] installs [used] into [src]...</span>",
+				"<span class='notice'>You install [used] into [src]...</span>"
+				)
+			playsound(loc, 'sound/items/deconstruct.ogg', 50, TRUE)
+			electronics_state = APC_ELECTRONICS_INSTALLED
+			locked = FALSE
+			stat &= ~MAINT
+			update_icon()
+			qdel(used)
 		return ITEM_INTERACT_COMPLETE
 
 	// APC frame repair. Takes no time, the trade-off is you sacrifice the metal used to build the replacement frame vs. being able to recover it from the old one.
@@ -359,6 +360,10 @@
 
 		// Only cover is broken, no need to remove any components.
 		if(!(stat & BROKEN) && opened == APC_COVER_OFF)
+			to_chat(user, "<span class='notice'>You begin to replace the missing cover of [src].</span>")
+			if(!do_after(user, 2 SECONDS, target = src))
+				return ITEM_INTERACT_COMPLETE
+
 			user.visible_message(
 				"<span class='notice'>[user] replaces the missing cover of [src].</span>",
 				"<span class='notice'>You replace the missing cover of [src].</span>"

--- a/code/modules/power/apc/apc.dm
+++ b/code/modules/power/apc/apc.dm
@@ -350,7 +350,7 @@
 			qdel(used)
 		return ITEM_INTERACT_COMPLETE
 
-	// APC frame repair. Takes no time, the trade-off is you sacrifice the metal used to build the replacement frame vs. being able to recover it from the old one.
+	// APC frame repair.
 	if(istype(used, /obj/item/mounted/frame/apc_frame) && opened)
 		if(!(stat & BROKEN || opened == APC_COVER_OFF || obj_integrity < max_integrity))
 			to_chat(user, "<span class='warning'>[src] has no damage to fix!</span>")

--- a/code/modules/power/apc/apc_construction.dm
+++ b/code/modules/power/apc/apc_construction.dm
@@ -45,7 +45,7 @@
 			to_chat(user, "<span class='warning'>Disconnect the wires first!</span>")
 			return
 
-		if(I.use_tool(src, user, FALSE, volume = I.tool_volume))
+		if(I.use_tool(src, user, 5 SECONDS, volume = I.tool_volume))
 			if(has_electronics())
 				electronics_state = APC_ELECTRONICS_NONE
 				if(stat & BROKEN)
@@ -103,25 +103,11 @@
 		opened = APC_OPENED
 		update_icon()
 
-	// 3. Broken, closed APC
-	if((stat & BROKEN) && opened == APC_CLOSED)
-		if(!I.use_tool(src, user, 1 SECONDS, volume = I.tool_volume))
-			return
-
-		user.visible_message(
-			"<span class='notice'>[user] rips the cover off [src].</span>",
-			"<span class='notice'>You rip the cover off [src].</span>",
-			"<span class='warning'>You hear metallic levering and a small flat object falling to the floor!</span>"
-			)
-		panel_open = FALSE // Avoid wacky behavour with wires.
-		opened = APC_COVER_OFF
-		update_icon()
-
 /obj/machinery/power/apc/screwdriver_act(mob/living/user, obj/item/I)
 	. = TRUE
 
 	if(opened)
-		to_chat(user, "<span class='warning'>Close the APC first!</span>") //Less hints more mystery!
+		to_chat(user, "<span class='warning'>Close the APC first!</span>")
 		return
 
 	if(emagged)

--- a/code/modules/power/apc/apc_construction.dm
+++ b/code/modules/power/apc/apc_construction.dm
@@ -57,7 +57,6 @@
 					update_icon()
 					return
 
-					//SSticker.mode:apcs-- //XSI said no and I agreed. -rastaf0
 				if(emagged) // We emag board, not APC's frame
 					emagged = FALSE
 					user.visible_message(

--- a/code/modules/power/apc/apc_construction.dm
+++ b/code/modules/power/apc/apc_construction.dm
@@ -167,7 +167,7 @@
 		return
 
 	WELDER_ATTEMPT_SLICING_MESSAGE
-	if(I.use_tool(src, user, 50, amount = 3, volume = I.tool_volume))
+	if(I.use_tool(src, user, 5 SECONDS, amount = 3, volume = I.tool_volume))
 		if((stat & BROKEN) || opened == APC_COVER_OFF)
 			new /obj/item/stack/sheet/metal(loc)
 			user.visible_message(\

--- a/code/modules/power/apc/apc_construction.dm
+++ b/code/modules/power/apc/apc_construction.dm
@@ -11,7 +11,7 @@
 			opened = APC_COVER_OFF
 			coverlocked = FALSE
 			visible_message(
-				"<span class='warning'>The APC cover falls off!</span>",
+				"<span class='warning'>The cover falls off [src]!</span>",
 				"<span class='warning'>You hear a small flat object falling to the floor!</span>"
 				)
 			update_icon()
@@ -21,81 +21,105 @@
 	if(!I.tool_start_check(src, user, 0))
 		return
 
-	if(opened) // a) on open apc
-		if(electronics_state == APC_ELECTRONICS_INSTALLED)
-			if(terminal)
-				to_chat(user, "<span class='warning'>Disconnect the wires first!</span>")
+	// 1. Opened APC
+	if(opened)
+		if(cell)
+			if(opened == APC_OPENED) // Do not magically create a new cover if it broke off.
+				opened = APC_CLOSED
+				coverlocked = TRUE //closing cover relocks it
+				update_icon()
+				user.visible_message(
+					"<span class='notice'>[user] closes the cover of [src].</span>",
+					"<span class='notice'>You close the cover of [src].</span>")
 				return
 
-			to_chat(user, "<span class='notice'>You start trying to remove the APC electronics...</span>" )
-			if(I.use_tool(src, user, 50, volume = I.tool_volume))
-				if(has_electronics())
-					electronics_state = APC_ELECTRONICS_NONE
-					if(stat & BROKEN)
-						user.visible_message(
-							"<span class='notice'>[user.name] rips out the broken the APC electronics inside [name]!</span>",
-							"<span class='notice'>You break the charred APC electronics and remove the remains.</span>",
-							"<span class='warning'>You hear metallic levering and a crack.</span>")
-						stat |= MAINT
-						update_icon()
-						return
+			else
+				to_chat(user, "<span class='warning'>Remove the cell first!</span>")
+				return
 
-						//SSticker.mode:apcs-- //XSI said no and I agreed. -rastaf0
-					if(emagged) // We emag board, not APC's frame
-						emagged = FALSE
-						user.visible_message(
-							"<span class='notice'>[user.name] has discarded the shorted APC electronics from [name]!</span>",
-							"<span class='notice'>You discarded the shorted board.</span>",
-							"<span class='warning'>You hear metallic levering.</span>"
-							)
-						stat |= MAINT
-						update_icon()
-						return
+		if(electronics_state == APC_ELECTRONICS_NONE)
+			to_chat(user, "<span class='warning'>There's nothing inside!</span>")
+			return
 
-					if(malfhack) // AI hacks board, not APC's frame
-						user.visible_message(\
-							"<span class='notice'>[user.name] has discarded the strangely programmed APC electronics from [name]!</span>",
-							"<span class='notice'>You discarded the strangely programmed board.</span>",
-							"<span class='warning'>You hear metallic levering.</span>"
-							)
-						malfai = null
-						malfhack = FALSE
-						stat |= MAINT
-						update_icon()
-						return
+		if(terminal)
+			to_chat(user, "<span class='warning'>Disconnect the wires first!</span>")
+			return
 
-					user.visible_message(\
-						"<span class='notice'>[user.name] has removed the APC electronics from [name]!</span>",
-						"<span class='notice'>You remove the APC electronics.</span>",
-						"<span class='warning'>You hear metallic levering.</span>"
-						)
-					new /obj/item/apc_electronics(loc)
+		if(I.use_tool(src, user, FALSE, volume = I.tool_volume))
+			if(has_electronics())
+				electronics_state = APC_ELECTRONICS_NONE
+				if(stat & BROKEN)
+					user.visible_message(
+						"<span class='notice'>[user] rips out the broken the APC electronics inside [src]!</span>",
+						"<span class='notice'>You break the charred APC electronics and remove the remains.</span>",
+						"<span class='warning'>You hear metallic levering and a crack.</span>")
 					stat |= MAINT
 					update_icon()
 					return
 
-		if(opened != APC_COVER_OFF) //cover isn't removed
-			opened = APC_CLOSED
-			coverlocked = TRUE //closing cover relocks it
-			update_icon()
-			return
+					//SSticker.mode:apcs-- //XSI said no and I agreed. -rastaf0
+				if(emagged) // We emag board, not APC's frame
+					emagged = FALSE
+					user.visible_message(
+						"<span class='notice'>[user] has discarded the shorted APC electronics from [src]!</span>",
+						"<span class='notice'>You discarded the shorted board.</span>",
+						"<span class='warning'>You hear metallic levering.</span>"
+						)
+					stat |= MAINT
+					update_icon()
+					return
 
-	if(!(stat & BROKEN)) // b) on closed and not broken APC
-		if(coverlocked && !(stat & MAINT)) // locked...
-			to_chat(user, "<span class='warning'>The cover is locked and cannot be opened!</span>")
-			return
+				if(malfhack) // AI hacks board, not APC's frame
+					user.visible_message(\
+						"<span class='notice'>[name] has discarded the strangely programmed APC electronics from [src]!</span>",
+						"<span class='notice'>You discarded the strangely programmed board.</span>",
+						"<span class='warning'>You hear metallic levering.</span>"
+						)
+					malfai = null
+					malfhack = FALSE
+					stat |= MAINT
+					update_icon()
+					return
 
+				user.visible_message(\
+					"<span class='notice'>[user] has removed the APC electronics from [src]!</span>",
+					"<span class='notice'>You remove the APC electronics.</span>",
+					"<span class='warning'>You hear metallic levering.</span>"
+					)
+				new /obj/item/apc_electronics(loc)
+				stat |= MAINT
+				update_icon()
+				return
+
+	// 2. Closed APC
+	if(!(stat & BROKEN))
 		if(panel_open) // wires are exposed
-			to_chat(user, "<span class='warning'>Exposed wires prevents you from opening it!</span>")
+			to_chat(user, "<span class='warning'>Exposed wiring prevents you from opening [src]!</span>")
+			return
+
+		if(coverlocked && !(stat & MAINT)) // locked...
+			to_chat(user, "<span class='warning'>The cover of [src] is locked!</span>")
 			return
 
 		opened = APC_OPENED
 		update_icon()
 
+	// 3. Broken, closed APC
+	if((stat & BROKEN) && opened == APC_CLOSED)
+		if(!I.use_tool(src, user, 1 SECONDS, volume = I.tool_volume))
+			return
+
+		user.visible_message(
+			"<span class='notice'>[user] rips the cover off [src].</span>",
+			"<span class='notice'>You rip the cover off [src].</span>",
+			"<span class='warning'>You hear metallic levering and a small flat object falling to the floor!</span>"
+			)
+		panel_open = FALSE // Avoid wacky behavour with wires.
+		opened = APC_COVER_OFF
+		update_icon()
+
 /obj/machinery/power/apc/screwdriver_act(mob/living/user, obj/item/I)
 	. = TRUE
-	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
-		return
 
 	if(opened)
 		to_chat(user, "<span class='warning'>Close the APC first!</span>") //Less hints more mystery!
@@ -105,26 +129,33 @@
 		to_chat(user, "<span class='warning'>The interface is broken!</span>")
 		return
 
+	if(!I.use_tool(src, user, FALSE, volume = I.tool_volume))
+		return
+
 	panel_open = !panel_open
 	to_chat(user, "<span class='notice'>The wires have been [panel_open ? "exposed" : "unexposed"]</span>")
 	update_icon()
 
 /obj/machinery/power/apc/wirecutter_act(mob/living/user, obj/item/I)
 	. = TRUE
-	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+
+	if(terminal && opened)
+		if(!I.use_tool(src, user, FALSE, volume = I.tool_volume))
+			return
+		terminal.dismantle(user, I)
 		return
 
 	if(panel_open && !opened)
+		if(!I.use_tool(src, user, FALSE, volume = I.tool_volume))
+			return
 		wires.Interact(user)
-	else if(terminal && opened)
-		terminal.dismantle(user, I)
 
 /obj/machinery/power/apc/multitool_act(mob/living/user, obj/item/I)
 	. = TRUE
-	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
-		return
 
 	if(panel_open && !opened)
+		if(!I.use_tool(src, user, FALSE, volume = I.tool_volume))
+			return
 		wires.Interact(user)
 
 /obj/machinery/power/apc/welder_act(mob/user, obj/item/I)
@@ -140,14 +171,14 @@
 		if((stat & BROKEN) || opened == APC_COVER_OFF)
 			new /obj/item/stack/sheet/metal(loc)
 			user.visible_message(\
-				"<span class='notice'>[user.name] has cut [src] apart with [I].</span>",
+				"<span class='notice'>[user] has cut [src] apart with [I].</span>",
 				"<span class='notice'>You disassembled the broken APC frame.</span>",
 				"<span class='warning'>You hear welding.</span>"
 				)
 		else
 			new /obj/item/mounted/frame/apc_frame(loc)
 			user.visible_message(\
-				"<span class='notice'>[user.name] has cut [src] from the wall with [I].</span>",
+				"<span class='notice'>[user] has cut [src] from the wall with [I].</span>",
 				"<span class='notice'>You cut the APC frame from the wall.</span>",
 				"<span class='warning'>You hear welding.</span>"
 				)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Contains the fixes and updates of #28795 without any of the buffs to construction speed.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
#28602 is causing issues with APC construction.

Better code and messages is good.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Same testing as #28602.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Made APC construction/deconstruction messages clearer and added them for all steps.
fix: APC electronics cannot be removed unless there is no cell inside.
fix: Using tools on an APC won't play tool sounds unless an interaction occurs.
fix: APC covers can now be reliably closed again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
