### PR TITLE
remove dead var /mob/var/can_strip

### DIFF
--- a/code/modules/mob/mob_vars.dm
+++ b/code/modules/mob/mob_vars.dm
@@ -57,7 +57,6 @@
 	var/gen_record = ""
 	var/lying_prev = 0
 	var/lastpuke = 0
-	var/can_strip = TRUE
 	var/list/languages = list()         // For speaking/listening.
 	var/list/speak_emote = list("says") // Verbs used when speaking. Defaults to 'say' if speak_emote is null.
 	var/emote_type = EMOTE_VISIBLE		// Define emote default type, 1 for seen emotes, 2 for heard emotes


### PR DESCRIPTION
## What Does This PR Do
This PR removes the dead var `/mob/var/can_strip`.
## Why It's Good For The Game
Dead code bad.
## Testing
Compiled.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC