### PR TITLE
Fix `check_ghost_client()` runtime + improve examine/hud conditions

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1766,7 +1766,7 @@
 
 /datum/mind/proc/check_ghost_client()
 	var/mob/dead/observer/G = get_ghost()
-	if(G.client)
+	if(G?.client)
 		return TRUE
 
 /datum/mind/proc/grab_ghost(force)

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -206,7 +206,7 @@
 	if(stat == DEAD || HAS_TRAIT(src, TRAIT_FAKEDEATH))
 		var/revivable_state = "dead"
 		if(ghost_can_reenter()) // Not DNR or AntagHUD
-			if((ismachineperson(src) && client) || (!ismachineperson(src) && timeofdeath && is_revivable()))
+			if((ismachineperson(src) && (client || check_ghost_client())) || (!ismachineperson(src) && timeofdeath && is_revivable()))
 				revivable_state = "flatline"
 			else if(get_ghost() || key)
 				revivable_state = "hassoul"

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -255,7 +255,7 @@
 			msg += "<span class='deadsay'>[p_they(TRUE)] [p_are()] limp and unresponsive"
 			if(get_int_organ(/obj/item/organ/internal/brain) && !client) // body has no online player inside - let's look for ghost
 				if(!check_ghost_client()) // our ghost is offline or no ghost attached to body
-					msg += "; there are no signs of lifes"
+					msg += "; there are no signs of life"
 				if(!get_ghost() && !key) // no ghost attached to body
 					msg += " and [p_their()] soul has departed"
 			msg += "...</span>\n"

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -253,10 +253,10 @@
 			msg += "<span class='warning'>[p_they(TRUE)] appear[p_s()] to have committed suicide... there is no hope of recovery.</span>\n"
 		if(!just_sleeping)
 			msg += "<span class='deadsay'>[p_they(TRUE)] [p_are()] limp and unresponsive"
-			if(get_int_organ(/obj/item/organ/internal/brain) && !key)
-				if(!check_ghost_client())
-					msg += "; there are no signs of life"
-				if(!get_ghost())
+			if(get_int_organ(/obj/item/organ/internal/brain) && !client) // body has no online player inside - let's look for ghost
+				if(!check_ghost_client()) // our ghost is offline or no ghost attached to body
+					msg += "; there are no signs of lifes"
+				if(!get_ghost() && !key) // no ghost attached to body
 					msg += " and [p_their()] soul has departed"
 			msg += "...</span>\n"
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes #29013
Makes examine conditions work even if player left server being inside his dead body (not as a ghost) - it's displayed properly now
Fixes case when IPC player dies, ghost decides to fly around and his body is displayed with improper icon - gray static line instead of a blue pulsating one

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Fixes and improvements are good

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

This time tested more with 2 differents sessions on local server. Runtime is gone; hud and examine descriptions display properly when player leaves a server or joins back

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Dead IPCs now have a proper diagnostic HUD icon.
fix: You are now properly displayed as inactive for other players when you leave a server being located in your dead body.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
