### PR TITLE
readds slime jelly toast recipe to new system

### DIFF
--- a/code/modules/cooking/recipes/cutting_board_recipes.dm
+++ b/code/modules/cooking/recipes/cutting_board_recipes.dm
@@ -477,6 +477,15 @@
 		PCWJ_ADD_REAGENT("cherryjelly", 5),
 	)
 
+/datum/cooking/recipe/jellied_slime_toast
+	container_type = /obj/item/reagent_containers/cooking/board
+	product_type = /obj/item/food/jelliedtoast/slime
+	catalog_category = COOKBOOK_CATEGORY_BURGS
+	steps = list(
+		PCWJ_ADD_ITEM(/obj/item/food/sliced/bread),
+		PCWJ_ADD_REAGENT("slimejelly", 5),
+	)
+
 /datum/cooking/recipe/human_burger
 	container_type = /obj/item/reagent_containers/cooking/board
 	product_type = /obj/item/food/human/burger


### PR DESCRIPTION
## What Does This PR Do
This PR adds the slime jellied toast recipe to the cutting board. This must have gotten lost during the automated conversion of recipes from the old to the new system.
## Why It's Good For The Game
Fixes regression.
## Testing
![2025_04_05__06_02_14__Paradise Station 13](https://github.com/user-attachments/assets/3c699db8-2b06-43be-b9b8-2862e35062d5)
Confirmed recipe worked.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Slime jelly toast, which was accidentally removed as a recipe, can be made again.
/:cl: