### PR TITLE
Gives Combat Gloves light armor

### DIFF
--- a/code/modules/clothing/gloves/misc_gloves.dm
+++ b/code/modules/clothing/gloves/misc_gloves.dm
@@ -33,7 +33,7 @@
 
 /obj/item/clothing/gloves/combat
 	name = "combat gloves"
-	desc = "These tactical gloves are both insulated and offer protection from heat sources."
+	desc = "A tough pair of military gloves reinforced with light armor that doesn't restrict movement. A Nomex underlayer provides near complete protection from extreme temperatures."
 	icon_state = "combat"
 	item_state = "swat_gl"
 	siemens_coefficient = 0
@@ -44,7 +44,7 @@
 	heat_protection = HANDS
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
 	resistance_flags = NONE
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, RAD = 0, FIRE = 200, ACID = 50)
+	armor = list(MELEE = 15, BULLET = 15, LASER = 15, ENERGY = 15, BOMB = 50, RAD = 0, FIRE = 200, ACID = 50)
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/clothing/species/vox/gloves.dmi',
 		"Drask" = 'icons/mob/clothing/species/drask/gloves.dmi',


### PR DESCRIPTION
## What Does This PR Do
Title. Combat gloves now get a small amount of armor in most categories. Also updates the description to reflect that.

## Why It's Good For The Game
You'd think that a pair of military-standard combat gloves would be better at protecting your hands than literal pieces of bone strapped to your arms. Now they are.

Description is good.

## Testing

N/A, number changes only.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
 
![Screenshot 2025-04-26 120906](https://github.com/user-attachments/assets/1f36c3ab-09e1-4df8-bc98-2da66dbc7115)

<hr>

## Changelog

:cl:
tweak: Armors up combat gloves.
/:cl: