### PR TITLE
Smith Polish: Lenses for Turrets

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -73,6 +73,8 @@
 	var/initial_eprojectile = null
 	/// What non-lethal mode projectile with the turret start with?
 	var/initial_projectile = null
+	/// What lens is fitted to the turret/gun?
+	var/obj/item/smithed_item/lens/fitted_lens
 
 
 /obj/machinery/porta_turret/Initialize(mapload)
@@ -381,6 +383,10 @@ GLOBAL_LIST_EMPTY(turret_icons)
 		if(installation)
 			var/obj/item/gun/energy/Gun = new installation(loc)
 			Gun.cell.charge = gun_charge
+			if(fitted_lens)
+				Gun.current_lens = fitted_lens
+				fitted_lens.forceMove(Gun)
+				Gun.current_lens.on_attached(Gun)
 			Gun.update_icon()
 		if(prob(50))
 			new /obj/item/stack/sheet/metal(loc, rand(1,4))
@@ -389,6 +395,18 @@ GLOBAL_LIST_EMPTY(turret_icons)
 	else
 		to_chat(user, "<span class='notice'>You remove the turret but did not manage to salvage anything.</span>")
 	qdel(src) // qdel
+
+/obj/machinery/porta_turret/screwdriver_act(mob/living/user, obj/item/I)
+	if(user.a_intent != INTENT_HELP)
+		return FALSE
+
+	if(!fitted_lens)
+		to_chat(user, "<span class='notice'>[src] has no attached lenses.</span>")
+		return
+	to_chat(user, "<span class='notice'>You remove the lens from [src]</span>")
+	user.put_in_hands(fitted_lens)
+	fitted_lens = null
+	return TRUE
 
 /obj/machinery/porta_turret/item_interaction(mob/living/user, obj/item/used, list/modifiers)
 	if((stat & BROKEN) && !syndicate)
@@ -404,6 +422,17 @@ GLOBAL_LIST_EMPTY(turret_icons)
 		else
 			to_chat(user, "<span class='notice'>Access denied.</span>")
 
+		return ITEM_INTERACT_COMPLETE
+
+	if(istype(used, /obj/item/smithed_item/lens))
+		if(used.flags & NODROP || !user.drop_item() || !used.forceMove(src))
+			to_chat(user, "<span class='warning'>[used] is stuck to your hand!</span>")
+			return ITEM_INTERACT_COMPLETE
+		var/obj/item/smithed_item/lens/new_lens = used
+		if(fitted_lens)
+			to_chat(user, "<span class='notice'>You swap the fitted lens in [src].</span>")
+			user.put_in_hands(fitted_lens)
+		fitted_lens = new_lens
 		return ITEM_INTERACT_COMPLETE
 
 	if(user.a_intent == INTENT_HELP)
@@ -759,7 +788,7 @@ GLOBAL_LIST_EMPTY(turret_icons)
 		return
 
 	if(!emagged)	//if it hasn't been emagged, cooldown before shooting again
-		if((last_fired + shot_delay > world.time) || !raised)
+		if((last_fired + (shot_delay / fitted_lens.fire_rate_mult) > world.time) || !raised)
 			return
 		last_fired = world.time
 
@@ -779,9 +808,16 @@ GLOBAL_LIST_EMPTY(turret_icons)
 			A = new projectile(loc)
 			playsound(loc, shot_sound, 75, 1)
 
+	var/lens_power_mult = 1
+	if(fitted_lens)
+		A.damage = A.damage * fitted_lens.damage_mult
+		A.stamina = A.damage * fitted_lens.damage_mult
+		A.speed = A.speed / fitted_lens.laser_speed_mult
+		lens_power_mult = fitted_lens.power_mult
+
 	// Lethal/emagged turrets use twice the power due to higher energy beams
 	// Emagged turrets again use twice as much power due to higher firing rates
-	use_power(reqpower * (2 * (emagged || lethal)) * (2 * emagged))
+	use_power(lens_power_mult * (reqpower * (2 * (emagged || lethal)) * (2 * emagged)))
 
 	if(istype(A))
 		A.original = target
@@ -868,6 +904,8 @@ GLOBAL_LIST_EMPTY(turret_icons)
 	var/finish_name="turret"	//the name applied to the product turret
 	var/installation = null		//the gun type installed
 	var/gun_charge = 0			//the gun charge of the gun type installed
+	/// The lens attached to the gun used
+	var/obj/item/smithed_item/lens/gun_lens
 
 /obj/machinery/porta_turret_construct/item_interaction(mob/living/user, obj/item/used, list/modifiers)
 	//this is a bit unwieldy but self-explanatory
@@ -925,6 +963,7 @@ GLOBAL_LIST_EMPTY(turret_icons)
 					return ITEM_INTERACT_COMPLETE
 				installation = used.type //installation becomes used.type
 				gun_charge = E.cell.charge //the gun's charge is stored in gun_charge
+				gun_lens = E.current_lens
 				to_chat(user, "<span class='notice'>You add [used] to the turret.</span>")
 
 				if(istype(E, /obj/item/gun/energy/laser/tag/blue))
@@ -1018,6 +1057,8 @@ GLOBAL_LIST_EMPTY(turret_icons)
 		Turret.name = finish_name
 		Turret.installation = installation
 		Turret.gun_charge = gun_charge
+		gun_lens.forceMove(Turret)
+		Turret.fitted_lens = gun_lens
 		Turret.enabled = FALSE
 		Turret.setup()
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Makes lenses applicable to turrets, such as AI turrets and custom built ones. Lenses can either be used on the completed turret, or it will inherit the lens from the gun used in construction.

## Why It's Good For The Game

Using eguns to make turrets would lead one to think that modifications attached to those eguns do something.

## Testing

Built LWAP turrets. One had no lens, one had an admin lens. Admin lens hit harder and shot marginally faster, with a faster projectile speed, than the turret without.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
![image](https://github.com/user-attachments/assets/7247caa5-60f4-4a63-b3ea-d1abd8256637)
![image](https://github.com/user-attachments/assets/60de5415-334d-4ce3-9514-d0673fa2fbcc)

<hr>

## Changelog

:cl:
add: Added ability to insert lenses into energy turrets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
