### PR TITLE
fix default value of enable_ruins in example config

### DIFF
--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -608,7 +608,7 @@ enable_space = true
 # Enable lavaland generation.
 enable_lavaland = true
 # Globally enable and disable placing of all ruins across lavaland and space.
-enable_ruins = false
+enable_ruins = true
 # Minimum number of extra space zlevels to generate
 minimum_space_zlevels = 2
 # Maximum number of extra space zlevels to generate


### PR DESCRIPTION
## What Does This PR Do
This PR sets `enable_ruins` to true in the example config.
## Why It's Good For The Game
Ruins are good
## Testing
Visual inspection
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog
:cl:
fix: Ruins should properly spawn in production
/:cl: