### PR TITLE
Adds admin message for improvised firebomb

### DIFF
--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -53,7 +53,8 @@
 			var/turf/bombturf = get_turf(src)
 			var/area/A = get_area(bombturf)
 
-			log_game("[key_name(user)] has primed a [name] for detonation at [A.name] [COORD(bombturf)].")
+			message_admins("[key_name_admin(user)] has primed a [name] for detonation at [A.name] [ADMIN_JMP(bombturf)]")
+			log_game("[key_name(user)] has primed a [name] for detonation at [A.name] [COORD(bombturf)]")
 			investigate_log("[key_name(user)] has primed a [name] for detonation at [A.name] [COORD(bombturf)])", INVESTIGATE_BOMB)
 			add_attack_logs(user, src, "has primed for detonation", ATKLOG_FEW)
 			if(iscarbon(user))


### PR DESCRIPTION
## What Does This PR Do
Adds an admin message to the improvised firebomb.
## Why It's Good For The Game
Provides better visibility to admins on events during a round.
## Images of changes
![image](https://github.com/user-attachments/assets/033cb323-efcd-4b2a-9f58-93f7455272e5)
## Testing
Threw multiple firebombs
Checked for proper message to be displayed.
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog
NPFC