### PR TITLE
fix morphs not being able to attack basic mobs

### DIFF
--- a/code/modules/mob/living/basic/basic_mob.dm
+++ b/code/modules/mob/living/basic/basic_mob.dm
@@ -201,6 +201,12 @@ RESTRICT_TYPE(/mob/living/basic)
 		return FALSE
 	return TRUE
 
+/mob/living/basic/attack_animal(mob/living/simple_animal/M)
+	. = ..()
+	if(.)
+		var/damage = rand(M.melee_damage_lower, M.melee_damage_upper)
+		return attack_threshold_check(damage, M.melee_damage_type)
+
 /mob/living/basic/handle_environment(datum/gas_mixture/readonly_environment)
 	SEND_SIGNAL(src, COMSIG_SIMPLEANIMAL_HANDLE_ENVIRONMENT, readonly_environment)
 


### PR DESCRIPTION
## What Does This PR Do
This PR fixes morphs not being able to attack and kill basic mobs. Fixes #29115.
## Why It's Good For The Game
Regression.
## Testing
Spawned as morph, spawned cow and pig, ensured I could kill and eat them. Changed over to goat, ensured I could attack morph and that morph took damage.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Simple mobs such as morphs can properly attack basic mobs such as cows and pigs.
/:cl: