### PR TITLE
Add investigate log for broken canisters

### DIFF
--- a/code/__HELPERS/atom_helpers.dm
+++ b/code/__HELPERS/atom_helpers.dm
@@ -13,6 +13,27 @@
 /// Only contains attacker name/ckey right now but could be expanded.
 /datum/attack_info
 	/// Name of the mob who performed the last attack.
-	var/last_attacker_name = null
+	var/last_attacker_name
 	/// Ckey of the player who performed the last attack.
-	var/last_attacker_ckey = null
+	var/last_attacker_ckey
+	/// Name and type of the weapon that the last attack was performed with.
+	var/last_attacker_weapon
+
+/datum/attack_info/proc/last_attacker_html()
+	var/name = "INVALID"
+	var/ckey = "INVALID"
+	if(last_attacker_name)
+		name = last_attacker_name
+	if(last_attacker_ckey)
+		var/client/C = get_client_by_ckey(last_attacker_ckey)
+		if(C)
+			ckey = "<a href='byond://?priv_msg=[C.ckey];type=;ticket_id='>[C.ckey]</a>"
+		else
+			ckey = "[C.ckey] (DC)"
+
+	return "[ckey]/([name])"
+
+/datum/attack_info/proc/last_weapon()
+	if(last_attacker_weapon)
+		return " ([last_attacker_weapon])"
+	return ""

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1500,8 +1500,10 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 		var/atom/checked_atom = .[++i]
 		. += checked_atom.contents
 
-/atom/proc/store_last_attacker(mob/living/attacker)
+/atom/proc/store_last_attacker(mob/living/attacker, obj/item/weapon)
 	if(!attack_info)
 		attack_info = new
 	attack_info.last_attacker_name = attacker.real_name
 	attack_info.last_attacker_ckey = attacker.ckey
+	if(istype(weapon))
+		attack_info.last_attacker_weapon = "[weapon] ([weapon.type])"

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -201,6 +201,8 @@ GLOBAL_DATUM_INIT(canister_icon_container, /datum/canister_icons, new())
 		holding_tank = null
 
 	T.blind_release_air(expelled_gas)
+	if(attack_info)
+		investigate_log("canister destroyed, last attacked by [attack_info.last_attacker_html()][attack_info.last_weapon()]", INVESTIGATE_ATMOS)
 
 /obj/machinery/atmospherics/portable/canister/proc/sync_pressure_appearance()
 	var/new_pressure_appearance = pressure_to_appearance(air_contents.return_pressure())
@@ -406,6 +408,14 @@ GLOBAL_DATUM_INIT(canister_icon_container, /datum/canister_icons, new())
 /obj/machinery/atmospherics/portable/canister/atmos_init()
 	. = ..()
 	update_icon()
+
+/obj/machinery/atmospherics/portable/canister/attacked_by(obj/item/attacker, mob/living/user)
+	. = ..()
+	store_last_attacker(user, attacker)
+
+/obj/machinery/atmospherics/portable/canister/attack_animal(mob/living/simple_animal/M)
+	. = ..()
+	store_last_attacker(M)
 
 /obj/machinery/atmospherics/portable/canister/toxins
 	name = "Canister \[Toxin (Plasma)\]"


### PR DESCRIPTION
## What Does This PR Do
This PR adds an investigate log for broken canisters, including the last attacker and weapon if known.
## Why It's Good For The Game
Improve admin powers.
## Testing
![2025_04_03__12_00_05__Paradise Station 13](https://github.com/user-attachments/assets/df08d410-543d-4b95-b76b-e0125d06eb38)
![2025_04_03__12_16_06__Paradise Station 13](https://github.com/user-attachments/assets/628890a7-8533-48cb-9a65-d966222f1be0)
### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog
NPFC
