### PR TITLE
Makes red lighting color more red

### DIFF
--- a/code/__DEFINES/lighting_defines.dm
+++ b/code/__DEFINES/lighting_defines.dm
@@ -36,7 +36,7 @@
 //Some defines to generalise colours used in lighting.
 //Important note on colors. Colors can end up significantly different from the basic html picture, especially when saturated
 #define LIGHT_COLOR_WHITE		"#FFFFFF"
-#define LIGHT_COLOR_RED        "#FA8282" //Warm but extremely diluted red. rgb(250, 130, 130)
+#define LIGHT_COLOR_RED        "#FF4B4B" //Warm, bright red. rgb(255, 75, 75)
 #define LIGHT_COLOR_GREEN      "#64C864" //Bright but quickly dissipating neon green. rgb(100, 200, 100)
 #define LIGHT_COLOR_BLUE       "#6496FA" //Cold, diluted blue. rgb(100, 150, 250)
 

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -287,7 +287,7 @@
 
 /obj/item/flashlight/flare/glowstick/red
 	name = "red glowstick"
-	color = LIGHT_COLOR_PURE_RED
+	color = LIGHT_COLOR_RED
 
 /obj/item/flashlight/flare/glowstick/blue
 	name = "blue glowstick"

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/legionnaire.dm
@@ -289,7 +289,7 @@
 	anchored = TRUE
 	density = FALSE
 	light_range = 4
-	light_color = LIGHT_COLOR_RED
+	light_color = LIGHT_COLOR_FLARE
 	var/mob/living/simple_animal/hostile/asteroid/elite/legionnaire/myowner = null
 
 /obj/structure/legionnaire_bonfire/Initialize(mapload)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Tweaks define for a `LIGHT_COLOR_RED` making it a bit more saturated with red color.
Changes red glowstick's color back to `LIGHT_COLOR_RED` as `PURE_RED` is too dark actually.
Changes legionnaire bonfire's lighting color from `LIGHT_COLOR_RED` to `LIGHT_COLOR_FLARE`.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Current red color is just nowhere as saturated as any other, like green, blue, pink, yellow, orange and so on. This PR makes it a bit more noticable that your lighting has a red color.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

https://discord.com/channels/145533722026967040/1355900526683750636

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

![image](https://github.com/user-attachments/assets/f2f4dd3e-a332-402a-9037-917a0355511d)

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Red color used by some lighting devices (cult pylon, esword, glowcap, glowstick etc.) is now a bit more saturated.
tweak: Legionnaire's bonfire now has more saturated lighting color.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
