### PR TITLE
bump lavaland ruin budget

### DIFF
--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -622,9 +622,9 @@ space_ruin_budget_min = 750
 # Maximum space ruin budget.
 space_ruin_budget_max = 1000
 # Minimum lavaland ruin budget.
-lavaland_ruin_budget_min = 350
+lavaland_ruin_budget_min = 500
 # Maximum lavaland ruin budget.
-lavaland_ruin_budget_max = 500
+lavaland_ruin_budget_max = 650
 # List of all space ruins that can generate in the world
 # Commenting something out in here DISABLES IT FROM SPAWNING
 active_space_ruins = [


### PR DESCRIPTION
## What Does This PR Do
This PR bumps the lavaland ruin budget to account for a second Lavaland level.
## Why It's Good For The Game
It's free real estate
## Images of changes
### Sample Before
![2025_04_11__13_42_09__D__lavaland_ruins_44311_ - XnView MP](https://github.com/user-attachments/assets/dbfc2498-7b18-4a80-b1bb-0c3f0375d681)
### Sample After
![2025_04_11__13_41_18__D__lavaland_ruins_9337_ - XnView MP](https://github.com/user-attachments/assets/b1d7b7d5-729d-4402-b41c-669da40ff9f4)
## Testing
See above
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: The amount of ruins spawning on Lavaland has been increased to account for the expanded size of the planet.
/:cl:
