### PR TITLE
Installs Glass Into Delta Arrivals Airlocks

### DIFF
--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -522,6 +522,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/north)
 "afc" = (
@@ -68703,6 +68704,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/south)
 "lpX" = (

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -438,7 +438,9 @@
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/pod_4)
 "aeM" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/glass{
+	name = "Escape Pod Airlock"
+	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/east)
 "aeN" = (
@@ -513,13 +515,13 @@
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/pod_4)
 "afb" = (
-/obj/machinery/door/airlock/external,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/north)
 "afc" = (
@@ -937,10 +939,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external{
-	id_tag = "admin_home";
-	locked = 1
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "admin_home"
 	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/north)
 "ahh" = (
@@ -1109,7 +1111,7 @@
 	},
 /area/station/hallway/secondary/entry/south)
 "aiE" = (
-/obj/machinery/door/airlock/titanium{
+/obj/machinery/door/airlock/titanium/glass{
 	id_tag = "s_docking_airlock"
 	},
 /turf/simulated/floor/mineral/titanium,
@@ -45018,10 +45020,10 @@
 /turf/simulated/wall,
 /area/station/maintenance/port2)
 "dbN" = (
-/obj/machinery/door/airlock/titanium{
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/titanium/glass{
 	id_tag = "s_docking_airlock"
 	},
-/obj/structure/fans/tiny,
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/arrival/station)
 "dbR" = (
@@ -59676,10 +59678,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/door/airlock/external{
-	id_tag = "admin_home";
-	locked = 1
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "admin_home"
 	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/north)
 "gua" = (
@@ -60104,19 +60106,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
-"gHk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	id_tag = "ferry_home"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/north)
 "gHB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/oil/maybe,
@@ -60660,16 +60649,16 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/west)
 "gWD" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	id_tag = "ferry_home"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "ferry_home"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/north)
 "gXQ" = (
@@ -68707,13 +68696,13 @@
 /turf/simulated/wall,
 /area/station/medical/paramedic)
 "lpL" = (
-/obj/machinery/door/airlock/external,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/south)
 "lpX" = (
@@ -80104,10 +80093,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/door/airlock/external{
-	id_tag = "specops_home";
-	locked = 1
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "specops_home"
 	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/east)
 "rfw" = (
@@ -92934,7 +92923,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "xcL" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/glass{
+	name = "Escape Pod Airlock"
+	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/south)
 "xcR" = (
@@ -129398,7 +129389,7 @@ aaa
 aaa
 aaa
 xgt
-gHk
+gWD
 mUk
 gWD
 ueF


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Converts the external airlocks and shuttle airlocks at Delta Arrivals to glass versions. The airlock on both pods remains opaque.

Locked airlocks now use lock helpers instead of var edits.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Windows give a nice good view!

Varedits are stinky, glorious airlock lock helpers let mappers easily see at a glance what airlocks are locked.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Locked airlocks now look like this
![image](https://github.com/user-attachments/assets/4e52fd83-7afb-498b-b0dc-f9579d9e0899)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Visual inspection.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Windows have been installed on Delta arrivals airlocks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
