### PR TITLE
add missing mints recipe

### DIFF
--- a/code/modules/cooking/recipes/ice_cream_mixer_recipes.dm
+++ b/code/modules/cooking/recipes/ice_cream_mixer_recipes.dm
@@ -851,6 +851,15 @@
 		PCWJ_USE_ICE_CREAM_MIXER(10 SECONDS),
 	)
 
+/datum/cooking/recipe/mint
+	container_type = /obj/item/reagent_containers/cooking/icecream_bowl
+	product_type = /obj/item/food/mint
+	catalog_category = COOKBOOK_CATEGORY_CANDY
+	steps = list(
+		PCWJ_ADD_REAGENT("toxin", 5),
+		PCWJ_USE_ICE_CREAM_MIXER(10 SECONDS),
+	)
+
 /datum/cooking/recipe/mint_2
 	container_type = /obj/item/reagent_containers/cooking/icecream_bowl
 	product_type = /obj/item/food/mint


### PR DESCRIPTION
## What Does This PR Do
This PR adds the toxin-based mint recipe to the ice cream mixer. This recipe somehow got lost in the recipe conversion.
## Why It's Good For The Game
Maintain parity with pre-existing recipe list wherever possible.
## Testing
Verified recipe worked.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: The toxin-based mint recipe can now properly be made in the ice cream mixer.
/:cl: