### PR TITLE
Fix holopara action buttons remaining if your holopara gets gibbed

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -137,6 +137,7 @@
 		return FALSE
 	to_chat(summoner, "<span class='danger'>Your [name] died somehow!</span>")
 	UnregisterSignal(summoner, COMSIG_LIVING_HEALTH_UPDATE)
+	summoner.remove_guardian_actions()
 	summoner.death()
 
 
@@ -182,8 +183,10 @@
 
 /mob/living/simple_animal/hostile/guardian/gib()
 	if(summoner)
+		summoner.remove_guardian_actions()
 		to_chat(summoner, "<span class='danger'>Your [src] was blown up!</span>")
 		summoner.Weaken(20 SECONDS)// your fermillier has died! ROLL FOR CON LOSS!
+	UnregisterSignal(summoner, COMSIG_LIVING_HEALTH_UPDATE)
 	ghostize()
 	qdel(src)
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -826,9 +826,6 @@
 	return
 
 /mob/living/singularity_act()
-	// Incorporeal mobs have no mass
-	if(incorporeal_move)
-		return
 	investigate_log("([key_name(src)]) has been consumed by the singularity.",INVESTIGATE_SINGULO) //Oh that's where the clown ended up!
 	gib()
 	return 20

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -826,6 +826,9 @@
 	return
 
 /mob/living/singularity_act()
+	// Incorporeal mobs have no mass
+	if(incorporeal_move)
+		return
 	investigate_log("([key_name(src)]) has been consumed by the singularity.",INVESTIGATE_SINGULO) //Oh that's where the clown ended up!
 	gib()
 	return 20


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #27801. The issue ended up being only the UI remaining on the summoner when the holopara is gibbed. All other behaviour is as intended
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
bugfix
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
- Went into scout mode as a ranged holopara and went across a singularity
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Holopara actions buttons are correctly removed from summoner on holopara gibbing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
