### PR TITLE
Fixes the perpetual pacemaker attack log

### DIFF
--- a/code/game/gamemodes/miniantags/pulsedemon/cross_shock_component.dm
+++ b/code/game/gamemodes/miniantags/pulsedemon/cross_shock_component.dm
@@ -52,11 +52,11 @@
 		if(!our_cable || !our_cable.powernet || !our_cable.powernet.available_power)
 			return
 		var/area/to_deduct_from = get_area(our_cable)
-		living_to_shock.electrocute_act(shock_damage, source)
+		living_to_shock.electrocute_act(shock_damage, parent)
 		to_deduct_from.powernet.use_active_power(energy_cost)
 		playsound(get_turf(parent), 'sound/effects/eleczap.ogg', 30, TRUE)
 	else
-		living_to_shock.electrocute_act(shock_damage, source)
+		living_to_shock.electrocute_act(shock_damage, parent)
 		playsound(get_turf(parent), 'sound/effects/eleczap.ogg', 30, TRUE)
 	COOLDOWN_START(src, last_shock, delay_between_shocks)
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #28844
Perpetual maker will now point to the parent as the attacker
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
immersion
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![dreamseeker_oyhIKxtFxv](https://github.com/user-attachments/assets/17bf5331-cd44-4fd8-be09-fbf9a82c7073)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Shocked a mob as a human that has eaten a pulse heart.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Perpetual pacemaker has a proper attack path again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
