### PR TITLE
randomizes whiteship pirate placement

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/whiteship.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/whiteship.dmm
@@ -6,6 +6,10 @@
 /obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/plating,
 /area/shuttle/abandoned)
+"bE" = (
+/obj/effect/spawner/random/pool/whiteship_mob,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/abandoned)
 "cf" = (
 /obj/effect/spawner/random/oil/often,
 /turf/simulated/floor/plating,
@@ -59,6 +63,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/turf/simulated/floor/plating,
+/area/shuttle/abandoned)
+"fT" = (
+/obj/effect/spawner/random/pool/whiteship_mob,
 /turf/simulated/floor/plating,
 /area/shuttle/abandoned)
 "gd" = (
@@ -214,7 +222,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/mob/living/simple_animal/hostile/pirate,
+/obj/effect/spawner/random/pool/whiteship_mob,
 /turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/abandoned)
 "ys" = (
@@ -243,6 +251,7 @@
 /area/shuttle/abandoned)
 "zH" = (
 /obj/machinery/light/small,
+/obj/effect/spawner/random/pool/whiteship_mob,
 /turf/simulated/floor/plating,
 /area/shuttle/abandoned)
 "zM" = (
@@ -304,6 +313,10 @@
 /obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/abandoned)
+"KW" = (
+/obj/effect/spawner/random/pool/whiteship_mob,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/abandoned)
 "KX" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -338,6 +351,7 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
 	},
+/obj/effect/spawner/random/pool/whiteship_mob,
 /turf/simulated/floor/wood,
 /area/shuttle/abandoned)
 "Pi" = (
@@ -520,7 +534,7 @@ zM
 zM
 zO
 AS
-vB
+bE
 wh
 vB
 vB
@@ -542,7 +556,7 @@ kO
 vB
 gd
 Of
-Of
+KW
 zO
 zO
 zM
@@ -622,7 +636,7 @@ vB
 sk
 zO
 Xq
-ux
+fT
 Xq
 zO
 zM

--- a/code/game/objects/effects/spawners/random/misc_spawners.dm
+++ b/code/game/objects/effects/spawners/random/misc_spawners.dm
@@ -115,3 +115,10 @@
 		/obj/item/flashlight/flare/glowstick/yellow,
 		/obj/item/flashlight/flare/glowstick/pink,
 	)
+
+/obj/effect/spawner/random/space_pirate
+	name = "random space pirate spawner"
+	loot = list(
+		/mob/living/simple_animal/hostile/pirate,
+		/mob/living/simple_animal/hostile/pirate/ranged,
+	)

--- a/code/game/objects/effects/spawners/random/pool/misc_pools.dm
+++ b/code/game/objects/effects/spawners/random/pool/misc_pools.dm
@@ -10,6 +10,6 @@
 	guaranteed = TRUE
 	point_value = 0
 	loot = list(
-		/obj/effect/spawner/random/space_pirate,
+		/mob/living/simple_animal/hostile/pirate,
 		/obj/effect/spawner/random/space_pirate,
 	)

--- a/code/game/objects/effects/spawners/random/pool/misc_pools.dm
+++ b/code/game/objects/effects/spawners/random/pool/misc_pools.dm
@@ -1,0 +1,15 @@
+/datum/spawn_pool/whiteship_mobs
+	id = "whiteship_mobs_spawn_pool"
+	available_points = 0
+
+/obj/effect/spawner/random/pool/whiteship_mob
+	icon = 'icons/effects/random_spawners.dmi'
+	icon_state = "giftbox"
+	spawn_pool_id = "whiteship_mobs_spawn_pool"
+	unique_picks = TRUE
+	guaranteed = TRUE
+	point_value = 0
+	loot = list(
+		/obj/effect/spawner/random/space_pirate,
+		/obj/effect/spawner/random/space_pirate,
+	)

--- a/code/game/objects/effects/spawners/random/pool/spawn_pool.dm
+++ b/code/game/objects/effects/spawners/random/pool/spawn_pool.dm
@@ -26,6 +26,7 @@
 	available_points -= points
 
 /datum/spawn_pool/proc/process_guaranteed_spawners()
+	shuffle_inplace(guaranteed_spawners)
 	while(length(guaranteed_spawners))
 		var/obj/effect/spawner/random/pool/spawner = guaranteed_spawners[length(guaranteed_spawners)]
 		guaranteed_spawners.len--

--- a/paradise.dme
+++ b/paradise.dme
@@ -1097,6 +1097,7 @@
 #include "code\game\objects\effects\spawners\random\random_spawner.dm"
 #include "code\game\objects\effects\spawners\random\toy_spawners.dm"
 #include "code\game\objects\effects\spawners\random\trash_spawners.dm"
+#include "code\game\objects\effects\spawners\random\pool\misc_pools.dm"
 #include "code\game\objects\effects\spawners\random\pool\pool_spawner.dm"
 #include "code\game\objects\effects\spawners\random\pool\space_loot.dm"
 #include "code\game\objects\effects\spawners\random\pool\spawn_pool.dm"


### PR DESCRIPTION
## What Does This PR Do
This PR creates a mini spawn pool for the whiteship pirates, giving them two guaranteed spawns; one melee pirate and one with a 50/50 chance of either a ranged or melee pirate, and placing spawners throughout the ship.
## Why It's Good For The Game
The existing placement of the pirates makes it easy to get rid of them. This varies things up a bit.
## Images of changes
The spawns:
![2025_04_05__05_06_54__paradise dme  whiteship dmm  - StrongDMM](https://github.com/user-attachments/assets/9b38da5a-50be-4ac5-99ed-cc34ea89bf36)
Some example results:
![2025_04_05__04_50_21__Paradise Station 13](https://github.com/user-attachments/assets/46f077d6-18c2-46de-b0b2-70b1c56fa52a)
![2025_04_05__05_11_13__Paradise Station 13](https://github.com/user-attachments/assets/43ec8f34-24a9-4a1a-8a2b-28f6d047bc66)
![2025_04_05__05_13_21__Paradise Station 13](https://github.com/user-attachments/assets/0330e2e2-99b3-4617-bf31-46311b993370)
## Testing
See above.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: The two pirates on the explorer ship may either be gunners or swordsmen, and may spawn in any of the ship's rooms.
/:cl: