### PR TITLE
Installs Glass into Farragus Docking Airlocks

### DIFF
--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -16206,12 +16206,12 @@
 	},
 /area/station/hallway/spacebridge/scidock)
 "chk" = (
-/obj/machinery/door/airlock/external{
-	hackProof = 1;
+/obj/machinery/door/airlock/external/glass{
+	name = "Escape Airlock";
 	id_tag = "emergency_home";
-	locked = 1;
-	name = "Escape Airlock"
+	hackProof = 1
 	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "cho" = (
@@ -32838,12 +32838,11 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central/north)
 "fof" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "specops_home";
-	locked = 1;
-	name = "External airlock"
-	},
 /obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "specops_home"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/south)
 "foi" = (
@@ -44606,12 +44605,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
 "ijl" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "trade_dock";
-	locked = 1;
-	name = "External airlock"
-	},
 /obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "trade_dock"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/west)
 "ijm" = (
@@ -48420,9 +48418,8 @@
 	},
 /area/station/supply/storage)
 "jcQ" = (
-/obj/machinery/door/airlock/external{
-	name = "Arrival Airlock"
-	},
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/south)
 "jcU" = (
@@ -58382,13 +58379,11 @@
 /area/station/hallway/primary/central/north)
 "lmS" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/external{
-	name = "External airlock"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "lmX" = (
@@ -71823,12 +71818,11 @@
 	},
 /area/station/hallway/primary/fore/north)
 "oBx" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "ferry_home";
-	locked = 1;
-	name = "External airlock"
-	},
 /obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "ferry_home"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/south)
 "oBD" = (
@@ -112378,11 +112372,11 @@
 /turf/simulated/mineral/ancient/outer,
 /area/station/hallway/primary/central/west)
 "yiw" = (
-/obj/machinery/door/airlock/external{
-	name = "Arrival Airlock";
-	locked = 1
-	},
 /obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "admin_home"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/south)
 "yix" = (


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Installs windows into the external and shuttle airlocks of the Farragus docking asteroid.

Replaces lock varedits with lock helpers.

Uses autoname helpers on arrival shuttle external airlocks.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Improves the view. Using helpers over varedits is good.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/user-attachments/assets/c2b1840d-f61b-4145-9e91-ab6caf122492)
![image](https://github.com/user-attachments/assets/67bfcea5-9b97-469e-9cfa-0530a0a03f39)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Visual inspection.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Farragus docking asteroid airlocks now have windows.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
