### PR TITLE
remove redundant spawner icon decls

### DIFF
--- a/code/game/objects/effects/spawners/random/decal_spawners.dm
+++ b/code/game/objects/effects/spawners/random/decal_spawners.dm
@@ -1,6 +1,5 @@
 /obj/effect/spawner/random/fungus
 	name = "fungus 100% chance"
-	icon = 'icons/effects/random_spawners.dmi'
 	icon_state = "fungus"
 	color = "#D5820B"
 	loot = list(/obj/effect/decal/cleanable/fungus)
@@ -19,7 +18,6 @@
 
 /obj/effect/spawner/random/blood
 	name = "blood 100% chance"
-	icon = 'icons/effects/random_spawners.dmi'
 	icon_state = "blood"
 	loot = list(/obj/effect/decal/cleanable/blood/splatter)
 
@@ -33,7 +31,6 @@
 
 /obj/effect/spawner/random/oil
 	name = "oil 100% chance"
-	icon = 'icons/effects/random_spawners.dmi'
 	icon_state = "oil"
 	loot = list(/obj/effect/decal/cleanable/blood/oil)
 
@@ -76,7 +73,6 @@
 
 /obj/effect/spawner/random/dirt
 	name = "dirt 100% chance"
-	icon = 'icons/effects/random_spawners.dmi'
 	icon_state = "dirt"
 	loot = list(/obj/effect/decal/cleanable/dirt)
 

--- a/code/game/objects/effects/spawners/random/engineering_spawners.dm
+++ b/code/game/objects/effects/spawners/random/engineering_spawners.dm
@@ -1,5 +1,4 @@
 /obj/effect/spawner/random/engineering
-	icon = 'icons/effects/random_spawners.dmi'
 	icon_state = "wrench"
 	record_spawn = TRUE
 

--- a/code/game/objects/effects/spawners/random/food_spawners.dm
+++ b/code/game/objects/effects/spawners/random/food_spawners.dm
@@ -1,6 +1,5 @@
 /obj/effect/spawner/random/snacks
 	name = "snacks spawner"
-	icon = 'icons/effects/random_spawners.dmi'
 	icon_state = "donkpocket_single"
 	loot = list(
 		list(
@@ -21,22 +20,18 @@
 	record_spawn = TRUE
 
 /obj/effect/spawner/random/food_or_drink
-	// TODO: Consolidate all the spawner icons once all the legacy random spawners have been migrated
-	icon = 'icons/effects/random_spawners.dmi'
+	icon_state = "soup"
 
 /obj/effect/spawner/random/food_or_drink/soup
 	name = "soup spawner"
-	icon_state = "soup"
 	loot_subtype_path = /obj/item/food/soup
 
 /obj/effect/spawner/random/food_or_drink/salad
 	name = "salad spawner"
-	icon_state = "soup"
 	loot_subtype_path = /obj/item/food/salad
 
 /obj/effect/spawner/random/food_or_drink/dinner
 	name = "dinner spawner"
-	icon_state = "soup"
 	loot = list(
 		/obj/item/food/burger/bigbite,
 		/obj/item/food/burger/fivealarm,
@@ -49,7 +44,6 @@
 
 /obj/effect/spawner/random/food_or_drink/three_course_meal
 	name = "three course meal spawner"
-	icon_state = "soup"
 	spawn_all_loot = TRUE
 	loot = list(
 		/obj/effect/spawner/random/food_or_drink/soup,

--- a/code/game/objects/effects/spawners/random/furniture_spawners.dm
+++ b/code/game/objects/effects/spawners/random/furniture_spawners.dm
@@ -1,6 +1,5 @@
 /obj/effect/spawner/random/storage
 	name = "storage furniture spawner"
-	icon = 'icons/effects/random_spawners.dmi'
 	icon_state = "shelf"
 	layer = BELOW_OBJ_LAYER
 	loot = list(

--- a/code/game/objects/effects/spawners/random/loot_spawners.dm
+++ b/code/game/objects/effects/spawners/random/loot_spawners.dm
@@ -1,6 +1,5 @@
 /obj/effect/spawner/random/loot
 	name = "random loot spawner"
-	icon = 'icons/effects/random_spawners.dmi'
 	icon_state = "loot"
 
 /obj/effect/spawner/random/loot/contraband_posters
@@ -77,7 +76,6 @@
 
 /obj/effect/spawner/random/loot_crate
 	name = "lootcrate spawner"
-	icon = 'icons/effects/random_spawners.dmi'
 	icon_state = "crate_secure"
 	spawn_inside = /obj/structure/closet/crate/secure/loot
 	loot = list(

--- a/code/game/objects/effects/spawners/random/misc_spawners.dm
+++ b/code/game/objects/effects/spawners/random/misc_spawners.dm
@@ -13,7 +13,6 @@
 	spawn_loot_count = rand(1, 2)
 
 /obj/effect/spawner/random/bureaucracy
-	icon = 'icons/effects/random_spawners.dmi'
 	icon_state = "folder"
 	name = "bureaucracy spawner"
 	loot = list(
@@ -32,7 +31,6 @@
 	record_spawn = TRUE
 
 /obj/effect/spawner/random/book
-	icon = 'icons/effects/random_spawners.dmi'
 	icon_state = "book"
 	name = "book spawner"
 	loot = list(
@@ -82,7 +80,6 @@
 	record_spawn = TRUE
 
 /obj/effect/spawner/random/jani_supplies
-	icon = 'icons/effects/random_spawners.dmi'
 	icon_state = "mopbucket"
 	name = "janitorial supplies spawner"
 	loot = list(
@@ -95,7 +92,6 @@
 
 /obj/effect/spawner/random/stock_parts
 	name = "stock parts spawner"
-	icon = 'icons/effects/random_spawners.dmi'
 	icon_state = "stock_parts"
 	loot_subtype_path = /obj/item/stock_parts
 
@@ -105,7 +101,6 @@
 
 /obj/effect/spawner/random/glowstick
 	name = "random glowstick spawner"
-	icon = 'icons/effects/random_spawners.dmi'
 	icon_state = "glowstick"
 	loot = list(
 		/obj/item/flashlight/flare/glowstick,
@@ -118,7 +113,6 @@
 
 /obj/effect/spawner/random/smithed_item
 	name = "random smithed item"
-	icon = 'icons/effects/random_spawners.dmi'
 	icon_state = "metal"
 	record_spawn = TRUE
 

--- a/code/game/objects/effects/spawners/random/outfit_spawners.dm
+++ b/code/game/objects/effects/spawners/random/outfit_spawners.dm
@@ -1,7 +1,6 @@
 /obj/effect/spawner/random/loot/outfit
 	name = "outfit spawner"
 	spawn_all_loot = TRUE
-	icon = 'icons/effects/random_spawners.dmi'
 	icon_state = "suit"
 
 /obj/effect/spawner/random/loot/outfit/clown

--- a/code/game/objects/effects/spawners/random/pool/misc_pools.dm
+++ b/code/game/objects/effects/spawners/random/pool/misc_pools.dm
@@ -3,7 +3,6 @@
 	available_points = 0
 
 /obj/effect/spawner/random/pool/whiteship_mob
-	icon = 'icons/effects/random_spawners.dmi'
 	icon_state = "giftbox"
 	spawn_pool_id = "whiteship_mobs_spawn_pool"
 	unique_picks = TRUE

--- a/code/game/objects/effects/spawners/random/pool/pool_spawner.dm
+++ b/code/game/objects/effects/spawners/random/pool/pool_spawner.dm
@@ -1,8 +1,5 @@
 /// A random spawner managed by a [/datum/spawn_pool].
 /obj/effect/spawner/random/pool
-	icon = 'icons/effects/random_spawners.dmi'
-	icon_state = "loot"
-
 	/// How much this spawner will subtract from the available budget if it
 	/// spawns. A value of `-1` (i.e., not setting the value on a subtype)
 	/// does not attempt to subtract from the budget. This is useful for

--- a/code/game/objects/effects/spawners/random/pool/space_loot.dm
+++ b/code/game/objects/effects/spawners/random/pool/space_loot.dm
@@ -3,8 +3,6 @@
 	available_points = 1700
 
 /obj/effect/spawner/random/pool/spaceloot
-	icon = 'icons/effects/random_spawners.dmi'
-	icon_state = "giftbox"
 	spawn_pool_id = "space_loot_spawn_pool"
 	record_spawn = TRUE
 

--- a/code/game/objects/effects/spawners/random/random_spawner.dm
+++ b/code/game/objects/effects/spawners/random/random_spawner.dm
@@ -2,7 +2,7 @@
  * Base class for all random spawners.
  */
 /obj/effect/spawner/random
-	icon = 'icons/effects/spawner_icons.dmi'
+	icon = 'icons/effects/random_spawners.dmi'
 	icon_state = "loot"
 	layer = OBJ_LAYER
 	/// Stops persistent lootdrop spawns from being shoved into lockers

--- a/code/game/objects/effects/spawners/random/toy_spawners.dm
+++ b/code/game/objects/effects/spawners/random/toy_spawners.dm
@@ -1,6 +1,5 @@
 /obj/effect/spawner/random/toy
 	name = "random toy spawner"
-	icon = 'icons/effects/random_spawners.dmi'
 	icon_state = "toy"
 
 /obj/effect/spawner/random/toy/mech_figure

--- a/code/game/objects/effects/spawners/random/traders/trader_department_spawners.dm
+++ b/code/game/objects/effects/spawners/random/traders/trader_department_spawners.dm
@@ -1,6 +1,5 @@
 /obj/effect/spawner/random/traders
 	name = "trader item spawner"
-	icon = 'icons/effects/random_spawners.dmi'
 	icon_state = "loot"
 	spawn_loot_count = 6
 

--- a/code/game/objects/effects/spawners/random/trash_spawners.dm
+++ b/code/game/objects/effects/spawners/random/trash_spawners.dm
@@ -1,7 +1,6 @@
 /// Food trash spawner, for when you specifically want it to look like someone
 /// didn't clean up after themselves after lunch.
 /obj/effect/spawner/random/food_trash
-	icon = 'icons/effects/random_spawners.dmi'
 	icon_state = "tray"
 	name = "Food trash spawner"
 	loot = list(
@@ -36,7 +35,6 @@
 	SSblackbox.record_feedback("tally", "random_spawners", 1, "[/obj/item/trash]")
 
 /obj/effect/spawner/random/trash
-	icon = 'icons/effects/random_spawners.dmi'
 	icon_state = "trash"
 
 	name = "Trash spawner"


### PR DESCRIPTION
## What Does This PR Do
This PR removes some redundant icon declarations on random spawners.
## Why It's Good For The Game
For a while these were split between random_spawners.dmi and spawner_icons.dmi. Now everything's in the right place.
## Testing
CI should say if there's any invalid icon states.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC