### PR TITLE
fix broken nettle soup recipe

### DIFF
--- a/code/modules/cooking/recipes/oven_recipes.dm
+++ b/code/modules/cooking/recipes/oven_recipes.dm
@@ -716,7 +716,7 @@
 	catalog_category = COOKBOOK_CATEGORY_DESSERTS
 	steps = list(
 		PCWJ_ADD_ITEM(/obj/item/food/dough),
-		PCWJ_ADD_PRODUCE(/obj/item/grown/cotton),
+		PCWJ_ADD_ITEM(/obj/item/grown/cotton),
 		PCWJ_ADD_REAGENT("milk", 5),
 		PCWJ_ADD_REAGENT("sugar", 5),
 		PCWJ_USE_OVEN(J_MED, 10 SECONDS),

--- a/code/modules/cooking/recipes/stove_recipes.dm
+++ b/code/modules/cooking/recipes/stove_recipes.dm
@@ -255,7 +255,7 @@
 	catalog_category = COOKBOOK_CATEGORY_SOUPS
 	steps = list(
 		PCWJ_ADD_ITEM(/obj/item/food/egg),
-		PCWJ_ADD_PRODUCE(/obj/item/grown/nettle/basic),
+		PCWJ_ADD_ITEM(/obj/item/grown/nettle/basic),
 		PCWJ_ADD_PRODUCE(/obj/item/food/grown/potato),
 		PCWJ_ADD_REAGENT("water", 10),
 		PCWJ_USE_STOVE(J_MED, 20 SECONDS),


### PR DESCRIPTION
## What Does This PR Do
This PR makes nettle soup use the correct recipe step type for nettle, because it counts as an item, not produce. Fixes #28904.
## Why It's Good For The Game
Bugfix.
## Testing
Verified nettle soup could be made with recipe as described.
![2025_04_07__08_03_56__Paradise Station 13](https://github.com/user-attachments/assets/b83c0827-d5ea-4281-b5a5-70c1ab26f414)
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Nettle soup can properly be made by following its recipe.
fix: Moffins can properly be made by following their recipe.
/:cl: