### PR TITLE
fixes vetus pinpointer tendril targeting

### DIFF
--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -537,10 +537,13 @@
 		return FALSE
 
 /obj/item/pinpointer/tendril/proc/scan_for_tendrils()
+	var/turf/our_turf = get_turf(src)
 	if(mode == MODE_TENDRIL)
 		target = null //Resets nearest_op every time it scans
 		var/closest_distance = 1000
 		for(var/obj/structure/spawner/lavaland/T in GLOB.tendrils)
+			if(T.z != our_turf.z)
+				continue
 			var/temp_distance = get_dist(T, get_turf(src))
 			if(temp_distance < closest_distance)
 				target = T


### PR DESCRIPTION
## What Does This PR Do
This PR fixes vetus pinpointers not correctly showing the direction of nearest tendrils. Fixes #28965.
## Why It's Good For The Game
Bugfix.
## Testing
Spawned in multisector lavaland, spawned pinpointer, activated, verified we got arrows.
![2025_04_11__11_54_52__](https://github.com/user-attachments/assets/d142abf1-290b-4322-89d5-e7d2c959e5b1)
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: The vetus pinpointer will properly target tendrils in your sector.
/:cl:
