### PR TITLE
refactor: remove unused var /mob/var/LAssailant

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -661,11 +661,6 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 		to_chat(user, "<span class='warning'>You cannot locate any eyes on this creature!</span>")
 		return
 
-	if(!iscarbon(user))
-		M.LAssailant = null
-	else
-		M.LAssailant = user
-
 	src.add_fingerprint(user)
 
 	playsound(loc, src.hitsound, 30, TRUE, -1)

--- a/code/game/objects/items/weapons/batons.dm
+++ b/code/game/objects/items/weapons/batons.dm
@@ -97,7 +97,6 @@
 	playsound(target, stun_sound, 75, TRUE, -1)
 	add_attack_logs(user, target, "Knocked down with [src]")
 	// Hit 'em
-	target.LAssailant = iscarbon(user) ? user : null
 	target.KnockDown(knockdown_duration)
 	on_cooldown = TRUE
 	addtimer(VARSET_CALLBACK(src, on_cooldown, FALSE), cooldown)

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -73,10 +73,6 @@
 
 /obj/item/storage/bible/attack__legacy__attackchain(mob/living/M, mob/living/user)
 	add_attack_logs(user, M, "Hit with [src]")
-	if(!iscarbon(user))
-		M.LAssailant = null
-	else
-		M.LAssailant = user
 
 	if(!(ishuman(user) || SSticker) && SSticker.mode.name != "monkey")
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")

--- a/code/modules/antagonists/vampire/vamp_datum.dm
+++ b/code/modules/antagonists/vampire/vamp_datum.dm
@@ -109,10 +109,6 @@ RESTRICT_TYPE(/datum/antagonist/vampire)
 		return
 	add_attack_logs(owner.current, H, "vampirebit & is draining their blood.", ATKLOG_ALMOSTALL)
 	owner.current.visible_message("<span class='danger'>[owner.current] grabs [H]'s neck harshly and sinks in [owner.current.p_their()] fangs!</span>", "<span class='danger'>You sink your fangs into [H] and begin to drain [H.p_their()] blood.</span>", "<span class='notice'>You hear a soft puncture and a wet sucking noise.</span>")
-	if(!iscarbon(owner.current))
-		H.LAssailant = null
-	else
-		H.LAssailant = owner
 	while(do_mob(owner.current, H, suck_rate, hidden = TRUE))
 		owner.current.do_attack_animation(H, ATTACK_EFFECT_BITE)
 		if(unique_suck_id in drained_humans)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -562,11 +562,6 @@
 		return FALSE
 	add_attack_logs(user, target, "Melee attacked with fists", target.ckey ? null : ATKLOG_ALL)
 
-	if(!iscarbon(user))
-		target.LAssailant = null
-	else
-		target.LAssailant = user
-
 	target.lastattacker = user.real_name
 	target.lastattackerckey = user.ckey
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1008,12 +1008,6 @@
 	AM.pulledby = src
 	if(pullin)
 		pullin.update_icon(UPDATE_ICON_STATE)
-	if(ismob(AM))
-		var/mob/M = AM
-		if(!iscarbon(src))
-			M.LAssailant = null
-		else
-			M.LAssailant = usr
 
 /mob/living/proc/check_pull()
 	if(pulling && !pulling.Adjacent(src))

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -305,7 +305,6 @@
 		return 0
 	user.put_in_active_hand(G)
 	G.synch()
-	LAssailant = user
 
 	playsound(src.loc, 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
 	/*if(user.dir == src.dir)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -25,7 +25,6 @@
 		for(var/datum/alternate_appearance/AA in viewing_alternate_appearances)
 			AA.viewers -= src
 		viewing_alternate_appearances = null
-	LAssailant = null
 	runechat_msg_location = null
 	if(length(observers))
 		for(var/mob/dead/observe as anything in observers)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -343,10 +343,6 @@
 		icon_state = "grabbed+1"
 
 		add_attack_logs(assailant, affecting, "Neck grabbed", ATKLOG_ALL)
-		if(!iscarbon(assailant))
-			affecting.LAssailant = null
-		else
-			affecting.LAssailant = assailant
 		hud.icon_state = "kill"
 		hud.name = "kill"
 		affecting.Stun(3 SECONDS) // Ensures the grab is able to be secured

--- a/code/modules/mob/mob_vars.dm
+++ b/code/modules/mob/mob_vars.dm
@@ -138,9 +138,6 @@
 //Generic list for proc holders. Only way I can see to enable certain verbs/procs. Should be modified if needed.
 	var/proc_holder_list[] = list()
 
-//The last mob/living/carbon to push/drag/grab this mob (mostly used by slimes friend recognition)
-	var/mob/living/carbon/LAssailant = null
-
 	var/list/mob_spell_list = list() //construct spells and mime spells. Spells that do not transfer from one mob to another and can not be lost in mindswap.
 
 //List of active diseases

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -322,10 +322,6 @@
 			"<span class='warning'>You hear the sound of someone being stuffed into a disposal unit.</span>"
 		)
 
-		if(!iscarbon(user))
-			target.LAssailant = null
-		else
-			target.LAssailant = user
 		add_attack_logs(user, target, "Disposal'ed", !!target.ckey ? null : ATKLOG_ALL)
 	else
 		return

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -269,7 +269,6 @@
 				if(/obj/item/food/monkeycube/wolpincube) 							// Wolpin
 					food = new /mob/living/carbon/human/wolpin(remote_eye.loc)
 			SSmobs.cubemonkeys += food
-			food.LAssailant = C
 			X.monkeys --
 			to_chat(owner, "[X] now has [X.monkeys] monkeys left.")
 	else
@@ -466,21 +465,19 @@
 		return
 	else if(turfarea.name == E.allowed_area || turfarea.xenobiology_compatible)
 		if(X.monkeys >= 1)
-			var/mob/living/carbon/human/monkey/food
 			switch(recycler.cube_type)
 				if(/obj/item/food/monkeycube) 										// Regular monkey
-					food = new /mob/living/carbon/human/monkey(T)
+					new /mob/living/carbon/human/monkey(T)
 				if(/obj/item/food/monkeycube/nian_wormecube) 						// Worme
-					food = new /mob/living/carbon/human/nian_worme(T)
+					new /mob/living/carbon/human/nian_worme(T)
 				if(/obj/item/food/monkeycube/farwacube) 								// Farwa
-					food = new /mob/living/carbon/human/farwa(T)
+					new /mob/living/carbon/human/farwa(T)
 				if(/obj/item/food/monkeycube/stokcube) 								// Stok
-					food = new /mob/living/carbon/human/stok(T)
+					new /mob/living/carbon/human/stok(T)
 				if(/obj/item/food/monkeycube/neaeracube) 							// Neara
-					food = new /mob/living/carbon/human/neara(T)
+					new /mob/living/carbon/human/neara(T)
 				if(/obj/item/food/monkeycube/wolpincube) 							// Wolpin
-					food = new /mob/living/carbon/human/wolpin(T)
-			food.LAssailant = C
+					new /mob/living/carbon/human/wolpin(T)
 			X.monkeys--
 			X.monkeys = round(X.monkeys, 0.1)
 			to_chat(user, "[X] now has [X.monkeys] monkeys left.")


### PR DESCRIPTION
## What Does This PR Do
This PR removes the variable `/mob/var/LAssailant`, which, since #22790, is only set and never read anywhere.
## Why It's Good For The Game
Dead code bad.
## Testing
Compiled.

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog
NPFC
