### PR TITLE
Making the Rapid Crate Sender (RCS) printable

### DIFF
--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -71,6 +71,16 @@
 	build_path = /obj/item/telepad_beacon
 	category = list("Bluespace")
 
+/datum/design/rcs
+	name = "Rapid Crate Sender"
+	desc = "Used to warp crates and closets to cargo telepads."
+	id = "rcs"
+	req_tech = list("programming" = 5, "bluespace" = 4, "engineering" = 4, "plasmatech" = 4)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 5000, MAT_GLASS = 3750)
+	build_path = /obj/item/rcs
+	category = list("Bluespace")
+
 /datum/design/beacon
 	name = "Tracking Beacon"
 	desc = "A bluespace tracking beacon."

--- a/code/modules/telesci/rcs.dm
+++ b/code/modules/telesci/rcs.dm
@@ -18,6 +18,7 @@
 	throw_range = 5
 	toolspeed = 1
 	usesound = 'sound/weapons/flash.ogg'
+	origin_tech = "bluespace=3"
 	/// Power cell (10000W)
 	var/obj/item/stock_parts/cell/high/rcell = null
 	/// Selected telepad

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -294,7 +294,7 @@ lobby_time = 240
 # Default timeout for world reboot (Seconds)
 restart_timeout = 75
 # Forbid people without a BYOND account joining the server
-guest_ban = false
+guest_ban = true
 # Allow players to use antagHUD?
 allow_antag_hud = true
 # Forbid players from rejoining if they use antag hud
@@ -433,7 +433,7 @@ enable_exp_admin_bypass = true
 allow_ai = true
 # Prevent guests (people without BYOND accounts) from playing following positions
 # Captain, HoS, HoP, CE, RD, CMO, Warden, Security, Detective, AI
-guest_job_ban = false
+guest_job_ban = true
 # Should assistants have maint access?
 assistant_maint_access = true
 # Should the amount of assistants be limited?

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -294,7 +294,7 @@ lobby_time = 240
 # Default timeout for world reboot (Seconds)
 restart_timeout = 75
 # Forbid people without a BYOND account joining the server
-guest_ban = true
+guest_ban = false
 # Allow players to use antagHUD?
 allow_antag_hud = true
 # Forbid players from rejoining if they use antag hud
@@ -433,7 +433,7 @@ enable_exp_admin_bypass = true
 allow_ai = true
 # Prevent guests (people without BYOND accounts) from playing following positions
 # Captain, HoS, HoP, CE, RD, CMO, Warden, Security, Detective, AI
-guest_job_ban = true
+guest_job_ban = false
 # Should assistants have maint access?
 assistant_maint_access = true
 # Should the amount of assistants be limited?


### PR DESCRIPTION
## What Does This PR Do

Adds the Rapid Crate Sender (RCS) design to protolathes. It has a technology level of programming 5, bluespace 4, engineering 4 and plasmatech 4; just like the cargo telepad beacons.

The design only requires glass and metal (3750 glass and 5000 metal without upgrades) which means it can be printed in autolathes should a design disk be made and inserted in one.

The Rapid Crate Senders now have the same origin tech as cargo telepad beacons, which is bluespace 3.

## Why It's Good For The Game

The smith's introduction made RCSs a lot more used than they were before, but did not add ways to make new ones, this leads to many peoples wanting to use the item but not many being available per maps (~4 are mapped in in every maps I believe, counting lavaland; Cyberiad has 6).
This PR will change this by allowing more RCS to be made so that everyone can build and use a crate teleportation network should they want to.

## Testing

- Maximized research levels, printed a RCS with a protolathe.
- Did research by hand, printed a RCS with a protolathe once the research requirements were met.
- Made a design disk for the RCS and uploaded it into an autolathe, then printed an RCS with said protolathe.
- Checked that price discount applies correctly for autolathe and protolathe upgrades, they do.
- Tried to print a RCS with a protolathe without having done research, I could not.
- Tried analyzing a RCS, it had the correct origin tech.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<img width="398" alt="Approval 1" src="https://github.com/user-attachments/assets/545678fb-344b-4a60-8b0d-d33a2c614bfc" />
<img width="404" alt="Approval 2" src="https://github.com/user-attachments/assets/4efcb4fe-662b-4cea-8dae-561dc286b81a" />

<hr>

## Changelog

:cl: leboucliervert
add: The NAS Trurl's quartermaster caved in to the other quartermasters' request during the last cargonian trade-together and made the Rapid Crate Sender designs available to every nanotrasen station. RCSs can now be printed at protolathes and a design disk can be made to print them at autolathes once the research requirements are met.
tweak: Rapid Crate Senders now have the same origin tech as cargo telepad beacons, which is bluespace 3.
/:cl:
