### PR TITLE
[AFD] Buffs Librarians

### DIFF
--- a/code/datums/spells/mime.dm
+++ b/code/datums/spells/mime.dm
@@ -139,20 +139,14 @@
 			if(user.mind)
 				to_chat(user, "<span class='notice'>You've already read this one.</span>")
 			return
-	if(used)
-		recoil(user)
-	else
-		user.mind.AddSpell(S)
-		to_chat(user, "<span class='notice'>You flip through the pages. Your understanding of the boundaries of reality increases. You can cast [spellname]!</span>")
-		user.create_log(MISC_LOG, "learned the spell [spellname] ([S])")
-		user.create_attack_log("<font color='orange'>[key_name(user)] learned the spell [spellname] ([S]).</font>")
-		onlearned(user)
+	user.mind.AddSpell(S)
+	to_chat(user, "<span class='notice'>You flip through the pages. Your understanding of the boundaries of reality increases. You can cast [spellname]!</span>")
+	user.create_log(MISC_LOG, "learned the spell [spellname] ([S])")
+	user.create_attack_log("<font color='orange'>[key_name(user)] learned the spell [spellname] ([S]).</font>")
+	onlearned(user)
 
-/obj/item/spellbook/oneuse/mime/recoil(mob/user)
-	to_chat(user, "<span class='notice'>You flip through the pages. Nothing of interest to you.</span>")
 
 /obj/item/spellbook/oneuse/mime/onlearned(mob/user)
-	used = TRUE
 	if(!locate(/datum/spell/mime/speak) in user.mind.spell_list) //add vow of silence if not known by user
 		user.mind.AddSpell(new /datum/spell/mime/speak)
 		to_chat(user, "<span class='notice'>You have learned how to use silence to improve your performance.</span>")

--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -145,3 +145,134 @@
 
 		if(message)
 			to_chat(target, message)
+			
+/datum/spell/summonitem/librarian
+	name = "Instant Book Summons"
+	desc = "This spell can be used to recall a previously marked item to your hand from anywhere in the universe. Only works on your special books."
+	base_cooldown = 10
+	cooldown_min = 10
+
+
+/datum/spell/summonitem/librarian/cast(list/targets, mob/user = usr)
+	for(var/mob/living/target in targets)
+		var/list/hand_items = list(target.get_active_hand(),target.get_inactive_hand())
+		var/butterfingers = FALSE
+		var/message
+
+		if(!marked_item) //linking item to the spell
+			message = "<span class='notice'>"
+			for(var/obj/item in hand_items)
+				if(ABSTRACT in item.flags)
+					continue
+				if(istype(item, /obj/item/spellbook/oneuse/mime) || istype(item, /obj/item/spellbook/oneuse/mime/fingergun) || istype(item, /obj/item/cqc_manual)  || istype(item, /obj/item/sleeping_carp_scroll))
+					marked_item = 		item
+					message += "You mark [item] for recall.</span>"
+					name = "Recall [item]"
+					break
+
+			if(!marked_item)
+				if(hand_items)
+					message = "<span class='caution'>You aren't holding anything that can be marked for recall.</span>"
+				else
+					message = "<span class='notice'>You must hold the desired item in your hands to mark it for recall.</span>"
+
+		else if(marked_item && (marked_item in hand_items)) //unlinking item to the spell
+			message = "<span class='notice'>You remove the mark on [marked_item] to use elsewhere.</span>"
+			name = "Instant Summons"
+			marked_item = 		null
+
+		else if(marked_item && !marked_item.loc) //the item was destroyed at some point
+			message = "<span class='warning'>You sense your marked item has been destroyed!</span>"
+			name = "Instant Summons"
+			marked_item = 		null
+
+		else	//Getting previously marked item
+			var/obj/item_to_retrieve = marked_item
+			var/visible_item = TRUE //Items that silently disappear will have the message suppressed
+			var/infinite_recursion = 0 //I don't want to know how someone could put something inside itself but these are wizards so let's be safe
+
+			while(!isturf(item_to_retrieve.loc) && infinite_recursion < 10) //if it's in something you get the whole thing.
+				if(istype(item_to_retrieve.loc, /obj/item/organ/internal/headpocket))
+					var/obj/item/organ/internal/headpocket/pocket = item_to_retrieve.loc
+					if(pocket.owner)
+						to_chat(pocket.owner, "<span class='warning'>Your [pocket.name] suddenly feels lighter. How strange!</span>")
+					visible_item = FALSE
+					break
+				if(istype(item_to_retrieve.loc, /obj/item/storage/hidden_implant)) //The implant should be left alone
+					var/obj/item/storage/S = item_to_retrieve.loc
+					for(var/mob/M in S.mobs_viewing)
+						to_chat(M, "<span class='warning'>[item_to_retrieve] suddenly disappears!</span>")
+					visible_item = FALSE
+					break
+				if(ismob(item_to_retrieve.loc)) //If its on someone, properly drop it
+					var/mob/M = item_to_retrieve.loc
+
+					if(issilicon(M) || !M.transfer_item_to(item_to_retrieve, target.loc)) //Items in silicons warp the whole silicon
+						M.visible_message("<span class='warning'>[M] suddenly disappears!</span>", "<span class='danger'>A force suddenly pulls you away!</span>")
+						M.loc.visible_message("<span class='caution'>[M] suddenly appears!</span>")
+						item_to_retrieve = null
+						break
+
+					if(ishuman(M)) //Edge case housekeeping
+						var/mob/living/carbon/human/C = M
+						for(var/X in C.bodyparts)
+							var/obj/item/organ/external/part = X
+							if(item_to_retrieve in part.embedded_objects)
+								part.remove_embedded_object(item_to_retrieve)
+								to_chat(C, "<span class='warning'>[item_to_retrieve] that was embedded in your [part] has mysteriously vanished. How fortunate!</span>")
+								if(!C.has_embedded_objects())
+									C.clear_alert("embeddedobject")
+								break
+							if(item_to_retrieve == part.hidden)
+								visible_item = FALSE
+								part.hidden = null
+								to_chat(C, "<span class='warning'>Your [part.name] suddenly feels emptier. How weird!</span>")
+								break
+
+				else
+					if(istype(item_to_retrieve.loc, /obj/machinery/atmospherics/portable/)) //Edge cases for moved machinery
+						var/obj/machinery/atmospherics/portable/P = item_to_retrieve.loc
+						P.disconnect()
+						P.update_icon()
+					if(is_type_in_typecache(item_to_retrieve.loc, blacklisted_summons))
+						break
+					item_to_retrieve = item_to_retrieve.loc
+					if(istype(item_to_retrieve, /obj/item/storage/backpack/modstorage))
+						var/obj/item/storage/backpack/modstorage/bag = item_to_retrieve
+						if(bag.source && bag.source.mod)
+							item_to_retrieve = bag.source.mod //Grab the modsuit.
+
+				infinite_recursion += 1
+
+			if(!item_to_retrieve)
+				return
+
+			if(!isturf(target.loc))
+				to_chat(target, "<span class='caution'>You attempt to cast the spell, but it fails! Perhaps you aren't available?</span>")
+				return
+			if(visible_item)
+				item_to_retrieve.loc.visible_message("<span class='warning'>[item_to_retrieve] suddenly disappears!</span>")
+			var/list/heres_disky = item_to_retrieve.search_contents_for(/obj/item/disk/nuclear)
+			heres_disky += item_to_retrieve.loc.search_contents_for(/obj/item/disk/nuclear) //So if you mark another item in a bag, we don't pull
+			for(var/obj/item/disk/nuclear/N in heres_disky)
+				N.forceMove(get_turf(item_to_retrieve))
+				N.visible_message("<span class='warning'>As [item_to_retrieve] vanishes, [N] remains behind!</span>")
+				break //If you have 2 nads, well, congrats? Keeps message from doubling up
+			if(target.hand) //left active hand
+				if(!target.equip_to_slot_if_possible(item_to_retrieve, ITEM_SLOT_LEFT_HAND, FALSE, TRUE))
+					if(!target.equip_to_slot_if_possible(item_to_retrieve, ITEM_SLOT_RIGHT_HAND, FALSE, TRUE))
+						butterfingers = TRUE
+			else			//right active hand
+				if(!target.equip_to_slot_if_possible(item_to_retrieve, ITEM_SLOT_RIGHT_HAND, FALSE, TRUE))
+					if(!target.equip_to_slot_if_possible(item_to_retrieve, ITEM_SLOT_LEFT_HAND, FALSE, TRUE))
+						butterfingers = TRUE
+			if(butterfingers)
+				item_to_retrieve.loc = target.loc
+				item_to_retrieve.loc.visible_message("<span class='caution'>[item_to_retrieve] suddenly appears!</span>")
+				playsound(get_turf(target),'sound/magic/summonitems_generic.ogg', 50, 1)
+			else
+				item_to_retrieve.loc.visible_message("<span class='caution'>[item_to_retrieve] suddenly appears in [target]'s hand!</span>")
+				playsound(get_turf(target),'sound/magic/summonitems_generic.ogg', 50, 1)
+
+		if(message)
+			to_chat(target, message)	

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -1141,6 +1141,12 @@
 	to_chat(user, "<span class='warning'>[src] suddenly vanishes!</span>")
 	qdel(src)
 
+/obj/item/spellbook/oneuse/summonitem/librarian
+	spell = /datum/spell/summonitem/librarian
+	spellname = "instant book summons"
+	icon_state = "booksummons"
+	desc = "This book is bright and garish, very hard to miss."
+
 /obj/item/spellbook/oneuse/fake_gib
 	spell = /datum/spell/touch/fake_disintegrate
 	spellname = "disintegrate"

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -578,6 +578,21 @@
 	backpack_contents = list(
 		/obj/item/videocam/advanced = 1)
 
+/obj/item/storage/box/librarian
+	name = "best selling books of 2568"
+	desc = "A bundle of books guaranteed to draw readers from all across the station. Nobody will ever call you useless again!"
+
+/obj/item/storage/box/librarian/populate_contents()
+	new /obj/item/spellbook/oneuse/mime(src)
+	new	/obj/item/spellbook/oneuse/mime/fingergun(src)
+	new /obj/item/cqc_manual(src)
+	new /obj/item/sleeping_carp_scroll(src)
+
+/datum/outfit/job/librarian/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	backpack_contents += /obj/item/storage/box/librarian
+	backpack_contents += /obj/item/spellbook/oneuse/summonitem/librarian
+
 /datum/outfit/job/librarian/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	if(visualsOnly)

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -315,20 +315,9 @@
 /obj/item/sleeping_carp_scroll/attack_self__legacy__attackchain(mob/living/carbon/human/user as mob)
 	if(!istype(user) || !user)
 		return
-	if(user.mind) //Prevents changelings and vampires from being able to learn it
-		if(IS_CHANGELING(user) || IS_MINDFLAYER(user))
-			to_chat(user, "<span class ='warning'>We try multiple times, but we are not able to comprehend the contents of the scroll!</span>")
-			return
-		else if(user.mind.has_antag_datum(/datum/antagonist/vampire)) //Vampires
-			to_chat(user, "<span class ='warning'>Your blood lust distracts you too much to be able to concentrate on the contents of the scroll!</span>")
-			return
 
 	var/datum/martial_art/the_sleeping_carp/theSleepingCarp = new(null)
 	theSleepingCarp.teach(user)
-	user.drop_item()
-	visible_message("<span class='warning'>[src] lights up in fire and quickly burns to ash.</span>")
-	new /obj/effect/decal/cleanable/ash(get_turf(src))
-	qdel(src)
 
 /obj/item/cqc_manual
 	name = "old manual"
@@ -339,24 +328,14 @@
 /obj/item/cqc_manual/attack_self__legacy__attackchain(mob/living/carbon/human/user)
 	if(!istype(user) || !user)
 		return
-	if(user.mind) //Prevents changelings and vampires from being able to learn it
-		if(IS_CHANGELING(user) || IS_MINDFLAYER(user))
-			to_chat(user, "<span class='warning'>We try multiple times, but we simply cannot grasp the basics of CQC!</span>")
-			return
-		else if(user.mind.has_antag_datum(/datum/antagonist/vampire)) //Vampires
-			to_chat(user, "<span class='warning'>Your blood lust distracts you from the basics of CQC!</span>")
-			return
-		else if(HAS_TRAIT(user, TRAIT_PACIFISM))
+	if(user.mind)
+		if(HAS_TRAIT(user, TRAIT_PACIFISM))
 			to_chat(user, "<span class='warning'>The mere thought of combat, let alone CQC, makes your head spin!</span>")
 			return
 
 	to_chat(user, "<span class='boldannounceic'>You remember the basics of CQC.</span>")
 	var/datum/martial_art/cqc/CQC = new(null)
 	CQC.teach(user)
-	user.drop_item()
-	visible_message("<span class='warning'>[src] beeps ominously, and a moment later it bursts up in flames.</span>")
-	new /obj/effect/decal/cleanable/ash(get_turf(src))
-	qdel(src)
 
 /obj/item/bostaff
 	name = "bo staff"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

1) Provides all Librarians a kit consisting of a CQC manual, Sleeping Carp scroll, Mime fingergun manual, and Mime invisible wall manual (default Mime wall, not the unbreakable 3-tile one)
2) Aforementioned items are now reusable
3) Provides Librarians with a modified version of Instant Summons that only works on these manuals but with lower cooldown (so they can safely lend their books without them being instantly stolen)
4) Removes Vampire/Changeling restriction on CQC and Carp, as it would be rude to leave them out of the fun.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Librarians have long been seen as merely assistants with extra access. But with some _real_ books for crew to read, they will finally become relevant...at least for a round or two, depending on how insane this ends up being.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Spawned in, made sure late librarians still had the items, made sure they are functional and reusable, made sure librarian's instant summons works as intended.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
add: CQC, Carp, Mime single-wall, and Mime fingergun manuals to Librarians
add: Instant Summons variant that only works on aforementioned manuals
tweak: Manuals can now be reused
tweak: Vampires and Changelings are unbanned from CQC and Carp.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
