### PR TITLE
[s] Smith insert slowdown fix

### DIFF
--- a/code/modules/smithing/smithed_items/inserts.dm
+++ b/code/modules/smithing/smithed_items/inserts.dm
@@ -77,7 +77,7 @@
 	name = "fireproofing plate"
 	desc = "A heavy plate of asbestos designed to fireproof a user. A firefighter's godsend."
 	burn_armor = 10
-	movement_speed_mod = -0.2
+	movement_speed_mod = -0.5
 	heat_insulation = 20
 	secondary_goal_candidate = TRUE
 
@@ -111,7 +111,7 @@
 	laser_armor = 10
 	explosive_armor = 10
 	radiation_armor = 10
-	movement_speed_mod = -0.2
+	movement_speed_mod = -0.5
 
 /obj/item/smithed_item/insert/engineering
 	name = "engineering mesh"
@@ -122,7 +122,7 @@
 	heat_insulation = 10
 	explosive_armor = 10
 	siemens_coeff = 0.4
-	movement_speed_mod = -0.2
+	movement_speed_mod = -0.5
 
 /obj/item/smithed_item/insert/heavy
 	name = "heavy duty plate"
@@ -133,7 +133,7 @@
 	explosive_armor = 10
 	heat_insulation = 10
 	siemens_coeff = -0.4
-	movement_speed_mod = -0.4
+	movement_speed_mod = -1
 
 /obj/item/smithed_item/insert/mobility
 	name = "mobility mesh"

--- a/code/modules/smithing/smithed_items/inserts.dm
+++ b/code/modules/smithing/smithed_items/inserts.dm
@@ -77,7 +77,7 @@
 	name = "fireproofing plate"
 	desc = "A heavy plate of asbestos designed to fireproof a user. A firefighter's godsend."
 	burn_armor = 10
-	movement_speed_mod = -0.5
+	movement_speed_mod = -1
 	heat_insulation = 20
 	secondary_goal_candidate = TRUE
 
@@ -111,7 +111,7 @@
 	laser_armor = 10
 	explosive_armor = 10
 	radiation_armor = 10
-	movement_speed_mod = -0.5
+	movement_speed_mod = -1
 
 /obj/item/smithed_item/insert/engineering
 	name = "engineering mesh"
@@ -122,7 +122,7 @@
 	heat_insulation = 10
 	explosive_armor = 10
 	siemens_coeff = 0.4
-	movement_speed_mod = -0.5
+	movement_speed_mod = -1
 
 /obj/item/smithed_item/insert/heavy
 	name = "heavy duty plate"
@@ -133,7 +133,7 @@
 	explosive_armor = 10
 	heat_insulation = 10
 	siemens_coeff = -0.4
-	movement_speed_mod = -1
+	movement_speed_mod = -1.5
 
 /obj/item/smithed_item/insert/mobility
 	name = "mobility mesh"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes insert slowdown values being too low to actually matter. Slowdown factors don't matter below 1, so now minor slowdown inserts have a 1 slowdown and major has a 1.5. 

## Why It's Good For The Game

Balance.

## Testing

Inserted masterwork heavy insert into suit. Was slowed down.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix Fixed smith insert slowdown values being too small to actually matter.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
