### PR TITLE
unfucks modlink linkage

### DIFF
--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -342,17 +342,17 @@
 				return TRUE
 	else
 		var/obj/item/clothing/neck/link_scryer/chosen_scryer = linked_thing
-		var/response = tgui_alert(user, "Would you like to copy or imprint the frequency?", "MODlink Frequency", list("Copy", "Imprint"))
+		var/response = tgui_alert(user, "Would you like to copy the frequency to the multitool or imprint the frequency to [src]?", "MODlink Frequency", list("Copy", "Imprint"))
 		if(!user.is_holding(I))
 			return FALSE
 		switch(response)
 			if("Copy")
-				mod_link.frequency = chosen_scryer.mod_link.frequency
-				to_chat(user, "<span class='notice'>You imprint the frequency to [src].</span>")
-				return TRUE
-			if("Imprint")
 				to_chat(user, "<span class='notice'>You save the frequency of [src] to the buffer.</span>")
 				M.buffer_uid = UID()
+				return TRUE
+			if("Imprint")
+				mod_link.frequency = chosen_scryer.mod_link.frequency
+				to_chat(user, "<span class='notice'>You imprint the frequency to [src].</span>")
 				return TRUE
 
 

--- a/code/modules/mod/mod_link.dm
+++ b/code/modules/mod/mod_link.dm
@@ -221,17 +221,17 @@
 				return TRUE
 	else
 		var/obj/item/clothing/neck/link_scryer/chosen_scryer = linked_thing
-		var/response = tgui_alert(user, "Would you like to copy or imprint the frequency?", "MODlink Frequency", list("Copy", "Imprint"))
+		var/response = tgui_alert(user, "Would you like to copy the frequency to the multitool or imprint the frequency to [src]?", "MODlink Frequency", list("Copy", "Imprint"))
 		if(!user.is_holding(I))
 			return FALSE
 		switch(response)
 			if("Copy")
-				mod_link.frequency = chosen_scryer.mod_link.frequency
-				to_chat(user, "<span class='notice'>You imprint the frequency to [src].</span>")
-				return TRUE
-			if("Imprint")
 				to_chat(user, "<span class='notice'>You save the frequency of [src] to the buffer.</span>")
 				M.buffer_uid = UID()
+				return TRUE
+			if("Imprint")
+				mod_link.frequency = chosen_scryer.mod_link.frequency
+				to_chat(user, "<span class='notice'>You imprint the frequency to [src].</span>")
 				return TRUE
 
 /obj/item/clothing/neck/link_scryer/get_cell()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Linkage options now do what they say when copying from a modlink to a modlink, rather than being inverted. The message is also now clearer for that linkage.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The buttons for linking scryer to scryer or scryer to modsuit should not be inverted from modsuit to modsuit or modsuit to scryer

<hr>

### Testing
Copied from modsuit, imprinted scryer
Copied from scryer to scyrer.

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Fixed modlink linkage being inverted at times
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
