### PR TITLE
[Fix] prevents external airlocks from getting deadlocked

### DIFF
--- a/code/game/machinery/airlock_control/airlock_controllers.dm
+++ b/code/game/machinery/airlock_control/airlock_controllers.dm
@@ -158,13 +158,19 @@
 	switch(state)
 		if(CONTROL_STATE_PREPARE)
 			if(check_doors_secured())
-				if(chamber_pressure <= target_pressure)
+				if(chamber_pressure < target_pressure)
 					state = CONTROL_STATE_PRESSURIZE
 					signalPumps(TRUE, TRUE, target_pressure)	//send a signal to start pressurizing
 
 				else if(chamber_pressure > target_pressure)
 					state = CONTROL_STATE_DEPRESSURIZE
 					signalPumps(TRUE, FALSE, target_pressure)	//send a signal to start depressurizing
+
+				else // Prevent airlock from deadlocking
+					cycleDoors(target_state)
+
+					state = CONTROL_STATE_IDLE
+					target_state = TARGET_NONE
 
 				//Check for vacuum - this is set after the pumps so the pumps are aiming for 0
 				if(!target_pressure)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds specific handling for when the chamber pressure matches the target pressure, preventing from the airlock deadlocking itself.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Airlocks should facilitate traversal between station and space, not prevent it. Also, functions as expected and I saw an engineer nearly die due to getting stuck outside.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
https://github.com/user-attachments/assets/245caae9-ef14-491a-884f-42d9fc5f1c7a


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
See video.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: External airlocks won't deadlock themselves.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
