### PR TITLE
Removes Redtext and Greentext

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -56,54 +56,44 @@ GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","E
 
 /datum/game_mode/proc/auto_declare_completion_changeling()
 	if(length(changelings))
-		var/list/text = list("<FONT size = 3><B>The changelings were:</B></FONT>")
+		var/list/text = list("<br><FONT size = 3><B>The changelings were:</B></FONT>")
 		for(var/datum/mind/changeling in changelings)
 			var/changelingwin = TRUE
 
-			text += "<br>[changeling.get_display_key()] was [changeling.name] ("
+			text += "<br>[changeling.get_display_key()] was [changeling.name] and "
 			if(changeling.current)
 				if(changeling.current.stat == DEAD)
-					text += "died"
+					text += "<span class='bold'>died</span>!"
 				else
-					text += "survived"
+					text += "<span class='bold'>survived</span>"
 				if(changeling.current.real_name != changeling.name)
 					text += " as [changeling.current.real_name]"
+				else
+					text += "!"
 			else
-				text += "body destroyed"
+				text += "<span class='bold'>had [changeling.p_their()] body destroyed</span>!"
 				changelingwin = FALSE
-			text += ")"
-
-			//Removed sanity if(changeling) because we -want- a runtime to inform us that the changelings list is incorrect and needs to be fixed.
-			var/datum/antagonist/changeling/cling = changeling.has_antag_datum(/datum/antagonist/changeling)
-			text += "<br><b>Changeling ID:</b> [cling.changelingID]."
-			text += "<br><b>Genomes Extracted:</b> [cling.absorbed_count]"
 
 			var/list/all_objectives = changeling.get_all_objectives(include_team = FALSE)
 
 			if(length(all_objectives))
-				var/count = 1
 				for(var/datum/objective/objective in all_objectives)
 					if(objective.check_completion())
-						text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='green'><B>Success!</B></font>"
 						if(istype(objective, /datum/objective/steal))
 							var/datum/objective/steal/S = objective
 							SSblackbox.record_feedback("nested tally", "changeling_steal_objective", 1, list("Steal [S.steal_target]", "SUCCESS"))
 						else
 							SSblackbox.record_feedback("nested tally", "changeling_objective", 1, list("[objective.type]", "SUCCESS"))
 					else
-						text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='red'>Fail.</font>"
 						if(istype(objective, /datum/objective/steal))
 							var/datum/objective/steal/S = objective
 							SSblackbox.record_feedback("nested tally", "changeling_steal_objective", 1, list("Steal [S.steal_target]", "FAIL"))
 						else
 							SSblackbox.record_feedback("nested tally", "changeling_objective", 1, list("[objective.type]", "FAIL"))
 						changelingwin = 0
-					count++
 
 			if(changelingwin)
-				text += "<br><font color='green'><B>The changeling was successful!</B></font>"
 				SSblackbox.record_feedback("tally", "changeling_success", 1, "SUCCESS")
 			else
-				text += "<br><font color='red'><B>The changeling has failed.</B></font>"
 				SSblackbox.record_feedback("tally", "changeling_success", 1, "FAIL")
 		return text.Join("")

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -521,20 +521,22 @@
 	var/jobtext = ""
 	if(ply.assigned_role)
 		jobtext = " the <b>[ply.assigned_role]</b>"
-	var/text = "<b>[ply.get_display_key()]</b> was <b>[ply.name]</b>[jobtext] and"
+	var/text = "<br><b>[ply.get_display_key()]</b> was <b>[ply.name]</b>[jobtext] and "
 	if(ply.current)
 		if(ply.current.stat == DEAD)
-			text += " <span class='redtext'>died</span>"
+			text += "<span class='bold'>died!</span>"
 		else
-			text += " <span class='greentext'>survived</span>"
+			text += "<span class='bold'>survived</span>"
 		if(fleecheck)
 			var/turf/T = get_turf(ply.current)
 			if(!T || !is_station_level(T.z))
-				text += " while <span class='redtext'>fleeing the station</span>"
+				text += " while <span class='bold'>fleeing the station</span>"
 		if(ply.current.real_name != ply.name)
-			text += " as <b>[ply.current.real_name]</b>"
+			text += "as <b>[ply.current.real_name]</b>"
+		else
+			text += "!"
 	else
-		text += " <span class='redtext'>had [ply.p_their()] body destroyed</span>"
+		text += "<span class='bold'>had [ply.p_their()] body destroyed</span>"
 	return text
 
 /proc/printeventplayer(datum/mind/ply)

--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -62,12 +62,6 @@
 	return ..()
 
 /datum/game_mode/abduction/declare_completion()
-	for(var/datum/team/abductor/team in actual_abductor_teams)
-		var/obj/machinery/abductor/console/console = get_team_console(team.team_number)
-		if(console.experiment.points >= team.experiment_objective.target_amount)
-			to_chat(world, "<span class='greenannounce'>[team.name] team fulfilled its mission!</span>")
-		else
-			to_chat(world, "<span class='boldannounceic'>[team.name] team failed its mission.</span>")
 	..()
 	return 1
 
@@ -78,14 +72,10 @@
 		for(var/datum/mind/abductor_mind in abductors)
 			text += printplayer(abductor_mind)
 			text += "<br>"
-			text += printobjectives(abductor_mind)
-			text += "<br>"
 		if(length(abductees))
 			text += "<br><span class='big'><b>The abductees were:</b></span><br>"
 			for(var/datum/mind/abductee_mind in abductees)
 				text += printplayer(abductee_mind)
-				text += "<br>"
-				text += printobjectives(abductee_mind)
 				text += "<br>"
 		return text.Join("")
 

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -82,7 +82,7 @@
 
 /datum/game_mode/proc/auto_declare_completion_traitor()
 	if(length(traitors))
-		var/list/text = list("<FONT size = 2><B>The traitors were:</B></FONT><br>")
+		var/list/text = list("<FONT size = 3><B>The traitors were:</B></FONT>")
 		for(var/datum/mind/traitor in traitors)
 			var/traitorwin = TRUE
 			text += printplayer(traitor)
@@ -102,62 +102,33 @@
 			var/all_objectives = traitor.get_all_objectives(include_team = FALSE)
 
 			if(length(all_objectives))//If the traitor had no objectives, don't need to process this.
-				var/count = 1
 				for(var/datum/objective/objective in all_objectives)
 					if(objective.check_completion())
-						text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='green'><B>Success!</B></font>"
 						if(istype(objective, /datum/objective/steal))
 							var/datum/objective/steal/S = objective
 							SSblackbox.record_feedback("nested tally", "traitor_steal_objective", 1, list("Steal [S.steal_target]", "SUCCESS"))
 						else
 							SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[objective.type]", "SUCCESS"))
 					else
-						text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='red'>Fail.</font>"
 						if(istype(objective, /datum/objective/steal))
 							var/datum/objective/steal/S = objective
 							SSblackbox.record_feedback("nested tally", "traitor_steal_objective", 1, list("Steal [S.steal_target]", "FAIL"))
 						else
 							SSblackbox.record_feedback("nested tally", "traitor_objective", 1, list("[objective.type]", "FAIL"))
 						traitorwin = FALSE
-					count++
-
-			var/special_role_text
-			if(traitor.special_role)
-				special_role_text = lowertext(traitor.special_role)
-			else
-				special_role_text = "antagonist"
 
 			var/datum/contractor_hub/H = LAZYACCESS(GLOB.contractors, traitor)
 			if(H)
-				var/count = 1
 				var/earned_tc = H.reward_tc_paid_out
-				for(var/c in H.contracts)
-					var/datum/syndicate_contract/C = c
-					// Locations
-					var/locations = list()
-					for(var/a in C.contract.candidate_zones)
-						var/area/A = a
-						locations += (A == C.contract.extraction_zone ? "<b><u>[A.map_name]</u></b>" : A.map_name)
-					var/display_locations = english_list(locations, and_text = " or ")
-					// Result
-					var/result = ""
-					if(C.status == CONTRACT_STATUS_COMPLETED)
-						result = "<font color='green'><B>Success!</B></font>"
-					else if(C.status != CONTRACT_STATUS_INACTIVE)
-						result = "<font color='red'>Fail.</font>"
-					text += "<br><font color='orange'><B>Contract #[count]</B></font>: Kidnap and extract [C.target_name] at [display_locations]. [result]"
-					count++
 				text += "<br><font color='orange'><B>[earned_tc] TC were earned from the contracts.</B></font>"
 
 			if(traitorwin)
-				text += "<br><font color='green'><B>The [special_role_text] was successful!</B></font><br>"
 				SSblackbox.record_feedback("tally", "traitor_success", 1, "SUCCESS")
 			else
-				text += "<br><font color='red'><B>The [special_role_text] has failed!</B></font><br>"
 				SSblackbox.record_feedback("tally", "traitor_success", 1, "FAIL")
 
 		if(length(SSticker.mode.implanted))
-			text += "<br><br><FONT size = 2><B>The mindslaves were:</B></FONT><br>"
+			text += "<br><FONT size = 3><B>The mindslaves were:</B></FONT><br>"
 			for(var/datum/mind/mindslave in SSticker.mode.implanted)
 				text += printplayer(mindslave)
 				var/datum/mind/master_mind = SSticker.mode.implanted[mindslave]
@@ -167,6 +138,6 @@
 		var/responses = jointext(GLOB.syndicate_code_response, ", ")
 
 		text += "<br><br><b>The code phrases were:</b> <span class='danger'>[phrases]</span><br>\
-					<b>The code responses were:</b> <span class='danger'>[responses]</span><br><br>"
+					<b>The code responses were:</b> <span class='danger'>[responses]</span>"
 
 		return text.Join("")

--- a/code/game/gamemodes/vampire/vampire_gamemode.dm
+++ b/code/game/gamemodes/vampire/vampire_gamemode.dm
@@ -50,55 +50,44 @@
 	if(!length(vampires))
 		return
 
-	var/list/text = list("<FONT size = 2><B>The vampires were:</B></FONT>")
+	var/list/text = list("<br><FONT size = 3><B>The vampires were:</B></FONT>")
 	for(var/datum/mind/vampire in vampires)
 		var/traitorwin = TRUE
 		var/datum/antagonist/vampire/V = vampire.has_antag_datum(/datum/antagonist/vampire)
-		text += "<br>[vampire.get_display_key()] was [vampire.name] ("
+		text += "<br>[vampire.get_display_key()] was [vampire.name] and "
 		if(vampire.current)
 			if(vampire.current.stat == DEAD)
-				text += "died"
+				text += "<span class='bold'>died!</span>"
 			else
-				text += "survived"
+				text += "<span class='bold'>survived</span>"
 				if(V.subclass)
-					text += " as a [V.subclass.name]"
+					text += "as a [V.subclass.name]!"
+				else
+					text += "!"
 		else
-			text += "body destroyed"
-		text += ")"
+			text += "<span class='bold'>had [vampire.p_their()] body destroyed!</span>"
 
 		var/list/all_objectives = vampire.get_all_objectives(include_team = FALSE)
 
 		if(length(all_objectives))//If the traitor had no objectives, don't need to process this.
-			var/count = 1
 			for(var/datum/objective/objective in all_objectives)
 				if(objective.check_completion())
-					text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='green'><B>Success!</B></font>"
 					if(istype(objective, /datum/objective/steal))
 						var/datum/objective/steal/S = objective
 						SSblackbox.record_feedback("nested tally", "vampire_steal_objective", 1, list("Steal [S.steal_target]", "SUCCESS"))
 					else
 						SSblackbox.record_feedback("nested tally", "vampire_objective", 1, list("[objective.type]", "SUCCESS"))
 				else
-					text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='red'>Fail.</font>"
 					if(istype(objective, /datum/objective/steal))
 						var/datum/objective/steal/S = objective
 						SSblackbox.record_feedback("nested tally", "vampire_steal_objective", 1, list("Steal [S.steal_target]", "FAIL"))
 					else
 						SSblackbox.record_feedback("nested tally", "vampire_objective", 1, list("[objective.type]", "FAIL"))
 					traitorwin = FALSE
-				count++
-
-		var/special_role_text
-		if(vampire.special_role)
-			special_role_text = lowertext(vampire.special_role)
-		else
-			special_role_text = "antagonist"
 
 		if(traitorwin)
-			text += "<br><font color='green'><B>The [special_role_text] was successful!</B></font>"
 			SSblackbox.record_feedback("tally", "vampire_success", 1, "SUCCESS")
 		else
-			text += "<br><font color='red'><B>The [special_role_text] has failed!</B></font>"
 			SSblackbox.record_feedback("tally", "vampire_success", 1, "FAIL")
 	return text.Join("")
 
@@ -106,18 +95,19 @@
 	if(!length(vampire_enthralled))
 		return
 
-	var/list/text = list("<FONT size = 2><B>The Enthralled were:</B></FONT>")
+	var/list/text = list("<br><FONT size = 3><B>The Enthralled were:</B></FONT>")
 	for(var/datum/mind/mind in vampire_enthralled)
-		text += "<br>[mind.get_display_key()] was [mind.name] ("
+		text += "<br>[mind.get_display_key()] was [mind.name] and "
 		if(mind.current)
 			if(mind.current.stat == DEAD)
-				text += "died"
+				text += "<span class='bold'>died!</span>"
 			else
-				text += "survived"
+				text += "<span class='bold'>survived</span>"
 			if(mind.current.real_name != mind.name)
-				text += " as [mind.current.real_name]"
+				text += "<span class='bold'> as [mind.current.real_name]!</span>"
+			else
+				text += "<span class='bold'>!</span>"
 		else
-			text += "body destroyed"
-		text += ")"
+			text += "<span class='bold'>had their body destroyed!</span>"
 	return text.Join("")
 

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -60,39 +60,34 @@
 /datum/game_mode/proc/auto_declare_completion_wizard()
 	if(!length(wizards))
 		return
-	var/list/text = list("<br><font size=3><b>the wizards/witches were:</b></font>")
+	var/list/text = list("<br><font size=3><b>The wizards/witches were:</b></font>")
 
 	for(var/datum/mind/wizard in wizards)
 
-		text += "<br><b>[wizard.get_display_key()]</b> was <b>[wizard.name]</b> ("
+		text += "<br><b>[wizard.get_display_key()]</b> was <b>[wizard.name]</b> and "
 		if(wizard.current)
 			if(wizard.current.stat == DEAD)
-				text += "died"
+				text += "<span class='bold'>died!</span>"
 			else
-				text += "survived"
+				text += "<span class='bold'>survived</span>"
 			if(wizard.current.real_name != wizard.name)
 				text += " as <b>[wizard.current.real_name]</b>"
+			else
+				text += "!"
 		else
-			text += "body destroyed"
-		text += ")"
+			text += "<span class='bold'>had their body destroyed</span>!"
 
-		var/count = 1
 		var/wizardwin = 1
 		for(var/datum/objective/objective in wizard.get_all_objectives(include_team = FALSE))
 			if(objective.check_completion())
-				text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='green'><B>Success!</B></font>"
 				SSblackbox.record_feedback("nested tally", "wizard_objective", 1, list("[objective.type]", "SUCCESS"))
 			else
-				text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='red'>Fail.</font>"
 				SSblackbox.record_feedback("nested tally", "wizard_objective", 1, list("[objective.type]", "FAIL"))
 				wizardwin = 0
-			count++
 
 		if(wizard.current && wizard.current.stat != DEAD && wizardwin)
-			text += "<br><font color='green'><B>The wizard was successful!</B></font>"
 			SSblackbox.record_feedback("tally", "wizard_success", 1, "SUCCESS")
 		else
-			text += "<br><font color='red'><B>The wizard has failed!</B></font>"
 			SSblackbox.record_feedback("tally", "wizard_success", 1, "FAIL")
 		if(wizard.spell_list)
 			text += "<br><B>[wizard.name] used the following spells: </B>"

--- a/code/modules/antagonists/mind_flayer/mindflayer_gamemode.dm
+++ b/code/modules/antagonists/mind_flayer/mindflayer_gamemode.dm
@@ -3,53 +3,39 @@
 	if(!length(mindflayers))
 		return
 
-	var/list/text = list("<font size='2'><b>The mindflayers were:</b></font>")
+	var/list/text = list("<br><font size='3'><b>The mindflayers were:</b></font>")
 	for(var/datum/mind/mindflayer in mindflayers)
 		var/traitorwin = TRUE
-		text += "<br>[mindflayer.get_display_key()] was [mindflayer.name] ("
+		text += "<br>[mindflayer.get_display_key()] was [mindflayer.name] and "
 		if(mindflayer.current)
 			if(mindflayer.current.stat == DEAD)
-				text += "died"
+				text += "<span class='bold'>died</span>!"
 			else
-				text += "survived"
+				text += "<span class='bold'>survived</span>!"
 		else
-			text += "body destroyed"
-		text += ")"
+			text += "<span class='bold'>had [mindflayer.p_their()] body destroyed</span>!"
 
 		var/list/all_objectives = mindflayer.get_all_objectives()
 
 		if(length(all_objectives))//If the traitor had no objectives, don't need to process this.
-			var/count = 1
 			for(var/datum/objective/objective in all_objectives)
 				if(objective.check_completion())
-					text += "<br><b>Objective #[count]</b>: [objective.explanation_text] <font color='green'><b>Success!</b></font>"
 					if(istype(objective, /datum/objective/steal))
 						var/datum/objective/steal/S = objective
 						SSblackbox.record_feedback("nested tally", "mindflayer_steal_objective", 1, list("Steal [S.steal_target]", "SUCCESS"))
 					else
 						SSblackbox.record_feedback("nested tally", "mindflayer_objective", 1, list("[objective.type]", "SUCCESS"))
 				else
-					text += "<br><b>Objective #[count]</b>: [objective.explanation_text] <font color='red'>Fail.</font>"
 					if(istype(objective, /datum/objective/steal))
 						var/datum/objective/steal/S = objective
 						SSblackbox.record_feedback("nested tally", "mindflayer_steal_objective", 1, list("Steal [S.steal_target]", "FAIL"))
 					else
 						SSblackbox.record_feedback("nested tally", "mindflayer_objective", 1, list("[objective.type]", "FAIL"))
 					traitorwin = FALSE
-				count++
-
-		var/special_role_text
-		if(mindflayer.special_role)
-			special_role_text = lowertext(mindflayer.special_role)
-		else
-			special_role_text = "antagonist"
 
 		if(traitorwin)
-			text += "<br><font color='green'><b>The [special_role_text] was successful!</b></font>"
 			SSblackbox.record_feedback("tally", "mindflayer_success", 1, "SUCCESS")
 		else
-			text += "<br><font color='red'><b>The [special_role_text] has failed!</b></font>"
 			SSblackbox.record_feedback("tally", "mindflayer_success", 1, "FAIL")
-
 	return text.Join("")
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Reworks the post-round scorecard by removing the display for objectives and pass/fail for traitors, mindslaves, vampires, thalls, changelings, mindflayers, wizards, and abductors.

This does not affect the lizard named Greentext. He's cool.

## Why It's Good For The Game

One thing we want to move away from is the strong incentives to complete one's objectives at any cost. With the idea that the objectives of an antag are more of a set of guidelines for if the antag cannot think of an appropriate way to impact the round, this removes one of the incentives to "win" and hopefully will guide antag players to more RP-oriented play.

This also allows for more varied objectives. By getting rid of redtext and greentext, you open the door for objectives that are not programmatically verifiable, such as sabotaging a particular office or ensuring an area is filthy.

## Images of changes

![image](https://github.com/user-attachments/assets/5263db67-4955-49b9-a208-ec538ace3275)

## Testing

Spawned a shitload of antags. Ended the round.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>
![image](https://github.com/user-attachments/assets/b59427d0-faa4-4c1c-a41a-85f81c492144)

## Changelog

:cl:
del: Removed redtext
del: Removed greentext
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
