### PR TITLE
allow COMSIG_ATOM_UPDATE_OVERLAY responders to add managed overlays directly

### DIFF
--- a/code/datums/components/ducttape.dm
+++ b/code/datums/components/ducttape.dm
@@ -24,11 +24,12 @@
 /datum/component/proc/add_tape_text(datum/source, mob/user, list/examine_list)
 	examine_list += "<span class='notice'>There's some sticky tape attached to [source].</span>"
 
-/datum/component/ducttape/proc/add_tape_overlay(obj/item/O)
+/datum/component/ducttape/proc/add_tape_overlay(obj/item/O, list/overlays)
+	SIGNAL_HANDLER // COMSIG_ATOM_UPDATE_OVERLAYS
 	tape_overlay = new('icons/obj/bureaucracy.dmi', "tape")
 	tape_overlay.Shift(EAST, x_offset - 2)
 	tape_overlay.Shift(NORTH, y_offset - 2)
-	O.add_overlay(tape_overlay)
+	overlays += tape_overlay
 
 /datum/component/ducttape/proc/remove_tape(obj/item/I, mob/user)
 	to_chat(user, "<span class='notice'>You tear the tape off [I]!</span>")

--- a/code/datums/components/shielded.dm
+++ b/code/datums/components/shielded.dm
@@ -33,8 +33,6 @@
 	COOLDOWN_DECLARE(charge_add_cd)
 	/// A callback for the sparks/message that play when a charge is used, see [/datum/component/shielded/proc/default_run_hit_callback]
 	var/datum/callback/on_hit_effects
-	///The visual effect
-	var/mutable_appearance/shield
 
 /datum/component/shielded/Initialize(max_charges = 3, recharge_start_delay = 20 SECONDS, charge_increment_delay = 1 SECONDS, charge_recovery = 1, lose_multiple_charges = FALSE, show_charge_as_alpha = FALSE, recharge_path = null, starting_charges = null, shield_icon_file = 'icons/effects/effects.dmi', shield_icon = "shield-old", shield_inhand = FALSE, run_hit_callback)
 	if(!isitem(parent) || max_charges <= 0)
@@ -122,7 +120,6 @@
 
 	if(wearer)
 		UnregisterSignal(wearer, list(COMSIG_ATOM_UPDATE_OVERLAYS, COMSIG_PARENT_QDELETING))
-		wearer.cut_overlay(shield)
 		wearer.update_appearance(UPDATE_ICON)
 		wearer = null
 
@@ -134,14 +131,12 @@
 		wearer.update_appearance(UPDATE_ICON)
 
 /// Used to draw the shield overlay on the wearer
-/datum/component/shielded/proc/on_update_overlays(atom/parent_atom)
-	SIGNAL_HANDLER
-	wearer.cut_overlay(shield)
+/datum/component/shielded/proc/on_update_overlays(atom/parent_atom, list/overlays)
+	SIGNAL_HANDLER // COMSIG_ATOM_UPDATE_OVERLAYS
 	var/mutable_appearance/shield_appearance = mutable_appearance(shield_icon_file, (current_charges > 0 ? shield_icon : "broken"), MOB_LAYER + 0.01)
 	if(show_charge_as_alpha)
 		shield_appearance.alpha = (current_charges/max_charges)*255
-	wearer.add_overlay(shield_appearance)
-	shield = shield_appearance
+	overlays += shield_appearance
 
 /**
  * This proc fires when we're hit, and is responsible for checking if we're charged, then deducting one + returning that we're blocking if so.

--- a/code/datums/elements/decal_element.dm
+++ b/code/datums/elements/decal_element.dm
@@ -132,25 +132,10 @@
 		INVOKE_ASYNC(source, TYPE_PROC_REF(/obj/item/, update_slot_icon))
 	return ..()
 
-/datum/element/decal/proc/apply_overlay(atom/source)
+/datum/element/decal/proc/apply_overlay(atom/source, list/overlays)
 	SIGNAL_HANDLER  // COMSIG_ATOM_UPDATE_OVERLAYS
 
-	source.add_overlay(pic)
-	// TODO: Fix this disgusting hack
-	//
-	// `COMSIG_ATOM_UPDATE_OVERLAYS` is sent at the end of
-	// /atom/proc/update_icon's stanza for updating overlays, instead
-	// somewhere useful, like, during it. /tg/ handles this by sending
-	// a list of overlays with the signal, allowing receivers to add to
-	// the list, instead of returning their own.
-	//
-	// This is much saner and more flexible, but would require refactoring
-	// many many uses of update_overlay() across the code base, which is left
-	// as an exercise for the next poor sap to touch this code (probably me).
-	if(source.managed_overlays && !islist(source.managed_overlays))
-		source.managed_overlays = list(source.managed_overlays, pic)
-	else
-		LAZYDISTINCTADD(source.managed_overlays, pic)
+	overlays += pic
 
 /datum/element/decal/proc/clean_react(datum/source, clean_types)
 	SIGNAL_HANDLER  // COMSIG_COMPONENT_CLEAN_ACT

--- a/code/datums/elements/rust_element.dm
+++ b/code/datums/elements/rust_element.dm
@@ -40,7 +40,7 @@
 	SIGNAL_HANDLER //COMSIG_ATOM_UPDATE_OVERLAYS
 
 	if(rust_overlay)
-		parent_atom.add_overlay(rust_overlay)
+		overlays += rust_overlay
 
 /// Because do_after sleeps we register the signal here and defer via an async call
 /datum/element/rust/proc/welder_tool_act(atom/source, obj/item/item, mob/user)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -555,7 +555,6 @@
 			else
 				managed_overlays = new_overlays
 			add_overlay(new_overlays)
-		SEND_SIGNAL(src, COMSIG_ATOM_UPDATE_OVERLAYS)
 
 	SEND_SIGNAL(src, COMSIG_ATOM_UPDATED_ICON, updates)
 
@@ -567,7 +566,8 @@
 /// Updates the overlays of the atom. It has to return a list of overlays if it can't call the parent to create one. The list can contain anything that would be valid for the add_overlay proc: Images, mutable appearances, icon states...
 /atom/proc/update_overlays()
 	PROTECTED_PROC(TRUE)
-	return list()
+	. = list()
+	SEND_SIGNAL(src, COMSIG_ATOM_UPDATE_OVERLAYS, .)
 
 /atom/proc/relaymove()
 	return


### PR DESCRIPTION
## What Does This PR Do
This PR adds a list argument to the `COMSIG_ATOM_UPDATE_OVERLAY` signal to allow responders to put the overlays they want managed into that list.
## Why It's Good For The Game
This is how we should have been doing this and cleans up a bunch of code where elements/components had to do some of their own overlay management.
## Testing
- [X] Spawned a wiz hardsuit and put it on, ensured the shield overlay was added and removed properly.
- [X] Called `rust_turf` on a wall, ensured the rust overlay was added properly.
- [X] Visually inspected Centcomm to ensure that decals were added to tiles properly.
- [X] Used duct tape on an item, ensured the duct tape overlay was added properly.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC