### PR TITLE
[s] Fixes exploit in material speed modifier

### DIFF
--- a/code/modules/smithing/smith_datums.dm
+++ b/code/modules/smithing/smith_datums.dm
@@ -59,7 +59,7 @@
 	/// Explosive armor multiplier
 	var/explosive_armor_mult = 1.0
 	/// Movement speed modifier
-	var/movement_speed_mod = 0
+	var/movement_speed_mod = 1.0
 	/// Heat insulation multiplier
 	var/heat_insulation_mult = 1.0
 	/// Electrical insulation multiplier


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes a bad value in the material datum that let some smith inserts have no movement penalties

## Why It's Good For The Game

Balance good, Exploits bad.

## Testing

Made an insert out of affected material. Verified proper movement penalty

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Fixed a bad smith material value negating movement speed modifiers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
