### PR TITLE
bump minimum megafauna spawn distance

### DIFF
--- a/code/game/objects/effects/spawners/random/pool/lavaland_pools.dm
+++ b/code/game/objects/effects/spawners/random/pool/lavaland_pools.dm
@@ -26,7 +26,7 @@
 	record_spawn = TRUE
 
 	var/fauna_scan_range = 12
-	var/megafauna_scan_range = 12
+	var/megafauna_scan_range = 16
 	var/turf/mining_base_gps
 
 	loot = list(

--- a/code/modules/lavaland/caves_theme.dm
+++ b/code/modules/lavaland/caves_theme.dm
@@ -32,7 +32,7 @@ GLOBAL_LIST_INIT(caves_default_flora_spawns, list(
 	var/perlin_upper_range = 0.3
 
 	var/fauna_scan_range = 12
-	var/megafauna_scan_range =7
+	var/megafauna_scan_range = 16
 
 /datum/caves_theme/New()
 	seed = rand(1, 999999)
@@ -84,11 +84,6 @@ GLOBAL_LIST_INIT(caves_default_flora_spawns, list(
 	perlin_lower_range = 0
 	perlin_upper_range = 0.3
 
-/datum/caves_theme/burrows/New()
-	. = ..()
-	fauna_scan_range = rand(4, 7)
-	megafauna_scan_range = rand(4, 7)
-
 /datum/caves_theme/burrows/on_change(turf/T)
 	if(prob(7))
 		new /obj/structure/flora/ash/rock/style_random(T)
@@ -96,6 +91,11 @@ GLOBAL_LIST_INIT(caves_default_flora_spawns, list(
 		lavaland_caves_spawn_flora(T)
 	else if(prob(1))
 		new /obj/effect/spawner/random/lavaland_fauna(T)
+
+/datum/caves_theme/deeprock/New()
+	. = ..()
+	fauna_scan_range = rand(4, 7)
+	megafauna_scan_range = rand(8, 16)
 
 /datum/caves_theme/deeprock/proc/maybe_make_room(turf/T)
 	if(rand(1, 150) != 1)


### PR DESCRIPTION
## What Does This PR Do
This PR bumps the minimum spawn distance between megafauna from 7 for most cave themes and `rand(4, 7)` for deadly deeprock to 16 and `rand(8, 16)` respectively. It also fixes a bug where the narrower, random ranges for fauna and megafauna spawn distance were being applied to blocked burrows, when they should have been used for deadly deeprock instead (a mistake I made in #28968).
## Why It's Good For The Game
The existing distance may be too narrow for people to be able to successfully kite megafauna away from each other. This gives players a tiny bit more leeway in dealing with threats.
## Testing
Procgen is always hard to test but I ran a couple rounds and spot checked the distance between megafauna, and didn't see any issues.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: The minimum spawn distance between megafauna has been increased slightly.
fix: The random change in minimum spawn distance for fauna and megafauna is now properly applied to Deadly Deeprock, not Blocked Burrows.
/:cl: