### PR TITLE
Returns every robotic/positronic brain's inherent right to be housed into flesh

### DIFF
--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -298,7 +298,7 @@
 
 /obj/item/mmi/syndie
 	name = "\improper Syndicate Man-Machine Interface"
-	desc = "The Syndicate's own brand of MMI. Mindslaves any brain inserted into it for as long as it's inside. Cyborgs, mechs, spiderbots, or IRCs made with this MMI will be slaved to the owner. Does not fit into NT AI cores. \
+	desc = "The Syndicate's own brand of MMI. Mindslaves any brain inserted into it for as long as it's inside. Cyborgs, mechs, spiderbots, or IRCs made with this MMI will be slaved to the owner. Does not fit into NT AI cores and is incompatible with organic bodies. \
 	Cyborgs will appear to be linked to an AI (if present). If someone attempts to detonate the cyborg, it will automatically block the attempt and then disconnect from the AI. No emagged equipment is provided."
 	origin_tech = "biotech=4;programming=4;syndicate=2"
 	syndiemmi = TRUE

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -576,8 +576,8 @@
 		to_chat(user, "<span class='danger'>You cannot install a computer brain into a meat enclosure.</span>")
 		return SURGERY_BEGINSTEP_SKIP
 
-	if(!ismachineperson(target))
-		to_chat(user, "<span class='danger'>[tool] cannot be installed into an organic body, as it is not designed to operate the complex biological systems of one!</span>")
+	if(istype(M, /obj/item/mmi/syndie))
+		to_chat(user, "<span class='danger'>[tool] cannot be installed into an organic body, as the hardware designed to operate the complex biology of one was repurposed to enslave the brain housed inside!</span>")
 		return SURGERY_BEGINSTEP_SKIP
 
 	if(!target.dna.species)

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -576,12 +576,12 @@
 		to_chat(user, "<span class='danger'>You cannot install a computer brain into a meat enclosure.</span>")
 		return SURGERY_BEGINSTEP_SKIP
 
-	if(istype(M, /obj/item/mmi/syndie)) //We do not want peoples to use syndi-MMIs as cheap mindslave implants
-		to_chat(user, "<span class='danger'>[tool] cannot be installed into an organic body, as the hardware designed to operate the complex biology of one was repurposed to enslave the brain housed inside!</span>")
-		return SURGERY_BEGINSTEP_SKIP
-
 	if(!target.dna.species)
 		to_chat(user, "<span class='danger'>You have no idea what species this person is. Report this on the bug tracker.</span>")
+		return SURGERY_BEGINSTEP_SKIP
+
+	if(!ismachineperson(target) && istype(M, /obj/item/mmi/syndie)) //We do not want peoples to use syndi-MMIs as cheap mindslave implants
+		to_chat(user, "<span class='danger'>[tool] cannot be installed into an organic body, as the hardware designed to operate the complex biology of one was repurposed to enslave the brain housed inside!</span>")
 		return SURGERY_BEGINSTEP_SKIP
 
 	if(!ismachineperson(target) && IS_MINDFLAYER(M.brainmob))

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -576,12 +576,16 @@
 		to_chat(user, "<span class='danger'>You cannot install a computer brain into a meat enclosure.</span>")
 		return SURGERY_BEGINSTEP_SKIP
 
-	if(istype(M, /obj/item/mmi/syndie)) // We basically do not want peoples to use syndi-MMIs as cheap mindslave implants
+	if(istype(M, /obj/item/mmi/syndie)) //We do not want peoples to use syndi-MMIs as cheap mindslave implants
 		to_chat(user, "<span class='danger'>[tool] cannot be installed into an organic body, as the hardware designed to operate the complex biology of one was repurposed to enslave the brain housed inside!</span>")
 		return SURGERY_BEGINSTEP_SKIP
 
 	if(!target.dna.species)
 		to_chat(user, "<span class='danger'>You have no idea what species this person is. Report this on the bug tracker.</span>")
+		return SURGERY_BEGINSTEP_SKIP
+
+	if(!ismachineperson(target) && IS_MINDFLAYER(M.brainmob))
+		to_chat(user, "<span class='danger'>[tool]'s lights flash brightly as you try to install it, it is refusing to interface with the augmented torso's connection port.</span>")
 		return SURGERY_BEGINSTEP_SKIP
 
 	if(!target.dna.species.has_organ["brain"])

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -576,7 +576,7 @@
 		to_chat(user, "<span class='danger'>You cannot install a computer brain into a meat enclosure.</span>")
 		return SURGERY_BEGINSTEP_SKIP
 
-	if(istype(M, /obj/item/mmi/syndie)) //See PR #26020 - We basically do not want peoples to use syndi-MMIs as cheap mindslave implants
+	if(istype(M, /obj/item/mmi/syndie)) // We basically do not want peoples to use syndi-MMIs as cheap mindslave implants
 		to_chat(user, "<span class='danger'>[tool] cannot be installed into an organic body, as the hardware designed to operate the complex biology of one was repurposed to enslave the brain housed inside!</span>")
 		return SURGERY_BEGINSTEP_SKIP
 

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -576,7 +576,7 @@
 		to_chat(user, "<span class='danger'>You cannot install a computer brain into a meat enclosure.</span>")
 		return SURGERY_BEGINSTEP_SKIP
 
-	if(istype(M, /obj/item/mmi/syndie))
+	if(istype(M, /obj/item/mmi/syndie)) //See PR #26020 - We basically do not want peoples to use syndi-MMIs as cheap mindslave implants
 		to_chat(user, "<span class='danger'>[tool] cannot be installed into an organic body, as the hardware designed to operate the complex biology of one was repurposed to enslave the brain housed inside!</span>")
 		return SURGERY_BEGINSTEP_SKIP
 


### PR DESCRIPTION
## What Does This PR Do

- Robotic and Positronic brains can now be placed into an organic's chest again, provided said chest is augmented.

- Syndicate MMIs can still not be placed into an organic body to not revert the balance change of #26020 .

- The syndicate MMI's description now tells you that it can't be used as a cheap mindslave implant.

- Adds a check to prevent mindflayers' positronic brains from being implanted into an organic, as it would probably break half of their abilities and the entire server.


## Why It's Good For The Game

- I want robo/posi brains to be able to be housed in a flesh chassis again as it will allow a different take on IRCs : instead of a servant easily recognised as an imprinted robotic brain, you can now have a robot posing as an organic which allows interesting debates and stories about IRCs posing as a organics without anyone noticing they are a machine until X event, leading to introspection and a change of the status of the character and community it lived in.

- It makes it easier to fix nanomachine-related / Robotic Factory cyborgification.


## Testing

- Tried placing a robotic brain in a debrained skrell's augmented torso, it was possible.
- Tried placing a positronic brain in a debrained skrell's augmented torso, it was possible.
- Tried placing a nanotrasen MMI in a debrained skrell's augmented torso, it was possible.
- Tried placing a syndicate MMI in a debrained skrell's augmented torso, it was not possible.
- Checked if the posi/robo brains / MMI could control the skrell after defibrillating it, it was the case.
- Checked that you cannot add a posi/robo brain / MMI to a mob that already has a brain, it was the case.
- Checked that you cannot add a mindflayer's posi brain into a debrained skrell's augmented torso, it was the case.
- Checked you can install any kind of MMI into an IPC's and IRC's torso, it was the case.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl: leboucliervert
tweak: Nanotrasen found out augmenting an organic's torso is enough to use a robotic brain to pilot it. Posibrain and nanotrasen-brand MMI compatibility was also confirmed but ignored as "uninteresting". UNRELATED: Brain cake prices down by 75% in Epsilon Eridani as many employees of Nanotrasen show renewed loyalty and interest in doing their job.
tweak: The syndicate MMI's description now tells you it cannot be placed into an organic body.
/:cl:
