### PR TITLE
add basic mobs to orbit menu

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -404,6 +404,8 @@
 		moblist.Add(M)
 	for(var/mob/living/simple_animal/M in sortmob)
 		moblist.Add(M)
+	for(var/mob/living/basic/M in sortmob)
+		moblist.Add(M)
 	return moblist
 
 // Format a power value in W, kW, MW, or GW.


### PR DESCRIPTION
## What Does This PR Do
This PR ensures that basic mobs are visible in the Orbit menu.
## Why It's Good For The Game
Orbit menu should be exhaustive.
## Testing
![2025_04_16__10_18_13__](https://github.com/user-attachments/assets/c59ebd5f-c265-41f5-b3a4-255a4ce21d83)
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Mobs using the new AI controllers should probably appear in the Orbit menu.
/:cl: