### PR TITLE
Chair rotation fix

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -162,8 +162,6 @@
 /obj/structure/chair/wood/narsie_act()
 	return
 
-/obj/structure/chair/Bump()
-
 /obj/structure/chair/wood/wings
 	icon_state = "wooden_chair_wings"
 	item_chair = /obj/item/chair/wood/wings

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -103,7 +103,6 @@
 		rotate()
 
 /obj/structure/chair/proc/handle_rotation()
-	SIGNAL_HANDLER //COMSIG_ATOM_DIR_CHANGE
 	handle_layer()
 	if(has_buckled_mobs())
 		for(var/m in buckled_mobs)

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -22,7 +22,11 @@
 	/// Used to handle rotation properly, should only be 1, 4, or 8
 	var/possible_dirs = 4
 	/// Will it set to the layer above the player or not? Use with Armrests.
-	var/uses_armrest = FALSE 
+	var/uses_armrest = FALSE
+
+/obj/structure/chair/setDir(newdir)
+	. = ..()
+	handle_rotation()
 
 /obj/structure/chair/examine(mob/user)
 	. = ..()
@@ -33,10 +37,6 @@
 		var/obj/structure/chair/wood/W = new/obj/structure/chair/wood(get_turf(src))
 		W.setDir(dir)
 		qdel(src)
-
-/obj/structure/chair/Move(atom/newloc, direct = 0, glide_size_override = 0, update_dir = TRUE)
-	. = ..()
-	handle_rotation()
 
 /obj/structure/chair/attackby__legacy__attackchain(obj/item/W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/assembly/shock_kit))
@@ -102,12 +102,13 @@
 	else
 		rotate()
 
-/obj/structure/chair/proc/handle_rotation(direction)
+/obj/structure/chair/proc/handle_rotation()
+	SIGNAL_HANDLER //COMSIG_ATOM_DIR_CHANGE
 	handle_layer()
 	if(has_buckled_mobs())
 		for(var/m in buckled_mobs)
 			var/mob/living/buckled_mob = m
-			buckled_mob.setDir(direction)
+			buckled_mob.setDir(dir)
 
 /obj/structure/chair/proc/handle_layer()
 	if(possible_dirs == 8) // We don't want chairs with corner dirs to sit over mobs, it is handled by armrests
@@ -126,10 +127,6 @@
 	. = ..()
 	handle_layer()
 
-/obj/structure/chair/setDir(newdir)
-	..()
-	handle_rotation(newdir)
-
 /obj/structure/chair/AltClick(mob/user)
 	if(user.stat || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !Adjacent(user) || is_ventcrawling(user))
 		return
@@ -144,7 +141,6 @@
 
 /obj/structure/chair/proc/rotate()
 	setDir(turn(dir, (360 / possible_dirs)))
-	handle_rotation()
 
 // Chair types
 /obj/structure/chair/light
@@ -165,6 +161,8 @@
 
 /obj/structure/chair/wood/narsie_act()
 	return
+
+/obj/structure/chair/Bump()
 
 /obj/structure/chair/wood/wings
 	icon_state = "wooden_chair_wings"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -212,7 +212,9 @@
 		stop_pulling()
 	var/current_dir
 	if(isliving(AM))
-		current_dir = AM.dir
+		var/mob/living/living_mob = AM
+		if(!living_mob.buckled)
+			current_dir = AM.dir
 	if(AM.Move(get_step(AM.loc, t), t, glide_size))
 		Move(get_step(loc, t), t)
 	if(current_dir)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fix #29001 and #27993 by making buckled mobs not reset their direction when pushed
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
bugfix
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Buckled mobs now change directions with the chair when pushed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
