### PR TITLE
fix deep-fried anything recipe collision

### DIFF
--- a/code/modules/cooking/cooking_container.dm
+++ b/code/modules/cooking/cooking_container.dm
@@ -136,7 +136,15 @@
 		return
 
 	if(reaction_status == PCWJ_NO_STEPS && !tracker.recipe_started)
-		to_chat(user, "<span class='notice'>You don't know what you'd begin to make with this.</span>")
+		if(!ismob(user))
+			return
+
+		if(tracker.step_reaction_message)
+			to_chat(user, "<span class='notice'>[tracker.step_reaction_message]</span>")
+			tracker.step_reaction_message = null
+		else
+			to_chat(user, "<span class='notice'>You don't know what you'd begin to make with this.</span>")
+
 		return
 
 	switch(reaction_status)

--- a/code/modules/cooking/recipes/midway_recipes.dm
+++ b/code/modules/cooking/recipes/midway_recipes.dm
@@ -70,12 +70,16 @@
 	if(!istype(food_item))
 		return PCWJ_CHECK_INVALID
 
+	if("deep fried" in food_item.cooktype)
+		tracker.step_reaction_message = "That is already deep-fried!"
+		return PCWJ_CHECK_INVALID
+
 	// check to see if this is something that belongs to another deep fryer
 	// recipe with only one item
 	for(var/datum/cooking/recipe/recipe in GLOB.pcwj_recipe_dictionary[/obj/item/reagent_containers/cooking/deep_basket])
 		if(length(recipe.steps) == 2) // One add step and one deep fry step
 			var/datum/cooking/recipe_step/add_item/add_item_step = recipe.steps[1]
-			if(istype(add_item_step) && add_item_step.check_conditions_met(added_item, tracker) == PCWJ_CHECK_VALID)
+			if(istype(add_item_step) && (src != add_item_step) && add_item_step.check_conditions_met(added_item, tracker) == PCWJ_CHECK_VALID)
 				return PCWJ_CHECK_INVALID
 
 	return PCWJ_CHECK_VALID
@@ -83,7 +87,7 @@
 /datum/cooking/recipe/deep_fried_anything
 	container_type = /obj/item/reagent_containers/cooking/deep_basket
 	steps = list(
-		PCWJ_ADD_ITEM(/obj/item/food),
+		new /datum/cooking/recipe_step/add_item/deep_fried_anything(),
 		PCWJ_USE_DEEP_FRYER(10 SECONDS),
 	)
 	appear_in_default_catalog = FALSE
@@ -100,6 +104,7 @@
 	result.color = "#FFAD33"
 	result.name = "deep-fried [food_item.name]"
 	result.desc = "It has been deep-fried."
+	result.cooktype["deep fried"] = TRUE
 	food_item.reagents.trans_to(result, food_item.reagents.total_volume)
 	qdel(food_item)
 

--- a/code/modules/cooking/steps/recipe_step.dm
+++ b/code/modules/cooking/steps/recipe_step.dm
@@ -10,6 +10,8 @@ RESTRICT_TYPE(/datum/cooking/recipe_step)
 
 /datum/cooking/recipe_step/proc/check_conditions_met(obj/used_item, datum/cooking/recipe_tracker/tracker)
 	SHOULD_CALL_PARENT(FALSE)
+	SHOULD_BE_PURE(TRUE)
+
 	return PCWJ_CHECK_VALID
 
 /// Attempt to satisfy the requirements of this step with the object *used_item*


### PR DESCRIPTION
## What Does This PR Do
This PR:
- converts the "deep fried anything" recipe to actually use the "deep fried anything" add-item step, so that it is properly filtered out of valid recipe results when using an item that's part of an existing deep fryer recipe.
- sets the /check_conditions_met proc to be pure so that recipes and the autochef to restrict how much of the game state can change as a result of calling it
- ensures that deep-fried food cannot be deep-fried twice
- adds a custom message when trying to deep-fry already deep-fried food similar to the one that existed pre kitchen-rework
## Why It's Good For The Game
Gets rid of debug log spam, improves experience around deep-frying things.
## Testing
Used raw potato sticks in deep fryer, ensured they turned into fries with no debug log. Deep fried fries, ensured they were converted as expected. Tried deep frying again, ensured they could not be and that the right message was displayed to the user.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Deep-fried food is properly prevented from being deep-fried multiple times.
/:cl: