### PR TITLE
replaces whiteship wide door with single doors

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/whiteship.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/whiteship.dmm
@@ -153,9 +153,7 @@
 /turf/simulated/floor/wood,
 /area/shuttle/abandoned)
 "tV" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 1
-	},
+/obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/abandoned)
 "uo" = (
@@ -490,7 +488,7 @@ zO
 zO
 zO
 zO
-wF
+tV
 tV
 zO
 zO


### PR DESCRIPTION
## What Does This PR Do
This PR replaces the wide glass door on the whiteship with two single-tile airlocks.
## Why It's Good For The Game
Fuck this door.
## Images of changes
![2025_04_05__03_33_28__paradise dme  whiteship dmm  - StrongDMM](https://github.com/user-attachments/assets/d03b9e25-8a65-429d-a122-4cdad6240331)
## Testing
Visual inspection.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: The explorer ship's wide cockpit airlock is now two glass airlocks.
/:cl:
