### PR TITLE
fix space sectors leading to lavaland

### DIFF
--- a/code/controllers/subsystem/non_firing/SSmapping.dm
+++ b/code/controllers/subsystem/non_firing/SSmapping.dm
@@ -312,7 +312,7 @@ SUBSYSTEM_DEF(mapping)
 /datum/controller/subsystem/mapping/proc/generate_lavaland_zlevels()
 	log_startup_progress("Loading Lavaland...")
 	var/watch = start_watch()
-	var/lavaland_z_level = GLOB.space_manager.add_new_zlevel(MINING, linkage = CROSSLINKED, traits = list(ORE_LEVEL, REACHABLE_BY_CREW, STATION_CONTACT, HAS_WEATHER, AI_OK))
+	var/lavaland_z_level = GLOB.space_manager.add_new_zlevel(MINING, linkage = SELFLOOPING, traits = list(ORE_LEVEL, REACHABLE_BY_CREW, STATION_CONTACT, HAS_WEATHER, AI_OK))
 	GLOB.maploader.load_map(file("_maps/map_files/generic/Lavaland.dmm"), z_offset = lavaland_z_level)
 	CHECK_TICK
 	log_startup_progress("Added lavaland levels in [stop_watch(watch)]s")


### PR DESCRIPTION
## What Does This PR Do
This PR fixes it so that leaving a space sector doesn't accidentally transit you to Lavaland.
## Why It's Good For The Game
Twisting the fabric of reality bad.
## Testing
Thinkin bout the code real hard.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl:
fix: Space levels are properly isolated from Lavaland and cannot teleport you there.
/:cl:
