### PR TITLE
add smith, and some service boards, to tech storage

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -34729,9 +34729,8 @@
 /turf/simulated/wall/indestructible/riveted,
 /area/station/science/toxins/test)
 "cvu" = (
-/obj/structure/table,
-/obj/item/analyzer,
-/obj/item/healthanalyzer,
+/obj/structure/rack,
+/obj/effect/spawner/random/tech_storage/service,
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
 "cvv" = (
@@ -34767,10 +34766,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/machinery/power/apc/directional/north,
 /obj/effect/spawner/random/tech_storage/robotics,
 /turf/simulated/floor/plating,
@@ -34785,6 +34781,8 @@
 "cvA" = (
 /obj/structure/table,
 /obj/item/plant_analyzer,
+/obj/item/healthanalyzer,
+/obj/item/analyzer,
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
 "cvB" = (
@@ -35473,10 +35471,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/tech_storage)
 "cyt" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/silicon,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/tech_storage)
@@ -35490,10 +35485,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
 "cyy" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/teleporter,
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
@@ -35507,10 +35499,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
 "cyA" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/supply,
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
@@ -35969,10 +35958,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/tech_storage)
 "czT" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/comms,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/tech_storage)
@@ -36370,34 +36356,22 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/tech_storage)
 "cBr" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/rnd,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/tech_storage)
 "cBs" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/medical,
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
 "cBt" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/engineering,
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
 "cBu" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/security,
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
@@ -70514,10 +70488,7 @@
 /turf/simulated/floor/engine,
 /area/station/science/misc_lab)
 "ppl" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -25848,18 +25848,6 @@
 "dCV" = (
 /turf/simulated/wall,
 /area/station/maintenance/disposal/west)
-"dCX" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/t_scanner,
-/obj/item/multitool,
-/obj/machinery/requests_console/directional/west,
-/turf/simulated/floor/plating,
-/area/station/engineering/tech_storage)
 "dDe" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/window/reinforced/grilled,
@@ -43233,6 +43221,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/blueshield)
+"hUq" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/tech_storage/service,
+/obj/machinery/alarm/directional/east,
+/turf/simulated/floor/plating,
+/area/station/engineering/tech_storage)
 "hUw" = (
 /obj/structure/chair/comfy/beige{
 	dir = 4
@@ -43831,10 +43825,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/southwest)
 "iaV" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -52217,10 +52208,7 @@
 	},
 /area/station/hallway/primary/aft/west)
 "jTo" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/robotics,
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
@@ -59525,10 +59513,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "lCO" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/engineering,
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
@@ -63058,10 +63043,13 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/asmaint)
 "mux" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 5
+/obj/structure/rack,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = -1
 	},
+/obj/item/multitool,
+/obj/item/clothing/glasses/meson,
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
 "muF" = (
@@ -72208,11 +72196,9 @@
 	},
 /area/station/science/toxins/mixing)
 "oJk" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/medical,
+/obj/machinery/requests_console/directional/west,
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
 "oJn" = (
@@ -86832,17 +86818,6 @@
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
-"shZ" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/multitool,
-/obj/item/clothing/glasses/meson,
-/obj/machinery/alarm/directional/east,
-/turf/simulated/floor/plating,
-/area/station/engineering/tech_storage)
 "sif" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -88026,6 +88001,9 @@
 "swI" = (
 /obj/structure/table,
 /obj/item/multitool,
+/obj/machinery/cell_charger{
+	pixel_y = 5
+	},
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
 "swL" = (
@@ -92310,10 +92288,7 @@
 	},
 /area/station/maintenance/apmaint)
 "twu" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/research,
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
@@ -102449,10 +102424,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "vQV" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/machinery/firealarm/directional/east,
 /obj/effect/spawner/random/tech_storage/teleporter,
 /turf/simulated/floor/plating,
@@ -104305,6 +104277,17 @@
 	icon_state = "dark"
 	},
 /area/station/turret_protected/ai_upload)
+"wpd" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/t_scanner,
+/obj/item/multitool,
+/turf/simulated/floor/plating,
+/area/station/engineering/tech_storage)
 "wph" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -104951,10 +104934,7 @@
 	},
 /area/station/command/bridge)
 "wvy" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -148229,7 +148209,7 @@ eDx
 swI
 dkQ
 drq
-baR
+jTo
 oJk
 wvy
 lCO
@@ -148486,7 +148466,7 @@ aDv
 dqp
 dqp
 dqp
-dCX
+dqp
 dqp
 dqp
 kok
@@ -148740,7 +148720,7 @@ aXD
 xbO
 xbO
 aDv
-jTo
+wpd
 dqF
 drr
 rji
@@ -149000,7 +148980,7 @@ aDv
 mux
 dqI
 nKD
-shZ
+dqp
 dqp
 dqp
 dqp
@@ -149257,7 +149237,7 @@ eDx
 cSf
 dqI
 dyM
-baR
+hUq
 twu
 iaV
 vQV

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -19746,10 +19746,8 @@
 	},
 /area/station/hallway/primary/port/north)
 "bBR" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
+/obj/effect/spawner/random/tech_storage/service,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -21509,20 +21507,14 @@
 	},
 /area/station/engineering/tech_storage)
 "bGU" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/medical,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/tech_storage)
 "bGW" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -22004,10 +21996,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/engineering,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -22022,10 +22011,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/tech_storage)
 "bIO" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/robotics,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22512,10 +22498,7 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central/north)
 "bKu" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/security,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -57189,10 +57172,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/electrical)
 "gnU" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/teleporter,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -67755,10 +67735,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
 "lpY" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/research,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -119,10 +119,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
 "abO" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/medical,
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
@@ -13771,10 +13768,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "cLj" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/supply,
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
@@ -16995,10 +16989,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft2)
 "dtL" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/robotics,
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
@@ -27311,10 +27302,7 @@
 	},
 /area/station/security/permabrig)
 "fvp" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
 	pixel_x = 1;
 	pixel_y = -1
@@ -53778,10 +53766,7 @@
 /turf/simulated/floor/grass/jungle,
 /area/station/maintenance/aft)
 "kLn" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/teleporter,
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
@@ -74151,10 +74136,7 @@
 	},
 /area/station/maintenance/apmaint)
 "oNo" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -94084,6 +94066,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/command/office/ce)
+"sKG" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/tech_storage/service,
+/turf/simulated/floor/plating,
+/area/station/engineering/tech_storage)
 "sKI" = (
 /obj/effect/spawner/random/barrier/grille_maybe,
 /obj/effect/decal/cleanable/dirt,
@@ -97676,10 +97663,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dorms/port)
 "ttM" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
 	pixel_x = 1;
 	pixel_y = -1
@@ -111566,10 +111550,7 @@
 /turf/simulated/wall/r_wall,
 /area/station/security/prisonershuttle)
 "wiP" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -113835,10 +113816,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dorms/starboard)
 "wKf" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/research,
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
@@ -142449,7 +142427,7 @@ kHZ
 tXi
 dtL
 vpm
-iET
+sKG
 iET
 wYo
 dGm

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -11906,20 +11906,14 @@
 	},
 /area/station/service/chapel)
 "bds" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/robotics,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/station/engineering/tech_storage)
 "bdt" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/medical,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -11939,10 +11933,7 @@
 	},
 /area/station/turret_protected/ai)
 "bdv" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/machinery/requests_console/directional/north,
 /obj/effect/spawner/random/tech_storage/engineering,
 /turf/simulated/floor/plasteel{
@@ -12992,10 +12983,7 @@
 	},
 /area/station/hallway/primary/fore/east)
 "bgm" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/silicon,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -13026,20 +13014,14 @@
 	},
 /area/station/engineering/tech_storage)
 "bgq" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/station/engineering/tech_storage)
 "bgr" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/teleporter,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -13056,7 +13038,25 @@
 /area/station/engineering/tech_storage)
 "bgt" = (
 /obj/structure/table,
-/obj/item/analyzer,
+/obj/item/analyzer{
+	pixel_y = -5
+	},
+/obj/item/flash{
+	pixel_x = -2;
+	pixel_y = 16
+	},
+/obj/item/flashlight{
+	pixel_x = 2;
+	pixel_y = 17
+	},
+/obj/item/flash{
+	pixel_x = -6;
+	pixel_y = 13
+	},
+/obj/item/flashlight{
+	pixel_x = 2;
+	pixel_y = 9
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -13191,10 +13191,7 @@
 	},
 /area/station/hallway/primary/starboard/east)
 "bgO" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/machinery/ai_status_display{
 	pixel_y = 31
 	},
@@ -13266,24 +13263,15 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/nw)
 "bhd" = (
-/obj/structure/table,
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/item/flash,
-/obj/item/flash,
 /obj/item/radio/intercom{
 	name = "north bump";
 	pixel_y = 28
 	},
+/obj/structure/rack,
+/obj/effect/spawner/random/tech_storage/service,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -13485,10 +13473,7 @@
 /turf/simulated/floor/bluegrid,
 /area/station/turret_protected/ai)
 "bhI" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -14127,10 +14112,7 @@
 	},
 /area/station/supply/storage)
 "bjv" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/tech_storage/rnd,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -14165,10 +14147,7 @@
 	},
 /area/station/engineering/tech_storage)
 "bjz" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
 	pixel_x = 1;
 	pixel_y = -1
@@ -15483,10 +15462,7 @@
 /turf/simulated/floor/plating/airless,
 /area/shuttle/arrival/station)
 "bnJ" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
 	pixel_x = 1;
 	pixel_y = -1
@@ -70367,10 +70343,7 @@
 	},
 /area/station/security/main)
 "qJI" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/rack,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},

--- a/code/game/objects/effects/spawners/random/tech_storage_spawners.dm
+++ b/code/game/objects/effects/spawners/random/tech_storage_spawners.dm
@@ -49,6 +49,23 @@
 	loot = list(
 		/obj/item/circuitboard/ore_redemption,
 		/obj/item/circuitboard/autolathe,
+		/obj/item/circuitboard/power_hammer,
+		/obj/item/circuitboard/lava_furnace,
+		/obj/item/circuitboard/casting_basin,
+		/obj/item/circuitboard/smart_hopper,
+		/obj/item/circuitboard/magma_crucible,
+	)
+
+/obj/effect/spawner/random/tech_storage/service
+	name = "service circuit boards spawner"
+	loot = list(
+		/obj/item/circuitboard/seed_extractor,
+		/obj/item/circuitboard/plantgenes,
+		/obj/item/circuitboard/hydroponics,
+		/obj/item/circuitboard/cooking/stove,
+		/obj/item/circuitboard/cooking/deep_fryer,
+		/obj/item/circuitboard/cooking/ice_cream_mixer,
+		/obj/item/circuitboard/cooking/oven,
 	)
 
 /obj/effect/spawner/random/tech_storage/research

--- a/code/modules/cooking/machines/deep_fryer.dm
+++ b/code/modules/cooking/machines/deep_fryer.dm
@@ -124,6 +124,7 @@
 /obj/item/circuitboard/cooking/deep_fryer
 	board_name = "Deep Fryer"
 	build_path = /obj/machinery/cooking/deepfryer
+	icon_state = "service"
 	board_type = "machine"
 	origin_tech = list(TECH_BIO = 1)
 	req_components = list(

--- a/code/modules/cooking/machines/grill.dm
+++ b/code/modules/cooking/machines/grill.dm
@@ -195,6 +195,7 @@
 	board_name = "Charcoal Grill"
 	build_path = /obj/machinery/cooking/grill
 	board_type = "machine"
+	icon_state = "service"
 	origin_tech = list(TECH_BIO = 1)
 	req_components = list(
 		/obj/item/stock_parts/micro_laser = 2,

--- a/code/modules/cooking/machines/ice_cream_mixer.dm
+++ b/code/modules/cooking/machines/ice_cream_mixer.dm
@@ -80,6 +80,7 @@
 	board_name = "Ice Cream Mixer"
 	build_path = /obj/machinery/cooking/ice_cream_mixer
 	board_type = "machine"
+	icon_state = "service"
 	origin_tech = list(TECH_BIO = 1)
 	req_components = list(
 		/obj/item/stock_parts/micro_laser = 2,

--- a/code/modules/cooking/machines/oven.dm
+++ b/code/modules/cooking/machines/oven.dm
@@ -157,6 +157,7 @@
 	board_name = "Convection Oven"
 	build_path = /obj/machinery/cooking/oven
 	board_type = "machine"
+	icon_state = "service"
 	origin_tech = list(TECH_BIO = 1)
 	req_components = list(
 		/obj/item/stack/cable_coil = 5,

--- a/code/modules/cooking/machines/stovetop.dm
+++ b/code/modules/cooking/machines/stovetop.dm
@@ -126,6 +126,7 @@
 	board_name = "Stovetop"
 	build_path = /obj/machinery/cooking/stovetop
 	board_type = "machine"
+	icon_state = "service"
 	origin_tech = list(TECH_BIO = 1)
 	req_components = list(
 		/obj/item/stock_parts/micro_laser = 2,


### PR DESCRIPTION
## What Does This PR Do
This PR adds a spawner for service circuitboards for tech storage, and updates the supply board spawner to include one of each smithing machines. It makes some minor mapping tweaks on some maps to arrange things so that there's a good spot for the new rack of boards. It also removes some pointless dir/atom varedits on the racks holding the circuit boards.
## Why It's Good For The Game
These inventories haven't been updated in a while and we have nice new spawners to make it easier to do so, so might as well flesh out the available boards.
## Images of changes
![2025_04_21__19_05_30__Paradise Station 13](https://github.com/user-attachments/assets/9277e63e-1a77-4cee-95bd-2b629d90007a)
![2025_04_21__19_08_04__Paradise Station 13](https://github.com/user-attachments/assets/adcc0f60-a272-4705-89b4-3803769da13c)
![2025_04_21__19_10_09__Paradise Station 13](https://github.com/user-attachments/assets/71305a85-8798-458b-b237-ee4096761d48)
![2025_04_21__19_20_48__Paradise Station 13](https://github.com/user-attachments/assets/13daa527-b48a-4017-a6d0-4822b504cb6e)
![2025_04_21__19_42_03__Paradise Station 13](https://github.com/user-attachments/assets/0c52e6e8-9bab-4fde-aaaa-07c7e4445812)

## Testing
Visual inspection.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
add: Several service-related boards from hydroponics and kitchen are now kept in tech storage.
add: Circuit boards from one of each smithing machines are now kept in tech storage alongside the other supply boards.
/:cl: