### PR TITLE
[s] Fixes Mobility Mesh Bug

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -772,6 +772,10 @@
 	var/insert_max = 1
 	/// Currently applied inserts
 	var/list/inserts = list()
+	/// Is there a mobility mesh inserted?
+	var/mobility_meshed = FALSE
+	/// What's the total slowdown from inserts?
+	var/insert_slowdown = 0
 
 
 /obj/item/clothing/suit/Initialize(mapload)

--- a/code/modules/crafting/smithed_items.dm
+++ b/code/modules/crafting/smithed_items.dm
@@ -213,8 +213,6 @@
 	var/explosive_armor = 0
 	/// Movement speed
 	var/movement_speed_mod = 0
-	/// Used in the mobility insert - does this negate slowdown
-	var/no_more_slowdown = FALSE
 	/// Heat insulation
 	var/heat_insulation = 0
 	/// Electrical insulation
@@ -240,18 +238,20 @@
 		return
 	attached_suit = target
 	attached_suit.armor = attached_suit.armor.attachArmor(armor)
-	attached_suit.slowdown -= movement_speed_mod
+	attached_suit.insert_slowdown -= movement_speed_mod
+	attached_suit.slowdown = initial(attached_suit.slowdown) + attached_suit.insert_slowdown
+	if(attached_suit.mobility_meshed)
+		attached_suit.slowdown = 0
 	attached_suit.siemens_coefficient -= siemens_coeff
 	attached_suit.min_cold_protection_temperature -= heat_insulation
 	attached_suit.max_heat_protection_temperature += heat_insulation
-	if(no_more_slowdown)
-		attached_suit.slowdown = 0
 
 /obj/item/smithed_item/insert/on_detached(mob/user)
 	attached_suit.armor = attached_suit.armor.detachArmor(armor)
-	if(no_more_slowdown)
-		attached_suit.slowdown = initial(attached_suit.slowdown)
-	attached_suit.slowdown += movement_speed_mod
+	attached_suit.insert_slowdown += movement_speed_mod
+	attached_suit.slowdown = initial(attached_suit.slowdown) + attached_suit.insert_slowdown
+	if(attached_suit.mobility_meshed)
+		attached_suit.slowdown = 0
 	attached_suit.siemens_coefficient += siemens_coeff
 	attached_suit.min_cold_protection_temperature += heat_insulation
 	attached_suit.max_heat_protection_temperature -= heat_insulation
@@ -337,7 +337,18 @@
 	burn_armor = -5
 	laser_armor = -5
 	heat_insulation = 10
-	no_more_slowdown = TRUE
+	/// Attached suit slowdown when the mobility mesh was applied
+	var/initial_slowdown = 0
+
+/obj/item/smithed_item/insert/mobility/on_attached(obj/item/clothing/suit/target)
+	. = ..()
+	attached_suit.mobility_meshed = TRUE
+	attached_suit.slowdown = 0
+
+/obj/item/smithed_item/insert/mobility/on_detached(mob/user)
+	attached_suit.mobility_meshed = FALSE
+	. = ..()
+
 
 /obj/item/smithed_item/insert/admin
 	name = "adminium mesh"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes an issue with mobility inserts.

## Why It's Good For The Game

Bugs bad.

## Testing

Tested fix repeatedly. Issue did not reoccur.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Fixed a bug with mobility meshes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
