### PR TITLE
Smith Polish - Item Insertion QOL

### DIFF
--- a/code/modules/smithing/machinery/casting_basin.dm
+++ b/code/modules/smithing/machinery/casting_basin.dm
@@ -115,13 +115,14 @@
 		to_chat(user, "<span class='warning'>[used] does not fit in [src]'s cast slot.</span>")
 		return
 
-	if(cast)
-		to_chat(user, "<span class='warning'>[src] already has a cast inserted.</span>")
-		return
-
 	if(used.flags & NODROP || !user.transfer_item_to(used, src))
 		to_chat(user, "<span class='warning'>[used] is stuck to your hand!</span>")
 		return ITEM_INTERACT_COMPLETE
+	if(cast)
+		user.put_in_active_hand(cast)
+		to_chat(user, "<span class='notice'>You swap [used] with [cast] in [src].</span>")
+	else
+		to_chat(user, "<span class='notice'>You insert [used] into [src].</span>")
 	cast = used
 	update_icon(UPDATE_OVERLAYS)
 	return ITEM_INTERACT_COMPLETE

--- a/code/modules/smithing/smith_machinery.dm
+++ b/code/modules/smithing/smith_machinery.dm
@@ -51,13 +51,15 @@
 		return FINISH_ATTACK
 
 	if(istype(used, /obj/item/smithed_item/component))
-		if(working_component)
-			to_chat(user, "<span class='warning'>There is already a component in the machine!</span>")
-			return ITEM_INTERACT_COMPLETE
-
 		if(used.flags & NODROP || !user.drop_item() || !used.forceMove(src))
 			to_chat(user, "<span class='warning'>[used] is stuck to your hand!</span>")
 			return ITEM_INTERACT_COMPLETE
+
+		if(working_component)
+			user.put_in_active_hand(working_component)
+			to_chat(user, "<span class='notice'>You swap [used] with [working_component] in [src].</span>")
+		else
+			to_chat(user, "<span class='notice'>You insert [used] into [src].</span>")
 
 		working_component = used
 		return ITEM_INTERACT_COMPLETE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

This PR makes it so if you try to add an item to a smithing machine that already contains that item, it swaps them. 

## Why It's Good For The Game

Quality of Life.

## Testing

<!-- How did you test the PR, if at all? -->

Tried to place a component in a power hammer that already contained a component. The components were swapped.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Smithing machines (power hammer, lava furnace, casting basin) now swap casts/components when you try to insert one while another is in the machine.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
