### PR TITLE
Stamping out Cigarettes Doesn't Teleport Them to Your Mouth Anymore

### DIFF
--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -131,7 +131,6 @@ LIGHTERS ARE IN LIGHTERS.DM
 
 /obj/item/clothing/mask/cigarette/attack_self__legacy__attackchain(mob/user)
 	if(lit)
-		user.drop_item_to_ground(src, force = TRUE)
 		user.visible_message(
 			"<span class='notice'>[user] calmly drops and treads on [src], putting it out instantly.</span>",
 			"<span class='notice'>You calmly drop and tread on [src], putting it out instantly.</span>",
@@ -290,10 +289,15 @@ LIGHTERS ARE IN LIGHTERS.DM
 	if(ismob(loc))
 		var/mob/living/M = loc
 		to_chat(M, "<span class='notice'>Your [name] goes out.</span>")
-		M.drop_item_to_ground(src, force = TRUE)		//Force the un-equip so the overlays update
-		butt.slot_flags |= ITEM_SLOT_MASK // Temporarily allow it to go on masks
-		M.equip_to_slot_if_possible(butt, ITEM_SLOT_MASK)
-		butt.slot_flags &= ~ITEM_SLOT_MASK
+		// Only put the butt in the user's mouth if there's already a cig there.
+		if(M.wear_mask == src)
+			to_chat(M, "<span class='userdanger'>Butt in your mouth!</span>")
+			M.drop_item_to_ground(src, force = TRUE) //Force the un-equip so the overlays update
+			butt.slot_flags |= ITEM_SLOT_MASK // Temporarily allow it to go on masks
+			M.equip_to_slot_if_possible(butt, ITEM_SLOT_MASK)
+			butt.slot_flags &= ~ITEM_SLOT_MASK
+		else
+			M.drop_item_to_ground(src, force = TRUE)
 
 	STOP_PROCESSING(SSobj, src)
 	qdel(src)

--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -131,6 +131,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 
 /obj/item/clothing/mask/cigarette/attack_self__legacy__attackchain(mob/user)
 	if(lit)
+		user.drop_item_to_ground(src, force = TRUE)
 		user.visible_message(
 			"<span class='notice'>[user] calmly drops and treads on [src], putting it out instantly.</span>",
 			"<span class='notice'>You calmly drop and tread on [src], putting it out instantly.</span>",


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #28322.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The last thing you want in your Nanotrasen cigarette is somebody's foot fungus. But as it turns out, that may be what you get.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Lit a cigarette in my mouth. Let it burn out. It stayed in my mouth.
Lit a cigarette in my hand, let it burn out. It fell to the floor.
Lit a cigarette as a service borg, picked it up, let it burn out. It fell to the floor and there was no runtime to be seen.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Cigarettes no longer teleport to your mouth when stamping them out.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
