### PR TITLE
add microwave back to box perma

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -76976,6 +76976,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/south)
+"stM" = (
+/obj/structure/table/reinforced,
+/obj/machinery/kitchen_machine/microwave,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/station/security/permabrig)
 "stX" = (
 /obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel{
@@ -105072,7 +105079,7 @@ abN
 qXR
 qQy
 yiL
-vSi
+stM
 lXd
 vSi
 esV


### PR DESCRIPTION
## What Does This PR Do
This PR adds a microwave back to Box perma. Fixes #28922. I double checked all other station permas have microwaves.
## Why It's Good For The Game
I goofed up and forgot there's donks in perma.
## Images of changes
Check MDB.
## Testing
Visual inspection.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Cyberiad perma has the expected microwave as all permas.
/:cl: