### PR TITLE
fix cigarette syringe injections

### DIFF
--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -67,8 +67,11 @@ LIGHTERS ARE IN LIGHTERS.DM
 
 	if(lit)
 		extinguish_cigarette(user)
-	
+
 /obj/item/clothing/mask/cigarette/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	if(istype(used, /obj/item/reagent_containers/syringe))
+		return ..()
+
 	if(used.cigarette_lighter_act(user, user, src))
 		return ITEM_INTERACT_COMPLETE
 


### PR DESCRIPTION
## What Does This PR Do
Checks for syringes, continues the attack chain if used is a syringe. Fixes #29135
## Why It's Good For The Game
regression fix
## Images of changes
![image](https://github.com/user-attachments/assets/11755317-ce25-4572-b636-867574a1c7fa)
## Testing
Injected cigarette. tried to draw from cigarette.
### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Syringes can inject into cigarettes.
/:cl: