### PR TITLE
Two handed component slight audio improvement

### DIFF
--- a/code/datums/components/two_handed.dm
+++ b/code/datums/components/two_handed.dm
@@ -105,7 +105,6 @@
 	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, PROC_REF(on_equip))
 	RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_drop))
 	RegisterSignal(parent, COMSIG_ACTIVATE_SELF, PROC_REF(on_attack_self))
-	//RegisterSignal(parent, COMSIG_ATTACK, PROC_REF(on_attack))
 	RegisterSignal(parent, COMSIG_ATOM_UPDATE_ICON, PROC_REF(on_update_icon))
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
 	RegisterSignal(parent, COMSIG_ITEM_SHARPEN_ACT, PROC_REF(on_sharpen))
@@ -322,12 +321,6 @@
 /datum/component/two_handed/proc/check_unwielded()
 	SIGNAL_HANDLER // COMSIG_TWOHANDED_WIELDED_TRY_WIELD_INTERACT
 	return wielded ? FALSE : TRUE;
-
-/**
- * on_attack triggers on attack with the parent item
- * /datum/component/two_handed/proc/on_attack(obj/item/source, mob/living/target, mob/living/user)
- * 		SIGNAL_HANDLER  // COMSIG_ATTACK
- */
 
 /**
  * on_update_icon triggers on call to update parent items icon

--- a/code/datums/components/two_handed.dm
+++ b/code/datums/components/two_handed.dm
@@ -105,7 +105,7 @@
 	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, PROC_REF(on_equip))
 	RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_drop))
 	RegisterSignal(parent, COMSIG_ACTIVATE_SELF, PROC_REF(on_attack_self))
-	RegisterSignal(parent, COMSIG_ATTACK, PROC_REF(on_attack))
+	//RegisterSignal(parent, COMSIG_ATTACK, PROC_REF(on_attack))
 	RegisterSignal(parent, COMSIG_ATOM_UPDATE_ICON, PROC_REF(on_update_icon))
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
 	RegisterSignal(parent, COMSIG_ITEM_SHARPEN_ACT, PROC_REF(on_sharpen))
@@ -227,6 +227,9 @@
 	if(wieldsound)
 		playsound(parent_item.loc, wieldsound, 50, TRUE)
 
+	if(attacksound)
+		parent_item.hitsound = attacksound
+
 	// Let's reserve the other hand
 	offhand_item = new(user)
 	offhand_item.name = "[parent_item.name] - offhand"
@@ -301,6 +304,9 @@
 	if(unwieldsound)
 		playsound(parent_item.loc, unwieldsound, 50, TRUE)
 
+	if(attacksound)
+		parent_item.hitsound = initial(parent_item.hitsound)
+
 	// Remove the object in the offhand
 	if(offhand_item)
 		UnregisterSignal(offhand_item, list(COMSIG_ITEM_DROPPED, COMSIG_PARENT_QDELETING))
@@ -319,12 +325,9 @@
 
 /**
  * on_attack triggers on attack with the parent item
+ * /datum/component/two_handed/proc/on_attack(obj/item/source, mob/living/target, mob/living/user)
+ * 		SIGNAL_HANDLER  // COMSIG_ATTACK
  */
-/datum/component/two_handed/proc/on_attack(obj/item/source, mob/living/target, mob/living/user)
-	SIGNAL_HANDLER  // COMSIG_ATTACK
-	if(wielded && attacksound)
-		var/obj/item/parent_item = parent
-		playsound(parent_item.loc, attacksound, 50, TRUE)
 
 /**
  * on_update_icon triggers on call to update parent items icon

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -99,6 +99,7 @@
 	icon = 'icons/obj/weapons/energy_melee.dmi'
 	lefthand_file = 'icons/mob/inhands/weapons_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons_righthand.dmi'
+	hitsound = "swing_hit"
 	icon_state = "dualsaber0"
 	force = 3
 	throwforce = 5
@@ -128,8 +129,21 @@
 	. = ..()
 	if(!blade_color)
 		blade_color = pick("red", "blue", "green", "purple")
-	AddComponent(/datum/component/parry, _stamina_constant = 2, _stamina_coefficient = 0.25, _parryable_attack_types = ALL_ATTACK_TYPES, _parry_cooldown = (4 / 3) SECONDS, _requires_two_hands = TRUE) // 0.3333 seconds of cooldown for 75% uptime
-	AddComponent(/datum/component/two_handed, force_wielded = force_wielded, force_unwielded = force_unwielded, wieldsound = wieldsound, unwieldsound = unwieldsound, wield_callback = CALLBACK(src, PROC_REF(on_wield)), unwield_callback = CALLBACK(src, PROC_REF(on_unwield)), only_sharp_when_wielded = TRUE)
+	AddComponent(/datum/component/parry, \
+		_stamina_constant = 2, \
+		_stamina_coefficient = 0.25, \
+		_parryable_attack_types = ALL_ATTACK_TYPES, \
+		_parry_cooldown = (4 / 3) SECONDS, /* 0.33 seconds of cooldown for 75% uptime */ \
+		_requires_two_hands = TRUE)
+	AddComponent(/datum/component/two_handed, \
+		force_wielded = force_wielded, \
+		force_unwielded = force_unwielded, \
+		wieldsound = wieldsound, \
+		unwieldsound = unwieldsound, \
+		attacksound = 'sound/weapons/blade1.ogg', \
+		wield_callback = CALLBACK(src, PROC_REF(on_wield)), \
+		unwield_callback = CALLBACK(src, PROC_REF(on_unwield)), \
+		only_sharp_when_wielded = TRUE)
 
 /obj/item/dualsaber/update_icon_state()
 	if(HAS_TRAIT(src, TRAIT_WIELDED))
@@ -226,18 +240,13 @@
 /obj/item/dualsaber/blue
 	blade_color = "blue"
 
-
 /obj/item/dualsaber/proc/on_wield(obj/item/source, mob/living/carbon/user)
 	if(user && HAS_TRAIT(user, TRAIT_HULK))
 		to_chat(user, "<span class='warning'>You lack the grace to wield this!</span>")
 		return COMPONENT_TWOHANDED_BLOCK_WIELD
-
-	hitsound = 'sound/weapons/blade1.ogg'
 	w_class = w_class_on
 
-
 /obj/item/dualsaber/proc/on_unwield()
-	hitsound = "swing_hit"
 	w_class = initial(w_class)
 
 /obj/item/dualsaber/IsReflect()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Changes the way two handed component uses its `attacksound`. Now it applies a new attack sound for when item is wielded and goes back to default when it's not. Sound's volume is also now in line with any other's item now
Usually, when item has no `hitsound`, it gets one on `New()`. But `initial(hit_sound)` returns `null` in this case, so hit sounds for two handed items should be set manually. 
Currently not a single item is using this, but with this PR dsword will become the first one. I just don't know if there is any other that needs this, tho.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Well, at this moment no one uses this var, but we can use it for dswords and upcoming refactored chainsaws. 

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Tested with dswords, chainsaws - sounds applied.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
