### PR TITLE
add BSA fires to investigate log

### DIFF
--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -273,7 +273,7 @@
 	name = "Bluespace Artillery Control"
 	var/obj/machinery/bsa/full/cannon
 	var/notice
-	var/target
+	var/atom/target
 	power_state = NO_POWER_USE
 	circuit = /obj/item/circuitboard/computer/bsa_control
 	icon = 'icons/obj/machines/particle_accelerator.dmi'
@@ -395,6 +395,7 @@
 		notice = "Cannon unpowered!"
 		return
 	notice = null
+	investigate_log("[key_name(user)] has fired the BSA at [ADMIN_VERBOSEJMP(cannon)] at the target [ADMIN_VERBOSEJMP(target)].", INVESTIGATE_BOMB)
 	cannon.fire(user, get_impact_turf(), target)
 
 /obj/machinery/computer/bsa_control/proc/deploy()


### PR DESCRIPTION
## What Does This PR Do
This PR adds BSA fires to the investigate log for bombs.
## Why It's Good For The Game
Currently the details of who fired a BSA are hidden in admin logs and require diving. This info should be easier to get to.
## Images of changes
![2025_04_26__13_42_08__](https://github.com/user-attachments/assets/cff49bc0-2415-4e2e-8d27-918e7802d8c9)
## Testing
Confirmed worked with person at console, as well as AI accessing console remotely.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC