### PR TITLE
add a blackbox for rock floors dug into ore_mined feedback

### DIFF
--- a/code/game/turfs/simulated/floor/asteroid_floors.dm
+++ b/code/game/turfs/simulated/floor/asteroid_floors.dm
@@ -28,6 +28,7 @@
 	new digResult(src, 5)
 	icon_plating = "[environment_type]_dug"
 	icon_state = "[environment_type]_dug"
+	SSblackbox.record_feedback("tally", "ore_mined", 5, "[digResult]")
 	dug = TRUE
 
 /turf/simulated/floor/plating/asteroid/proc/can_dig(mob/user)


### PR DESCRIPTION
## What Does This PR Do
This PR adds item types dug up from rock floors, such as volcanic ash, to the `ore_mined` blackbox feedback.
## Why It's Good For The Game
We should be tracking how much ash is mined alongside all the other materials found on Lavaland.
## Testing
Visual inspection.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC