### PR TITLE
Fixes some acid procs

### DIFF
--- a/code/game/objects/effects/alien_acid.dm
+++ b/code/game/objects/effects/alien_acid.dm
@@ -63,6 +63,11 @@
 		var/mob/living/L = entered
 		if(HAS_TRAIT(L, TRAIT_FLYING))
 			return
+		if(ishuman(L))
+			var/mob/living/carbon/human/H = L
+			var/obj/item/clothing/S = H.shoes
+			if(S?.resistance_flags & ACID_PROOF || S?.resistance_flags & UNACIDABLE)
+				return
 		if(L.m_intent != MOVE_INTENT_WALK && prob(40))
 			var/acid_used = min(acid_level * 0.05, 20)
 			if(L.acid_act(10, acid_used, "feet"))

--- a/code/game/objects/effects/alien_acid.dm
+++ b/code/game/objects/effects/alien_acid.dm
@@ -63,17 +63,10 @@
 		var/mob/living/L = entered
 		if(HAS_TRAIT(L, TRAIT_FLYING))
 			return
-		if(ishuman(L))
-			var/mob/living/carbon/human/H = L
-			var/obj/item/clothing/S = H.shoes
-			if(S?.resistance_flags & ACID_PROOF || S?.resistance_flags & UNACIDABLE)
-				return
 		if(L.m_intent != MOVE_INTENT_WALK && prob(40))
 			var/acid_used = min(acid_level * 0.05, 20)
 			if(L.acid_act(10, acid_used, "feet"))
 				acid_level = max(0, acid_level - acid_used * 10)
-				playsound(L, 'sound/weapons/sear.ogg', 50, TRUE)
-				to_chat(L, "<span class='userdanger'>[src] burns you!</span>")
 
 //xenomorph corrosive acid
 /obj/effect/acid/alien

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -1235,13 +1235,13 @@ so that different stomachs can handle things in different ways VB*/
 		. |= LH.GetAccess()
 
 /mob/living/carbon/proc/can_breathe_gas()
-	if(!wear_mask)
+	if(internal == null)
 		return TRUE
 
-	if(!(wear_mask.flags & BLOCK_GAS_SMOKE_EFFECT) && internal == null)
-		return TRUE
+	if(wear_mask?.flags & BLOCK_GAS_SMOKE_EFFECT || head?.flags & BLOCK_GAS_SMOKE_EFFECT)
+		return FALSE
 
-	return FALSE
+	return TRUE
 
 //to recalculate and update the mob's total tint from tinted equipment it's wearing.
 /mob/living/carbon/proc/update_tint()

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -1235,7 +1235,7 @@ so that different stomachs can handle things in different ways VB*/
 		. |= LH.GetAccess()
 
 /mob/living/carbon/proc/can_breathe_gas()
-	if(internal == null)
+	if(isnull(internal)) // no internals - breath from environment
 		return TRUE
 
 	if(wear_mask?.flags & BLOCK_GAS_SMOKE_EFFECT || head?.flags & BLOCK_GAS_SMOKE_EFFECT)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -407,6 +407,8 @@ emp_act
 	//DAMAGE//
 	for(var/obj/item/organ/external/affecting in damaged)
 		affecting.receive_damage(acidity, 2 * acidity)
+		to_chat(src, "<span class='userdanger'>The acid burns you!</span>")
+		playsound(src, 'sound/weapons/sear.ogg', 50, TRUE)
 
 		if(istype(affecting, /obj/item/organ/external/head))
 			var/obj/item/organ/external/head/head_organ = affecting

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -350,6 +350,8 @@
 
 /mob/living/acid_act(acidpwr, acid_volume)
 	take_organ_damage(acidpwr * min(1, acid_volume * 0.1))
+	to_chat(src, "<span class='userdanger'>The acid burns you!</span>")
+	playsound(src, 'sound/weapons/sear.ogg', 50, TRUE)
 	return 1
 
 /mob/living/welder_act(mob/user, obj/item/I)

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -362,11 +362,11 @@
 			H.adjustFireLoss(clamp((volume - 5) * 3, 8, 75))
 			return
 
-		var/has_melted_something = FALSE
-		if(H.wear_mask && !(H.wear_mask.resistance_flags & ACID_PROOF))
+		var/protected = TRUE
+		if(H.wear_mask && !(H.wear_mask.resistance_flags & ACID_PROOF) && !(H.head?.resistance_flags & ACID_PROOF))
 			to_chat(H, "<span class='danger'>Your [H.wear_mask.name] melts away!</span>")
 			qdel(H.wear_mask)
-			has_melted_something = TRUE
+			protected = FALSE
 
 		if(H.head && !(H.head.resistance_flags & ACID_PROOF))
 			if(istype(H.head, /obj/item/clothing/head/mod) && ismodcontrol(H.back))
@@ -378,9 +378,9 @@
 			else
 				to_chat(H, "<span class='danger'>Your [H.head.name] melts away!</span>")
 				qdel(H.head)
-			has_melted_something = TRUE
+			protected = FALSE
 
-		if(has_melted_something)
+		if(protected)
 			return
 
 	if(volume >= 5)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

"The acid burns you!" message and its sound now appear only when you are actually getting damage from it.
Stops your mask from getting melted if your helmet is `ACID_PROOF`.
Allows you to use breathing tube implant without a gas mask, but with a helmet that has `BLOCK_GAS_SMOKE_EFFECT` to prevent breathing in gases.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

It's good when your helmet is actually acid proof. It prevents, for example, cases when a nukie is getting hit by a facid grenade, it melts his gas mask through an `ACID_PROOF` helmet and he is getting one hundred and fourty units of acid which will slowly kill him.

Also i believe that `can_breathe_gas` didn't take into account breathing tube implant which is not being a mask-slot item, but still allows to breath through internals. So you may now, for example, wear a magnate modsuit without a mask, but with turned on internals attached to your tube implant and be immune to gas breathing.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

<!-- How did you test the PR, if at all? -->

Local server, was throwing facid grenades all around and entering them with an acid proof modsuit, without it, with a mask on, without a mask, with internals and without. No issues noticed.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Your gas mask won't anymore get melted by an acid if your helmet is acid proof.
fix: You will receive "The acid burns you!" message and sound only when you are actually getting damage from it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
