### PR TITLE
Added a few non-lethal SHAME suicide paths for the disabler.

### DIFF
--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -107,7 +107,7 @@
 	return ..()
 
 /obj/item/gun/energy/disabler/suicide_act(mob/user)
-	user.visible_message("<span class='suicide'>[user] is putting the barrel of [src] in [user.p_their()] mouth.  It looks like [user.p_theyre()] trying to shirk [user.p_their()] reponsibilities!</span>")
+	user.visible_message("<span class='suicide'>[user] is putting the barrel of [src] in [user.p_their()] mouth.  It looks like [user.p_theyre()] trying to shirk [user.p_their()] responsibilities!</span>")
 	sleep(25)
 	if(user.is_holding(src))
 		if(can_shoot())
@@ -118,7 +118,7 @@
 		else
 			playsound(loc, 'sound/weapons/empty.ogg', 50, TRUE, -1)
 	else
-		user.visible_message("<span class='suicide'>[user] fumbles [src]!  [user.p_they(TRUE)] can't even get this right!</span>")
+		user.visible_message("<span class='suicide'>[user] fumbles [src]! [user.p_they(TRUE)] can't even get this right!</span>")
 	return SHAME
 
 //////////////////////////////

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -106,6 +106,21 @@
 
 	return ..()
 
+/obj/item/gun/energy/disabler/suicide_act(mob/user)
+	user.visible_message("<span class='suicide'>[user] is putting the barrel of [src] in [user.p_their()] mouth.  It looks like [user.p_theyre()] trying to shirk [user.p_their()] reponsibilities!</span>")
+	sleep(25)
+	if(user.is_holding(src))
+		if(can_shoot())
+			playsound(loc, fire_sound, 50, TRUE, -1)
+			var/obj/item/ammo_casing/energy/shot = ammo_type[select]
+			cell.use(shot.e_cost)
+			update_icon()
+		else
+			playsound(loc, 'sound/weapons/empty.ogg', 50, TRUE, -1)
+	else
+		user.visible_message("<span class='suicide'>[user] fumbles [src]!  [user.p_they(TRUE)] can't even get this right!</span>")
+	return SHAME
+
 //////////////////////////////
 // MARK: DISABLER SMG
 //////////////////////////////

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -107,7 +107,7 @@
 	return ..()
 
 /obj/item/gun/energy/disabler/suicide_act(mob/user)
-	user.visible_message("<span class='suicide'>[user] is putting the barrel of [src] in [user.p_their()] mouth.  It looks like [user.p_theyre()] trying to shirk [user.p_their()] responsibilities!</span>")
+	user.visible_message("<span class='suicide'>[user] is putting the barrel of [src] in [user.p_their()] mouth. It looks like [user.p_theyre()] trying to shirk [user.p_their()] responsibilities!</span>")
 	sleep(25)
 	if(user.is_holding(src))
 		if(can_shoot())


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Adds nonlethal suicide for the disabler as a little treat for security players, since it's supposed to be a non-lethal weapon and it will currently just melt you face like any other energy weapon.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Just a little extra shenanigans for one of the more high-stress jobs on the station.  Also considering the disabler is the widest availability non-lethal, it might be expected that going through certain motions would also have a non-lethal result during phases where security has too much time on their hands.

I was originally considering doing a few other non-lethal weapons, and then I got into select-fire weapons, and then the changes just got too big with too much duplicated code, so I reined it back in to just a bit of extra flavor on the vanilla disabler.


<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

A few revs just to tweak things to taste with minimal chatter.  Ultimately it's a very simple change.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog



:cl:
add: suicide_act for the disabler
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
