### PR TITLE
readds deep-fryer recipe for any food

### DIFF
--- a/code/modules/cooking/recipes/midway_recipes.dm
+++ b/code/modules/cooking/recipes/midway_recipes.dm
@@ -63,6 +63,46 @@
 	)
 	appear_in_default_catalog = FALSE
 
+/datum/cooking/recipe_step/add_item/deep_fried_anything
+
+/datum/cooking/recipe_step/add_item/deep_fried_anything/check_conditions_met(obj/added_item, datum/cooking/recipe_tracker/tracker)
+	var/obj/item/food/food_item = added_item
+	if(!istype(food_item))
+		return PCWJ_CHECK_INVALID
+
+	// check to see if this is something that belongs to another deep fryer
+	// recipe with only one item
+	for(var/datum/cooking/recipe/recipe in GLOB.pcwj_recipe_dictionary[/obj/item/reagent_containers/cooking/deep_basket])
+		if(length(recipe.steps) == 2) // One add step and one deep fry step
+			var/datum/cooking/recipe_step/add_item/add_item_step = recipe.steps[1]
+			if(istype(add_item_step) && add_item_step.check_conditions_met(added_item, tracker) == PCWJ_CHECK_VALID)
+				return PCWJ_CHECK_INVALID
+
+	return PCWJ_CHECK_VALID
+
+/datum/cooking/recipe/deep_fried_anything
+	container_type = /obj/item/reagent_containers/cooking/deep_basket
+	steps = list(
+		PCWJ_ADD_ITEM(/obj/item/food),
+		PCWJ_USE_DEEP_FRYER(10 SECONDS),
+	)
+	appear_in_default_catalog = FALSE
+
+/datum/cooking/recipe/deep_fried_anything/create_product(datum/cooking/recipe_tracker/tracker)
+	var/obj/item/reagent_containers/cooking/container = locateUID(tracker.container_uid)
+	if(!istype(container))
+		stack_trace("couldn't find container for deep fried everything recipe")
+
+	var/obj/item/food/food_item = container.contents[1]
+	var/obj/item/food/result = new(container)
+	result.icon = food_item.icon
+	result.icon_state = food_item.icon_state
+	result.color = "#FFAD33"
+	result.name = "deep-fried [food_item.name]"
+	result.desc = "It has been deep-fried."
+	food_item.reagents.trans_to(result, food_item.reagents.total_volume)
+	qdel(food_item)
+
 /datum/cooking/recipe/jellybean_red
 	container_type = /obj/item/reagent_containers/cooking/mould/bean
 	product_type = /obj/item/food/candy/jellybean/red

--- a/code/modules/food_and_drinks/food_base.dm
+++ b/code/modules/food_and_drinks/food_base.dm
@@ -377,11 +377,4 @@
 	icon_state = "cereal_box"
 	list_reagents = list("nutriment" = 3)
 
-/obj/item/food/deepfryholder
-	name = "Deep Fried Foods Holder Obj"
-	desc = "If you can see this description the code for the deep fryer fucked up."
-	icon = 'icons/obj/food/food.dmi'
-	icon_state = "deepfried_holder_icon"
-	list_reagents = list("nutriment" = 3)
-
 #undef MAX_WEIGHT_CLASS

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -170,7 +170,6 @@
 		/obj/item/food/grown,
 		/obj/item/food/grown/shell,
 		/obj/item/food/grown/mushroom,
-		/obj/item/food/deepfryholder,
 		/obj/item/food/chinese,
 		/obj/item/food/human,
 		/obj/item/food/monstermeat,


### PR DESCRIPTION
## What Does This PR Do
This PR adds a custom recipe to the deep fryer, re-enabling the ability to deep-fry any food item. It removes the old unnecessary `/obj/item/food/deepfryholder` object. Note this doesn't add the emagged ability back yet.
## Why It's Good For The Game
Brings back functionality that was temporarily missing after the kitchen rework.
## Images of changes
![2025_04_05__06_39_29__Paradise Station 13](https://github.com/user-attachments/assets/1f3f6d2c-4edb-4a82-9311-7d387db61ac1)
## Testing
- [X] Confirmed food items could be deep-fried.
- [X] Confirmed that existing recipes with only one food item as an input continued to produce the correct output.
- [X] Confirmed that food items that were part of existing recipes produced a deep-fried result.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: The ability of the deep fryer to deep fry any food item has been added.
/:cl: