### PR TITLE
Migrates Engi Cart to the New Attack Chain - Cleans up Engi Cart Code - Makes Pre-Filled Engi Cart Variant and Adds it to All Stations

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -40245,11 +40245,11 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/engineeringcart,
 /obj/item/radio/intercom{
 	name = "east bump";
 	pixel_x = 28
 	},
+/obj/structure/engineeringcart/full,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/equipmentstorage)
 "cPQ" = (

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -12232,6 +12232,7 @@
 /obj/item/stack/sheet/rglass{
 	amount = 50
 	},
+/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -12581,8 +12582,7 @@
 	},
 /area/station/engineering/control)
 "bMk" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
+/obj/structure/engineeringcart/full,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -20079,6 +20079,9 @@
 	},
 /obj/structure/table/reinforced,
 /mob/living/simple_animal/bot/floorbot,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "yellow"
@@ -20575,10 +20578,9 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
 "byt" = (
-/obj/structure/rack,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
+/obj/structure/engineeringcart/full{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "yellow"

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -55527,11 +55527,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
 "laM" = (
-/obj/structure/engineeringcart,
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/structure/engineeringcart/full,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -59633,6 +59633,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
 "lYI" = (
+/obj/structure/engineeringcart/full{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "caution"

--- a/code/game/objects/structures/engicart.dm
+++ b/code/game/objects/structures/engicart.dm
@@ -48,7 +48,7 @@
 	return TRUE
 
 /obj/structure/engineeringcart/item_interaction(mob/living/user, obj/item/used, list/modifiers)
-	. = TRUE
+	. = ITEM_INTERACT_COMPLETE
 	var/fail_msg = "<span class='warning'>There is already one of those in [src]!</span>"
 	if(used.is_robot_module())
 		to_chat(usr, "<span class='warning'>You cannot interface your modules with [src]!</span>")
@@ -74,7 +74,7 @@
 		if(!put_in_cart(used, user))
 			return
 
-		my_metal=used
+		my_metal = used
 		update_icon(UPDATE_OVERLAYS)
 		return
 
@@ -86,7 +86,7 @@
 		if(!put_in_cart(used, user))
 			return
 
-		my_plasteel=used
+		my_plasteel = used
 		update_icon(UPDATE_OVERLAYS)
 		return
 
@@ -98,7 +98,7 @@
 		if(!put_in_cart(used, user))	
 			return
 
-		my_flashlight=used
+		my_flashlight = used
 		update_icon(UPDATE_OVERLAYS)
 		return
 
@@ -110,7 +110,7 @@
 		if(!put_in_cart(used, user))
 			return
 
-		my_blue_toolbox=used
+		my_blue_toolbox = used
 		update_icon(UPDATE_OVERLAYS)
 		return
 
@@ -122,7 +122,7 @@
 		if(!put_in_cart(used, user))
 			return
 
-		my_yellow_toolbox=used
+		my_yellow_toolbox = used
 		update_icon(UPDATE_OVERLAYS)
 		return
 
@@ -134,7 +134,7 @@
 		if(!put_in_cart(used, user))
 			return
 
-		my_red_toolbox=used
+		my_red_toolbox = used
 		update_icon(UPDATE_OVERLAYS)
 		return
 

--- a/code/game/objects/structures/engicart.dm
+++ b/code/game/objects/structures/engicart.dm
@@ -51,7 +51,7 @@
 	. = ITEM_INTERACT_COMPLETE
 	var/fail_msg = "<span class='warning'>There is already one of those in [src]!</span>"
 	if(used.is_robot_module())
-		to_chat(usr, "<span class='warning'>You cannot interface your modules with [src]!</span>")
+		to_chat(user, "<span class='warning'>You cannot interface your modules with [src]!</span>")
 		return
 
 	if(istype(used, /obj/item/stack/sheet/glass))
@@ -147,7 +147,7 @@
 		anchored = FALSE
 		user.visible_message(
 			"<span class='notice'>[user] loosens [src]'s casters.</span>",
-			"<span class='notice'> You have loosened [src]'s casters.</span>",
+			"<span class='notice'>You have loosened [src]'s casters.</span>",
 			"<span class='notice'>You hear ratcheting.</span>"
 		)
 		return

--- a/code/game/objects/structures/engicart.dm
+++ b/code/game/objects/structures/engicart.dm
@@ -6,180 +6,242 @@
 	face_while_pulling = FALSE
 	anchored = FALSE
 	density = TRUE
-	var/obj/item/stack/sheet/glass/myglass = null
-	var/obj/item/stack/sheet/metal/mymetal = null
-	var/obj/item/stack/sheet/plasteel/myplasteel = null
-	var/obj/item/flashlight/myflashlight = null
-	var/obj/item/storage/toolbox/mechanical/mybluetoolbox = null
-	var/obj/item/storage/toolbox/electrical/myyellowtoolbox = null
-	var/obj/item/storage/toolbox/emergency/myredtoolbox = null
+	new_attack_chain = TRUE
+	var/obj/item/stack/sheet/glass/my_glass = null
+	var/obj/item/stack/sheet/metal/my_metal = null
+	var/obj/item/stack/sheet/plasteel/my_plasteel = null
+	var/obj/item/flashlight/my_flashlight = null
+	var/obj/item/storage/toolbox/mechanical/my_blue_toolbox = null
+	var/obj/item/storage/toolbox/electrical/my_yellow_toolbox = null
+	var/obj/item/storage/toolbox/emergency/my_red_toolbox = null
+
+/obj/structure/engineeringcart/full
+
+/obj/structure/engineeringcart/full/Initialize(mapload)
+	. = ..()
+	my_glass = new /obj/item/stack/sheet/glass/fifty(src)
+	my_metal = new /obj/item/stack/sheet/metal/fifty(src)
+	my_plasteel = new /obj/item/stack/sheet/plasteel/fifty(src)
+	my_flashlight = new /obj/item/flashlight(src)
+	my_blue_toolbox = new /obj/item/storage/toolbox/mechanical/(src)
+	my_yellow_toolbox = new /obj/item/storage/toolbox/electrical/(src)
+	my_red_toolbox = new /obj/item/storage/toolbox/emergency/(src)
+	update_icon(UPDATE_OVERLAYS)
 
 /obj/structure/engineeringcart/Destroy()
-	QDEL_NULL(myglass)
-	QDEL_NULL(mymetal)
-	QDEL_NULL(myplasteel)
-	QDEL_NULL(myflashlight)
-	QDEL_NULL(mybluetoolbox)
-	QDEL_NULL(myyellowtoolbox)
-	QDEL_NULL(myredtoolbox)
+	QDEL_NULL(my_glass)
+	QDEL_NULL(my_metal)
+	QDEL_NULL(my_plasteel)
+	QDEL_NULL(my_flashlight)
+	QDEL_NULL(my_blue_toolbox)
+	QDEL_NULL(my_yellow_toolbox)
+	QDEL_NULL(my_red_toolbox)
 	return ..()
 
-/obj/structure/engineeringcart/proc/put_in_cart(obj/item/I, mob/user)
-	user.drop_item()
-	I.loc = src
-	to_chat(user, "<span class='notice'>You put [I] into [src].</span>")
-	return
-
-/obj/structure/engineeringcart/attackby__legacy__attackchain(obj/item/I, mob/user, params)
-	var/fail_msg = "<span class='notice'>There is already one of those in [src].</span>"
-	if(!I.is_robot_module())
-		if(istype(I, /obj/item/stack/sheet/glass))
-			if(!myglass)
-				put_in_cart(I, user)
-				myglass=I
-				update_icon(UPDATE_OVERLAYS)
-			else
-				to_chat(user, fail_msg)
-		else if(istype(I, /obj/item/stack/sheet/metal))
-			if(!mymetal)
-				put_in_cart(I, user)
-				mymetal=I
-				update_icon(UPDATE_OVERLAYS)
-			else
-				to_chat(user, fail_msg)
-		else if(istype(I, /obj/item/stack/sheet/plasteel))
-			if(!myplasteel)
-				put_in_cart(I, user)
-				myplasteel=I
-				update_icon(UPDATE_OVERLAYS)
-			else
-				to_chat(user, fail_msg)
-		else if(istype(I, /obj/item/flashlight))
-			if(!myflashlight)
-				put_in_cart(I, user)
-				myflashlight=I
-				update_icon(UPDATE_OVERLAYS)
-			else
-				to_chat(user, fail_msg)
-		else if(istype(I, /obj/item/storage/toolbox/mechanical))
-			if(!mybluetoolbox)
-				put_in_cart(I, user)
-				mybluetoolbox=I
-				update_icon(UPDATE_OVERLAYS)
-			else
-				to_chat(user, fail_msg)
-		else if(istype(I, /obj/item/storage/toolbox/electrical))
-			if(!myyellowtoolbox)
-				put_in_cart(I, user)
-				myyellowtoolbox=I
-				update_icon(UPDATE_OVERLAYS)
-			else
-				to_chat(user, fail_msg)
-		else if(istype(I, /obj/item/storage/toolbox))
-			if(!myredtoolbox)
-				put_in_cart(I, user)
-				myredtoolbox=I
-				update_icon(UPDATE_OVERLAYS)
-			else
-				to_chat(user, fail_msg)
-	else
-		to_chat(usr, "<span class='warning'>You cannot interface your modules [src]!</span>")
-
-/obj/structure/engineeringcart/tool_act(mob/living/user, obj/item/I, tool_type)
-	if(I.is_robot_module())
-		to_chat(user, "<span class='warning'>You cannot interface your modules [src]!</span>")
+/obj/structure/engineeringcart/proc/put_in_cart(obj/item/used, mob/user)
+	if(!user.drop_item())
+		to_chat(user, "<span class='warning'>[used] is stuck to your hand!</span>")
 		return FALSE
+
+	used.loc = src
+	to_chat(user, "<span class='notice'>You put [used] into [src].</span>")
+	return TRUE
+
+/obj/structure/engineeringcart/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	. = TRUE
+	var/fail_msg = "<span class='warning'>There is already one of those in [src]!</span>"
+	if(used.is_robot_module())
+		to_chat(usr, "<span class='warning'>You cannot interface your modules with [src]!</span>")
+		return
+
+	if(istype(used, /obj/item/stack/sheet/glass))
+		if(my_glass)
+			to_chat(user, fail_msg)
+			return
+
+		if(!put_in_cart(used, user))
+			return
+
+		my_glass = used
+		update_icon(UPDATE_OVERLAYS)
+		return
+
+	if(istype(used, /obj/item/stack/sheet/metal))
+		if(my_metal)
+			to_chat(user, fail_msg)
+			return
+
+		if(!put_in_cart(used, user))
+			return
+
+		my_metal=used
+		update_icon(UPDATE_OVERLAYS)
+		return
+
+	if(istype(used, /obj/item/stack/sheet/plasteel))
+		if(my_plasteel)
+			to_chat(user, fail_msg)
+			return
+
+		if(!put_in_cart(used, user))
+			return
+
+		my_plasteel=used
+		update_icon(UPDATE_OVERLAYS)
+		return
+
+	if(istype(used, /obj/item/flashlight))
+		if(my_flashlight)
+			to_chat(user, fail_msg)
+			return
+
+		if(!put_in_cart(used, user))	
+			return
+
+		my_flashlight=used
+		update_icon(UPDATE_OVERLAYS)
+		return
+
+	if(istype(used, /obj/item/storage/toolbox/mechanical))
+		if(my_blue_toolbox)
+			to_chat(user, fail_msg)
+			return
+
+		if(!put_in_cart(used, user))
+			return
+
+		my_blue_toolbox=used
+		update_icon(UPDATE_OVERLAYS)
+		return
+
+	if(istype(used, /obj/item/storage/toolbox/electrical))
+		if(my_yellow_toolbox)
+			to_chat(user, fail_msg)
+			return
+
+		if(!put_in_cart(used, user))
+			return
+
+		my_yellow_toolbox=used
+		update_icon(UPDATE_OVERLAYS)
+		return
+
+	if(istype(used, /obj/item/storage/toolbox))
+		if(my_red_toolbox)
+			to_chat(user, fail_msg)
+			return
+
+		if(!put_in_cart(used, user))
+			return
+
+		my_red_toolbox=used
+		update_icon(UPDATE_OVERLAYS)
+		return
+
 	return ..()
 
-/obj/structure/engineeringcart/wrench_act(mob/living/user, obj/item/I)
-	if(!anchored && !isinspace())
-		I.play_tool_sound(src, I.tool_volume)
-		user.visible_message(
-			"[user] tightens [src]'s casters.",
-			"<span class='notice'>You have tightened [src]'s casters.</span>",
-			"You hear ratchet."
-		)
-		anchored = TRUE
-	else if(anchored)
-		I.play_tool_sound(src, I.tool_volume)
-		user.visible_message(
-			"[user] loosens [src]'s casters.",
-			"<span class='notice'> You have loosened [src]'s casters.</span>",
-			"You hear ratchet."
-		)
+/obj/structure/engineeringcart/wrench_act(mob/living/user, obj/item/tool)
+	. = TRUE
+	if(anchored)
+		tool.play_tool_sound(src, tool.tool_volume)
 		anchored = FALSE
+		user.visible_message(
+			"<span class='notice'>[user] loosens [src]'s casters.</span>",
+			"<span class='notice'> You have loosened [src]'s casters.</span>",
+			"<span class='notice'>You hear ratcheting.</span>"
+		)
+		return
 
-	return TRUE
+	if(!anchored && !isinspace())
+		tool.play_tool_sound(src, tool.tool_volume)
+		anchored = TRUE
+		user.visible_message(
+			"<span class='notice'>[user] tightens [src]'s casters.</span>",
+			"<span class='notice'>You have tightened [src]'s casters.</span>",
+			"<span class='notice'>You hear ratcheting.</span>"
+		)
 
 /obj/structure/engineeringcart/attack_hand(mob/user)
 	var/list/engicart_items = list()
 
-	if(myglass)
-		engicart_items["Glass"] = image(icon = myglass.icon, icon_state = myglass.icon_state)
-	if(mymetal)
-		engicart_items["Metal"] = image(icon = mymetal.icon, icon_state = mymetal.icon_state)
-	if(myplasteel)
-		engicart_items["Plasteel"] = image(icon = myplasteel.icon, icon_state = myplasteel.icon_state)
-	if(myflashlight)
-		engicart_items["Flashlight"] = image(icon = myflashlight.icon, icon_state = myflashlight.icon_state)
-	if(mybluetoolbox)
-		engicart_items["Mechanical Toolbox"] = image(icon = mybluetoolbox.icon, icon_state = mybluetoolbox.icon_state)
-	if(myredtoolbox)
-		engicart_items["Emergency Toolbox"] = image(icon = myredtoolbox.icon, icon_state = myredtoolbox.icon_state)
-	if(myyellowtoolbox)
-		engicart_items["Electrical Toolbox"] = image(icon = myyellowtoolbox.icon, icon_state = myyellowtoolbox.icon_state)
+	if(my_glass)
+		engicart_items["Glass"] = image(icon = my_glass.icon, icon_state = my_glass.icon_state)
+	if(my_metal)
+		engicart_items["Metal"] = image(icon = my_metal.icon, icon_state = my_metal.icon_state)
+	if(my_plasteel)
+		engicart_items["Plasteel"] = image(icon = my_plasteel.icon, icon_state = my_plasteel.icon_state)
+	if(my_flashlight)
+		engicart_items["Flashlight"] = image(icon = my_flashlight.icon, icon_state = my_flashlight.icon_state)
+	if(my_blue_toolbox)
+		engicart_items["Mechanical Toolbox"] = image(icon = my_blue_toolbox.icon, icon_state = my_blue_toolbox.icon_state)
+	if(my_red_toolbox)
+		engicart_items["Emergency Toolbox"] = image(icon = my_red_toolbox.icon, icon_state = my_red_toolbox.icon_state)
+	if(my_yellow_toolbox)
+		engicart_items["Electrical Toolbox"] = image(icon = my_yellow_toolbox.icon, icon_state = my_yellow_toolbox.icon_state)
 
 	if(!length(engicart_items))
 		return
 
 	var/pick = show_radial_menu(user, src, engicart_items, custom_check = CALLBACK(src, PROC_REF(check_menu), user), require_near = TRUE)
-
 	if(!pick)
 		return
 
 	switch(pick)
 		if("Glass")
-			if(!myglass)
+			if(!my_glass)
 				return
-			user.put_in_hands(myglass)
-			to_chat(user, "<span class='notice'>You take [myglass] from [src].</span>")
-			myglass = null
+
+			user.put_in_hands(my_glass)
+			to_chat(user, "<span class='notice'>You take [my_glass] from [src].</span>")
+			my_glass = null
+
 		if("Metal")
-			if(!mymetal)
+			if(!my_metal)
 				return
-			user.put_in_hands(mymetal)
-			to_chat(user, "<span class='notice'>You take [mymetal] from [src].</span>")
-			mymetal = null
+
+			user.put_in_hands(my_metal)
+			to_chat(user, "<span class='notice'>You take [my_metal] from [src].</span>")
+			my_metal = null
+
 		if("Plasteel")
-			if(!myplasteel)
+			if(!my_plasteel)
 				return
-			user.put_in_hands(myplasteel)
-			to_chat(user, "<span class='notice'>You take [myplasteel] from [src].</span>")
-			myplasteel = null
+
+			user.put_in_hands(my_plasteel)
+			to_chat(user, "<span class='notice'>You take [my_plasteel] from [src].</span>")
+			my_plasteel = null
+
 		if("Flashlight")
-			if(!myflashlight)
+			if(!my_flashlight)
 				return
-			user.put_in_hands(myflashlight)
-			to_chat(user, "<span class='notice'>You take [myflashlight] from [src].</span>")
-			myflashlight = null
+
+			user.put_in_hands(my_flashlight)
+			to_chat(user, "<span class='notice'>You take [my_flashlight] from [src].</span>")
+			my_flashlight = null
+
 		if("Mechanical Toolbox")
-			if(!mybluetoolbox)
+			if(!my_blue_toolbox)
 				return
-			user.put_in_hands(mybluetoolbox)
-			to_chat(user, "<span class='notice'>You take [mybluetoolbox] from [src].</span>")
-			mybluetoolbox = null
+
+			user.put_in_hands(my_blue_toolbox)
+			to_chat(user, "<span class='notice'>You take [my_blue_toolbox] from [src].</span>")
+			my_blue_toolbox = null
+
 		if("Emergency Toolbox")
-			if(!myredtoolbox)
+			if(!my_red_toolbox)
 				return
-			user.put_in_hands(myredtoolbox)
-			to_chat(user, "<span class='notice'>You take [myredtoolbox] from [src].</span>")
-			myredtoolbox = null
+
+			user.put_in_hands(my_red_toolbox)
+			to_chat(user, "<span class='notice'>You take [my_red_toolbox] from [src].</span>")
+			my_red_toolbox = null
+
 		if("Electrical Toolbox")
-			if(!myyellowtoolbox)
+			if(!my_yellow_toolbox)
 				return
-			user.put_in_hands(myyellowtoolbox)
-			to_chat(user, "<span class='notice'>You take [myyellowtoolbox] from [src].</span>")
-			myyellowtoolbox = null
+
+			user.put_in_hands(my_yellow_toolbox)
+			to_chat(user, "<span class='notice'>You take [my_yellow_toolbox] from [src].</span>")
+			my_yellow_toolbox = null
 
 	update_icon(UPDATE_OVERLAYS)
 
@@ -188,17 +250,17 @@
 
 /obj/structure/engineeringcart/update_overlays()
 	. = ..()
-	if(myplasteel)
+	if(my_plasteel)
 		. += "cart_plasteel"
-	if(mymetal)
+	if(my_metal)
 		. += "cart_metal"
-	if(myglass)
+	if(my_glass)
 		. += "cart_glass"
-	if(myflashlight)
+	if(my_flashlight)
 		. += "cart_flashlight"
-	if(mybluetoolbox)
+	if(my_blue_toolbox)
 		. += "cart_bluetoolbox"
-	if(myredtoolbox)
+	if(my_red_toolbox)
 		. += "cart_redtoolbox"
-	if(myyellowtoolbox)
+	if(my_yellow_toolbox)
 		. += "cart_yellowtoolbox"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Migrates the Engineering Cart to the new attack chain.
- Cleans up the cart's code to be nice and shiny.
- Allows cyborgs to wrench/unwrench the cart.
- Makes a new pre-filled version of the cart.
- Adds the pre-filled cart to all stations.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Ancient object with code not touched since the beginning of time getting updated is good.

Showing off the surprising amount of stuff this thing can carry with its pre-equipped variant may encourage more usage, as with the pre-equipped janitorial cart.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Delta
![image](https://github.com/user-attachments/assets/e5db8494-644d-48c2-839b-7048c4213f9e)
Meta
![image](https://github.com/user-attachments/assets/870ee868-037b-457d-8dfb-5ecbf2410716)
Cere
![image](https://github.com/user-attachments/assets/bacd82d7-6644-4878-9c2d-d86a22be506f)

Emerald and Delta already have a cart, it has just been filled up.
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Placed items into and removed from cart and added back in.
Transferred items to different cart.
Tried to add duplicate items to cart.
Wrenched cart as human and borg.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Engineering's engi cart now comes pre-filled.
add: Added engineering cart to Meta, Delta, and Cere.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
