### PR TITLE
update raw meat examine text to explain making meatballs/patties

### DIFF
--- a/code/modules/food_and_drinks/food/foods/meat.dm
+++ b/code/modules/food_and_drinks/food/foods/meat.dm
@@ -269,10 +269,14 @@
 	bitesize = 3
 	list_reagents = list("protein" = 2)
 
+/obj/item/food/meat/patty_raw/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>Use it in hand to shape it into a raw meatball.</span>"
+
 /obj/item/food/meat/patty_raw/attack_self__legacy__attackchain(mob/user)
 	user.visible_message(
-		"<span class='notice'>[user] shapes [src] into a ball.</span>",
-		"<span class='notice'>You shape [src] into a ball.</span>"
+		"<span class='notice'>[user] shapes [src] into a raw meatball.</span>",
+		"<span class='notice'>You shape [src] into a raw meatball.</span>"
 	)
 	playsound(user, 'sound/effects/blobattack.ogg', 50, 1)
 	var/obj/item/food/meat/raw_meatball/M = new(get_turf(user))
@@ -289,6 +293,11 @@
 	filling_color = "#DB0000"
 	list_reagents = list("protein" = 4, "vitamin" = 1)
 	tastes = list("raw meat" = 1)
+
+/obj/item/food/ground_meat/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>Use it in hand to shape it into a raw meatball.</span>"
+	. += "<span class='notice'>Use it in hand again to flatten it into a raw patty.</span>"
 
 /obj/item/food/ground_meat/attack_self__legacy__attackchain(mob/living/user)
 	user.visible_message(
@@ -310,6 +319,10 @@
 	filling_color = "#DB4444"
 	list_reagents = list("protein" = 4, "vitamin" = 1)
 	tastes = list("raw meat" = 1)
+
+/obj/item/food/meat/raw_meatball/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>Use it in hand to flatten it into a raw patty.</span>"
 
 /obj/item/food/meat/raw_meatball/attack_self__legacy__attackchain(mob/user)
 	user.visible_message(


### PR DESCRIPTION
## What Does This PR Do
This PR updates the descriptions of ground meat, raw patties, and raw meatballs to explain how to change them into one another.
## Why It's Good For The Game
This should have been explained in the original kitchen rework.
## Testing
![2025_04_03__12_04_29__Paradise Station 13](https://github.com/user-attachments/assets/f9919e4e-3fe2-4b25-a56f-9a4438e18054)
### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: Ground meat, raw patties, and raw meatballs now describe how to turn them into one another in their examine text.
/:cl: