### PR TITLE
more whiteship signaller features

### DIFF
--- a/code/controllers/subsystem/non_firing/SSlate_mapping.dm
+++ b/code/controllers/subsystem/non_firing/SSlate_mapping.dm
@@ -14,6 +14,10 @@ SUBSYSTEM_DEF(late_mapping)
 	GLOB.air_alarms = sortAtom(GLOB.air_alarms)
 	GLOB.apcs = sortAtom(GLOB.apcs)
 
+	for(var/obj/machinery/computer/shuttle/console in GLOB.machines)
+		if(console.find_destinations_in_late_mapping)
+			console.connect()
+
 	if(length(maze_generators))
 		var/watch = start_watch()
 		log_startup_progress("Generating mazes...")

--- a/code/modules/shuttle/dock_generator.dm
+++ b/code/modules/shuttle/dock_generator.dm
@@ -3,17 +3,26 @@
 	desc = "A signaling device for the NT expeditionary vessel, used to designate new docking areas."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "gangtool-white"
+	new_attack_chain = TRUE
 
 	var/list/placed_docks = list()
-	var/max_docks = 3
+	var/max_docks = 6
+	var/shuttleId = "whiteship"
+	var/possible_destinations
 
 /obj/item/whiteship_port_generator/examine(mob/user)
 	. = ..()
 	var/count = max_docks - length(placed_docks)
 	var/plural = count > 1
-	. += "There [plural ? "are" : "is"] [count] use[plural ? "s" : ""] left."
+	. += "<span class='notice'>There [plural ? "are" : "is"] [count] use[plural ? "s" : ""] left.</span>"
+	. += "<span class='notice'><b>Alt-Click</b> to call the ship to an existing docking area.</span>"
 
-/obj/item/whiteship_port_generator/attack_self__legacy__attackchain(mob/living/user)
+/obj/item/whiteship_port_generator/activate_self(mob/user)
+	. = FINISH_ATTACK
+
+	if(..())
+		return
+
 	if(is_station_level(user.z))
 		log_admin("[key_name(user)] attempted to create a whiteship dock in the station's sector at [COORD(user)].")
 		to_chat(user, "<span class='notice'>New docking areas cannot be designated within the station's sector!</span>")
@@ -29,10 +38,15 @@
 		to_chat(user, "<span class='notice'>New docking areas cannot be designated planet side!</span>")
 		return
 
+	var/list/docks_per_z = list()
 	for(var/obj/placed_dock in placed_docks)
-		if(placed_dock.z == user.z)
-			to_chat(user, "<span class='notice'>A docking area has already been placed in this sector!</span>")
-			return
+		if(!("[placed_dock.z]" in docks_per_z))
+			docks_per_z["[placed_dock.z]"] = 0
+		docks_per_z["[placed_dock.z]"]++
+
+	if(docks_per_z["[user.z]"] >= 3)
+		to_chat(user, "<span class='notice'>This sector cannot support any more docking areas!</span>")
+		return
 
 	var/list/dir_choices = list("North" = NORTH, "East" = EAST, "South" = SOUTH, "West" = WEST)
 	var/dir_choice = tgui_input_list(user, "Select the new docking area orientation.", "Dock Orientation", dir_choices)
@@ -99,6 +113,7 @@
 	for(var/obj/machinery/computer/shuttle/white_ship/S in GLOB.machines)
 		S.possible_destinations = null
 		S.connect()
+		possible_destinations = S.possible_destinations
 
 	log_admin("[key_name(user)] created a whiteship dock named '[name]' at [COORD(port)].")
 
@@ -107,3 +122,72 @@
 	else
 		to_chat(user, "<span class='notice'>Landing zone set. The signaller vanishes!</span>")
 		qdel(src)
+
+/obj/item/whiteship_port_generator/AltClick(mob/user, modifiers)
+	for(var/obj/machinery/computer/shuttle/white_ship/S in GLOB.machines)
+		possible_destinations = S.possible_destinations
+		break
+
+	ui_interact(user)
+
+/obj/item/whiteship_port_generator/ui_state(mob/user)
+	return GLOB.default_state
+
+/obj/item/whiteship_port_generator/ui_interact(mob/user, datum/tgui/ui = null)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "ShuttleConsole", name)
+		ui.open()
+
+/// Pretty much a straight copy-paste of [/obj/machinery/computer/shuttle/proc/ui_data].
+/// Yes it could be refactored but tearing all of the "make the shuttle move" code out of
+/// the console whose job it is to exclusively do that is unsurprisingly messy.
+/obj/item/whiteship_port_generator/ui_data(mob/user)
+	var/list/data = list()
+	var/obj/docking_port/mobile/M = SSshuttle.getShuttle(shuttleId)
+	data["status"] = M ? M.getStatusText() : null
+	if(M)
+		data["shuttle"] = TRUE	//this should just be boolean, right?
+		var/list/docking_ports = list()
+		data["docking_ports"] = docking_ports
+		var/list/options = params2list(possible_destinations)
+		for(var/obj/docking_port/stationary/S in SSshuttle.stationary_docking_ports)
+			if(!options.Find(S.id))
+				continue
+			if(!M.check_dock(S))
+				continue
+			docking_ports[++docking_ports.len] = list("name" = S.name, "id" = S.id)
+		data["docking_ports_len"] = length(docking_ports)
+	return data
+
+/// Pretty much a straight copy-paste of [/obj/machinery/computer/shuttle/proc/ui_act].
+/// Yes it could be refactored but tearing all of the "make the shuttle move" code out of
+/// the console whose job it is to exclusively do that is unsurprisingly messy.
+/obj/item/whiteship_port_generator/ui_act(action, params)
+	if(..())	//we can't actually interact, so no action
+		return TRUE
+	if(!allowed(usr))
+		to_chat(usr, "<span class='danger'>Access denied.</span>")
+		return TRUE
+	var/list/options = params2list(possible_destinations)
+	if(action == "move")
+		var/destination = params["move"]
+		if(!options.Find(destination))//figure out if this translation works
+			message_admins("<span class='boldannounceooc'>EXPLOIT:</span> [ADMIN_LOOKUPFLW(usr)] attempted to move [src] to an invalid location! [ADMIN_COORDJMP(src)]")
+			return
+		switch(SSshuttle.moveShuttle(shuttleId, destination, TRUE, usr))
+			if(0)
+				atom_say("Shuttle en route.")
+				usr.create_log(MISC_LOG, "used [src] to call the [shuttleId] shuttle")
+				add_fingerprint(usr)
+				return TRUE
+			if(1)
+				to_chat(usr, "<span class='warning'>Invalid shuttle requested.</span>")
+			if(2)
+				to_chat(usr, "<span class='notice'>Unable to comply.</span>")
+			if(3)
+				atom_say("Shuttle is regenerating fuel. Please wait...")
+			if(4)
+				atom_say("Shuttle is currently en-route. The shuttle cannot be rerouted at this time.")
+			if(5)
+				atom_say("Shuttle is currently departing. Please wait...")

--- a/code/modules/shuttle/dock_generator.dm
+++ b/code/modules/shuttle/dock_generator.dm
@@ -116,12 +116,7 @@
 		possible_destinations = S.possible_destinations
 
 	log_admin("[key_name(user)] created a whiteship dock named '[name]' at [COORD(port)].")
-
-	if(dock_count < max_docks)
-		to_chat(user, "<span class='notice'>Landing zone set.</span>")
-	else
-		to_chat(user, "<span class='notice'>Landing zone set. The signaller vanishes!</span>")
-		qdel(src)
+	to_chat(user, "<span class='notice'>Landing zone set.</span>")
 
 /obj/item/whiteship_port_generator/AltClick(mob/user, modifiers)
 	for(var/obj/machinery/computer/shuttle/white_ship/S in GLOB.machines)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -939,8 +939,8 @@
 	var/admin_controlled
 	var/max_connect_range = 7
 	var/moved = FALSE	//workaround for nukie shuttle, hope I find a better way to do this...
-	/// Do we want to search for shuttle destinations as part of Initialize (fixed) or LateInitialize (variable)
-	var/find_destinations_in_late_init = FALSE
+	/// Do we want to search for shuttle destinations as part of Initialize (fixed) or when SSlate_mapping fires (variable)
+	var/find_destinations_in_late_mapping = FALSE
 
 /obj/machinery/computer/shuttle/New(location, obj/item/circuitboard/shuttle/C)
 	..()
@@ -950,12 +950,9 @@
 
 /obj/machinery/computer/shuttle/Initialize(mapload)
 	. = ..()
-	if(find_destinations_in_late_init && mapload) // We only care about this in mapload, if its mid round its fine
-		return INITIALIZE_HINT_LATELOAD
+	if(find_destinations_in_late_mapping && mapload) // We only care about this in mapload, if its mid round its fine
+		return
 
-	connect()
-
-/obj/machinery/computer/shuttle/LateInitialize()
 	connect()
 
 /obj/machinery/computer/shuttle/proc/connect()
@@ -1094,7 +1091,7 @@
 	circuit = /obj/item/circuitboard/white_ship
 	shuttleId = "whiteship"
 	possible_destinations = null // Set at runtime
-	find_destinations_in_late_init = TRUE
+	find_destinations_in_late_mapping = TRUE
 
 /obj/machinery/computer/shuttle/admin
 	name = "admin shuttle console"


### PR DESCRIPTION
## What Does This PR Do
This PR makes several changes to the whiteship signaller:
- The number of docks that can be created on a sector is increased from 1 to 3.
- The number of docks that can be created, total, is increased from 3 to 6.
- Alt-clicking on the signaller opens a shuttle console interface, allowing the holder to move the shuttle to any dock remotely.

A tiny refactor was made to move shuttle consoles checking for docking ports on late init to SSlate_mapping, because doing it on late init is pointless because SSshuttles isn't initialized until much later in the init order. This was necessary in order to allow the signaller to look up available connections from the shuttle console without having to use the shuttle console at least once, first.
## Why It's Good For The Game
As part of the discussion on #28883 I mentioned that providing a docking port close to ruins seemed to encourage cooperation and more interesting gameplay by making it easier for explorers to travel together, have a safe place to fall back to while doing PVE, and make it easier to collect and utilize loot. The tradeoff to that is that it may make space exploration far too easy, obviating the need for protracted jetpack travel through space.

By providing these features to the signaller, we can make it so that explorers do have to travel to get to ruins, but can use the signaller to transit the whiteship to their location, making it a kind of Skyrim-style fast travel where you need to discover a location once on foot but then making it painless to travel back to it, so long as you have the signaller with you.
## Testing
https://github.com/user-attachments/assets/7b703485-ce17-4380-bcb9-b7869ec2a09f
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
add: The signaller for the explorer ship can now be used to call the ship to you remotely, via alt-clicking on it.
tweak: The number of docks that can be created on a sector is increased from 1 to 3.
tweak: The number of docks that can be created, total, is increased from 3 to 6.
/:cl: