### PR TITLE
refactor: pull last attacker data to atom level

### DIFF
--- a/code/__HELPERS/atom_helpers.dm
+++ b/code/__HELPERS/atom_helpers.dm
@@ -8,3 +8,11 @@
 		location = location.loc
 	if(our_turf && include_turf) // At this point, only the turf is left, provided it exists.
 		. += our_turf
+
+/// A datum storing information about attacks an atom has received.
+/// Only contains attacker name/ckey right now but could be expanded.
+/datum/attack_info
+	/// Name of the mob who performed the last attack.
+	var/last_attacker_name = null
+	/// Ckey of the player who performed the last attack.
+	var/last_attacker_ckey = null

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -178,9 +178,7 @@
 		if(hitsound)
 			playsound(loc, hitsound, get_clamped_volume(), TRUE, extrarange = stealthy_audio ? SILENCED_SOUND_EXTRARANGE : -1, falloff_distance = 0)
 
-	target.lastattacker = user.real_name
-	target.lastattackerckey = user.ckey
-
+	target.store_last_attacker(user)
 	user.do_attack_animation(target)
 	add_fingerprint(user)
 

--- a/code/controllers/subsystem/SSblackbox.dm
+++ b/code/controllers/subsystem/SSblackbox.dm
@@ -326,10 +326,10 @@ SUBSYSTEM_DEF(blackbox)
 	// Empty string is important here!
 	var/laname = ""
 	var/lakey = ""
-	if(L.lastattacker)
-		laname = L.lastattacker
-	if(L.lastattackerckey)
-		lakey = L.lastattackerckey
+	if(L.attack_info?.last_attacker_name)
+		laname = L.attack_info.last_attacker_name
+	if(L.attack_info?.last_attacker_ckey)
+		lakey = L.attack_info.last_attacker_ckey
 
 	var/datum/db_query/deathquery = SSdbcore.NewQuery({"
 		INSERT INTO death (name, byondkey, job, special, pod, tod, laname, lakey, gender, bruteloss, fireloss, brainloss, oxyloss, coord, server_id, death_rid, last_words)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -137,6 +137,8 @@
 	var/receive_ricochet_damage_coeff = 0.33
 	/// AI controller that controls this atom. type on init, then turned into an instance during runtime
 	var/datum/ai_controller/ai_controller
+	/// Information about attacks performed on this atom.
+	var/datum/attack_info/attack_info
 
 	/// Whether this atom is using the new attack chain.
 	var/new_attack_chain = FALSE
@@ -247,6 +249,8 @@
 		return TRUE
 
 /atom/Destroy()
+	QDEL_NULL(attack_info)
+
 	if(alternate_appearances)
 		for(var/aakey in alternate_appearances)
 			var/datum/alternate_appearance/AA = alternate_appearances[aakey]
@@ -1495,3 +1499,9 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 	while(i < length(.))
 		var/atom/checked_atom = .[++i]
 		. += checked_atom.contents
+
+/atom/proc/store_last_attacker(mob/living/attacker)
+	if(!attack_info)
+		attack_info = new
+	attack_info.last_attacker_name = attacker.real_name
+	attack_info.last_attacker_ckey = attacker.ckey

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -425,7 +425,7 @@
 		qdel(src)
 		return
 	add_attack_logs(user, M, "used a cult spell ([src]) on")
-	M.lastattacker = user.real_name
+	M.store_last_attacker(user)
 
 /obj/item/melee/blood_magic/afterattack__legacy__attackchain(atom/target, mob/living/carbon/user, proximity)
 	. = ..()

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -315,8 +315,7 @@ CONTENTS:
 		H.update_inv_r_hand()
 
 /obj/item/abductor_baton/proc/StunAttack(mob/living/L,mob/living/user)
-	L.lastattacker = user.real_name
-	L.lastattackerckey = user.ckey
+	L.store_last_attacker(user)
 
 	L.KnockDown(7 SECONDS)
 	L.apply_damage(80, STAMINA)

--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -15,7 +15,6 @@
 	var/pushed_over = FALSE
 	/// If the cutout actually appears as what it portray and not a discolored version
 	var/deceptive = FALSE
-	var/lastattacker = null
 
 /obj/item/cardboard_cutout/attack_hand(mob/living/user)
 	if(user.a_intent == INTENT_HELP || pushed_over)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -279,8 +279,7 @@
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK, 33)
 
 	if(user)
-		L.lastattacker = user.real_name
-		L.lastattackerckey = user.ckey
+		L.store_last_attacker(user)
 		L.visible_message(
 			"<span class='danger'>[user] has stunned [L] with [src]!</span>",
 			"<span class='userdanger'>[L == user ? "You stun yourself" : "[user] has stunned you"] with [src]!</span>"
@@ -319,8 +318,7 @@
 
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK, 33)
 
-	L.lastattacker = user.real_name
-	L.lastattackerckey = user.ckey
+	L.store_last_attacker(user)
 	L.visible_message("<span class='danger'>[src] stuns [L]!</span>")
 	add_attack_logs(user, L, "stunned")
 	playsound(src, 'sound/weapons/egloves.ogg', 50, TRUE, -1)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -567,8 +567,7 @@
 	else
 		target.LAssailant = user
 
-	target.lastattacker = user.real_name
-	target.lastattackerckey = user.ckey
+	target.store_last_attacker(user)
 
 	var/damage = rand(user.dna.species.punchdamagelow, user.dna.species.punchdamagehigh)
 	damage += attack.damage

--- a/code/modules/mob/mob_vars.dm
+++ b/code/modules/mob/mob_vars.dm
@@ -38,8 +38,6 @@
 	var/use_me = TRUE //Allows all mobs to use the me verb by default, will have to manually specify they cannot
 	var/damageoverlaytemp = 0
 	var/computer_id = null
-	var/lastattacker = null // real name of the person  doing the attacking
-	var/lastattackerckey = null // their ckey
 	var/list/attack_log_old = list()
 	var/list/debug_log = null
 


### PR DESCRIPTION
## What Does This PR Do
This PR takes the "last attacker name" and "last attacker ckey" fields on /mobs and moves them into a separate type, stored on /atom. It also removes an unused field with a similar name on the cardboard cutout.
## Why It's Good For The Game
Allows us to track attacker data for things that aren't mobs.
## Testing
Ensured attack info was filled in properly, killed a mob previously inhabited by a client and ensured the row in the deaths DB table included the correct info.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog
NPFC