### PR TITLE
Fixes OpenDream not compiling outside of CI

### DIFF
--- a/tools/ci/lints.dm
+++ b/tools/ci/lints.dm
@@ -39,7 +39,6 @@
 #pragma ImplicitNullType disabled
 #pragma LostTypeInfo disabled
 // END TYPEMAKER
-#pragma UnimplementedAccess error
 
 //3000-3999
 #pragma EmptyBlock error


### PR DESCRIPTION
Some dweeb (https://github.com/ParadiseSS13/Paradise/pull/26729) didn't bother to read the documentation when they went and changed a bunch of pragmas willy-nilly. So Paradise hasn't compiled in OD for months unless you pass `--suppress-unimplemented` which is why CI still works.