### PR TITLE
Fix simple mobs lose their `icon` on `gib()`

### DIFF
--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -5,7 +5,8 @@
 		return FALSE
 	// hide and freeze for the GC
 	notransform = TRUE
-	icon = null
+	if(gib_nullifies_icon)
+		icon = null
 	invisibility = 101
 
 	playsound(src.loc, 'sound/goonstation/effects/gib.ogg', 50, 1)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -119,3 +119,5 @@
 	var/last_taste_text
 	///If a creature gets to be super special and have extra range on their chat messages
 	var/extra_message_range = 0
+	/// Sets our icon to `null` when `gib()` is used
+	var/gib_nullifies_icon = TRUE

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -10,6 +10,7 @@
 	universal_speak = FALSE
 	status_flags = CANPUSH
 	healable = TRUE
+	gib_nullifies_icon = FALSE // prevents players from having transparent icon when their body is gibbed
 
 	var/icon_living = ""
 	var/icon_dead = ""


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Makes it so when a simple mob is gibbed, player that used to control him will be properly shown in a ghost form, instead of being fully transparent (having no icon to display)

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

There is no reason to set icon to null. For simple mobs at least, but i still don't know if it's actually used by something, so i'm not removing it globally

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Terror spiders are a great example. If you are located inside the body and gib() is called, your icon will be set to null.
Before (yeah you can see the icon on RMB context menu, but not otherwise):
![image](https://github.com/user-attachments/assets/7c07af89-2c24-4abb-8657-e7408b081e8e)

After:
![image](https://github.com/user-attachments/assets/d329c8c0-120a-49c8-9e95-459e36acb015)

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Gibbed simple mobs will now always have a proper icon for a ghost form.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
