### PR TITLE
Smith Polish: Makes tool bits affect surgery fail rate

### DIFF
--- a/code/modules/smithing/smithed_items/tool_bits.dm
+++ b/code/modules/smithing/smithed_items/tool_bits.dm
@@ -129,6 +129,7 @@
 	desc = "A hyper-advanced bit restricted to central command officials."
 	speed_mod = -1
 	efficiency_mod = 1
+	failure_rate = -20
 	durability = 300
 	quality = /datum/smith_quality/masterwork
 	material = /datum/smith_material/platinum

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -328,6 +328,7 @@
 	surgery.step_in_progress = TRUE
 
 	var/speed_mod = 1
+	var/fail_mod = 1
 	var/advance = FALSE
 	var/retry = FALSE
 	var/prob_success = 100
@@ -349,6 +350,8 @@
 
 	if(tool)
 		speed_mod = tool.toolspeed
+		for(var/obj/item/smithed_item/tool_bit/bit in tool.attached_bits)
+			fail_mod -= (bit.failure_rate / 100)
 
 	// Using an unoptimal tool slows down your surgery
 	var/implement_speed_mod = 1
@@ -373,6 +376,7 @@
 	var/chem_check_result = chem_check(target)
 	var/pain_mod = deal_pain(user, target, target_zone, tool, surgery)
 	prob_success *= pain_mod
+	prob_success *= fail_mod
 
 	var/step_result
 
@@ -401,6 +405,8 @@
 			surgery.complete(target)
 
 	surgery.step_in_progress = FALSE
+	for(var/obj/item/smithed_item/tool_bit/bit in tool.attached_bits)
+		bit.damage_bit()
 	if(advance)
 		INVOKE_ASYNC(src, PROC_REF(play_success_sound), user, target, target_zone, tool, surgery)
 		return SURGERY_INITIATE_SUCCESS


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Makes tool bit failure rate affect surgery failure chance.

## Why It's Good For The Game

Bits doing what they are advertised to do is good.

## Testing

Used var-editted bit on scalpel. Saw adjusted success chance in break point during surgery action.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Tool bit failure rate now affects surgery failure chance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
