### PR TITLE
fix tendrils spawning in deeprock oases

### DIFF
--- a/code/modules/lavaland/caves_theme.dm
+++ b/code/modules/lavaland/caves_theme.dm
@@ -114,10 +114,10 @@ GLOBAL_LIST_INIT(caves_default_flora_spawns, list(
 		if(safe_replace(NT) && prob(min(probmodifer / distance, 100)))
 			var/turf/changed = NT.ChangeTurf(/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface)
 			if(prob(5))
-				new /obj/effect/spawner/random/lavaland_fauna(T)
+				new /obj/effect/spawner/random/lavaland_fauna(changed)
 			else if(prob(10))
 				lavaland_caves_spawn_flora(changed)
-			oasis_turfs |= NT
+			oasis_turfs |= changed
 
 	if(prob(50))
 		tempradius = round(tempradius / 3)


### PR DESCRIPTION
## What Does This PR Do
This PR fixes tendrils spawning in oases, accidentally caused by #28968.
## Why It's Good For The Game
Miners should be able to get to tendrils.
## Testing
Ran several deeprock rounds, ensured tendrils didn't spawn in center of oases.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Lavaland tendrils should no longer spawn in the middle of deeprock lakes.
/:cl:
