### PR TITLE
Fixes roundstart asteroid mining mods not being spaceproof

### DIFF
--- a/code/__DEFINES/mod.dm
+++ b/code/__DEFINES/mod.dm
@@ -37,6 +37,9 @@
 #define SEALED_COVER "sealed_cover"
 #define CAN_OVERSLOT "can_overslot"
 
+// Flags for skin modifiers
+#define MAKE_SPACEPROOF (1<<0)
+
 //Defines used to override MOD clothing's icon and worn icon files in the skin.
 #define MOD_ICON_OVERRIDE "mod_icon_override"
 

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -702,7 +702,15 @@
 			overslotting_parts -= part
 			continue
 		overslotting_parts |= part
+	var/used_skin_modifiers = theme.skin_modifiers[new_skin]
+	apply_modifiers(used_skin_modifiers)
 	wearer?.regenerate_icons()
+
+/obj/item/mod/control/proc/apply_modifiers(modifiers)
+	if(modifiers & MAKE_SPACEPROOF)
+		min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
+		for(var/obj/item/clothing/part in mod_parts)
+			part.min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
 
 /obj/item/mod/control/proc/on_exit(datum/source, atom/movable/part, direction)
 	SIGNAL_HANDLER

--- a/code/modules/mod/mod_paint.dm
+++ b/code/modules/mod/mod_paint.dm
@@ -4,7 +4,6 @@
 	icon = 'icons/obj/clothing/modsuit/mod_construction.dmi'
 	icon_state = "skinapplier"
 	var/skin = "civilian"
-	var/make_spaceproof = FALSE //Used on the miner asteroid skin to make the suit spaceproof when upgrading.
 	var/compatible_theme = /datum/mod_theme/standard
 
 /obj/item/mod/skin_applier/Initialize(mapload)
@@ -22,10 +21,6 @@
 		to_chat(user, "<span class='warning'>Theme is not compatible!</span>")
 		return TRUE
 	mod.set_mod_skin(skin)
-	if(make_spaceproof)
-		mod.min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
-		for(var/obj/item/clothing/C in mod.mod_parts)
-			C.min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
 	to_chat(user, "<span class='notice'>You apply the theme to [mod].</span>")
 	qdel(src)
 	return TRUE
@@ -34,7 +29,6 @@
 	skin = "asteroid"
 	compatible_theme = /datum/mod_theme/mining
 	desc = "This one-use skin applier will add a skin to MODsuits of a specific type. This one applies to mining modsuits, and makes them spaceproof. Enjoy the days when you had MODsuits on the asteroid. Wait a minute."
-	make_spaceproof = TRUE
 
 /obj/item/mod/skin_applier/corpsman
 	skin = "corpsman"

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -51,6 +51,8 @@
 	var/list/inbuilt_modules = list()
 	/// Allowed items in the chestplate's suit storage.
 	var/list/allowed_suit_storage = list()
+	/// List of modifiers that we apply after applying new skin
+	var/list/skin_modifiers = list()
 	/// List of skins with their appropriate clothing flags.
 	var/list/skins = list(
 		"standard" = list(
@@ -309,6 +311,9 @@
 		/obj/item/gun/energy/kinetic_accelerator,
 	)
 	inbuilt_modules = list(/obj/item/mod/module/ash_accretion, /obj/item/mod/module/sphere_transform)
+	skin_modifiers = list(
+		"asteroid" = MAKE_SPACEPROOF
+	)
 	skins = list(
 		"mining" = list(
 			HELMET_FLAGS = list(


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Moves proc that makes mod spaceproof to a different place as well as making it easier to add new modifiers that depend on a skin.
Fixes #27165

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

It's a fix

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Spawned in mod, it had cold protection. Spawned in a regular mining mod and applied a new skin - it applied cold protection as well.
![image](https://github.com/user-attachments/assets/b5c5f791-a356-4c28-b56c-9e066867cea2)

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Mining modsuits with asteroid skin from space ruins are now actually spaceproof.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
