### PR TITLE
Enspookifies descriptions of cult items and structures

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -12,7 +12,7 @@
 
 /obj/item/melee/cultblade
 	name = "cult blade"
-	desc = "An arcane weapon wielded by the followers of a cult."
+	desc = "A powerful blade made of darkened metal. An aura of barely-perceptible red light seems to surround it."
 	icon = 'icons/obj/cult.dmi'
 	icon_state = "blood_blade"
 	item_state = "blood_blade"
@@ -74,7 +74,7 @@
 
 /obj/item/restraints/legcuffs/bola/cult
 	name = "runed bola"
-	desc = "A strong bola, bound with dark magic. Throw it to trip and slow your victim. Will not hit fellow cultists."
+	desc = "A bola, crafted of dark metal and sinuous cords. The inscriptions covering the weights prevent it from striking the Faithful."
 	icon_state = "bola_cult"
 	item_state = "bola_cult"
 	breakouttime = 45
@@ -96,7 +96,7 @@
 /obj/item/clothing/head/hooded/culthood
 	name = "cult hood"
 	icon_state = "culthood"
-	desc = "A hood worn by the followers of a cult."
+	desc = "An armored hood reinforced with dark metal and covered with esoteric inscriptions urging you toward martyrdom. Serve your purpose."
 	flags = BLOCKHAIR
 	flags_inv = HIDEFACE
 	flags_cover = HEADCOVERSEYES
@@ -150,7 +150,7 @@
 
 /obj/item/clothing/suit/hooded/cultrobes/cult_shield
 	name = "empowered cultist robes"
-	desc = "An empowered garb which creates a powerful shield around the user."
+	desc = "An imposing set of armored robes, heavily reinforced with dark metal. Strange sigils and glyphs cover the suit, crackling with unholy power."
 	icon_state = "cult_armour"
 	item_state = "cult_armour"
 	w_class = WEIGHT_CLASS_BULKY
@@ -161,7 +161,7 @@
 
 /obj/item/clothing/head/hooded/cult_hoodie
 	name = "empowered cultist hood"
-	desc = "An empowered garb which creates a powerful shield around the user."
+	desc = "An armored hood, heavily reinforced with dark metal. The inscriptions covering the interior fill you with confidence and determination."
 	icon_state = "cult_hoodalt"
 	armor = list(MELEE = 35, BULLET = 20, LASER = 35, ENERGY = 10, BOMB = 15, RAD = 0, FIRE = 5, ACID = 5)
 	body_parts_covered = HEAD
@@ -192,7 +192,7 @@
 
 /obj/item/clothing/suit/hooded/cultrobes/flagellant_robe
 	name = "flagellant's robes"
-	desc = "Blood-soaked robes infused with dark magic; allows the user to move at inhuman speeds, but at the cost of increased damage."
+	desc = "A set of blood-soaked robes inscribed with unholy sigils. Wearing them greatly increases movement speed, but the cursed fabrics will take an additional tithe when the wearer is hit."
 	icon_state = "flagellantrobe"
 	item_state = "flagellantrobe"
 	flags_inv = HIDEJUMPSUIT
@@ -225,7 +225,7 @@
 
 /obj/item/clothing/head/hooded/flagellant_hood
 	name = "flagellant's robes"
-	desc = "Blood-soaked garb infused with dark magic; allows the user to move at inhuman speeds, but at the cost of increased damage."
+	desc = "A blood-soaked hood inscribed with unholy sigils. The interior is covered in small barbs, reminding you of your duty."
 	icon_state = "flagellanthood"
 	item_state = "flagellanthood"
 	flags = BLOCKHAIR
@@ -240,7 +240,7 @@
 
 /obj/item/whetstone/cult
 	name = "eldritch whetstone"
-	desc = "A block, empowered by dark magic. Sharp weapons will be enhanced when used on the stone."
+	desc = "A block of dark, cracked metal, criss-crossed by glowing lines of unholy power. The block can grant any blade a razor's edge, but is unlikely to survive imbuement."
 	icon_state = "cult_sharpener"
 	increment = 5
 	max = 40
@@ -258,14 +258,14 @@
 
 /obj/item/reagent_containers/drinks/bottle/unholywater
 	name = "flask of unholy water"
-	desc = "Toxic to nonbelievers; this water renews and reinvigorates the faithful of a cult."
+	desc = "A small flask made of darkened glass, and covered with minute inscriptions. The dark liquid within rejuvenates believers, and scalds the faithless."
 	icon_state = "holyflask"
 	color = "#333333"
 	list_reagents = list("unholywater" = 40)
 
 /obj/item/clothing/glasses/hud/health/night/cultblind
 	name = "zealot's blindfold"
-	desc = "May the master guide you through the darkness and shield you from the light."
+	desc = "A thick blindfold made of dark cloth. The runes and sigils sewn into the fabric amplify the vision of the faithful."
 	icon_state = "blindfold"
 	item_state = "blindfold"
 	see_in_dark = 8
@@ -285,7 +285,7 @@
 
 /obj/item/shuttle_curse
 	name = "cursed orb"
-	desc = "You peer within this smokey orb and glimpse terrible fates befalling the escape shuttle."
+	desc = "A small metal orb, crackling with the power of a barely-restrained curse. Crushing the orb will unleash its energy, targeting the vessel which attempts to save the station from its fate."
 	icon = 'icons/obj/cult.dmi'
 	icon_state ="shuttlecurse"
 	var/global/curselimit = 0
@@ -316,7 +316,7 @@
 
 /obj/item/cult_shift
 	name = "veil shifter"
-	desc = "This relic teleports you forward by a medium distance."
+	desc = "A small rod of black metal, surrounded by red crystals that blaze with unholy power. The relic can shift the faithful forward in space with little more than a thought."
 	icon = 'icons/obj/cult.dmi'
 	icon_state ="shifter"
 	var/uses = 4
@@ -426,7 +426,7 @@
 
 /obj/item/shield/mirror
 	name = "mirror shield"
-	desc = "An infamous shield used by eldritch sects to confuse and disorient their enemies."
+	desc = "A small shield of polished metal. The surface glows with eldritch power, and is capable of reflecting incoming attacks."
 	icon = 'icons/obj/cult.dmi'
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
@@ -560,8 +560,8 @@
 	return FALSE
 
 /obj/item/cult_spear
-	name = "blood halberd"
-	desc = "A sickening spear composed entirely of crystallized blood. Will stun people who have been recently marked if the spear is wielded."
+	name = "blood spear"
+	desc = "A mighty polearm made entirely of crystalized blood, held together with eldritch power. Throwing the weapon will cause its enchantments to discharge violently on impact."
 	icon = 'icons/obj/cult.dmi'
 	lefthand_file = 'icons/mob/inhands/weapons_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons_righthand.dmi'
@@ -642,7 +642,7 @@
 
 /datum/action/innate/cult/spear
 	name = "Bloody Bond"
-	desc = "Call the blood spear back to your hand!"
+	desc = "Recall the blood spear to your hand."
 	button_background_icon_state = "bg_cult"
 	button_overlay_icon_state = "bloodspear"
 	default_button_position = "11:31,4:-2"
@@ -670,7 +670,7 @@
 
 /obj/item/gun/projectile/shotgun/boltaction/enchanted/arcane_barrage/blood
 	name = "blood bolt barrage"
-	desc = "Blood for blood."
+	desc = "A crackling orb of blood-red energy, straining for the chance to kill. Simply point at the target, and let it loose."
 	item_state = "disintegrate"
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
@@ -717,17 +717,17 @@
 
 /obj/item/blood_orb
 	name = "orb of blood"
+	desc = "A solid orb of crystalized blood, likely taken unwillingly. The orb can be used to transfer vitae between the faithful."
 	icon = 'icons/obj/cult.dmi'
 	icon_state = "summoning_orb"
 	item_state = "summoning_orb"
-	desc = "It's an orb of crystalized blood. Can be used to transfer blood between cultists."
 	var/blood = 50
 
 /obj/item/portal_amulet
 	name = "reality sunderer"
+	desc = "An elaborately carved amulet resembling a human eye. Looking directly at it sends shivers down your spine. Allows cultists to open portals over teleport runes, destroying the rune in the process."
 	icon = 'icons/obj/cult.dmi'
 	icon_state = "amulet"
-	desc = "An elaborately carved amulet resembling a human eye. Looking directly at it sends shivers down your spine. Allows cultists to open portals over teleport runes, destroying the rune in the process."
 	w_class = WEIGHT_CLASS_SMALL
 
 

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -11,19 +11,19 @@
 //Noncult As we may have this on maps
 /obj/structure/cult/altar
 	name = "Altar"
-	desc = "A bloodstained altar."
+	desc = "A sacrifical altar, stained with long-dried blood. Any power it had is long gone."
 	icon_state = "altar"
 
 /obj/structure/cult/forge
 	name = "Daemon forge"
-	desc = "A forge used in crafting unholy armors and weapons."
+	desc = "A forge composed of dark stone and darker metal, covered in incomprehensible inscriptions. The fire within the forge burns low, it is incapable of producing anything."
 	icon_state = "forge"
 	light_range = 2
 	light_color = LIGHT_COLOR_LAVA
 
 /obj/structure/cult/pylon
 	name = "Pylon"
-	desc = "A floating crystal that hums with an unearthly energy."
+	desc = "An otherworldly crystal that hangs in mid-air. Its light is feeble and sputtering, acting as little more than dim illumination."
 	icon_state = "pylon"
 	light_range = 1.5
 	light_color = LIGHT_COLOR_RED
@@ -136,7 +136,7 @@
 
 /obj/structure/cult/functional/altar
 	name = "altar"
-	desc = "A bloodstained altar dedicated to a cult."
+	desc = "A sacrifical altar, covered in fresh blood. The runes covering its sides glow with barely-restrained power."
 	icon_state = "altar"
 	max_integrity = 150 //Sturdy
 	death_message = "<span class='danger'>The altar breaks into splinters, releasing a cascade of spirits into the air!</span>"
@@ -155,7 +155,7 @@
 
 /obj/structure/cult/functional/forge
 	name = "daemon forge"
-	desc = "A forge used in crafting the unholy weapons used by the armies of a cult."
+	desc = "A compact forge made of dark stone and darker metal. Molten metal flows through inscribed channels in the construction, ready to be turned into the unholy armaments of a cult."
 	icon_state = "forge"
 	light_range = 2
 	light_color = LIGHT_COLOR_LAVA
@@ -220,7 +220,7 @@ GLOBAL_LIST_INIT(blacklisted_pylon_turfs, typecacheof(list(
 
 /obj/structure/cult/functional/pylon
 	name = "pylon"
-	desc = "A floating crystal that slowly heals those faithful to a cult."
+	desc = "A floating, otherworldly crystal that radiates a baleful red light. Wherever the light touches, matter warps, and the faithful are invigorated."
 	icon_state = "pylon"
 	light_range = 1.5
 	light_color = LIGHT_COLOR_RED
@@ -326,7 +326,7 @@ GLOBAL_LIST_INIT(blacklisted_pylon_turfs, typecacheof(list(
 
 /obj/effect/gateway
 	name = "gateway"
-	desc = "You're pretty sure that the abyss is staring back."
+	desc = "There's something inside. It's staring back."
 	icon = 'icons/obj/cult.dmi'
 	icon_state = "hole"
 	density = TRUE

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -3,7 +3,7 @@
 
 /obj/item/melee/cultblade/dagger
 	name = "ritual dagger"
-	desc = "A strange dagger said to be used by sinister groups for \"preparing\" a corpse before sacrificing it to their dark gods."
+	desc = "A small, well-balanced dagger that radiates an aura of palpable menace. The blade tapers to a razor-sharp point that is ideal for drawing with."
 	icon_state = "blood_dagger"
 	item_state = "blood_dagger"
 	w_class = WEIGHT_CLASS_SMALL


### PR DESCRIPTION
## What Does This PR Do
Title. Updates the descriptions of various Cult items to make them more atmospheric and spooky.

## Why It's Good For The Game
Descriptions are good. Spook is good.

## Testing

loaded in and read words

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
 
<hr>

## Changelog

:cl:
tweak: Updates descriptions of many Cult items and structures.
/:cl:
