### PR TITLE
Standardise security and medical records examination (QOL)

### DIFF
--- a/code/modules/mob/living/carbon/human/human_examine.dm
+++ b/code/modules/mob/living/carbon/human/human_examine.dm
@@ -214,7 +214,7 @@
 		var/mental_status = hasHUD(user, EXAMINE_HUD_MEDICAL_WRITE) ? "<a href='byond://?src=[UID()];mental=1'>\[[mental]\]</a>" : "\[[mental]\]"
 		msg += "<span class='deptradio'>Physical status: </span>[medical_status]\n"
 		msg += "<span class='deptradio'>Mental Status: </span>[mental_status]\n"
-		msg += "<span class='deptradio'>Medical records:</span> <a href='byond://?src=[UID()];medrecord=`'>\[View\]</a> <a href='byond://?src=[UID()];medrecordadd=`'>\[Add comment\]</a>\n"
+		msg += "<span class='deptradio'>Medical records:</span> <a href='byond://?src=[UID()];medrecord=`'>\[View\]</a> <a href='byond://?src=[UID()];medrecordComment=`'>\[View comment log\]</a> <a href='byond://?src=[UID()];medrecordadd=`'>\[Add comment\]</a>\n"
 
 	if(hasHUD(user, EXAMINE_HUD_SECURITY_READ))
 		var/perpname = get_visible_name(TRUE)
@@ -237,7 +237,7 @@
 
 			var/criminal_status = hasHUD(user, EXAMINE_HUD_SECURITY_WRITE) ? "<a href='byond://?src=[UID()];criminal=1'>\[[criminal]\]</a>" : "\[[criminal]\]"
 			msg += "<span class='deptradio'>Criminal status:</span> [criminal_status]\n"
-			msg += "<span class='deptradio'>Security records:</span> <a href='byond://?src=[UID()];secrecordComment=`'>\[View comment log\]</a> <a href='byond://?src=[UID()];secrecordadd=`'>\[Add comment\]</a>\n"
+			msg += "<span class='deptradio'>Security records:</span> <a href='byond://?src=[UID()];secrecord=`'>\[View\]</a> <a href='byond://?src=[UID()];secrecordComment=`'>\[View comment log\]</a> <a href='byond://?src=[UID()];secrecordadd=`'>\[Add comment\]</a>\n"
 			msg += "<span class='deptradio'>Latest entry:</span> [commentLatest]\n"
 
 	if(hasHUD(user, EXAMINE_HUD_MALF_READ))


### PR DESCRIPTION
## What Does This PR Do

Allows security HUD users to read people's security records without needing to use a console.
Allows health HUD users to read people's comment logs without having to first open their entire medical record.

## Why It's Good For The Game

Security officers should be able to read people's security records without needing an entire console, this will help open more roleplay opportunities based on people's characters' lore.

Doctors should not have to flood their chat with people's health records every time they want to check if the CMO really allowed them to obtain LSD from medical chemistry.

## Images of changes

Before :
- Security HUD :
<img width="343" alt="Secrecord master" src="https://github.com/user-attachments/assets/2dde0810-5d26-4e2f-9681-16d8d0ffa227" />

- Health HUD :
<img width="346" alt="Medrecord Master" src="https://github.com/user-attachments/assets/860ef9fc-e046-4ed6-946d-351a7193b940" />


After :
- Security HUD : 
<img width="346" alt="Secrecord record viewing" src="https://github.com/user-attachments/assets/ba883a7f-ae84-443d-84c8-bf4708b2582a" />

- Health HUD :
<img width="346" alt="Medrecord comment log" src="https://github.com/user-attachments/assets/69ef980d-cd71-4118-bc36-7e7a19a61352" />

## Testing

- Tried to see someone's security record with a security HUD, I succeeded.
- Tried to see someone's medical record's comment logs with a health HUD, I succeeded.
- Tried to add comments on someone's medical record with a health HUD but no ID, I could not.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl:
tweak: Security HUDs now allow access to security records thanks to an improvement in wireless connections.
tweak: Medical HUDs now allow direct access to medical record's comment logs.
/:cl:
