### PR TITLE
Smith Polish: Fixes lens fire rate modifications

### DIFF
--- a/code/modules/smithing/smithed_items/lens.dm
+++ b/code/modules/smithing/smithed_items/lens.dm
@@ -38,14 +38,22 @@
 		return
 	attached_gun = target
 	attached_gun.fire_delay = attached_gun.fire_delay / fire_rate_mult
+	if(attached_gun.GetComponent(/datum/component/automatic_fire))
+		var/datum/component/automatic_fire/auto_comp = attached_gun.GetComponent(/datum/component/automatic_fire)
+		auto_comp.autofire_shot_delay = auto_comp.autofire_shot_delay / fire_rate_mult
 	for(var/obj/item/ammo_casing/energy/casing in attached_gun.ammo_type)
+		casing.delay = casing.delay / fire_rate_mult
 		casing.e_cost = casing.e_cost * power_mult
 		casing.lens_damage_multiplier = casing.lens_damage_multiplier * damage_mult
 		casing.lens_speed_multiplier = casing.lens_speed_multiplier / laser_speed_mult
 
 /obj/item/smithed_item/lens/on_detached()
 	attached_gun.fire_delay = attached_gun.fire_delay * fire_rate_mult
+	if(attached_gun.GetComponent(/datum/component/automatic_fire))
+		var/datum/component/automatic_fire/auto_comp = attached_gun.GetComponent(/datum/component/automatic_fire)
+		auto_comp.autofire_shot_delay = auto_comp.autofire_shot_delay * fire_rate_mult
 	for(var/obj/item/ammo_casing/energy/casing in attached_gun.ammo_type)
+		casing.delay = casing.delay * fire_rate_mult
 		casing.e_cost = casing.e_cost / power_mult
 		casing.lens_damage_multiplier = casing.lens_damage_multiplier / damage_mult
 		casing.lens_speed_multiplier = casing.lens_speed_multiplier * laser_speed_mult


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes how fire rate modifications are applied to energy weapons and automatic energy weapons to better apply their effects.

## Why It's Good For The Game

Lenses should do as advertised.

## Testing

Created masterwork rapid lens. Put it in disabler smg. Observed dakka.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Fixes lens fire rate modifier application
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
