### PR TITLE
AI Programs: Malf AI in APCs can no longer use programs.

### DIFF
--- a/code/game/machinery/ai_resource.dm
+++ b/code/game/machinery/ai_resource.dm
@@ -157,7 +157,9 @@ GLOBAL_LIST_EMPTY(ai_nodes)
 	if(!resource_key)
 		return
 	for(var/mob/living/silicon/ai/new_ai as anything in GLOB.ai_list)
-		if(new_ai.stat || new_ai.in_storage)
+		if(new_ai.stat || new_ai.in_storage || new_ai.shunted)
+			continue
+		if(istype(new_ai.loc, /obj/machinery/power/apc))
 			continue
 		if(!assigned_ai) // Not found
 			assigned_ai = new_ai // Assign to the first AI in the list to start
@@ -309,6 +311,10 @@ GLOBAL_LIST_EMPTY(ai_nodes)
 	data["ai_list"] = list()
 	data["nodes_list"] = list()
 	for(var/mob/living/silicon/ai/A in GLOB.ai_list)
+		if(istype(A.loc, /obj/machinery/power/apc)) // AIs in APCs as malf should be hidden
+			continue
+		if(A.shunted)
+			continue
 		var/list/ai_data = list(
 			"name" = A.name,
 			"uid" = A.UID(),
@@ -352,7 +358,14 @@ GLOBAL_LIST_EMPTY(ai_nodes)
 		if("reassign")
 			if(!length(GLOB.ai_list))
 				return FALSE
-			var/new_ai = tgui_input_list(usr, "Pick a new AI", "AI Selector", GLOB.ai_list)
+			var/list/ais = list()
+			for(var/mob/living/silicon/ai/new_ai as anything in GLOB.ai_list)
+				if(new_ai.stat || new_ai.in_storage || new_ai.shunted)
+					continue
+				if(istype(new_ai.loc, /obj/machinery/power/apc))
+					continue
+				ais += new_ai
+			var/new_ai = tgui_input_list(usr, "Pick a new AI", "AI Selector", ais)
 			if(!new_ai)
 				return FALSE
 			var/obj/machinery/ai_node/selected_node = locateUID(params["uid"])

--- a/code/modules/mob/living/silicon/ai/ai_programs.dm
+++ b/code/modules/mob/living/silicon/ai/ai_programs.dm
@@ -245,6 +245,9 @@
 
 /datum/spell/ai_spell/choose_program/cast(list/targets, mob/living/silicon/ai/user)
 	. = ..()
+	if(istype(user.loc, /obj/machinery/power/apc))
+		to_chat(user, "<span class='warning'>Error: APCs do not have enough processing power to handle programs!</span>")
+		return
 	user.program_picker.ui_interact(user)
 
 /// RGB Lighting - Recolors Lights


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Makes it so if a malf AI shunts to an APC it cannot learn programs or use them.

Likewise, shunted AIs no longer appear on the RD's console, similarly to dead AIs. They continue to receive program data from nodes, as nodes do not auto-switch when an AI dies - only if they cryo. 

## Why It's Good For The Game

APC AIs don't need programs, they're APCs.

## Testing

Spawned as malf AI, shunted to APC. Could not see self on RD console. Did not receive new node connections, as standard. Existing nodes remained connected, as standard. Same appearance as if I had died.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Shunted AIs no longer receive new node connections, nor appear on the RD's console.
fix: Fixed malf being able to use AI programs while in an APC.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
