### PR TITLE
refactor: add commonly used investigate category defines

### DIFF
--- a/code/__DEFINES/misc_defines.dm
+++ b/code/__DEFINES/misc_defines.dm
@@ -425,10 +425,16 @@
 #define EXPLOSION_BLOCK_PROC -1
 
 // Defines for investigate to prevent typos and for styling
-#define INVESTIGATE_RENAME "renames"
-
+#define INVESTIGATE_ATMOS "atmos"
 #define INVESTIGATE_BOMB "bombs"
+#define INVESTIGATE_CARGO "cargo"
+#define INVESTIGATE_GRAVITY "gravity"
 #define INVESTIGATE_HOTMIC "hotmic"
+#define INVESTIGATE_RADIATION "radiation"
+#define INVESTIGATE_RENAME "renames"
+#define INVESTIGATE_SINGULO "singulo"
+#define INVESTIGATE_SUPERMATTER "supermatter"
+#define INVESTIGATE_WIRES "wires"
 
 // The SQL version required by this version of the code
 #define SQL_VERSION 64

--- a/code/controllers/subsystem/SSradiation.dm
+++ b/code/controllers/subsystem/SSradiation.dm
@@ -27,7 +27,7 @@ PROCESSING_SUBSYSTEM_DEF(radiation)
 	var/atom/master = contamination.parent
 	SSblackbox.record_feedback("tally", "contaminated", 1, master.type)
 	var/msg = "has become contaminated with enough radiation to emit radiation waves || Source: [contamination.source] || Strength: [contamination.alpha_strength + contamination.beta_strength + contamination.gamma_strength]"
-	master.investigate_log(msg, "radiation")
+	master.investigate_log(msg, INVESTIGATE_RADIATION)
 
 /datum/controller/subsystem/processing/radiation/fire(resumed)
 	if(world.time > last_rad_cache_update + rad_cache_update_interval)

--- a/code/game/gamemodes/miniantags/guardian/types/gaseous.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/gaseous.dm
@@ -51,7 +51,7 @@
 	if(!picked_gas)
 		return
 	to_chat(src, "<span class='bolddanger'>You are now expelling [picked_gas].</span>")
-	investigate_log("set their gas type to [picked_gas].", "atmos")
+	investigate_log("set their gas type to [picked_gas].", INVESTIGATE_ATMOS)
 	moles_of_gas = possible_gases[picked_gas]
 	switch(picked_gas)
 		if("Oxygen")

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -202,7 +202,7 @@
 	if(used.get_heat() > 300)
 		message_admins("Plasma airlock ignited by [key_name_admin(user)] in ([x],[y],[z] - <a href='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
 		log_game("Plasma airlock ignited by [key_name(user)] in ([x],[y],[z])")
-		investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]","atmos")
+		investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]",INVESTIGATE_ATMOS)
 		ignite(used.get_heat())
 		return ITEM_INTERACT_COMPLETE
 

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -313,7 +313,7 @@ GLOBAL_LIST_INIT(sandbag_recipes, list (
 	var/turf/T = get_turf(src)
 	message_admins("Plasma sheets ignited by [key_name_admin(user)]([ADMIN_QUE(user, "?")]) ([ADMIN_FLW(user, "FLW")]) in ([COORD(T)] - [ADMIN_JMP(T)]")
 	log_game("Plasma sheets ignited by [key_name(user)] in [COORD(T)]")
-	investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]", "atmos")
+	investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]", INVESTIGATE_ATMOS)
 	user.create_log(MISC_LOG, "Plasma sheets ignited using [I]", src)
 	fire_act()
 

--- a/code/game/objects/items/stacks/tiles/tile_mineral.dm
+++ b/code/game/objects/items/stacks/tiles/tile_mineral.dm
@@ -15,7 +15,7 @@
 							"<span class='warning'>You set the plasma tiles on fire!</span>")
 		message_admins("Plasma tiles ignited by [key_name_admin(user)](<A href='byond://?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) (<A href='byond://?_src_=holder;adminplayerobservefollow=\ref[user]'>FLW</A>) in ([x],[y],[z] - <A href='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
 		log_game("Plasma tiles ignited by [key_name(user)] in ([x],[y],[z])")
-		investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]","atmos")
+		investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]",INVESTIGATE_ATMOS)
 		qdel(src)
 
 /obj/item/stack/tile/mineral/uranium

--- a/code/game/objects/items/theft_items.dm
+++ b/code/game/objects/items/theft_items.dm
@@ -226,10 +226,10 @@
 	if(user)
 		add_attack_logs(user, victim, "[victim] consumed by [src] thrown by [user] ")
 		message_admins("[src] has consumed [key_name_admin(victim)] [ADMIN_JMP(src)], thrown by [key_name_admin(user)].")
-		investigate_log("has consumed [key_name(victim)], thrown by [key_name(user)]", "supermatter")
+		investigate_log("has consumed [key_name(victim)], thrown by [key_name(user)]", INVESTIGATE_SUPERMATTER)
 	else
 		message_admins("[src] has consumed [key_name_admin(victim)] [ADMIN_JMP(src)] via throw impact.")
-		investigate_log("has consumed [key_name(victim)] via throw impact.", "supermatter")
+		investigate_log("has consumed [key_name(victim)] via throw impact.", INVESTIGATE_SUPERMATTER)
 	victim.visible_message("<span class='danger'>As [victim] is hit by [src], both flash into dust and silence fills the room...</span>",
 		"<span class='userdanger'>You're hit by [src] and everything suddenly goes silent.\n[src] flashes into dust, and soon as you can register this, you do as well.</span>",
 		"<span class='hear'>Everything suddenly goes silent.</span>")
@@ -316,7 +316,7 @@
 		radiation_pulse(user, 2000, GAMMA_RAD)
 		playsound(src, 'sound/effects/supermatter.ogg', 50, TRUE)
 		message_admins("[sliver] has consumed [key_name_admin(user)] [ADMIN_JMP(src)].")
-		investigate_log("has consumed [key_name(user)].", "supermatter")
+		investigate_log("has consumed [key_name(user)].", INVESTIGATE_SUPERMATTER)
 		user.dust()
 		icon_state = "core_container_cracked_empty"
 		qdel(sliver)
@@ -389,7 +389,7 @@
 			return
 		victim.dust()
 		message_admins("[src] has consumed [key_name_admin(victim)] [ADMIN_JMP(src)].")
-		investigate_log("has irradiated [key_name(victim)].", "supermatter")
+		investigate_log("has irradiated [key_name(victim)].", INVESTIGATE_SUPERMATTER)
 	else if(istype(AM, /obj/singularity))
 		return
 	else if(istype(AM, /obj/item/nuke_core_container))
@@ -397,7 +397,7 @@
 	else if(istype(AM, /obj/machinery/atmospherics/supermatter_crystal))
 		return
 	else
-		investigate_log("has consumed [AM].", "supermatter")
+		investigate_log("has consumed [AM].", INVESTIGATE_SUPERMATTER)
 		qdel(AM)
 
 	if(user)

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -76,7 +76,7 @@
 
 					return
 
-				investigate_log("has become a singularity. Caused by [user.key]","singulo")
+				investigate_log("has become a singularity. Caused by [user.key]",INVESTIGATE_SINGULO)
 				user.visible_message("<span class='warning'>[user] erupts in evil laughter as [user.p_they()] put[user.p_s()] the Bag of Holding into another Bag of Holding!</span>", "<span class='warning'>You can't help but laugh wildly as you put the Bag of Holding into another Bag of Holding, complete darkness surrounding you.</span>","<span class='danger'> You hear the sound of scientific evil brewing!</span>")
 				qdel(W)
 				var/obj/singularity/singulo = new /obj/singularity(get_turf(user))

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -283,7 +283,7 @@
 		var/turf/T = locate(user)
 		message_admins("Plasma falsewall ignited by [key_name_admin(user)] in [ADMIN_VERBOSEJMP(T)]")
 		log_game("Plasma falsewall ignited by [key_name(user)] in [AREACOORD(T)]")
-		investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]","atmos")
+		investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]",INVESTIGATE_ATMOS)
 		burnbabyburn()
 	else
 		return ..()

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -186,7 +186,7 @@
 	if(W.get_heat())
 		message_admins("Plasma mineral door ignited by [key_name_admin(user)] in ([x], [y], [z] - <a href='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)", 0, 1)
 		log_game("Plasma mineral door ignited by [key_name(user)] in ([x], [y], [z])")
-		investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]","atmos")
+		investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]",INVESTIGATE_ATMOS)
 		TemperatureAct(100)
 	else
 		return ..()

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -101,7 +101,7 @@
 			if(P.firer)
 				message_admins("[key_name_admin(P.firer)] ignited a plasma statue with [P.name] at [COORD(loc)]")
 				log_game("[key_name(P.firer)] ignited a plasma statue with [P.name] at [COORD(loc)]")
-				investigate_log("[key_name(P.firer)] ignited a plasma statue with [P.name] at [COORD(loc)]", "atmos")
+				investigate_log("[key_name(P.firer)] ignited a plasma statue with [P.name] at [COORD(loc)]", INVESTIGATE_ATMOS)
 			else
 				message_admins("A plasma statue was ignited with [P.name] at [COORD(loc)]. No known firer.")
 				log_game("A plasma statue was ignited with [P.name] at [COORD(loc)]. No known firer.")
@@ -112,7 +112,7 @@
 	if(W.get_heat() > 300)//If the temperature of the object is over 300, then ignite
 		message_admins("[key_name_admin(user)] ignited a plasma statue at [COORD(loc)]")
 		log_game("[key_name(user)] ignited plasma a statue at [COORD(loc)]")
-		investigate_log("[key_name(user)] ignited a plasma statue at [COORD(loc)]", "atmos")
+		investigate_log("[key_name(user)] ignited a plasma statue at [COORD(loc)]", INVESTIGATE_ATMOS)
 		ignite(W.get_heat())
 		return
 	return ..()
@@ -126,7 +126,7 @@
 						"<span class='warning'>You hear a 'whoompf' and a roar.</span>")
 	message_admins("[key_name_admin(user)] ignited a plasma statue at [COORD(loc)]")
 	log_game("[key_name(user)] ignited plasma a statue at [COORD(loc)]")
-	investigate_log("[key_name(user)] ignited a plasma statue at [COORD(loc)]", "atmos")
+	investigate_log("[key_name(user)] ignited a plasma statue at [COORD(loc)]", INVESTIGATE_ATMOS)
 	ignite(2500)
 
 /obj/structure/statue/plasma/proc/PlasmaBurn()

--- a/code/game/turfs/simulated/floor/mineral_floors.dm
+++ b/code/game/turfs/simulated/floor/mineral_floors.dm
@@ -41,7 +41,7 @@
 	if(attacking.get_heat() > 300)//If the temperature of the object is over 300, then ignite
 		message_admins("Plasma flooring was ignited by [key_name_admin(user)]([ADMIN_QUE(user,"?")]) ([ADMIN_FLW(user,"FLW")]) in ([x],[y],[z] - <a href='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
 		log_game("Plasma flooring was <b>ignited by [key_name(user)] in ([x],[y],[z])")
-		investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]","atmos")
+		investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]",INVESTIGATE_ATMOS)
 		ignite(attacking.get_heat())
 		return FINISH_ATTACK
 
@@ -53,7 +53,7 @@
 		ignite(2500) //Big enough to ignite
 		message_admins("Plasma wall ignited by [key_name_admin(user)] in ([x], [y], [z] - <A href='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
 		log_game("Plasma wall ignited by [key_name(user)] in ([x], [y], [z])")
-		investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]","atmos")
+		investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]",INVESTIGATE_ATMOS)
 
 /turf/simulated/floor/mineral/plasma/proc/PlasmaBurn()
 	make_plating()

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -96,7 +96,7 @@
 	if(attacking.get_heat() > 300)//If the temperature of the object is over 300, then ignite
 		message_admins("Plasma wall ignited by [key_name_admin(user)] in ([x], [y], [z] - <a href='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
 		log_game("Plasma wall ignited by [key_name(user)] in ([x], [y], [z])")
-		investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]","atmos")
+		investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]",INVESTIGATE_ATMOS)
 		ignite(attacking.get_heat())
 
 		return FINISH_ATTACK
@@ -109,7 +109,7 @@
 							"<span class='warning'>You hear a 'whoompf' and a roar.</span>")
 		message_admins("Plasma wall ignited by [key_name_admin(user)] in ([x], [y], [z] - <A href='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
 		log_game("Plasma wall ignited by [key_name(user)] in ([x], [y], [z])")
-		investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]","atmos")
+		investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]",INVESTIGATE_ATMOS)
 
 /turf/simulated/wall/mineral/plasma/proc/PlasmaBurn(temperature)
 	new girder_type(src)

--- a/code/modules/atmospherics/machinery/atmospherics.dm
+++ b/code/modules/atmospherics/machinery/atmospherics.dm
@@ -239,7 +239,7 @@ Pipelines + Other Objects -> Pipe network
 		"<span class='notice'>You have unfastened [src].</span>",
 		"<span class='italics'>You hear ratcheting.</span>"
 	)
-	investigate_log("was <span class='warning'>REMOVED</span> by [key_name(usr)]", "atmos")
+	investigate_log("was <span class='warning'>REMOVED</span> by [key_name(usr)]", INVESTIGATE_ATMOS)
 
 	//You unwrenched a pipe full of pressure? let's splat you into the wall silly.
 	if(unsafe_wrenching)

--- a/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
@@ -20,7 +20,7 @@
 /obj/machinery/atmospherics/binary/passive_gate/CtrlClick(mob/living/user)
 	if(can_use_shortcut(user))
 		toggle(user)
-		investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", "atmos")
+		investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", INVESTIGATE_ATMOS)
 	return ..()
 
 /obj/machinery/atmospherics/binary/passive_gate/examine(mob/user)
@@ -111,7 +111,7 @@
 	switch(action)
 		if("power")
 			toggle()
-			investigate_log("was turned [on ? "on" : "off"] by [key_name(usr)]", "atmos")
+			investigate_log("was turned [on ? "on" : "off"] by [key_name(usr)]", INVESTIGATE_ATMOS)
 			return TRUE
 
 		if("max_rate")
@@ -126,4 +126,4 @@
 			target_pressure = clamp(text2num(params["rate"]), 0 , MAX_OUTPUT_PRESSURE)
 			. = TRUE
 	if(.)
-		investigate_log("was set to [target_pressure] kPa by [key_name(usr)]", "atmos")
+		investigate_log("was set to [target_pressure] kPa by [key_name(usr)]", INVESTIGATE_ATMOS)

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -36,21 +36,21 @@ Thus, the two variables affect pump operation are set in New():
 /obj/machinery/atmospherics/binary/pump/CtrlClick(mob/living/user)
 	if(can_use_shortcut(user))
 		toggle(user)
-		investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", "atmos")
+		investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", INVESTIGATE_ATMOS)
 	return ..()
 
 /obj/machinery/atmospherics/binary/pump/AICtrlClick(mob/living/silicon/user)
 	toggle(user)
-	investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", "atmos")
+	investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", INVESTIGATE_ATMOS)
 
 /obj/machinery/atmospherics/binary/pump/AltClick(mob/living/user)
 	if(can_use_shortcut(user))
 		set_max(user)
-		investigate_log("was set to [target_pressure] kPa by [key_name(user)]", "atmos")
+		investigate_log("was set to [target_pressure] kPa by [key_name(user)]", INVESTIGATE_ATMOS)
 
 /obj/machinery/atmospherics/binary/pump/AIAltClick(mob/living/silicon/user)
 	set_max(user)
-	investigate_log("was set to [target_pressure] kPa by [key_name(user)]", "atmos")
+	investigate_log("was set to [target_pressure] kPa by [key_name(user)]", INVESTIGATE_ATMOS)
 
 /obj/machinery/atmospherics/binary/pump/on
 	icon_state = "map_on"
@@ -135,7 +135,7 @@ Thus, the two variables affect pump operation are set in New():
 	switch(action)
 		if("power")
 			toggle()
-			investigate_log("was turned [on ? "on" : "off"] by [key_name(usr)]", "atmos")
+			investigate_log("was turned [on ? "on" : "off"] by [key_name(usr)]", INVESTIGATE_ATMOS)
 			return TRUE
 
 		if("max_rate")
@@ -150,7 +150,7 @@ Thus, the two variables affect pump operation are set in New():
 			target_pressure = clamp(text2num(params["rate"]), 0 , MAX_OUTPUT_PRESSURE)
 			. = TRUE
 	if(.)
-		investigate_log("was set to [target_pressure] kPa by [key_name(usr)]", "atmos")
+		investigate_log("was set to [target_pressure] kPa by [key_name(usr)]", INVESTIGATE_ATMOS)
 
 /obj/machinery/atmospherics/binary/pump/power_change()
 	if(!..())

--- a/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
@@ -42,13 +42,13 @@
 	parent1.update = 0
 	parent2.update = 0
 	parent1.reconcile_air()
-	investigate_log("was opened by [usr ? key_name(usr) : "a remote signal"]", "atmos")
+	investigate_log("was opened by [usr ? key_name(usr) : "a remote signal"]", INVESTIGATE_ATMOS)
 	return
 
 /obj/machinery/atmospherics/binary/valve/proc/close()
 	open = FALSE
 	update_icon(UPDATE_ICON_STATE)
-	investigate_log("was closed by [usr ? key_name(usr) : "a remote signal"]", "atmos")
+	investigate_log("was closed by [usr ? key_name(usr) : "a remote signal"]", INVESTIGATE_ATMOS)
 	return
 
 /obj/machinery/atmospherics/binary/valve/attack_ai(mob/user)

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -33,21 +33,21 @@ Thus, the two variables affect pump operation are set in New():
 /obj/machinery/atmospherics/binary/volume_pump/CtrlClick(mob/living/user)
 	if(can_use_shortcut(user))
 		toggle(user)
-		investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", "atmos")
+		investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", INVESTIGATE_ATMOS)
 	return ..()
 
 /obj/machinery/atmospherics/binary/volume_pump/AICtrlClick(mob/living/silicon/user)
 	toggle(user)
-	investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", "atmos")
+	investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", INVESTIGATE_ATMOS)
 
 /obj/machinery/atmospherics/binary/volume_pump/AltClick(mob/living/user)
 	if(can_use_shortcut(user))
 		set_max(user)
-		investigate_log("was set to [target_pressure] kPa by [key_name(user)]", "atmos")
+		investigate_log("was set to [target_pressure] kPa by [key_name(user)]", INVESTIGATE_ATMOS)
 
 /obj/machinery/atmospherics/binary/volume_pump/AIAltClick(mob/living/silicon/user)
 	set_max(user)
-	investigate_log("was set to [target_pressure] kPa by [key_name(user)]", "atmos")
+	investigate_log("was set to [target_pressure] kPa by [key_name(user)]", INVESTIGATE_ATMOS)
 
 /obj/machinery/atmospherics/binary/volume_pump/on
 	on = TRUE
@@ -131,7 +131,7 @@ Thus, the two variables affect pump operation are set in New():
 	switch(action)
 		if("power")
 			toggle()
-			investigate_log("was turned [on ? "on" : "off"] by [key_name(usr)]", "atmos")
+			investigate_log("was turned [on ? "on" : "off"] by [key_name(usr)]", INVESTIGATE_ATMOS)
 			return TRUE
 
 		if("max_rate")
@@ -146,7 +146,7 @@ Thus, the two variables affect pump operation are set in New():
 			transfer_rate = clamp(text2num(params["rate"]), 0 , MAX_TRANSFER_RATE)
 			. = TRUE
 	if(.)
-		investigate_log("was set to [transfer_rate] L/s by [key_name(usr)]", "atmos")
+		investigate_log("was set to [transfer_rate] L/s by [key_name(usr)]", INVESTIGATE_ATMOS)
 
 /obj/machinery/atmospherics/binary/volume_pump/power_change()
 	if(!..())

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -38,21 +38,21 @@
 /obj/machinery/atmospherics/trinary/filter/CtrlClick(mob/living/user)
 	if(can_use_shortcut(user))
 		toggle(user)
-		investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", "atmos")
+		investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", INVESTIGATE_ATMOS)
 	return ..()
 
 /obj/machinery/atmospherics/trinary/filter/AICtrlClick(mob/living/silicon/user)
 	toggle(user)
-	investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", "atmos")
+	investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", INVESTIGATE_ATMOS)
 
 /obj/machinery/atmospherics/trinary/filter/AltClick(mob/living/user)
 	if(can_use_shortcut(user))
 		set_max(user)
-		investigate_log("was set to [target_pressure] kPa by [key_name(user)]", "atmos")
+		investigate_log("was set to [target_pressure] kPa by [key_name(user)]", INVESTIGATE_ATMOS)
 
 /obj/machinery/atmospherics/trinary/filter/AIAltClick(mob/living/silicon/user)
 	set_max(user)
-	investigate_log("was set to [target_pressure] kPa by [key_name(user)]", "atmos")
+	investigate_log("was set to [target_pressure] kPa by [key_name(user)]", INVESTIGATE_ATMOS)
 
 /obj/machinery/atmospherics/trinary/filter/flipped
 	icon_state = "mmap"
@@ -205,12 +205,12 @@
 	switch(action)
 		if("power")
 			toggle()
-			investigate_log("was turned [on ? "on" : "off"] by [key_name(usr)]", "atmos")
+			investigate_log("was turned [on ? "on" : "off"] by [key_name(usr)]", INVESTIGATE_ATMOS)
 			return TRUE
 
 		if("set_filter")
 			filter_type = text2num(params["filter"])
-			investigate_log("was set to filter [filter_type] by [key_name(usr)]", "atmos")
+			investigate_log("was set to filter [filter_type] by [key_name(usr)]", INVESTIGATE_ATMOS)
 			return TRUE
 
 		if("max_pressure")
@@ -225,7 +225,7 @@
 			target_pressure = clamp(text2num(params["pressure"]), 0, MAX_OUTPUT_PRESSURE)
 			. = TRUE
 	if(.)
-		investigate_log("was set to [target_pressure] kPa by [key_name(usr)]", "atmos")
+		investigate_log("was set to [target_pressure] kPa by [key_name(usr)]", INVESTIGATE_ATMOS)
 
 /obj/machinery/atmospherics/trinary/filter/item_interaction(mob/living/user, obj/item/used, list/modifiers)
 	if(is_pen(used))

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -19,21 +19,21 @@
 /obj/machinery/atmospherics/trinary/mixer/CtrlClick(mob/living/user)
 	if(can_use_shortcut(user))
 		toggle(user)
-		investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", "atmos")
+		investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", INVESTIGATE_ATMOS)
 	return ..()
 
 /obj/machinery/atmospherics/trinary/mixer/AICtrlClick(mob/living/silicon/user)
 	toggle(user)
-	investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", "atmos")
+	investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", INVESTIGATE_ATMOS)
 
 /obj/machinery/atmospherics/trinary/mixer/AltClick(mob/living/user)
 	if(can_use_shortcut(user))
 		set_max(user)
-		investigate_log("was set to [target_pressure] kPa by [key_name(user)]", "atmos")
+		investigate_log("was set to [target_pressure] kPa by [key_name(user)]", INVESTIGATE_ATMOS)
 
 /obj/machinery/atmospherics/trinary/mixer/AIAltClick(mob/living/silicon/user)
 	set_max(user)
-	investigate_log("was set to [target_pressure] kPa by [key_name(user)]", "atmos")
+	investigate_log("was set to [target_pressure] kPa by [key_name(user)]", INVESTIGATE_ATMOS)
 
 /obj/machinery/atmospherics/trinary/mixer/flipped
 	icon_state = "mmap"
@@ -172,19 +172,19 @@
 	switch(action)
 		if("power")
 			toggle()
-			investigate_log("was turned [on ? "on" : "off"] by [key_name(usr)]", "atmos")
+			investigate_log("was turned [on ? "on" : "off"] by [key_name(usr)]", INVESTIGATE_ATMOS)
 			return TRUE
 
 		if("set_node")
 			if(params["node_name"] == "Node 1")
 				node1_concentration = clamp(round(text2num(params["concentration"]), 0.01), 0, 1)
 				node2_concentration = round(1 - node1_concentration, 0.01)
-				investigate_log("was set to [node1_concentration] % on node 1 by [key_name(usr)]", "atmos")
+				investigate_log("was set to [node1_concentration] % on node 1 by [key_name(usr)]", INVESTIGATE_ATMOS)
 				return TRUE
 			else
 				node2_concentration = clamp(round(text2num(params["concentration"]), 0.01), 0, 1)
 				node1_concentration = round(1 - node2_concentration, 0.01)
-				investigate_log("was set to [node2_concentration] % on node 2 by [key_name(usr)]", "atmos")
+				investigate_log("was set to [node2_concentration] % on node 2 by [key_name(usr)]", INVESTIGATE_ATMOS)
 				return TRUE
 
 		if("max_pressure")
@@ -199,7 +199,7 @@
 			target_pressure = clamp(text2num(params["pressure"]), 0, MAX_OUTPUT_PRESSURE)
 			. = TRUE
 	if(.)
-		investigate_log("was set to [target_pressure] kPa by [key_name(usr)]", "atmos")
+		investigate_log("was set to [target_pressure] kPa by [key_name(usr)]", INVESTIGATE_ATMOS)
 
 /obj/machinery/atmospherics/trinary/mixer/item_interaction(mob/living/user, obj/item/used, list/modifiers)
 	if(is_pen(used))

--- a/code/modules/atmospherics/machinery/components/trinary_devices/tvalve.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/tvalve.dm
@@ -73,7 +73,7 @@
 	parent3.update = 0
 	parent1.reconcile_air()
 
-	investigate_log("was set to side by [usr ? key_name(usr) : "a remote signal"]", "atmos")
+	investigate_log("was set to side by [usr ? key_name(usr) : "a remote signal"]", INVESTIGATE_ATMOS)
 	return 1
 
 /obj/machinery/atmospherics/trinary/tvalve/proc/go_straight()
@@ -88,7 +88,7 @@
 	parent3.update = 0
 	parent1.reconcile_air()
 
-	investigate_log("was set to straight by [usr ? key_name(usr) : "a remote signal"]", "atmos")
+	investigate_log("was set to straight by [usr ? key_name(usr) : "a remote signal"]", INVESTIGATE_ATMOS)
 	return 1
 
 /obj/machinery/atmospherics/trinary/tvalve/attack_ai(mob/user)

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -193,12 +193,12 @@
 		if("power")
 			on = !on
 			change_power_mode(on ? ACTIVE_POWER_USE : IDLE_POWER_USE)
-			investigate_log("was turned [on ? "on" : "off"] by [key_name(usr)]", "atmos")
+			investigate_log("was turned [on ? "on" : "off"] by [key_name(usr)]", INVESTIGATE_ATMOS)
 			update_icon()
 			. = TRUE
 		if("cooling")
 			swap_function()
-			investigate_log("was changed to [cooling ? "cooling" : "heating"] by [key_name(usr)]", "atmos")
+			investigate_log("was changed to [cooling ? "cooling" : "heating"] by [key_name(usr)]", INVESTIGATE_ATMOS)
 			. = TRUE
 		if("target")
 			var/target = params["target"]
@@ -215,7 +215,7 @@
 				. = TRUE
 			if(.)
 				target_temperature = clamp(target, min_temperature, max_temperature)
-				investigate_log("was set to [target_temperature] K by [key_name(usr)]", "atmos")
+				investigate_log("was set to [target_temperature] K by [key_name(usr)]", INVESTIGATE_ATMOS)
 
 /obj/machinery/atmospherics/unary/thermomachine/freezer
 	icon_state = "freezer"

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -270,10 +270,10 @@ GLOBAL_DATUM_INIT(canister_icon_container, /datum/canister_icons, new())
 		if(close_valve)
 			valve_open = FALSE
 			update_icon()
-			investigate_log("Valve was <b>closed</b> by [key_name(user)].<br>", "atmos")
+			investigate_log("Valve was <b>closed</b> by [key_name(user)].<br>", INVESTIGATE_ATMOS)
 
 		else if(valve_open && holding_tank)
-			investigate_log("[key_name(user)] started a transfer into [holding_tank].<br>", "atmos")
+			investigate_log("[key_name(user)] started a transfer into [holding_tank].<br>", INVESTIGATE_ATMOS)
 
 /obj/machinery/atmospherics/portable/canister/attack_ai(mob/user)
 	add_hiddenprint(user)
@@ -352,7 +352,7 @@ GLOBAL_DATUM_INIT(canister_icon_container, /datum/canister_icons, new())
 				pressure = text2num(pressure)
 			if(.)
 				release_pressure = clamp(round(pressure), can_min_release_pressure, can_max_release_pressure)
-				investigate_log("was set to [release_pressure] kPa by [key_name(ui.user)].", "atmos")
+				investigate_log("was set to [release_pressure] kPa by [key_name(ui.user)].", INVESTIGATE_ATMOS)
 
 		if("valve")
 			var/logmsg
@@ -376,7 +376,7 @@ GLOBAL_DATUM_INIT(canister_icon_container, /datum/canister_icons, new())
 			else
 				logmsg = "Valve was <b>closed</b> by [key_name(ui.user)], stopping the transfer into the [holding_tank || "air"].<br>"
 
-			investigate_log(logmsg, "atmos")
+			investigate_log(logmsg, INVESTIGATE_ATMOS)
 			release_log += logmsg
 
 		if("eject")

--- a/code/modules/atmospherics/machinery/portable/portable_pump.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_pump.dm
@@ -112,7 +112,7 @@
 				on = FALSE
 				update_icon()
 		else if(on && holding_tank && direction == DIRECTION_OUT)
-			investigate_log("[key_name(user)] started a transfer into [holding_tank].<br>", "atmos")
+			investigate_log("[key_name(user)] started a transfer into [holding_tank].<br>", INVESTIGATE_ATMOS)
 
 /obj/machinery/atmospherics/portable/pump/attack_ai(mob/user)
 	add_hiddenprint(user)
@@ -163,7 +163,7 @@
 				return
 			on = !on
 			if(on && direction == DIRECTION_OUT)
-				investigate_log("[key_name(usr)] started a transfer into [holding_tank].<br>", "atmos")
+				investigate_log("[key_name(usr)] started a transfer into [holding_tank].<br>", INVESTIGATE_ATMOS)
 			update_icon()
 			return TRUE
 
@@ -173,7 +173,7 @@
 			else
 				direction = DIRECTION_OUT
 			if(on && holding_tank)
-				investigate_log("[key_name(usr)] started a transfer into [holding_tank].<br>", "atmos")
+				investigate_log("[key_name(usr)] started a transfer into [holding_tank].<br>", INVESTIGATE_ATMOS)
 			update_icon()
 			return TRUE
 

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -445,7 +445,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	var/turf/T = get_turf(src)
 	message_admins("Plasma coin ignited by [key_name_admin(user)]([ADMIN_QUE(user, "?")]) ([ADMIN_FLW(user, "FLW")]) in ([COORD(T)] - [ADMIN_JMP(T)]")
 	log_game("Plasma coin ignited by [key_name(user)] in [COORD(T)]")
-	investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]", "atmos")
+	investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]", INVESTIGATE_ATMOS)
 	user.create_log(MISC_LOG, "Plasma coin ignited using [I]", src)
 	fire_act()
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -826,7 +826,7 @@
 	return
 
 /mob/living/singularity_act()
-	investigate_log("([key_name(src)]) has been consumed by the singularity.","singulo") //Oh that's where the clown ended up!
+	investigate_log("([key_name(src)]) has been consumed by the singularity.",INVESTIGATE_SINGULO) //Oh that's where the clown ended up!
 	gib()
 	return 20
 

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -60,7 +60,7 @@
 		toast() // mmmm toasty.
 	else
 		visible_message("<span class='warning'>[src] chews through [C].</span>")
-	investigate_log("was chewed through by a mouse in [get_area(F)]([F.x], [F.y], [F.z] - [ADMIN_JMP(F)])","wires")
+	investigate_log("was chewed through by a mouse in [get_area(F)]([F.x], [F.y], [F.z] - [ADMIN_JMP(F)])",INVESTIGATE_WIRES)
 	C.deconstruct()
 
 /mob/living/simple_animal/mouse/handle_automated_speech()

--- a/code/modules/pda/nanobank.dm
+++ b/code/modules/pda/nanobank.dm
@@ -415,7 +415,7 @@
 					playsound(pda, 'sound/machines/ping.ogg', 50, FALSE)
 				order.requires_head_approval = FALSE
 				SSeconomy.process_supply_order(order, TRUE)
-				pda.investigate_log("| [key_name(user)] has authorized an order for [pack.name]. Remaining Cargo Balance: [SSeconomy.cargo_account.credit_balance].", "cargo")
+				pda.investigate_log("| [key_name(user)] has authorized an order for [pack.name]. Remaining Cargo Balance: [SSeconomy.cargo_account.credit_balance].", INVESTIGATE_CARGO)
 				SSblackbox.record_feedback("tally", "cargo_shuttle_order", 1, pack.name)
 			else
 				pda.atom_say("ERROR: Account tied to order cannot pay, auto-denying order")
@@ -449,7 +449,7 @@
 		if(!can_deny)
 			return
 		SSeconomy.request_list -= order
-		pda.investigate_log("| [key_name(user)] has denied an order for [order.object.name] through the Nanobank app.", "cargo")
+		pda.investigate_log("| [key_name(user)] has denied an order for [order.object.name] through the Nanobank app.", INVESTIGATE_CARGO)
 
 /datum/data/pda/app/nanobank/proc/pay_with_account(user, amount, purpose, transactor, datum/money_account/target)
 	if(user_account.suspended)

--- a/code/modules/power/cables/cable.dm
+++ b/code/modules/power/cables/cable.dm
@@ -136,7 +136,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	if(shock(user, 50))
 		return
 	user.visible_message("[user] cuts the cable.", "<span class='notice'>You cut the cable.</span>")
-	investigate_log("was cut by [key_name(usr, 1)] in [get_area(user)]([T.x], [T.y], [T.z] - [ADMIN_JMP(T)])","wires")
+	investigate_log("was cut by [key_name(usr, 1)] in [get_area(user)]([T.x], [T.y], [T.z] - [ADMIN_JMP(T)])",INVESTIGATE_WIRES)
 	deconstruct()
 
 /obj/structure/cable/proc/cable_color(colorC)
@@ -154,7 +154,7 @@ By design, d1 is the smallest direction and d2 is the highest
 /obj/structure/cable/deconstruct(disassembled = TRUE)
 	var/turf/T = get_turf(src)
 	if(usr)
-		investigate_log("was deconstructed by [key_name(usr, 1)] in [get_area(usr)]([T.x], [T.y], [T.z] - [ADMIN_JMP(T)])","wires")
+		investigate_log("was deconstructed by [key_name(usr, 1)] in [get_area(usr)]([T.x], [T.y], [T.z] - [ADMIN_JMP(T)])",INVESTIGATE_WIRES)
 	if(!(flags & NODECONSTRUCT))
 		if(d1)	// 0-X cables are 1 unit, X-X cables are 2 units long
 			new/obj/item/stack/cable_coil(T, 2, color)

--- a/code/modules/power/engines/singularity/collector.dm
+++ b/code/modules/power/engines/singularity/collector.dm
@@ -37,7 +37,7 @@
 	if(!loaded_tank)
 		return
 	if(!loaded_tank.air_contents.toxins())
-		investigate_log("<font color='red'>out of fuel</font>.", "singulo")
+		investigate_log("<font color='red'>out of fuel</font>.", INVESTIGATE_SINGULO)
 		playsound(src, 'sound/machines/ding.ogg', 50, TRUE)
 		eject()
 	else
@@ -68,7 +68,7 @@
 		if(!locked)
 			toggle_power()
 			user.visible_message("[user.name] turns the [name] [active ? "on" : "off"].", "You turn the [name] [active ? "on" : "off"].")
-			investigate_log("turned [active ? "<font color='green'>on</font>" : "<font color='red'>off</font>"] by [user.key]. [loaded_tank ? "Fuel: [round(loaded_tank.air_contents.toxins() / 0.29)]%" : "<font color='red'>It is empty</font>"].", "singulo")
+			investigate_log("turned [active ? "<font color='green'>on</font>" : "<font color='red'>off</font>"] by [user.key]. [loaded_tank ? "Fuel: [round(loaded_tank.air_contents.toxins() / 0.29)]%" : "<font color='red'>It is empty</font>"].", INVESTIGATE_SINGULO)
 		else
 			to_chat(user, "<span class='warning'>The controls are locked!</span>")
 

--- a/code/modules/power/engines/singularity/emitter.dm
+++ b/code/modules/power/engines/singularity/emitter.dm
@@ -85,7 +85,7 @@
 /obj/machinery/power/emitter/Destroy()
 	msg_admin_attack("Emitter deleted at ([x],[y],[z] - [ADMIN_JMP(src)]) [usr ? "Broken by [key_name_admin(usr)]" : ""]", ATKLOG_FEW)
 	log_game("Emitter deleted at ([x],[y],[z])")
-	investigate_log("<font color='red'>deleted</font> at ([x],[y],[z]) [usr ? "Broken by [key_name(usr)]" : ""]","singulo")
+	investigate_log("<font color='red'>deleted</font> at ([x],[y],[z]) [usr ? "Broken by [key_name(usr)]" : ""]",INVESTIGATE_SINGULO)
 	QDEL_NULL(sparks)
 	return ..()
 
@@ -125,11 +125,11 @@
 		toggle = "off"
 		shot_number = 0
 		fire_delay = maximum_fire_delay
-		investigate_log("turned <font color='red'>off</font> by [key_name(user)]", "singulo")
+		investigate_log("turned <font color='red'>off</font> by [key_name(user)]", INVESTIGATE_SINGULO)
 	else
 		active = TRUE
 		toggle = "on"
-		investigate_log("turned <font color='green'>on</font> by [key_name(user)]", "singulo")
+		investigate_log("turned <font color='green'>on</font> by [key_name(user)]", INVESTIGATE_SINGULO)
 
 	to_chat(user, "You turn [src] [toggle].")
 	message_admins("Emitter turned [toggle] by [key_name_admin(user)] in ([x], [y], [z] - <A href='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
@@ -249,12 +249,12 @@
 		if(!powered)
 			powered = TRUE
 			update_icon()
-			investigate_log("regained power and turned <font color='green'>on</font>","singulo")
+			investigate_log("regained power and turned <font color='green'>on</font>",INVESTIGATE_SINGULO)
 	else
 		if(powered)
 			powered = FALSE
 			update_icon()
-			investigate_log("lost power and turned <font color='red'>off</font>","singulo")
+			investigate_log("lost power and turned <font color='red'>off</font>",INVESTIGATE_SINGULO)
 		return
 
 	if(!check_delay())

--- a/code/modules/power/engines/singularity/field_generator.dm
+++ b/code/modules/power/engines/singularity/field_generator.dm
@@ -115,7 +115,7 @@ GLOBAL_LIST_EMPTY(field_generator_fields)
 					"<span class='notice'>You turn on [src].</span>", \
 					"<span class='italics'>You hear heavy droning.</span>")
 				turn_on()
-				investigate_log("<font color='green'>activated</font> by [user.key].", "singulo")
+				investigate_log("<font color='green'>activated</font> by [user.key].", INVESTIGATE_SINGULO)
 
 				add_fingerprint(user)
 	else
@@ -231,7 +231,7 @@ GLOBAL_LIST_EMPTY(field_generator_fields)
 	else
 		visible_message("<span class='danger'>[src] shuts down!</span>", "<span class='italics'>You hear something shutting down.</span>")
 		turn_off()
-		investigate_log("ran out of energy and <font color='red'>deactivated</font>","singulo")
+		investigate_log("ran out of energy and <font color='red'>deactivated</font>",INVESTIGATE_SINGULO)
 		energy = 0
 		check_energy_level()
 		return FALSE
@@ -380,7 +380,7 @@ GLOBAL_LIST_EMPTY(field_generator_fields)
 				// [src ? "[get_location_name(src, TRUE)] [COORD(src)]" : "nonexistent location"] [ADMIN_JMP(src)] works much better and actually works at all
 				// Oh and yes, this exact comment was pasted from the exact same thing I did to tcomms code. Dont at me.
 				message_admins("A singularity exists and a containment field has failed on the same Z-Level. Singulo location: [O ? "[get_location_name(O, TRUE)] [COORD(O)]" : "nonexistent location"] [ADMIN_JMP(O)] | Field generator location: [src ? "[get_location_name(src, TRUE)] [COORD(src)]" : "nonexistent location"] [ADMIN_JMP(src)]")
-				investigate_log("has <font color='red'>failed</font> whilst a singulo exists.", "singulo")
+				investigate_log("has <font color='red'>failed</font> whilst a singulo exists.", INVESTIGATE_SINGULO)
 		O.last_warning = world.time
 
 /obj/machinery/field/generator/shock_field(mob/living/user)

--- a/code/modules/power/engines/singularity/investigate.dm
+++ b/code/modules/power/engines/singularity/investigate.dm
@@ -1,4 +1,4 @@
 /area/station/engineering/engine/poweralert(state, source)
 	if(state != poweralm)
-		investigate_log("has a power alarm!", "singulo")
+		investigate_log("has a power alarm!", INVESTIGATE_SINGULO)
 	..()

--- a/code/modules/power/engines/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/engines/singularity/particle_accelerator/particle_accelerator.dm
@@ -120,7 +120,7 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	. = ..()
 	if(master && master.active)
 		master.toggle_power()
-		investigate_log("was moved whilst active; it <font color='red'>powered down</font>.","singulo")
+		investigate_log("was moved whilst active; it <font color='red'>powered down</font>.",INVESTIGATE_SINGULO)
 
 /obj/machinery/particle_accelerator/control_box/blob_act(obj/structure/blob/B)
 	if(prob(50))

--- a/code/modules/power/engines/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/engines/singularity/particle_accelerator/particle_control.dm
@@ -113,9 +113,9 @@
 		else
 			message_admins("PA Control Computer increased to [strength] by [key_name_admin(usr)] in ([x],[y],[z] - <A href='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
 			log_game("PA Control Computer increased to [strength] by [key_name(usr)] in ([x],[y],[z])")
-			investigate_log("increased to <font color='red'>[strength]</font> by [key_name(usr)]","singulo")
+			investigate_log("increased to <font color='red'>[strength]</font> by [key_name(usr)]",INVESTIGATE_SINGULO)
 
-			investigate_log("increased to <font color='red'>[strength]</font> by [usr.key]","singulo")
+			investigate_log("increased to <font color='red'>[strength]</font> by [usr.key]",INVESTIGATE_SINGULO)
 		strength_change()
 
 /obj/machinery/particle_accelerator/control_box/proc/remove_strength(s)
@@ -126,7 +126,7 @@
 		else
 			message_admins("PA Control Computer decreased to [strength] by [key_name_admin(usr)] in ([x],[y],[z] - <A href='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
 			log_game("PA Control Computer decreased to [strength] by [key_name(usr)] in ([x],[y],[z])")
-			investigate_log("decreased to <font color='green'>[strength]</font> by [key_name(usr)]","singulo")
+			investigate_log("decreased to <font color='green'>[strength]</font> by [key_name(usr)]",INVESTIGATE_SINGULO)
 
 		strength_change()
 
@@ -151,7 +151,7 @@
 	if(active)
 		//a part is missing!
 		if(length(connected_parts) < 6)
-			investigate_log("lost a connected part; It <font color='red'>powered down</font>.","singulo")
+			investigate_log("lost a connected part; It <font color='red'>powered down</font>.",INVESTIGATE_SINGULO)
 			toggle_power()
 			return
 		//emit some particles
@@ -233,7 +233,7 @@
 
 /obj/machinery/particle_accelerator/control_box/proc/toggle_power()
 	active = !active
-	investigate_log("turned [active?"<font color='red'>ON</font>":"<font color='green'>OFF</font>"] by [usr ? usr.key : "outside forces"]","singulo")
+	investigate_log("turned [active?"<font color='red'>ON</font>":"<font color='green'>OFF</font>"] by [usr ? usr.key : "outside forces"]",INVESTIGATE_SINGULO)
 	if(active)
 		msg_admin_attack("PA Control Computer turned ON by [key_name_admin(usr)]", ATKLOG_FEW)
 		usr.create_log(MISC_LOG, "PA Control Computer turned ON", src)

--- a/code/modules/power/engines/singularity/singularity.dm
+++ b/code/modules/power/engines/singularity/singularity.dm
@@ -98,7 +98,7 @@ GLOBAL_VAR_INIT(global_singulo_id, 1)
 	if(!iscarbon(user))
 		return
 	var/mob/living/carbon/C = user
-	investigate_log("has consumed the brain of [key_name(C)] after being touched with telekinesis", "singulo")
+	investigate_log("has consumed the brain of [key_name(C)] after being touched with telekinesis", INVESTIGATE_SINGULO)
 	C.visible_message("<span class='danger'>[C] suddenly slumps over.</span>", \
 		"<span class='userdanger'>As you concentrate on the singularity, your understanding of the cosmos expands exponentially. An immense wealth of raw information is at your fingertips, and you're determined not to squander a single morsel. Within mere microseconds, you absorb a staggering amount of information—more than any AI could ever hope to access—and you can't help but feel a godlike sense of power. However, the gravity of this situation swiftly sinks in. As you sense your skull starting to collapse under pressure, you can't help but admit to yourself: That was a really dense idea, wasn't it?</span>")
 	var/obj/item/organ/internal/brain/B = C.get_int_organ(/obj/item/organ/internal/brain)
@@ -117,7 +117,7 @@ GLOBAL_VAR_INIT(global_singulo_id, 1)
 	switch(severity)
 		if(1)
 			if(current_size <= STAGE_TWO)
-				investigate_log("has been destroyed by a heavy explosion.", "singulo")
+				investigate_log("has been destroyed by a heavy explosion.", INVESTIGATE_SINGULO)
 				qdel(src)
 				return
 			else
@@ -171,7 +171,7 @@ GLOBAL_VAR_INIT(global_singulo_id, 1)
 	var/count = locate(/obj/machinery/field/containment) in urange(30, src, 1)
 	if(!count)
 		message_admins("A singularity has been created without containment fields active at [x], [y], [z] (<A href='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
-	investigate_log("was created. [count ? "" : "<font color='red'>No containment fields were active</font>"]", "singulo")
+	investigate_log("was created. [count ? "" : "<font color='red'>No containment fields were active</font>"]", INVESTIGATE_SINGULO)
 
 /obj/singularity/proc/do_dissipate()
 	if(!dissipate)
@@ -267,7 +267,7 @@ GLOBAL_VAR_INIT(global_singulo_id, 1)
 	if(current_size >= STAGE_FIVE)
 		notify_dead()
 	if(current_size == allowed_size)
-		investigate_log("<font color='red'>grew to size [current_size]</font>", "singulo")
+		investigate_log("<font color='red'>grew to size [current_size]</font>", INVESTIGATE_SINGULO)
 		return 1
 	else if(current_size < (--temp_allowed_size))
 		expand(temp_allowed_size)
@@ -277,7 +277,7 @@ GLOBAL_VAR_INIT(global_singulo_id, 1)
 
 /obj/singularity/proc/check_energy()
 	if(energy <= 0)
-		investigate_log("collapsed.", "singulo")
+		investigate_log("collapsed.", INVESTIGATE_SINGULO)
 		qdel(src)
 		return 0
 	switch(energy)//Some of these numbers might need to be changed up later -Mport
@@ -329,7 +329,7 @@ GLOBAL_VAR_INIT(global_singulo_id, 1)
 			qdel(A)
 		else
 			visible_message("<span class='userdanger'>[GET_CULT_DATA(entity_name, A.name)] strikes down [src]!</span>")
-			investigate_log("has been destroyed by Nar'Sie", "singulo")
+			investigate_log("has been destroyed by Nar'Sie", INVESTIGATE_SINGULO)
 			qdel(src)
 
 	return

--- a/code/modules/power/engines/singularity/singulogen.dm
+++ b/code/modules/power/engines/singularity/singulogen.dm
@@ -15,7 +15,7 @@
 	var/turf/T = get_turf(src)
 	if(src.energy >= 200)
 		message_admins("A [creation_type] has been created at [x], [y], [z] (<A href='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
-		investigate_log("A [creation_type] has been created at [x], [y], [z]","singulo")
+		investigate_log("A [creation_type] has been created at [x], [y], [z]",INVESTIGATE_SINGULO)
 
 		var/obj/singularity/S = new creation_type(T, 50)
 		transfer_fingerprints_to(S)

--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -248,7 +248,7 @@
 	radio.listening = FALSE
 	radio.follow_target = src
 	radio.config(list("Engineering" = 0))
-	investigate_log("has been created.", "supermatter")
+	investigate_log("has been created.", INVESTIGATE_SUPERMATTER)
 	if(is_main_engine)
 		GLOB.main_supermatter_engine = src
 	soundloop = new(list(src), TRUE)
@@ -257,7 +257,7 @@
 	if(warp)
 		vis_contents -= warp
 		QDEL_NULL(warp)
-	investigate_log("has been destroyed.", "supermatter")
+	investigate_log("has been destroyed.", INVESTIGATE_SUPERMATTER)
 	SSair.atmos_machinery -= src
 	QDEL_NULL(radio)
 	GLOB.poi_list -= src
@@ -395,14 +395,14 @@
 				to_chat(M, "<span class='boldannounceic'>You hold onto \the [M.loc] as hard as you can, as reality distorts around you. You feel safe.</span>")
 
 	if(max(combined_gas, forced_combined_gas) > MOLE_CRUNCH_THRESHOLD)
-		investigate_log("has collapsed into a singularity.", "supermatter")
+		investigate_log("has collapsed into a singularity.", INVESTIGATE_SUPERMATTER)
 		if(T)
 			var/obj/singularity/S = new(T)
 			S.energy = 800
 			S.consume(src)
 			return //No boom for me sir
 	else if(max(power, forced_power) > POWER_PENALTY_THRESHOLD)
-		investigate_log("has spawned additional energy balls.", "supermatter")
+		investigate_log("has spawned additional energy balls.", INVESTIGATE_SUPERMATTER)
 		if(T)
 			var/obj/singularity/energy_ball/E = new(T)
 			E.energy = 200 //Gets us about 9 balls
@@ -669,7 +669,7 @@
 				radio.autosay("<span class='big'>[emergency_alert] Integrity: [get_integrity()]%</span>", name, null)
 				lastwarning = REALTIMEOFDAY
 				if(!has_reached_emergency)
-					investigate_log("has reached the emergency point for the first time.", "supermatter")
+					investigate_log("has reached the emergency point for the first time.", INVESTIGATE_SUPERMATTER)
 					message_admins("[src] has reached the emergency point [ADMIN_JMP(src)].")
 					has_reached_emergency = TRUE
 			else if(damage >= damage_archived) // The damage is still going up
@@ -697,7 +697,7 @@
 	if(!istype(L))
 		return FALSE
 	if(!istype(proj, /obj/item/projectile/beam/emitter/hitscan) && power_changes)
-		investigate_log("has been hit by [proj] fired by [key_name(proj.firer)]", "supermatter")
+		investigate_log("has been hit by [proj] fired by [key_name(proj.firer)]", INVESTIGATE_SUPERMATTER)
 	if(proj.flag != BULLET)
 		if(power_changes) //This needs to be here I swear
 			power += proj.damage * bullet_energy
@@ -709,7 +709,7 @@
 
 /obj/machinery/atmospherics/supermatter_crystal/singularity_act()
 	var/gain = 100
-	investigate_log("Supermatter shard consumed by singularity.", "singulo")
+	investigate_log("Supermatter shard consumed by singularity.", INVESTIGATE_SINGULO)
 	message_admins("Singularity has consumed a supermatter shard and can now become stage six.")
 	visible_message("<span class='userdanger'>[src] is consumed by the singularity!</span>")
 	var/supermatter_sound = sound('sound/effects/supermatter.ogg')
@@ -737,7 +737,7 @@
 	if(!iscarbon(user))
 		return
 	var/mob/living/carbon/C = user
-	investigate_log("has consumed the brain of [key_name(C)] after being touched with telekinesis", "supermatter")
+	investigate_log("has consumed the brain of [key_name(C)] after being touched with telekinesis", INVESTIGATE_SUPERMATTER)
 	C.visible_message("<span class='danger'>[C] suddenly slumps over.</span>", \
 		"<span class='userdanger'>As you mentally focus on the supermatter you feel the contents of your skull start melting away. That was a really dense idea.</span>")
 	var/obj/item/organ/internal/brain/B = C.get_int_organ(/obj/item/organ/internal/brain)
@@ -784,7 +784,7 @@
 	if(!cause)
 		cause = "contact"
 	nom.visible_message(vis_msg, mob_msg, "<span class='italics'>You hear an unearthly noise as a wave of heat washes over you.</span>")
-	investigate_log("has been attacked ([cause]) by [key_name(nom)]", "supermatter")
+	investigate_log("has been attacked ([cause]) by [key_name(nom)]", INVESTIGATE_SUPERMATTER)
 	playsound(get_turf(src), 'sound/effects/supermatter.ogg', 50, TRUE)
 	Consume(nom)
 
@@ -832,7 +832,7 @@
 		user.visible_message("<span class='danger'>As [user] touches [src] with \a [used], silence fills the room...</span>",\
 			"<span class='userdanger'>You touch [src] with [used], and everything suddenly goes silent.</span>\n<span class='notice'>[used] flashes into dust as you flinch away from [src].</span>",\
 			"<span class='italics'>Everything suddenly goes silent.</span>")
-		investigate_log("has been attacked ([used]) by [key_name(user)]", "supermatter")
+		investigate_log("has been attacked ([used]) by [key_name(user)]", INVESTIGATE_SUPERMATTER)
 		Consume(used)
 		playsound(get_turf(src), 'sound/effects/supermatter.ogg', 50, TRUE)
 
@@ -867,7 +867,7 @@
 		if(user.status_flags & GODMODE)
 			return
 		message_admins("[src] has consumed [key_name_admin(user)] [ADMIN_JMP(src)].")
-		investigate_log("has consumed [key_name(user)].", "supermatter")
+		investigate_log("has consumed [key_name(user)].", INVESTIGATE_SUPERMATTER)
 		user.dust()
 		if(power_changes)
 			matter_power += 200
@@ -879,7 +879,7 @@
 			if(AM.fingerprintslast)
 				suspicion = "last touched by [AM.fingerprintslast]"
 			message_admins("[src] has consumed [AM], [suspicion] [ADMIN_JMP(src)].")
-			investigate_log("has consumed [AM] - [suspicion].", "supermatter")
+			investigate_log("has consumed [AM] - [suspicion].", INVESTIGATE_SUPERMATTER)
 			if(istype(AM, /obj/machinery/atmospherics/supermatter_crystal))
 				power += 5000//releases A LOT of power
 				matter_power += 500000
@@ -893,7 +893,7 @@
 	//Some poor sod got eaten, go ahead and irradiate people nearby.
 	radiation_pulse(src, 12000, GAMMA_RAD, TRUE)
 	for(var/mob/living/L in range(10))
-		investigate_log("has irradiated [key_name(L)] after consuming [AM].", "supermatter")
+		investigate_log("has irradiated [key_name(L)] after consuming [AM].", INVESTIGATE_SUPERMATTER)
 		if(L in view())
 			L.show_message("<span class='danger'>As [src] slowly stops resonating, you find your skin covered in new radiation burns.</span>", 1,
 				"<span class='danger'>The unearthly ringing subsides and you notice you have new radiation burns.</span>", 2)
@@ -1261,7 +1261,7 @@
 	event.start_event()
 
 /obj/machinery/atmospherics/supermatter_crystal/proc/enable_for_the_first_time()
-	investigate_log("has been powered for the first time.", "supermatter")
+	investigate_log("has been powered for the first time.", INVESTIGATE_SUPERMATTER)
 	message_admins("[src] has been powered for the first time [ADMIN_JMP(src)].")
 	has_been_powered = TRUE
 	make_next_event_time()

--- a/code/modules/power/engines/supermatter/supermatter_event.dm
+++ b/code/modules/power/engines/supermatter/supermatter_event.dm
@@ -16,7 +16,7 @@
 
 /datum/engi_event/supermatter_event/start_event()
 	supermatter.event_active = src
-	supermatter.investigate_log("event [src] has been triggered", "supermatter")
+	supermatter.investigate_log("event [src] has been triggered", INVESTIGATE_SUPERMATTER)
 	. = ..()
 
 /datum/engi_event/supermatter_event/on_end()

--- a/code/modules/power/engines/tesla/energy_ball.dm
+++ b/code/modules/power/engines/tesla/energy_ball.dm
@@ -261,7 +261,7 @@
 	if(!iscarbon(user))
 		return
 	var/mob/living/carbon/C = user
-	investigate_log("has consumed the brain of [key_name(C)] after being touched with telekinesis", "singulo")
+	investigate_log("has consumed the brain of [key_name(C)] after being touched with telekinesis", INVESTIGATE_SINGULO)
 	C.visible_message("<span class='danger'>[C] suddenly slumps over.</span>", \
 		"<span class='userdanger'>As you mentally focus on the energy ball you feel the contents of your skull become overcharged. That was shockingly stupid.</span>")
 	var/obj/item/organ/internal/brain/B = C.get_int_organ(/obj/item/organ/internal/brain)

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -111,7 +111,7 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 			. += "<span class='notice'>The cover screws are loose.</span>"
 
 /obj/machinery/gravity_generator/main/Destroy() // If we somehow get deleted, remove all of our other parts.
-	investigate_log("was destroyed!", "gravity")
+	investigate_log("was destroyed!", INVESTIGATE_GRAVITY)
 	on = FALSE
 	update_gen_list()
 	for(var/area/A in world)
@@ -129,7 +129,7 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 	breaker_on = FALSE
 	update_icon()
 	set_gravity(FALSE)
-	investigate_log("has broken down.", "gravity")
+	investigate_log("has broken down.", INVESTIGATE_GRAVITY)
 
 /obj/machinery/gravity_generator/main/set_fix()
 	..()
@@ -227,7 +227,7 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 	. = TRUE
 	if(action == "breaker")
 		breaker_on = !breaker_on
-		investigate_log("was toggled [breaker_on ? "<font color='green'>ON</font>" : "<font color='red'>OFF</font>"] by [usr.key].", "gravity")
+		investigate_log("was toggled [breaker_on ? "<font color='green'>ON</font>" : "<font color='red'>OFF</font>"] by [usr.key].", INVESTIGATE_GRAVITY)
 		set_power()
 
 // Power and Icon States
@@ -235,7 +235,7 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 /obj/machinery/gravity_generator/main/power_change()
 	if(!..())
 		return
-	investigate_log("has [stat & NOPOWER ? "lost" : "regained"] power.", "gravity")
+	investigate_log("has [stat & NOPOWER ? "lost" : "regained"] power.", INVESTIGATE_GRAVITY)
 	set_power()
 
 /obj/machinery/gravity_generator/main/get_status()
@@ -264,7 +264,7 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 	else if(breaker_on)
 		charging_state = GRAV_POWER_UP
 
-	investigate_log("is now [charging_state == GRAV_POWER_UP ? "charging" : "discharging"].", "gravity")
+	investigate_log("is now [charging_state == GRAV_POWER_UP ? "charging" : "discharging"].", INVESTIGATE_GRAVITY)
 	update_icon()
 
 /**
@@ -281,7 +281,7 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 	if(gravity) // If we turned on
 		if(generators_in_area() == 0) // And there's no other gravity generators on this z level
 			alert = TRUE
-			investigate_log("was brought online and is now producing gravity for this level.", "gravity")
+			investigate_log("was brought online and is now producing gravity for this level.", INVESTIGATE_GRAVITY)
 			message_admins("The gravity generator was brought online. (<A href='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>[src_area.name]</a>)")
 			for(var/area/A in world)
 				if((A.type in areas) && A.z == z)
@@ -289,7 +289,7 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 
 	else if(generators_in_area() == 1) // Turned off, and there is only one gravity generator on the Z level
 		alert = TRUE
-		investigate_log("was brought offline and there is now no gravity for this level.", "gravity")
+		investigate_log("was brought offline and there is now no gravity for this level.", INVESTIGATE_GRAVITY)
 		message_admins("The gravity generator was brought offline with no backup generator. (<A href='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>[src_area.name]</a>)")
 		for(var/area/A in world)
 			if((A.type in areas) && A.z == z)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -243,7 +243,7 @@
 		if(area)
 			message_admins("SMES deleted at (<a href='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>[area.name]</a>)")
 			log_game("SMES deleted at ([area.name])")
-			investigate_log("<font color='red'>deleted</font> at ([area.name])", "singulo")
+			investigate_log("<font color='red'>deleted</font> at ([area.name])", INVESTIGATE_SINGULO)
 	if(terminal)
 		disconnect_terminal()
 	return ..()
@@ -293,7 +293,7 @@
 
 			if(output_used < 0.0001)		// Either from no charge or set to 0
 				outputting = FALSE
-				investigate_log("lost power and turned <font color='red'>off</font>", "singulo")
+				investigate_log("lost power and turned <font color='red'>off</font>", INVESTIGATE_SINGULO)
 		else if(output_attempt && charge > 0 && output_level > 0)
 			outputting = TRUE
 		else
@@ -425,7 +425,7 @@
 		log_smes(usr)
 
 /obj/machinery/power/smes/proc/log_smes(mob/user)
-		investigate_log("input/output; [input_level>output_level?"<font color='green'>":"<font color='red'>"][input_level]/[output_level]</font> | Charge: [charge] | Output-mode: [output_attempt?"<font color='green'>on</font>":"<font color='red'>off</font>"] | Input-mode: [input_attempt?"<font color='green'>auto</font>":"<font color='red'>off</font>"] by [user ? key_name(user) : "outside forces"]", "singulo")
+		investigate_log("input/output; [input_level>output_level?"<font color='green'>":"<font color='red'>"][input_level]/[output_level]</font> | Charge: [charge] | Output-mode: [output_attempt?"<font color='green'>on</font>":"<font color='red'>off</font>"] | Input-mode: [input_attempt?"<font color='green'>auto</font>":"<font color='red'>off</font>"] by [user ? key_name(user) : "outside forces"]", INVESTIGATE_SINGULO)
 
 /obj/machinery/power/smes/proc/inputting(do_input)
 	input_attempt = do_input

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -454,7 +454,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				var/obj/item/new_item = new being_built.build_path(src)
 				new_item.scatter_atom()
 				if(istype(new_item, /obj/item/storage/backpack/holding))
-					new_item.investigate_log("built by [key]","singulo")
+					new_item.investigate_log("built by [key]",INVESTIGATE_SINGULO)
 				if(!istype(new_item, /obj/item/stack/sheet)) // To avoid materials dupe glitches
 					new_item.materials = efficient_mats.Copy()
 				if(being_built.locked)

--- a/code/modules/supply/supply_console.dm
+++ b/code/modules/supply/supply_console.dm
@@ -368,7 +368,7 @@
 		SSeconomy.process_supply_order(order, FALSE)
 		if(order.ordered_by_department.crate_auto_approve && order.ordered_by_department.auto_approval_cap >= order.object.get_cost())
 			approve_crate(user, order.ordernum)
-		investigate_log("| [key_name(user)] has placed an order for [order.object.amount] [order.object.name] with reason: '[order.comment]'", "cargo")
+		investigate_log("| [key_name(user)] has placed an order for [order.object.amount] [order.object.name] with reason: '[order.comment]'", INVESTIGATE_CARGO)
 
 /obj/machinery/computer/supplycomp/proc/approve_crate(mob/user, order_num)
 	for(var/datum/supply_order/department_order in SSeconomy.request_list)
@@ -410,7 +410,7 @@
 					if(istype(order.object, /datum/supply_packs/abstract/shuttle))
 						update_static_data(user) // pack is going to be disabled, need to update pack data
 					SStgui.update_uis(src)
-					investigate_log("| [key_name(user)] has authorized an order for [pack.name]. Remaining Cargo Balance: [cargo_account.credit_balance].", "cargo")
+					investigate_log("| [key_name(user)] has authorized an order for [pack.name]. Remaining Cargo Balance: [cargo_account.credit_balance].", INVESTIGATE_CARGO)
 					SSblackbox.record_feedback("tally", "cargo_shuttle_order", 1, pack.name)
 				else
 					atom_say("ERROR: Account tied to order cannot pay, auto-denying order")
@@ -437,7 +437,7 @@
 			SSeconomy.request_list -= order
 		else
 			return //how did we get here?
-		investigate_log("| [key_name(user)] has denied an order for [order.object.name].", "cargo")
+		investigate_log("| [key_name(user)] has denied an order for [order.object.name].", INVESTIGATE_CARGO)
 		break
 
 /obj/machinery/computer/supplycomp/proc/move_shuttle(mob/user)
@@ -447,7 +447,7 @@
 		to_chat(user, "<span class='warning'>For safety reasons, the automated supply shuttle cannot transport [SSshuttle.supply.blocking_item].</span>")
 	else if(SSshuttle.supply.getDockedId() == "supply_home")
 		SSshuttle.toggleShuttle("supply", "supply_home", "supply_away", 1)
-		investigate_log("| [key_name(user)] has sent the supply shuttle away. Shuttle contents: [SSeconomy.sold_atoms]", "cargo")
+		investigate_log("| [key_name(user)] has sent the supply shuttle away. Shuttle contents: [SSeconomy.sold_atoms]", INVESTIGATE_CARGO)
 	else
 		SSshuttle.supply.request(SSshuttle.getDock("supply_home"))
 


### PR DESCRIPTION
## What Does This PR Do
This PR moves a bunch of commonly used investigate log categories into defines.
## Why It's Good For The Game
Consistency good, we already had some of these so no reason not to pull the most common categories in.
## Testing
Compiled.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog
NPFC
