### PR TITLE
fix pumpkin/blumpkin pie recipe collision

### DIFF
--- a/code/modules/cooking/recipes/oven_recipes.dm
+++ b/code/modules/cooking/recipes/oven_recipes.dm
@@ -157,7 +157,7 @@
 	catalog_category = COOKBOOK_CATEGORY_DESSERTS
 	steps = list(
 		PCWJ_ADD_ITEM(/obj/item/food/sliceable/flatdough),
-		PCWJ_ADD_PRODUCE(/obj/item/food/grown/pumpkin/blumpkin),
+		PCWJ_ADD_PRODUCE(/obj/item/food/grown/pumpkin/blumpkin, exact = TRUE),
 		PCWJ_ADD_REAGENT("milk", 5),
 		PCWJ_ADD_REAGENT("sugar", 5),
 		PCWJ_USE_OVEN(J_MED, 10 SECONDS),
@@ -932,7 +932,7 @@
 	catalog_category = COOKBOOK_CATEGORY_DESSERTS
 	steps = list(
 		PCWJ_ADD_ITEM(/obj/item/food/sliceable/flatdough),
-		PCWJ_ADD_PRODUCE(/obj/item/food/grown/pumpkin),
+		PCWJ_ADD_PRODUCE(/obj/item/food/grown/pumpkin, exact = TRUE),
 		PCWJ_ADD_REAGENT("milk", 5),
 		PCWJ_ADD_REAGENT("sugar", 5),
 		PCWJ_USE_OVEN(J_MED, 10 SECONDS),

--- a/code/modules/cooking/steps/recipe_step_add_produce.dm
+++ b/code/modules/cooking/steps/recipe_step_add_produce.dm
@@ -24,7 +24,7 @@ RESTRICT_TYPE(/datum/cooking/recipe_step/add_produce)
 	if(!istype(added_item, /obj/item/food/grown))
 		return PCWJ_CHECK_INVALID
 	if(exact_path)
-		if(added_item == produce_type)
+		if(added_item.type == produce_type)
 			return PCWJ_CHECK_VALID
 	else
 		if(istype(added_item, produce_type))


### PR DESCRIPTION
## What Does This PR Do
This PR fixes a recipe collision between pumpkin and blumpkin pies by specifying exact types for the input ingredients. Also fixes a bug in the add_produce recipe step for exact paths. Fixes #28864.
## Why It's Good For The Game
We don't want recipes with the same inputs resulting in two different possible outputs.
## Testing
Confirmed both recipes worked with expected ingredients and no debug errors.
![2025_03_31__18_16_27__Paradise Station 13](https://github.com/user-attachments/assets/015d0d2f-6062-410e-b93b-c856cbf08b5d)
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl:
fix: Pumpkin and blumpkin pie recipes work properly.
/:cl:
