### PR TITLE
unregister COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON on chasm turfchange

### DIFF
--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -50,6 +50,10 @@
 	SIGNAL_HANDLER // COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON
 	drop_stuff(created)
 
+/turf/simulated/floor/chasm/ChangeTurf(turf/simulated/floor/T, defer_change, keep_icon, ignore_air, copy_existing_baseturf)
+	UnregisterSignal(src, COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON)
+	. = ..()
+
 /turf/simulated/floor/chasm/Entered(atom/movable/AM)
 	..()
 	START_PROCESSING(SSprocessing, src)


### PR DESCRIPTION
## What Does This PR Do
This PR modifies the TurfChange on chasms to unregister the signal introduced in #28889.
## Why It's Good For The Game
If a TurfChange gets called, this receiver persists, and SSatoms will send the signal to the new turf type, even if it doesn't have th necessary proc to respond to it, causing a runtime.
## Testing
Activated and threw a shelter capsule near a chasm, ensured the shelter changed a chasm turf, ensured no runtimes.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC