### PR TITLE
pain

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -412,18 +412,16 @@ GLOBAL_LIST_EMPTY(turret_icons)
 	if(user.a_intent == INTENT_HELP)
 		return ..()
 
-	// otherwise, if the turret was attacked with the intention of harming it:
-	user.changeNext_move(CLICK_CD_MELEE)
-	user.do_item_attack_animation()
+/obj/machinery/porta_turret/attacked_by(obj/item/attacker, mob/living/user)
+	. = ..()
+	// TODO: move to play_attack_sound when we actually use obj_integrity
 	playsound(src.loc, 'sound/weapons/smash.ogg', 60, 1)
 
 	//if the force of impact dealt at least 1 damage, the turret gets pissed off
-	if(used.force * 0.5 > 1)
+	if(attacker.force * 0.5 > 1)
 		if(!attacked && !emagged)
 			attacked = TRUE
 			addtimer(VARSET_CALLBACK(src, attacked, FALSE), 6 SECONDS)
-
-	return ITEM_INTERACT_SKIP_TO_AFTER_ATTACK
 
 /obj/machinery/porta_turret/attack_animal(mob/living/simple_animal/M)
 	M.changeNext_move(CLICK_CD_MELEE)


### PR DESCRIPTION
## What Does This PR Do
This PR fixes not being able to perform melee attacks on turrets. Fixes #28378. This doesn't fix the host of dumb interaction problems turrets have nor the fact they have a completely different health system for melee attacks than for projectile attacks, that will come later.
## Why It's Good For The Game
Bugfix.
## Testing
Attacked laser tag turret with welder, confirmed animation and sound played.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Turrets can properly be melee attacked.
/:cl: