### PR TITLE
/New -> /Initialize Migration §3: Mech parts.

### DIFF
--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -2,8 +2,8 @@
 
 /obj/item/mecha_parts/mecha_equipment/medical
 
-/obj/item/mecha_parts/mecha_equipment/medical/New()
-	..()
+/obj/item/mecha_parts/mecha_equipment/medical/Initialize(mapload)
+	. = ..()
 	START_PROCESSING(SSobj, src)
 
 
@@ -254,8 +254,8 @@
 	equip_cooldown = 10
 	origin_tech = "materials=3;biotech=4;magnets=4"
 
-/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/New()
-	..()
+/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/Initialize(mapload)
+	. = ..()
 	create_reagents(max_volume)
 	reagents.set_reacting(FALSE)
 	syringes = new

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -134,10 +134,10 @@
 	energy_drain = 0
 	range = MECHA_MELEE | MECHA_RANGED
 
-/obj/item/mecha_parts/mecha_equipment/extinguisher/New()
+/obj/item/mecha_parts/mecha_equipment/extinguisher/Initialize(mapload)
+	. = ..()
 	create_reagents(1000)
 	reagents.add_reagent("water", 1000)
-	..()
 
 /obj/item/mecha_parts/mecha_equipment/extinguisher/action(atom/target) //copypasted from extinguisher. TODO: Rewrite from scratch.
 	if(!action_checks(target) || get_dist(chassis, target)>3)
@@ -209,9 +209,9 @@
 	toolspeed = 1
 	usesound = 'sound/items/deconstruct.ogg'
 
-/obj/item/mecha_parts/mecha_equipment/rcd/New()
+/obj/item/mecha_parts/mecha_equipment/rcd/Initialize(mapload)
+	. = ..()
 	GLOB.rcd_list += src
-	..()
 
 /obj/item/mecha_parts/mecha_equipment/rcd/Destroy()
 	GLOB.rcd_list -= src
@@ -335,10 +335,10 @@
 	var/obj/item/stack/cable_coil/cable
 	var/max_cable = 1000
 
-/obj/item/mecha_parts/mecha_equipment/cable_layer/New()
+/obj/item/mecha_parts/mecha_equipment/cable_layer/Initialize(mapload)
+	. = ..()
 	cable = new(src)
 	cable.amount = 0
-	..()
 
 /obj/item/mecha_parts/mecha_equipment/cable_layer/can_attach(obj/mecha/working/M)
 	if(..())

--- a/code/game/mecha/mecha_parts.dm
+++ b/code/game/mecha/mecha_parts.dm
@@ -39,8 +39,8 @@
 /obj/item/mecha_parts/chassis/ripley
 	name = "\improper Ripley chassis"
 
-/obj/item/mecha_parts/chassis/ripley/New()
-	..()
+/obj/item/mecha_parts/chassis/ripley/Initialize(mapload)
+	. = ..()
 	construct = new /datum/construction/mecha/ripley_chassis(src)
 
 /obj/item/mecha_parts/part/ripley_torso
@@ -74,8 +74,8 @@
 /obj/item/mecha_parts/chassis/gygax
 	name = "\improper Gygax chassis"
 
-/obj/item/mecha_parts/chassis/gygax/New()
-	..()
+/obj/item/mecha_parts/chassis/gygax/Initialize(mapload)
+	. = ..()
 	construct = new /datum/construction/mecha/gygax_chassis(src)
 
 /obj/item/mecha_parts/part/gygax_torso
@@ -123,8 +123,8 @@
 /obj/item/mecha_parts/chassis/durand
 	name = "\improper Durand chassis"
 
-/obj/item/mecha_parts/chassis/durand/New()
-	..()
+/obj/item/mecha_parts/chassis/durand/Initialize(mapload)
+	. = ..()
 	construct = new /datum/construction/mecha/durand_chassis(src)
 
 /obj/item/mecha_parts/part/durand_torso
@@ -169,8 +169,8 @@
 /obj/item/mecha_parts/chassis/firefighter
 	name = "\improper Firefighter chassis"
 
-/obj/item/mecha_parts/chassis/firefighter/New()
-	..()
+/obj/item/mecha_parts/chassis/firefighter/Initialize(mapload)
+	. = ..()
 	construct = new /datum/construction/mecha/firefighter_chassis(src)
 
 ////////// HONK
@@ -178,8 +178,8 @@
 /obj/item/mecha_parts/chassis/honker
 	name = "\improper H.O.N.K chassis"
 
-/obj/item/mecha_parts/chassis/honker/New()
-	..()
+/obj/item/mecha_parts/chassis/honker/Initialize(mapload)
+	. = ..()
 	construct = new /datum/construction/mecha/honker_chassis(src)
 
 /obj/item/mecha_parts/part/honker_torso
@@ -212,16 +212,16 @@
 /obj/item/mecha_parts/chassis/reticence
 	name = "\improper Reticence chassis"
 
-/obj/item/mecha_parts/chassis/reticence/New()
-	..()
+/obj/item/mecha_parts/chassis/reticence/Initialize(mapload)
+	. = ..()
 	construct = new /datum/construction/mecha/reticence_chassis(src)
 
 /obj/effect/dummy/mecha_emote_step
 	var/emote
 
-/obj/effect/dummy/mecha_emote_step/New(e)
+/obj/effect/dummy/mecha_emote_step/Initialize(mapload, emote_)
 	. = ..()
-	emote = e
+	emote = emote_
 
 /obj/item/mecha_parts/chassis/reticence/hear_message(mob/living/M, msg)
 	if(!istype(M) || !istype(construct, /datum/construction/reversible/mecha/reticence))
@@ -261,8 +261,8 @@
 /obj/item/mecha_parts/chassis/phazon
 	name = "\improper Phazon chassis"
 
-/obj/item/mecha_parts/chassis/phazon/New()
-	..()
+/obj/item/mecha_parts/chassis/phazon/Initialize(mapload)
+	. = ..()
 	construct = new /datum/construction/mecha/phazon_chassis(src)
 
 /obj/item/mecha_parts/chassis/phazon/attackby__legacy__attackchain(obj/item/I, mob/user, params)
@@ -310,8 +310,8 @@
 /obj/item/mecha_parts/chassis/odysseus
 	name = "\improper Odysseus Chassis"
 
-/obj/item/mecha_parts/chassis/odysseus/New()
-	..()
+/obj/item/mecha_parts/chassis/odysseus/Initialize(mapload)
+	. = ..()
 	construct = new /datum/construction/mecha/odysseus_chassis(src)
 
 /obj/item/mecha_parts/part/odysseus_head
@@ -353,8 +353,8 @@
 /obj/item/mecha_parts/chassis/nkarrdem
 	name = "\improper Nkarrdem Chassis"
 
-/obj/item/mecha_parts/chassis/nkarrdem/New()
-	..()
+/obj/item/mecha_parts/chassis/nkarrdem/Initialize(mapload)
+	. = ..()
 	construct = new /datum/construction/mecha/nkarrdem_chassis(src)
 
 /obj/item/mecha_parts/part/nkarrdem_head


### PR DESCRIPTION
## What Does This PR Do
This PR refactors all mech parts to use /Initialize instead of /New.
## Why It's Good For The Game
See #27261.
## Testing
- [X] Created one of each affected item, ensured constructor parameters were initialized correctly.
- [X] Constructed a Reticence, ensured that custom emote action steps worked as expected.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC