### PR TITLE
Better AI Program Blackboxing

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai_programs.dm
+++ b/code/modules/mob/living/silicon/ai/ai_programs.dm
@@ -160,7 +160,6 @@
 					to_chat(A, "<span class='warning'>You cannot afford this upgrade!</span>")
 					return FALSE
 				program.upgrade(A)
-				SSblackbox.record_feedback("tally", "ai_program_upgrade", 1, "[program.type]")
 			to_chat(A, program.unlock_text)
 			A.playsound_local(A, program.unlock_sound, 50, FALSE, use_reverb = FALSE)
 			return TRUE

--- a/code/modules/mob/living/silicon/ai/ai_programs.dm
+++ b/code/modules/mob/living/silicon/ai/ai_programs.dm
@@ -206,7 +206,7 @@
 		return
 	upgrade_level++
 	if(!first_install)
-		SSblackbox.record_feedback("tally", "ai_program_upgrade", 1, "[program.type]")
+		SSblackbox.record_feedback("tally", "ai_program_upgrade", 1, "[src.type]")
 		bandwidth_used++
 		user.program_picker.bandwidth--
 

--- a/code/modules/mob/living/silicon/ai/ai_programs.dm
+++ b/code/modules/mob/living/silicon/ai/ai_programs.dm
@@ -143,7 +143,6 @@
 							return TRUE
 
 				// No same active program found, install the new active power.
-				SSblackbox.record_feedback("tally", "ai_program_installed", 1, new_spell.name)
 				program.upgrade(A, first_install = TRUE) // Usually does nothing for actives, but is needed for hybrid abilities like the enhanced tracker
 				A.AddSpell(new_spell)
 				to_chat(A, program.unlock_text)
@@ -208,6 +207,7 @@
 		return
 	upgrade_level++
 	if(!first_install)
+		SSblackbox.record_feedback("tally", "ai_program_upgrade", 1, "[program.type]")
 		bandwidth_used++
 		user.program_picker.bandwidth--
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Improves the blackboxing for AI programs.

## Why It's Good For The Game

Duplicate blackboxes are bad. We should also probably blackbox which ones are upgraded.

## Testing

Compiled.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
