### PR TITLE
[MAP] Adds Whiteship dock points to several big ruins

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -4220,6 +4220,14 @@
 /obj/item/paper/fluff/ruins/deepstorage/log2,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/deepstorage)
+"zP" = (
+/obj/docking_port/stationary/whiteship{
+	name = "Designation Error";
+	dir = 8;
+	id = "whiteship_deep"
+	},
+/turf/template_noop,
+/area/template_noop)
 "zU" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -8041,7 +8049,7 @@ qn
 qn
 qn
 qn
-qn
+zP
 qn
 qn
 qn
@@ -8107,10 +8115,10 @@ qn
 qn
 qn
 qn
-ab
 qn
 qn
-ab
+qn
+qn
 qn
 qn
 qn
@@ -8251,7 +8259,7 @@ qn
 qn
 qn
 qn
-ab
+qn
 qn
 qn
 qn
@@ -8324,7 +8332,7 @@ qn
 qn
 qn
 qn
-ab
+qn
 qn
 qn
 qn

--- a/_maps/map_files/RandomRuins/SpaceRuins/meatpackers.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/meatpackers.dmm
@@ -2190,6 +2190,14 @@
 	icon_state = "bar"
 	},
 /area/ruin/unpowered/bmp_ship/midship)
+"Eb" = (
+/obj/docking_port/stationary/whiteship{
+	id = "whiteship_kerberos";
+	name = "Disabled Vessel";
+	dir = 8
+	},
+/turf/template_noop,
+/area/template_noop)
 "Ht" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -2854,7 +2862,7 @@ aa
 "}
 (13,1,1) = {"
 aa
-aa
+Eb
 aa
 aa
 aa

--- a/_maps/map_files/RandomRuins/SpaceRuins/moonoutpost19.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/moonoutpost19.dmm
@@ -687,6 +687,14 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/moonbase19)
+"bX" = (
+/obj/docking_port/stationary/whiteship{
+	id = "whiteship_MO19";
+	name = "Sealed Outpost";
+	dir = 8
+	},
+/turf/template_noop,
+/area/template_noop)
 "bY" = (
 /obj/structure/railing,
 /turf/simulated/floor/plasteel,
@@ -12785,7 +12793,7 @@ aa
 aa
 aa
 aa
-aa
+bX
 "}
 (2,1,1) = {"
 aa


### PR DESCRIPTION
## What Does This PR Do
Title. The Moon Outpost 13, Deepstorage, and Meatpacker Ship ruins have all been given Whiteship landing points.

## Why It's Good For The Game
These ruins are super cool, but rarely get seen due to how much floating around aimlessly is involved in locating ruins as an explorer.

This should see these awesome ruins explored more often.

## Images of changes

![Screenshot 2025-04-03 175248](https://github.com/user-attachments/assets/5236f180-7dd5-4f94-ae30-c1d38dd2510f)
Whiteship

![Screenshot 2025-04-03 175233](https://github.com/user-attachments/assets/bd73c2e0-854b-4d90-aa94-fedbe0894ff1)
Moon Outpost

![Screenshot 2025-04-03 175321](https://github.com/user-attachments/assets/83745bd5-c48f-4660-989a-a6d5776ac27b)
Deepstorage

## Testing

Drove the Whiteship to every new location, didn't crash into anything or crash the game.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  
<hr>

## Changelog

:cl:
add: Added Whiteship landing zones to three ruins
/:cl:
