### PR TITLE
Adds hooks for debugger specific behaviour

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           path: $HOME/BYOND
           key: ${{ runner.os }}-byond
-      # We test PARADISE_PRODUCTION_HARDWARE here because we dont in station_maploaD_tests
+      # We test PARADISE_PRODUCTION_HARDWARE here because we dont in station_mapload_tests
       - name: Compile All Maps
         run: |
           tools/ci/install_byond.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,12 +86,13 @@ jobs:
         with:
           path: $HOME/BYOND
           key: ${{ runner.os }}-byond
+      # We test PARADISE_PRODUCTION_HARDWARE here because we dont in station_maploaD_tests
       - name: Compile All Maps
         run: |
           tools/ci/install_byond.sh
           source $HOME/BYOND/byond/bin/byondsetup
           tools/ci/generate_maplist.sh
-          DreamMaker -DMULTIINSTANCE -DCIMAP paradise.dme
+          DreamMaker -DMULTIINSTANCE -DCIMAP -DPARADISE_PRODUCTION_HARDWARE paradise.dme
 
   station_mapload_tests:
     name: Station Tests

--- a/code/__HELPERS/debugger.dm
+++ b/code/__HELPERS/debugger.dm
@@ -2,6 +2,13 @@
 // These procs are named EXACTLY as they are since the debugger itself will hook into these procs internally
 // Do not change these names. Please. -aa
 
+#ifndef PARADISE_PRODUCTION_HARDWARE
+// Use GLOB.debugger_enabled for debugger-specific behaviour like not delaying MC subsystems for delays
+// This is gated behind PARADISE_PRODUCTION_HARDWARE not being set so we dont have the check overhead in the MC loop on prod
+// By gating it we can ensure in CI that nothing has slipped in
+GLOBAL_VAR_INIT(debugger_enabled, FALSE)
+#endif
+
 /proc/auxtools_stack_trace(msg)
 	CRASH(msg)
 
@@ -22,3 +29,6 @@
 	var/debug_server = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
 	if(debug_server)
 		CALL_EXT(debug_server, "auxtools_shutdown")()
+		#ifndef PARADISE_PRODUCTION_HARDWARE
+		GLOB.debugger_enabled = TRUE
+		#endif


### PR DESCRIPTION
## What Does This PR Do
Adds a new global var, `debugger_enabled`, for specific behaviour when the debugger is plugged in.

This var existing is gated behind the `PARADISE_PRODUCTION_HARDWARE` define **NOT** being set. Why? Because one of the primary uses for this would be tweaking MC logic to not delay SS runs after long debugger pauses, and I don't want ANY extra overhead in the MC tick loop.

Said MC changes are not in this PR, as I am not smart enough to do them anymore.

## Why It's Good For The Game
Dev-assists are always fun

## Images of changes
N/A

## Testing
Tried building with and without the prod define, compiled just fine. If someone could test this with the debugger that would be real nice.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog
NPFC