### PR TITLE
Smith Addition: Productivity Bit

### DIFF
--- a/code/datums/ores.dm
+++ b/code/datums/ores.dm
@@ -17,8 +17,8 @@
  * Returns [MINERAL_ALLOW_DIG] if the containing turf should be changed to its
  * "dug" state, [MINERAL_PREVENT_DIG] if it should remain as is.
  */
-/datum/ore/proc/on_mine(turf/source, mob/user, triggered_by_explosion = FALSE)
-	var/amount = rand(drop_min, drop_max)
+/datum/ore/proc/on_mine(turf/source, mob/user, triggered_by_explosion = FALSE, productivity_mult = 1)
+	var/amount = round(rand(drop_min, drop_max) * productivity_mult)
 
 	if(ispath(drop_type, /obj/item/stack/ore))
 		new drop_type(source, amount)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -182,6 +182,8 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	var/bit_failure_rate = 0
 	/// Efficiency modifier for tools that use energy or fuel
 	var/bit_efficiency_mod = 1
+	/// Productivity modifier for tools
+	var/bit_productivity_mod = 1
 
 	///////////////////////////
 	// MARK: item hover FX

--- a/code/game/turfs/simulated/floor/asteroid_floors.dm
+++ b/code/game/turfs/simulated/floor/asteroid_floors.dm
@@ -24,8 +24,8 @@
 	if(prob(floor_variance))
 		icon_state = "[environment_type][rand(0,12)]"
 
-/turf/simulated/floor/plating/asteroid/proc/getDug()
-	new digResult(src, 5)
+/turf/simulated/floor/plating/asteroid/proc/getDug(productivity_mod = 1)
+	new digResult(src, 5 * productivity_mod)
 	icon_plating = "[environment_type]_dug"
 	icon_state = "[environment_type]_dug"
 	dug = TRUE
@@ -85,7 +85,7 @@
 			if(!can_dig(user))
 				return TRUE
 			to_chat(user, "<span class='notice'>You dig a hole.</span>")
-			getDug()
+			getDug(used.bit_productivity_mod)
 			return TRUE
 
 	else if(istype(used, /obj/item/storage/bag/ore))

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -95,24 +95,24 @@
 		if(do_after(user, mine_time * P.toolspeed, target = src))
 			if(ismineralturf(src)) //sanity check against turf being deleted during digspeed delay
 				to_chat(user, "<span class='notice'>You finish cutting into the rock.</span>")
-				gets_drilled(user)
+				gets_drilled(user, productivity_mult = P.bit_productivity_mod)
 				SSblackbox.record_feedback("tally", "pick_used_mining", 1, P.name)
 
 		return FINISH_ATTACK
 	else
 		return attack_hand(user)
 
-/turf/simulated/mineral/proc/mine_ore(mob/user, triggered_by_explosion)
+/turf/simulated/mineral/proc/mine_ore(mob/user, triggered_by_explosion, productivity_mult = 1)
 	if(!ore)
 		return MINERAL_ALLOW_DIG
 
 	for(var/obj/effect/temp_visual/mining_overlay/M in src)
 		qdel(M)
 
-	return ore.on_mine(src, user, triggered_by_explosion)
+	return ore.on_mine(src, user, triggered_by_explosion, productivity_mult)
 
-/turf/simulated/mineral/proc/gets_drilled(mob/user, triggered_by_explosion = FALSE)
-	if(mine_ore(user, triggered_by_explosion) == MINERAL_PREVENT_DIG)
+/turf/simulated/mineral/proc/gets_drilled(mob/user, triggered_by_explosion = FALSE, productivity_mult = 1)
+	if(mine_ore(user, triggered_by_explosion, productivity_mult) == MINERAL_PREVENT_DIG)
 		return
 
 	ChangeTurf(turf_type, defer_change)

--- a/code/modules/smithing/components/tool_bits_components.dm
+++ b/code/modules/smithing/components/tool_bits_components.dm
@@ -28,6 +28,12 @@
 	materials = list(MAT_TITANIUM = 8000, MAT_PLASMA = 8000)
 	finished_product = /obj/item/smithed_item/tool_bit/heavy
 
+/obj/item/smithed_item/component/bit_mount/productivity
+	name = "productivity bit mount"
+	desc = "This is the primary component of a productivity bit."
+	materials = list(MAT_METAL = 2000, MAT_PLASMA = 2000)
+	finished_product = /obj/item/smithed_item/tool_bit/productivity
+
 /obj/item/smithed_item/component/bit_mount/economical
 	name = "economical bit mount"
 	desc = "This is the primary component of an economical bit."
@@ -69,6 +75,12 @@
 	desc = "This is the secondary component of a heavy duty bit."
 	materials = list(MAT_METAL = 8000, MAT_PLASMA = 8000)
 	finished_product = /obj/item/smithed_item/tool_bit/heavy
+
+/obj/item/smithed_item/component/bit_head/productivity
+	name = "productivity bit mount"
+	desc = "This is the secondary component of a productivity bit."
+	materials = list(MAT_BLUESPACE = 2000)
+	finished_product = /obj/item/smithed_item/tool_bit/productivity
 
 /obj/item/smithed_item/component/bit_head/economical
 	name = "economical bit head"

--- a/code/modules/smithing/components/tool_bits_components.dm
+++ b/code/modules/smithing/components/tool_bits_components.dm
@@ -79,7 +79,7 @@
 /obj/item/smithed_item/component/bit_head/productivity
 	name = "productivity bit mount"
 	desc = "This is the secondary component of a productivity bit."
-	materials = list(MAT_BLUESPACE = 2000)
+	materials = list(MAT_GOLD = 2000, MAT_SILVER = 2000)
 	finished_product = /obj/item/smithed_item/tool_bit/productivity
 
 /obj/item/smithed_item/component/bit_head/economical

--- a/code/modules/smithing/smith_datums.dm
+++ b/code/modules/smithing/smith_datums.dm
@@ -70,6 +70,8 @@
 	var/tool_speed_mult = 1.0
 	/// Tool precision multiplier
 	var/tool_failure_mult = 1.0
+	/// Tool productivity mult
+	var/tool_productivity_mult = 1.0
 	/// How much larger does a bit with this material make it?
 	var/size_mod = 0
 	/// Projectile speed multiplier
@@ -106,6 +108,7 @@
 	heat_insulation_mult = MINOR_MATERIAL_BUFF
 	siemens_coeff_mult = MINOR_MATERIAL_DEBUFF
 	tool_failure_mult = MINOR_MATERIAL_DEBUFF
+	tool_productivity_mult = MINOR_MATERIAL_BUFF
 	power_draw_mult = MINOR_MATERIAL_DEBUFF
 	projectile_damage_multiplier = MINOR_MATERIAL_DEBUFF
 	secondary_goal_candidate = TRUE
@@ -120,6 +123,7 @@
 	radiation_armor_mult = MAJOR_MATERIAL_BUFF
 	tool_speed_mult = MINOR_MATERIAL_BUFF
 	tool_failure_mult = MINOR_MATERIAL_DEBUFF
+	tool_productivity_mult = MAJOR_MATERIAL_BUFF
 	size_mod = 1
 	fire_rate_multiplier = MINOR_MATERIAL_BUFF
 	durability_mult = MINOR_MATERIAL_DEBUFF
@@ -132,6 +136,7 @@
 	explosive_armor_mult = MINOR_MATERIAL_BUFF
 	siemens_coeff_mult = MINOR_MATERIAL_BUFF
 	tool_speed_mult = MINOR_MATERIAL_BUFF
+	tool_productivity_mult = MINOR_MATERIAL_DEBUFF
 	projectile_damage_multiplier = MINOR_MATERIAL_BUFF
 	durability_mult = MINOR_MATERIAL_DEBUFF
 	secondary_goal_candidate = TRUE
@@ -161,6 +166,7 @@
 	radiation_armor_mult = MAJOR_MATERIAL_DEBUFF
 	tool_speed_mult = MINOR_MATERIAL_BUFF
 	tool_failure_mult = MINOR_MATERIAL_DEBUFF
+	tool_productivity_mult = MINOR_MATERIAL_DEBUFF
 	size_mod = 1
 	projectile_speed_mult = MINOR_MATERIAL_BUFF
 	power_draw_mult = MINOR_MATERIAL_DEBUFF
@@ -178,6 +184,7 @@
 	explosive_armor_mult = MINOR_MATERIAL_BUFF
 	siemens_coeff_mult = MAJOR_MATERIAL_BUFF
 	tool_failure_mult = MINOR_MATERIAL_DEBUFF
+	tool_productivity_mult = MAJOR_MATERIAL_BUFF
 	durability_mult = MAJOR_MATERIAL_BUFF
 
 /datum/smith_material/bluespace
@@ -189,6 +196,7 @@
 	siemens_coeff_mult = MINOR_MATERIAL_BUFF
 	radiation_armor_mult = MINOR_MATERIAL_DEBUFF
 	tool_speed_mult = MAJOR_MATERIAL_BUFF
+	tool_productivity_mult = MAJOR_MATERIAL_BUFF
 	power_draw_mult = MAJOR_MATERIAL_BUFF
 	projectile_damage_multiplier = MAJOR_MATERIAL_BUFF
 
@@ -236,6 +244,7 @@
 	heat_insulation_mult = MINOR_MATERIAL_DEBUFF
 	radiation_armor_mult = MINOR_MATERIAL_BUFF
 	tool_speed_mult = MINOR_MATERIAL_BUFF
+	tool_productivity_mult = MINOR_MATERIAL_BUFF
 	size_mod = -1
 	projectile_speed_mult = MINOR_MATERIAL_BUFF
 	power_draw_mult = MINOR_MATERIAL_BUFF
@@ -252,6 +261,7 @@
 	siemens_coeff_mult = MINOR_MATERIAL_BUFF
 	radiation_armor_mult = MINOR_MATERIAL_BUFF
 	tool_speed_mult = MINOR_MATERIAL_BUFF
+	tool_productivity_mult = MINOR_MATERIAL_BUFF
 	size_mod = -1
 	power_draw_mult = MINOR_MATERIAL_DEBUFF
 	projectile_damage_multiplier = MINOR_MATERIAL_DEBUFF
@@ -267,6 +277,7 @@
 	heat_insulation_mult = MINOR_MATERIAL_DEBUFF
 	siemens_coeff_mult = MINOR_MATERIAL_DEBUFF
 	tool_failure_mult = MINOR_MATERIAL_DEBUFF
+	tool_productivity_mult = MAJOR_MATERIAL_BUFF
 	size_mod = -1
 	projectile_damage_multiplier = MINOR_MATERIAL_BUFF
 	power_draw_mult = MINOR_MATERIAL_BUFF

--- a/code/modules/smithing/smithed_items/tool_bits.dm
+++ b/code/modules/smithing/smithed_items/tool_bits.dm
@@ -6,6 +6,10 @@
 	var/base_speed_mod = 0
 	/// Base Efficiency modifier
 	var/base_efficiency_mod = 0
+	/// Base productivity modifier
+	var/base_productivity_mod = 0
+	/// Productivity mod
+	var/productivity_mod = 1.0
 	/// Speed modifier
 	var/speed_mod = 1.0
 	/// Efficiency modifier
@@ -34,6 +38,7 @@
 	speed_mod = 1 + (base_speed_mod * quality.stat_mult * material.tool_speed_mult)
 	failure_rate = initial(failure_rate) * quality.stat_mult * material.tool_failure_mult
 	efficiency_mod = 1 + (base_efficiency_mod * quality.stat_mult * material.power_draw_mult)
+	productivity_mod = 1 + (base_productivity_mod * quality.stat_mult * material.tool_productivity_mult)
 
 /obj/item/smithed_item/tool_bit/on_attached(obj/item/target)
 	if(!istype(target))
@@ -43,12 +48,14 @@
 	attached_tool.toolspeed = attached_tool.toolspeed * speed_mod
 	attached_tool.bit_failure_rate += failure_rate
 	attached_tool.bit_efficiency_mod = attached_tool.bit_efficiency_mod * efficiency_mod
+	attached_tool.bit_productivity_mod = attached_tool.bit_productivity_mod * productivity_mod
 
 /obj/item/smithed_item/tool_bit/on_detached()
 	attached_tool.toolspeed = attached_tool.toolspeed / speed_mod
 	attached_tool.w_class -= size_mod
 	attached_tool.bit_failure_rate -= failure_rate
 	attached_tool.bit_efficiency_mod = attached_tool.bit_efficiency_mod / efficiency_mod
+	attached_tool.bit_productivity_mod = attached_tool.bit_productivity_mod / productivity_mod
 	attached_tool.attached_bits -= src
 	attached_tool = null
 
@@ -98,6 +105,7 @@
 	desc = "A tool bit that's fairly balanced in all aspects."
 	base_speed_mod = -0.1
 	failure_rate = 2
+	base_productivity_mod = 0.5
 	base_efficiency_mod = -0.1
 	secondary_goal_candidate = TRUE
 
@@ -110,6 +118,13 @@
 	size_mod = 1
 	durability = 120
 
+/obj/item/smithed_item/tool_bit/productivity
+	name = "productivity bit"
+	desc = "A tool bit that minimizes waste."
+	base_speed_mod = -0.1
+	base_productivity_mod = 2
+	durability = 50
+
 /obj/item/smithed_item/tool_bit/economical
 	name = "economical bit"
 	desc = "An advanced tool bit that maximises efficiency."
@@ -121,6 +136,7 @@
 	name = "advanced bit"
 	desc = "An advanced tool bit that's fairly balanced in all aspects."
 	base_speed_mod = -0.25
+	base_productivity_mod = 1
 	failure_rate = 2
 	base_efficiency_mod = -0.3
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

The productivity bit is a new tool bit the smith can make. When attached to a pickaxe, drill, shovel, or sonic jackhammer, this bit will increase the amount of ore mined and sand dug significantly, depending on material and quality.

## Why It's Good For The Game

It gives the smith something more to work with miners with, promoting cooperation and enhancing tools that are often unused (pickaxes).

## Testing

Added bit to drill. Drilled some sand, drilled some ore. Saw larger returns on investment.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  
![image](https://github.com/user-attachments/assets/ac23e323-b36e-4a21-a041-c2e372a1b96b)

<hr>

## Changelog

:cl:
add: Added productivity bit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
