### PR TITLE
Makes Mantis Blades Cheaper

### DIFF
--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -957,7 +957,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	Can be used to parry incoming melee attacks."
 	reference = "MBK"
 	item = /obj/item/storage/box/syndie_kit/syndie_mantis
-	cost = 75
+	cost = 50
 	surplus = 0
 	can_discount = FALSE
 	excludefrom = list(UPLINK_TYPE_NUCLEAR)

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -403,7 +403,7 @@
 	name = "'Scylla' mantis blade implant"
 	desc = "A reverse-engineered mantis blade implant. While the monomolecular edge was lost, they remain deadly weapons."
 	id = "mantis_blade_nt"
-	req_tech = list("materials" = 7, "engineering" = 6, "combat" = 7, "syndicate" = 6)
+	req_tech = list("materials" = 7, "engineering" = 6, "combat" = 7, "syndicate" = 4)
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 6 SECONDS
 	materials = list(MAT_METAL = 10000, MAT_SILVER = 2000, MAT_GOLD = 2000, MAT_TITANIUM = 3000, MAT_DIAMOND = 4000)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

What it says on the tin. Syndicate mantis blades now cost 50 TC. They still cannot be obtained from surplus or be discounted, per balance's request.

Nanotrasen mantis blades now only require illegals 4 instead of illegals 6.

## Why It's Good For The Game

Mantis blades got nerfed into the ground, and yet are prohibitively expensive still while there are much much better things available. This makes them more than a meme choice.

It also makes nanotrasen mantis blades not require the insurmountably high illegals 6 to obtain.

## Testing

Compiled.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
![image](https://github.com/user-attachments/assets/4653593b-bbcb-428a-ad99-3f1f2fdab807)

<hr>

## Changelog

:cl:
tweak: Cheapened mantis blades
tweak: Reduced research requirements for NT mantis blades
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
