### PR TITLE
fixes cooking containers causing premature reagent reaction

### DIFF
--- a/code/modules/cooking/cooking_container.dm
+++ b/code/modules/cooking/cooking_container.dm
@@ -45,7 +45,7 @@
 
 /obj/item/reagent_containers/cooking/Initialize(mapload)
 	. = ..()
-	flags |= REAGENT_NOREACT
+	reagents.set_reacting(FALSE)
 	update_lip_effect()
 	clear_cooking_data()
 


### PR DESCRIPTION
## What Does This PR Do
This PR fixes cooking containers causing premature reagent reactions, as in the case of the recipe for chocolate bars containing the same reagents as the chemical reaction for chocolate bars. Fixes #28903. This doesn't fix the problem of recipes transferring excess reagents to finished products, which, in the case of extra milk in the container, would cause a reaction making another chocolate bar on top of the ice cream mixer, but that's a whole other thing.
## Why It's Good For The Game
Bugfix. Was setting the noreact flag on the wrong thing.
## Testing
Performed recipe, ensured reagents didn't react.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Cooking containers will properly prevent chemical reactions of ingredients when following a recipe.
/:cl: