### PR TITLE
fix atmos machines not updating appearance on shuttle rotate

### DIFF
--- a/code/modules/atmospherics/machinery/atmospherics.dm
+++ b/code/modules/atmospherics/machinery/atmospherics.dm
@@ -76,6 +76,10 @@ Pipelines + Other Objects -> Pipe network
 	// Updates all pipe overlays and underlays
 	update_underlays()
 
+/obj/machinery/atmospherics/onShuttleMove(turf/oldT, turf/T1, rotation, mob/caller)
+	. = ..()
+	update_underlays()
+
 /obj/machinery/atmospherics/Destroy()
 	SSair.atmos_machinery -= src
 	SSair.pipenets_to_build -= src


### PR DESCRIPTION
## What Does This PR Do
This PR fixes atmos machines like pipes, vents and scrubbers not updating their appearance properly when they are rotated as a result of a shuttle move.
## Why It's Good For The Game
Visual bugfix.
## Testing
Created whiteship dock facing East, called ship, ensured airlock atmos machines had the correct appearance.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Atmos machines now properly update their appearance when the shuttle they are on moves.
/:cl: