### PR TITLE
ensure atoms spawned over chasms fall when appropriate

### DIFF
--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -42,6 +42,14 @@
 	var/drop_y = 1
 	var/drop_z = 2 // so that it doesn't send you to CC if something fucks up.
 
+/turf/simulated/floor/chasm/Initialize(mapload)
+	. = ..()
+	RegisterSignal(src, COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON, PROC_REF(on_new_atom_at_loc))
+
+/turf/simulated/floor/chasm/proc/on_new_atom_at_loc(turf/location, atom/created, init_flags)
+	SIGNAL_HANDLER // COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON
+	drop_stuff(created)
+
 /turf/simulated/floor/chasm/Entered(atom/movable/AM)
 	..()
 	START_PROCESSING(SSprocessing, src)

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -360,7 +360,9 @@ GLOBAL_LIST_EMPTY(wormhole_effect)
 	inactive = TRUE
 	menu_open = FALSE
 
-	sleep(5 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(post_activate)), 5 SECONDS)
+
+/obj/item/wormhole_jaunter/wormhole_weaver/proc/post_activate()
 	if(emp_inflicted)
 		return
 


### PR DESCRIPTION
## What Does This PR Do
This PR adds a signal to chasm turfs letting them know when atoms are initialized on them, and calling their standard drop behavior on those atoms when that occurs. This means that e.g. in the case of legions falling into chasms, the bodies and cores they drop will also get chasmed properly. It's a little goofy visually, the legion falls, then the body spawns, then the body falls, but 99.9% of the time the legion is already dead when players stumble across it. This is a minimally invasive solution; really we should probably use something like /tg/'s chasm component, but this is a lightweight fix in comparison.
## Why It's Good For The Game
Seeing a body on the ground when it's actually a chasm is deceptive and not really fair to players if they walk into the chasm thinking it's solid ground.
## Testing
Spawned althland excavation facility, took over and spawned legions near ledges, ensured they left no trace after falling.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Legion bodies will properly fall into chasms when a legion dies by falling.
/:cl:
