### PR TITLE
Warning if clients are still on 515

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -457,6 +457,7 @@
 		tooltips = new /datum/tooltip(src)
 
 	Master.UpdateTickRate()
+	INVOKE_ASYNC(src, TYPE_PROC_REF(/client, nag_516))
 
 	// Tell clients about active testmerges
 	if(world.TgsAvailable() && length(GLOB.revision_info.testmerges))
@@ -1337,6 +1338,18 @@
 		return
 
 	window_scaling = text2num(winget(src, null, "dpi"))
+
+// This is in its own proc so we can async it out
+/client/proc/nag_516()
+	if(byond_version >= 516)
+		return
+
+	var/choice = alert(src, "Warning - You are currently on BYOND version [byond_version].[byond_build]. Soon, Paradise will start enforcing 516 as the minimum required version, and 515 will no longer work. Please update now to avoid being unable to play in the future.", "BYOND Version Warning", "Update Now", "Ignore for now")
+	if(choice != "Update Now")
+		return
+
+	src << link("https://secure.byond.com/download/")
+
 
 #undef LIMITER_SIZE
 #undef CURRENT_SECOND


### PR DESCRIPTION
## What Does This PR Do
This is gonna annoy a lot of people, but needs to be done.

Not only is a 516 not compatible with 515 clients, but the split between IE-Trident and Webview is causing a lot of inconsistencies within TGUI and other things, and developing perfect support is not in our appetite given one is going to be deprecated.

# If there are bugs with 516, PLEASE REPORT THEM SO WE CAN GET IT SORTED

## Why It's Good For The Game
We need to move on

## Images of changes
Only shows if youre on 515
![image](https://github.com/user-attachments/assets/51f83297-7c3b-4d6f-a76f-02f65cf570d5)


## Testing
Tested on 515, saw message
Tested on 516, no message

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl: AffectedArc07
add: Added a warning if you are on old BYOND
/:cl:
