### PR TITLE
fix some submaps docs formatting

### DIFF
--- a/docs/mapping/submaps.md
+++ b/docs/mapping/submaps.md
@@ -190,7 +190,7 @@ If a map manipulation fails, it should do both these things:
   are in different places every round.
 - The sky is the limit, literally.
 
-# Submaps Design Guidelines
+## Submaps Design Guidelines
 
 1. Currently, while they do not have to be exactly rectangular, submaps cannot
    be larger than 24x24 tiles. This is in order to prevent them from being too
@@ -200,7 +200,7 @@ If a map manipulation fails, it should do both these things:
    about a map. If you have issues with the balance or design of a map, those
    issues should be addressed with ordinary remap PRs.
 
-## Stations
+### Stations
 
 1. For the time being, submaps on stations may only be used in maintenance
    tunnels, and only one submap per area (i.e. fore, aft) is permitted.
@@ -228,15 +228,15 @@ If a map manipulation fails, it should do both these things:
    being hidden with walls or no longer accessible via their pre-existing
    primary paths through maintenance.
 
-6. All pre-existing balance guidelines regarding mapping apply to submaps:
-   https://devdocs.paradisestation.org/mapping/design/#balance-guidelines
-
-   Loot counts must remain consistent. Walls should only be reinforced in
+6. All [pre-existing balance guidelines][guidelines] regarding mapping apply to
+   submaps. Loot counts must remain consistent. Walls should only be reinforced in
    appropriate places. There should be no "treasure troves" or hoards only
    accessible with detailed map knowledge. AI cameras cannot be placed in maints
    submaps. Antag/sec balance, tactical flexibility, and navigability must be
    considered. Dead ends are to be avoided. Department maintenance airlocks may
    not be moved or removed.
+
+   [guidelines]: https://devdocs.paradisestation.org/mapping/design/#balance-guidelines
 
 7. One submap must be an exact duplicate of the original area's contents. A
    submap will never not be chosen, and so it's necessary there be a submap of
@@ -252,7 +252,7 @@ If a map manipulation fails, it should do both these things:
    prototype this, they are welcome to, but there is no guarantee it will be
    accepted. A PR of this kind is not subject to the 24x24 size constraint rule.
 
-## Ruins
+### Ruins
 
 1. Submaps on ruins are allowed to be more flexible. There's currently no limit
    on how many submaps may be used on a given ruin, however the 24x24 tile limit


### PR DESCRIPTION
## What Does This PR Do
This PR fixes some formatting in the docs for submaps.
## Why It's Good For The Game
Proper header hierarchy and linkability is good. Raw links are bad.
## Images of changes
### Before
![2025_04_21__22_05_00__Guide to Submaps - Paradise Contributor Documentation](https://github.com/user-attachments/assets/94d03d56-0cb4-4f9c-8368-649be5caec69)
### After
![2025_04_21__22_05_11__Guide to Submaps - Paradise Contributor Documentation](https://github.com/user-attachments/assets/e27d09ae-64aa-4371-9ebf-feaca80626a8)
## Testing
See above.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC