### PR TITLE
fill in area around doppler radar with no lava helpers

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
@@ -294,6 +294,7 @@
 /area/mine/laborcamp)
 "co" = (
 /obj/structure/barricade/wooden,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "cp" = (
@@ -1074,9 +1075,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/outpost/mechbay)
-"gt" = (
-/turf/simulated/mineral/volcanic/lava_land_surface,
-/area/lavaland/surface/outdoors/targetable)
 "gu" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/stripes/line{
@@ -1163,6 +1161,7 @@
 /obj/structure/lattice/catwalk/mining,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "gQ" = (
@@ -1628,10 +1627,6 @@
 	icon_state = "darkfull"
 	},
 /area/mine/outpost/hallway/west)
-"jk" = (
-/obj/structure/flora/ash/leaf_shroom,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/targetable)
 "jn" = (
 /obj/machinery/light{
 	dir = 4
@@ -2207,6 +2202,7 @@
 "my" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "mA" = (
@@ -2331,6 +2327,7 @@
 /obj/item/trash/liquidfood,
 /obj/item/trash/tastybread,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "nh" = (
@@ -2653,6 +2650,7 @@
 /area/mine/outpost/lockers)
 "oL" = (
 /obj/effect/mapping_helpers/turfs/rust,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/wall,
 /area/lavaland/surface/outdoors/targetable)
 "oM" = (
@@ -3294,6 +3292,7 @@
 "rS" = (
 /obj/effect/spawner/random/fungus/maybe,
 /obj/effect/mapping_helpers/turfs/rust,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/wall,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "rT" = (
@@ -3692,6 +3691,7 @@
 /area/mine/outpost/cafeteria)
 "um" = (
 /obj/structure/glowshroom,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "uq" = (
@@ -4262,6 +4262,7 @@
 	pixel_x = -32
 	},
 /obj/effect/spawner/random/cobweb/left/rare,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "xu" = (
@@ -4958,6 +4959,7 @@
 /obj/structure/sign/electricshock{
 	pixel_y = -32
 	},
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "Bm" = (
@@ -5161,6 +5163,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/mine/outpost/production)
+"Ct" = (
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/mineral/volcanic/lava_land_surface,
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "Cv" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/railing{
@@ -5524,12 +5530,14 @@
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
 	},
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "Ey" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/glowshroom,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "EF" = (
@@ -6242,6 +6250,7 @@
 /turf/simulated/wall,
 /area/mine/outpost/production)
 "If" = (
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/mineral/volcanic/lava_land_surface,
 /area/mine/outpost/hallway/east)
 "Ij" = (
@@ -6272,12 +6281,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/mine/laborcamp)
-"In" = (
-/obj/structure/sign/nanotrasen{
-	pixel_y = -32
-	},
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/targetable)
 "Iq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7602,11 +7605,6 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
-"PH" = (
-/obj/structure/lattice/catwalk/mining,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
 "PK" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -7868,6 +7866,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "Ra" = (
@@ -8576,6 +8575,7 @@
 "UR" = (
 /obj/effect/mapping_helpers/turfs/rust,
 /obj/effect/spawner/random/fungus/maybe,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/wall,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "US" = (
@@ -8645,6 +8645,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "Vz" = (
@@ -8780,6 +8781,7 @@
 /turf/simulated/floor/plating,
 /area/mine/laborcamp)
 "Wn" = (
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/mineral/volcanic/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Wq" = (
@@ -9105,6 +9107,7 @@
 	name = "south bump";
 	pixel_y = -28
 	},
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "XW" = (
@@ -16623,8 +16626,8 @@ Hv
 hb
 NW
 Kl
-of
-PH
+Ct
+oP
 WH
 LE
 oM
@@ -16785,7 +16788,7 @@ Kl
 Zh
 Kl
 Kl
-of
+Ct
 Bj
 WH
 EM
@@ -17105,11 +17108,11 @@ re
 re
 Yr
 Yr
-PH
+oP
 um
 co
-gt
-gt
+Yr
+Yr
 rS
 WH
 dB
@@ -17268,10 +17271,10 @@ LJ
 LJ
 zA
 gP
-gt
-gt
-gt
-oO
+Yr
+Yr
+Yr
+Yh
 Wj
 oj
 oj
@@ -17430,10 +17433,10 @@ Wq
 Wq
 Wq
 Ol
-gt
-oO
-oO
-zP
+Yr
+Yh
+Yh
+IJ
 oj
 fj
 CN
@@ -17592,9 +17595,9 @@ Wq
 cZ
 BB
 wX
-oO
-oO
-In
+Yh
+Yh
+LV
 oj
 oj
 RG
@@ -17754,9 +17757,9 @@ iy
 kf
 iy
 kC
-oO
-oO
-zP
+Yh
+Yh
+IJ
 tB
 zs
 hf
@@ -17914,11 +17917,11 @@ Yh
 Yh
 IJ
 IJ
-oO
+Yh
 VM
-oO
-oO
-oO
+Yh
+Yh
+Yh
 tB
 uh
 Gb
@@ -18076,11 +18079,11 @@ Yh
 Bv
 Yh
 Yh
-oO
+Yh
 dd
-zP
-oO
-oO
+IJ
+Yh
+Yh
 tB
 VH
 Gb
@@ -18238,11 +18241,11 @@ Yh
 Yh
 Yh
 Yh
-oO
+Yh
 dx
-zP
-oO
-oO
+IJ
+Yh
+Yh
 oj
 qt
 Ox
@@ -18400,11 +18403,11 @@ Yh
 Yh
 aI
 Yh
-oO
+Yh
 dd
-oO
-jk
-oO
+Yh
+fw
+Yh
 tB
 yL
 Sl
@@ -18562,11 +18565,11 @@ Yh
 Yh
 Yh
 Yh
-oO
+Yh
 VM
-oO
-oO
-zP
+Yh
+Yh
+IJ
 xS
 uh
 gU
@@ -18727,8 +18730,8 @@ Yh
 Cv
 Qu
 Mi
-oO
-oO
+Yh
+Yh
 tB
 vi
 Gb
@@ -19557,7 +19560,7 @@ mw
 NF
 kT
 If
-of
+Ct
 hI
 pG
 Tc
@@ -19879,9 +19882,9 @@ OJ
 kT
 NF
 kT
-gt
-gt
-zP
+Yr
+Yr
+IJ
 oO
 oO
 oO
@@ -20039,10 +20042,10 @@ oD
 OJ
 OJ
 Wn
-gt
-gt
+Yr
+Yr
 oL
-gt
+Yr
 oO
 oO
 oO


### PR DESCRIPTION
## What Does This PR Do
This PR surrounds the non-building area of the mining station near the doppler radar with no lava mapping helpers.
## Why It's Good For The Game
These areas shouldn't be getting turned into lava/chasms randomly.
## Images of changes
![2025_04_21__20_19_28__paradise dme  lavaland_surface_nt dmm  - StrongDMM](https://github.com/user-attachments/assets/d4b4797d-02b2-4dbb-af39-a043b4e0b645)
## Testing
Visual inspection.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Parts of the mining station near the doppler radar will no longer be subject to random lava/plasma/chasm river generation.
/:cl: