### PR TITLE
Adjusts input for atmos buildmode

### DIFF
--- a/code/modules/buildmode/submodes/atmos.dm
+++ b/code/modules/buildmode/submodes/atmos.dm
@@ -23,14 +23,14 @@
 // FIXME this is a little tedious, something where you don't have to fill in each field would be cooler
 // maybe some kind of stat panel thing?
 /datum/buildmode_mode/atmos/change_settings(mob/user)
-	pressure = tgui_input_number(user, "Atmospheric Pressure", "Input", ONE_ATMOSPHERE, 100000, 0 round_value = FALSE)
+	pressure = tgui_input_number(user, "Atmospheric Pressure", "Input", ONE_ATMOSPHERE, 100000, 0, round_value = FALSE)
 	temperature = tgui_input_number(user, "Temperature", "Input", T20C, 100000, round_value = FALSE)
-	oxygen = tgui_input_number(user, "Oxygen ratio", "Input", O2STANDARD, 100000, 0 round_value = FALSE )
+	oxygen = tgui_input_number(user, "Oxygen ratio", "Input", O2STANDARD, 100000, 0, round_value = FALSE )
 	nitrogen = tgui_input_number(user, "Nitrogen ratio", "Input", N2STANDARD, 100000, 0 round_value = FALSE)
-	plasma = tgui_input_number(user, "Plasma ratio", "Input", 0, 100000, 0 round_value = FALSE)
+	plasma = tgui_input_number(user, "Plasma ratio", "Input", 0, 100000, 0, round_value = FALSE)
 	cdiox = tgui_input_number(user, "CO2 ratio", "Input", 0, 100000, 0 round_value = FALSE)
-	nitrox = tgui_input_number(user, "N2O ratio", "Input", 0, 100000, 0 round_value = FALSE)
-	agentbx = tgui_input_number(user, "Agent B ratio", "Input", 0, 100000, 0 round_value = FALSE)
+	nitrox = tgui_input_number(user, "N2O ratio", "Input", 0, 100000, 0, round_value = FALSE)
+	agentbx = tgui_input_number(user, "Agent B ratio", "Input", 0, 100000, 0, round_value = FALSE)
 
 /datum/buildmode_mode/atmos/proc/ppratio_to_moles(ppratio)
 	// ideal gas equation: Pressure * Volume = Moles * r * Temperature

--- a/code/modules/buildmode/submodes/atmos.dm
+++ b/code/modules/buildmode/submodes/atmos.dm
@@ -23,14 +23,14 @@
 // FIXME this is a little tedious, something where you don't have to fill in each field would be cooler
 // maybe some kind of stat panel thing?
 /datum/buildmode_mode/atmos/change_settings(mob/user)
-	pressure = tgui_input_number(user, "Atmospheric Pressure", "Input", ONE_ATMOSPHERE)
-	temperature = tgui_input_number(user, "Temperature", "Input", T20C)
-	oxygen = tgui_input_number(user, "Oxygen ratio", "Input", O2STANDARD)
-	nitrogen = tgui_input_number(user, "Nitrogen ratio", "Input", N2STANDARD)
-	plasma = tgui_input_number(user, "Plasma ratio", "Input", 0)
-	cdiox = tgui_input_number(user, "CO2 ratio", "Input", 0)
-	nitrox = tgui_input_number(user, "N2O ratio", "Input", 0)
-	agentbx = tgui_input_number(user, "Agent B ratio", "Input", 0)
+	pressure = tgui_input_number(user, "Atmospheric Pressure", "Input", ONE_ATMOSPHERE, 100000, 0 round_value = FALSE)
+	temperature = tgui_input_number(user, "Temperature", "Input", T20C, 100000, round_value = FALSE)
+	oxygen = tgui_input_number(user, "Oxygen ratio", "Input", O2STANDARD, 100000, 0 round_value = FALSE )
+	nitrogen = tgui_input_number(user, "Nitrogen ratio", "Input", N2STANDARD, 100000, 0 round_value = FALSE)
+	plasma = tgui_input_number(user, "Plasma ratio", "Input", 0, 100000, 0 round_value = FALSE)
+	cdiox = tgui_input_number(user, "CO2 ratio", "Input", 0, 100000, 0 round_value = FALSE)
+	nitrox = tgui_input_number(user, "N2O ratio", "Input", 0, 100000, 0 round_value = FALSE)
+	agentbx = tgui_input_number(user, "Agent B ratio", "Input", 0, 100000, 0 round_value = FALSE)
 
 /datum/buildmode_mode/atmos/proc/ppratio_to_moles(ppratio)
 	// ideal gas equation: Pressure * Volume = Moles * r * Temperature

--- a/code/modules/buildmode/submodes/atmos.dm
+++ b/code/modules/buildmode/submodes/atmos.dm
@@ -24,7 +24,7 @@
 // maybe some kind of stat panel thing?
 /datum/buildmode_mode/atmos/change_settings(mob/user)
 	pressure = tgui_input_number(user, "Atmospheric Pressure", "Input", ONE_ATMOSPHERE, 100000, 0, round_value = FALSE)
-	temperature = tgui_input_number(user, "Temperature", "Input", T20C, 100000, round_value = FALSE)
+	temperature = tgui_input_number(user, "Temperature", "Input", T20C, 100000, 0, round_value = FALSE)
 	oxygen = tgui_input_number(user, "Oxygen ratio", "Input", O2STANDARD, 100000, 0, round_value = FALSE )
 	nitrogen = tgui_input_number(user, "Nitrogen ratio", "Input", N2STANDARD, 100000, 0, round_value = FALSE)
 	plasma = tgui_input_number(user, "Plasma ratio", "Input", 0, 100000, 0, round_value = FALSE)

--- a/code/modules/buildmode/submodes/atmos.dm
+++ b/code/modules/buildmode/submodes/atmos.dm
@@ -26,9 +26,9 @@
 	pressure = tgui_input_number(user, "Atmospheric Pressure", "Input", ONE_ATMOSPHERE, 100000, 0, round_value = FALSE)
 	temperature = tgui_input_number(user, "Temperature", "Input", T20C, 100000, round_value = FALSE)
 	oxygen = tgui_input_number(user, "Oxygen ratio", "Input", O2STANDARD, 100000, 0, round_value = FALSE )
-	nitrogen = tgui_input_number(user, "Nitrogen ratio", "Input", N2STANDARD, 100000, 0 round_value = FALSE)
+	nitrogen = tgui_input_number(user, "Nitrogen ratio", "Input", N2STANDARD, 100000, 0, round_value = FALSE)
 	plasma = tgui_input_number(user, "Plasma ratio", "Input", 0, 100000, 0, round_value = FALSE)
-	cdiox = tgui_input_number(user, "CO2 ratio", "Input", 0, 100000, 0 round_value = FALSE)
+	cdiox = tgui_input_number(user, "CO2 ratio", "Input", 0, 100000, 0, round_value = FALSE)
 	nitrox = tgui_input_number(user, "N2O ratio", "Input", 0, 100000, 0, round_value = FALSE)
 	agentbx = tgui_input_number(user, "Agent B ratio", "Input", 0, 100000, 0, round_value = FALSE)
 


### PR DESCRIPTION
## What Does This PR Do
Adjusts buildmode tgui input for atmos
## Why It's Good For The Game
Prevents accidents and turns off rounding, allowing for floats.
## Testing
TBC

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog
NPFC