### PR TITLE
Slight Touchup of Meta Toxins

### DIFF
--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -36240,10 +36240,13 @@
 	},
 /area/station/hallway/secondary/exit)
 "cRQ" = (
-/obj/machinery/alarm/directional/north,
 /obj/machinery/atmospherics/unary/thermomachine/freezer,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitepurple"
 	},
 /area/station/science/toxins/mixing)
 "cRS" = (
@@ -39888,14 +39891,6 @@
 	icon_state = "C9"
 	},
 /area/station/hallway/primary/central/north)
-"dER" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/station/science/toxins/mixing)
 "dFf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -40226,6 +40221,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -40923,7 +40919,8 @@
 "eeI" = (
 /obj/machinery/atmospherics/unary/thermomachine/heater,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitepurple"
 	},
 /area/station/science/toxins/mixing)
 "efd" = (
@@ -42216,10 +42213,10 @@
 /area/station/maintenance/aft)
 "eGn" = (
 /obj/structure/window/reinforced,
-/obj/structure/rack,
 /obj/item/extinguisher,
 /obj/item/clothing/mask/gas,
 /obj/item/grenade/chem_grenade/firefighting,
+/obj/structure/rack,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple"
@@ -43225,9 +43222,11 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "fbL" = (
-/obj/machinery/atmospherics/unary/portables_connector,
+/obj/machinery/atmospherics/trinary/mixer{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	dir = 1;
 	icon_state = "whitepurple"
 	},
 /area/station/science/toxins/mixing)
@@ -43913,6 +43912,9 @@
 /area/station/maintenance/fsmaint)
 "fpl" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -50046,6 +50048,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
+"hUJ" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "darkpurple"
+	},
+/area/station/science/toxins/mixing)
 "hUK" = (
 /obj/structure/table,
 /obj/item/hatchet,
@@ -52193,11 +52205,10 @@
 /turf/simulated/floor/engine,
 /area/station/maintenance/turbine)
 "iPW" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/requests_console/directional/north,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitepurple"
 	},
 /area/station/science/toxins/mixing)
 "iQm" = (
@@ -52440,9 +52451,12 @@
 	},
 /area/station/security/interrogation)
 "iVX" = (
-/obj/machinery/requests_console/directional/north,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitepurple"
 	},
 /area/station/science/toxins/mixing)
 "iWb" = (
@@ -56931,6 +56945,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
+"kUU" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple"
+	},
+/area/station/science/toxins/mixing)
 "kVn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/door_assembly/door_assembly_fre{
@@ -59744,6 +59767,17 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"mdT" = (
+/obj/structure/extinguisher_cabinet{
+	name = "east bump";
+	pixel_x = 27
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkpurple"
+	},
+/area/station/science/toxins/mixing)
 "mdZ" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -59899,6 +59933,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -61158,14 +61195,13 @@
 "mJt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whitepurplecorner"
 	},
 /area/station/science/toxins/mixing)
 "mJv" = (
@@ -64357,8 +64393,8 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
 "nYJ" = (
-/obj/structure/rack,
-/obj/item/rpd,
+/obj/machinery/computer/area_atmos,
+/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple"
@@ -65059,6 +65095,9 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -66517,6 +66556,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -67049,6 +67091,9 @@
 "piJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -68176,6 +68221,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -68968,12 +69016,10 @@
 	},
 /area/station/hallway/secondary/exit)
 "pZE" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal,
+/obj/machinery/alarm/directional/north,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitepurple"
 	},
 /area/station/science/toxins/mixing)
 "qal" = (
@@ -70045,6 +70091,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/rack,
+/obj/item/rpd,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple"
@@ -70384,6 +70432,16 @@
 	icon_state = "red"
 	},
 /area/station/security/main)
+"qEI" = (
+/obj/item/radio/intercom{
+	name = "east bump";
+	pixel_x = 28
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple"
+	},
+/area/station/science/toxins/mixing)
 "qEX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -76032,6 +76090,16 @@
 	icon_state = "dark"
 	},
 /area/station/legal/courtroom/gallery)
+"sYv" = (
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
+/obj/machinery/atmospherics/portable/canister,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/station/science/toxins/mixing)
 "sYJ" = (
 /obj/effect/landmark/start/botanist,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -80386,6 +80454,19 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass/no_creep,
 /area/station/science/research)
+"uVm" = (
+/obj/machinery/camera{
+	c_tag = "Science Toxins Mixing - Aft Starboard";
+	dir = 8;
+	network = list("Research","SS13")
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment/corner,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurple"
+	},
+/area/station/science/toxins/mixing)
 "uVp" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -80864,6 +80945,9 @@
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -82863,17 +82947,6 @@
 /obj/item/flag/syndi,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
-"waQ" = (
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/machinery/atmospherics/trinary/mixer,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurple"
-	},
-/area/station/science/toxins/mixing)
 "waX" = (
 /obj/effect/decal/cleanable/blood/writing,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -83074,10 +83147,9 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
 "wgF" = (
-/obj/machinery/economy/vending/plasmaresearch,
 /obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/economy/vending/plasmaresearch,
 /turf/simulated/floor/plasteel{
-	dir = 6;
 	icon_state = "darkpurple"
 	},
 /area/station/science/toxins/mixing)
@@ -84265,9 +84337,6 @@
 	dir = 1
 	},
 /obj/machinery/alarm/directional/east,
-/obj/machinery/computer/area_atmos{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
@@ -85400,16 +85469,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/east)
-"xhE" = (
-/obj/structure/extinguisher_cabinet{
-	name = "east bump";
-	pixel_x = 27
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkpurple"
-	},
-/area/station/science/toxins/mixing)
 "xhF" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -87456,22 +87515,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/atmos)
-"ybP" = (
-/obj/machinery/camera{
-	c_tag = "Science Toxins Mixing - Aft Starboard";
-	dir = 8;
-	network = list("Research","SS13")
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/portable/canister,
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurple"
-	},
-/area/station/science/toxins/mixing)
 "ybT" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -121960,7 +122003,7 @@ qwA
 eGn
 nYJ
 mgu
-naq
+kUU
 naq
 naq
 wZi
@@ -123250,7 +123293,7 @@ tDw
 tDw
 bXG
 iVX
-dER
+kgx
 fpl
 pIF
 qRR
@@ -123507,11 +123550,11 @@ tDw
 tDw
 bXG
 fbL
-waQ
-ybP
-xhE
+tvT
+fpl
+pIF
 wgF
-rOZ
+cEK
 abq
 aaa
 aaa
@@ -123763,12 +123806,12 @@ bXG
 bXG
 bXG
 bXG
+sYv
+qEI
+uVm
+mdT
+hUJ
 cEK
-cEK
-cEK
-cEK
-cEK
-rOZ
 abq
 aaa
 aaa
@@ -124019,13 +124062,13 @@ aaa
 aaa
 abq
 aef
-abq
-aaa
-aaa
-aaa
-aaa
-aaa
-abq
+cEK
+cEK
+cEK
+cEK
+cEK
+cEK
+cEK
 aef
 abq
 aaa


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Slightly enlarges the lower portion of toxins mixing.
- Rotates the toxins mixer.
- Moves the disposals unit so it doesn't block access to the thermomachine when a canister is wrenched to it.
- Fixes missing purple floor border.
- Relocates the area air control computer outside of toxins storage.
- Relocates the RPED rack to avoid a 1 tile wide section.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
- Less claustrophobic.
- Consistent floor patterning.
- Always-accessible thermomachine controls.
- I have realized that the entire point of the area control computer is that you can safely purge toxic spills without opening the door to the toxic spill. Cyberiad, Delta, and Emerald already follow this design principle.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/user-attachments/assets/03575a7b-a30e-4f94-a542-2644bc7e08f4)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Visual inspection of the area.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Slightly enlarged meta toxins.
tweak: Meta toxins scrubber control computer is now located outside toxins storage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
