### PR TITLE
Standardizes Cargo Telepads in Science

### DIFF
--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -3427,6 +3427,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/telepad_cargo,
+/obj/effect/turf_decal/box,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -41686,7 +41686,8 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/science/rnd)
 "daM" = (
-/obj/item/kirbyplants/large,
+/obj/effect/turf_decal/box,
+/obj/machinery/telepad_cargo,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplecorner"
 	},

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -43222,11 +43222,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
 "iEW" = (
-/obj/structure/table/glass,
-/obj/item/storage/belt/utility,
-/obj/item/wrench,
 /obj/machinery/requests_console/directional/east,
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/telepad_cargo,
+/obj/effect/turf_decal/box,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "whitepurple"
@@ -69222,6 +69221,8 @@
 /obj/structure/table/glass,
 /obj/item/weldingtool/research,
 /obj/item/stack/cable_coil,
+/obj/item/wrench,
+/obj/item/storage/belt/utility,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple"

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -86470,11 +86470,12 @@
 	},
 /area/station/security/permabrig)
 "xIS" = (
-/obj/structure/rack,
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/machinery/newscaster/directional/west,
+/obj/machinery/telepad_cargo,
+/obj/effect/turf_decal/box,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurple"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Adds cargo telepads to non-box stations.

## Why It's Good For The Game

Science should be standardized, and having cargo telepads is generally a good thing.

## Images of changes

![image](https://github.com/user-attachments/assets/7c26935f-4f23-4004-90b7-e81f9bc7c869)
![image](https://github.com/user-attachments/assets/efac285a-7236-42d9-a59b-38f92f6fb0d1)
![image](https://github.com/user-attachments/assets/484dfde0-399b-47c3-aa78-b96935b2b114)
![image](https://github.com/user-attachments/assets/83b01b9f-d64e-4f80-ad4b-b790a6279588)


## Testing

Compiled

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
![image](https://github.com/user-attachments/assets/5633efa1-1f1b-4e38-91f7-e8850147ba54)

<hr>

## Changelog

:cl:
add: Adds cargo telepads to all non-box RND rooms.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
