### PR TITLE
Smith Polish: Lens and Bit Batch Crafting

### DIFF
--- a/code/modules/smithing/machinery/kinetic_assembler.dm
+++ b/code/modules/smithing/machinery/kinetic_assembler.dm
@@ -18,6 +18,13 @@
 	var/obj/item/smithed_item/component/trim
 	/// Finished product
 	var/obj/item/smithed_item/finished_product
+	/// Products that are produced in batches
+	var/list/batched_item_types = list(
+		/obj/item/smithed_item/lens,
+		/obj/item/smithed_item/tool_bit
+	)
+	/// Amount of extra items made in batches
+	var/batch_extras = 2
 
 /obj/machinery/smithing/kinetic_assembler/Initialize(mapload)
 	. = ..()
@@ -29,6 +36,7 @@
 	component_parts += new /obj/item/stock_parts/manipulator(null)
 	component_parts += new /obj/item/stock_parts/micro_laser(null)
 	component_parts += new /obj/item/stack/sheet/glass(null)
+	batched_item_types = typecacheof(batched_item_types)
 	RefreshParts()
 
 /obj/machinery/smithing/kinetic_assembler/examine(mob/user)
@@ -213,4 +221,13 @@
 		return
 	playsound(src, 'sound/magic/fellowship_armory.ogg', 50, TRUE)
 	finished_product.forceMove(src.loc)
+	SSblackbox.record_feedback("tally", "smith_assembler_production", 1, "[finished_product.type]")
+	if(is_type_in_typecache(finished_product, batched_item_types))
+		for(var/iterator in 1 to batch_extras)
+			var/obj/item/smithed_item/extra_product = new finished_product.type(src.loc)
+			extra_product.quality = finished_product.quality
+			extra_product.material = finished_product.material
+			extra_product.set_stats()
+			extra_product.update_appearance(UPDATE_NAME)
+			extra_product.scatter_atom()
 	finished_product = null


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Lenses and Bits have durability. You also need a set of them to outfit a toolbelt's worth of tools or an armory's worth of eguns. This PR makes it so that lenses and bits are crafted as a set of 3, to provide replacements to broken ones as well as for better outfitting.

## Why It's Good For The Game

Makes Smith gameplay smoother. 

## Testing

Smithed a masterwork balanced bit. Got 3 when it was completed.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Lenses and Tool Bits are now crafted in batches of 3
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
