### PR TITLE
Fix kinetic accelerator desc taking up half your chat when it has modkits inside it

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -37,7 +37,6 @@
 				. |= "<span class='notice'>You can use a crowbar on it to remove it's installed mod kits.</span>"
 				. += "<span class='notice'>There is a [M.name] mod installed, using <b>[M.cost]%</b> capacity.</span>"
 
-
 /obj/item/gun/energy/kinetic_accelerator/attackby__legacy__attackchain(obj/item/I, mob/user)
 	if(istype(I, /obj/item/borg/upgrade/modkit) && max_mod_capacity)
 		var/obj/item/borg/upgrade/modkit/MK = I

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -34,8 +34,9 @@
 			. += "<b>[get_remaining_mod_capacity()]%</b> mod capacity remaining."
 			for(var/A in get_modkits())
 				var/obj/item/borg/upgrade/modkit/M = A
+				. |= "<span class='notice'>You can use a crowbar on it to remove it's installed mod kits.</span>"
 				. += "<span class='notice'>There is a [M.name] mod installed, using <b>[M.cost]%</b> capacity.</span>"
-				. += "<span class='notice'>You can use a crowbar on it to remove it's installed mod kits.</span>"
+
 
 /obj/item/gun/energy/kinetic_accelerator/attackby__legacy__attackchain(obj/item/I, mob/user)
 	if(istype(I, /obj/item/borg/upgrade/modkit) && max_mod_capacity)


### PR DESCRIPTION
## Why It's Good For The Game
MY EYES- No but less jokingly this shouldn't happen and it was my fault so I'm fixing it now
![image](https://github.com/user-attachments/assets/bb94b965-4e47-4ce2-8367-49774ff53abb)

## Images of changes
Without modkits
![image](https://github.com/user-attachments/assets/8593247e-85af-49b0-bfcf-383e40695aa3)

With modkits
![image](https://github.com/user-attachments/assets/499b0004-2a38-424f-a65c-f6ccc2c75266)

## Testing
Went in, stared hard at it.

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
fix: Fixed the kinetic crusher description telling you you could remove modkits with a crowbar too many times.
/:cl: