### PR TITLE
Nerfs Productivity Bit

### DIFF
--- a/code/datums/ores.dm
+++ b/code/datums/ores.dm
@@ -18,7 +18,7 @@
  * "dug" state, [MINERAL_PREVENT_DIG] if it should remain as is.
  */
 /datum/ore/proc/on_mine(turf/source, mob/user, triggered_by_explosion = FALSE, productivity_mult = 1)
-	var/amount = round(rand(drop_min, drop_max) * productivity_mult)
+	var/amount = round(rand(drop_min, drop_max) + productivity_mult)
 
 	if(ispath(drop_type, /obj/item/stack/ore))
 		new drop_type(source, amount)

--- a/code/datums/ores.dm
+++ b/code/datums/ores.dm
@@ -17,8 +17,8 @@
  * Returns [MINERAL_ALLOW_DIG] if the containing turf should be changed to its
  * "dug" state, [MINERAL_PREVENT_DIG] if it should remain as is.
  */
-/datum/ore/proc/on_mine(turf/source, mob/user, triggered_by_explosion = FALSE, productivity_mult = 1)
-	var/amount = round(rand(drop_min, drop_max) + productivity_mult)
+/datum/ore/proc/on_mine(turf/source, mob/user, triggered_by_explosion = FALSE, productivity_mod = 1)
+	var/amount = round(rand(drop_min, drop_max) + productivity_mod)
 
 	if(ispath(drop_type, /obj/item/stack/ore))
 		new drop_type(source, amount)

--- a/code/game/turfs/simulated/floor/asteroid_floors.dm
+++ b/code/game/turfs/simulated/floor/asteroid_floors.dm
@@ -25,7 +25,7 @@
 		icon_state = "[environment_type][rand(0,12)]"
 
 /turf/simulated/floor/plating/asteroid/proc/getDug(productivity_mod = 1)
-	new digResult(src, 5 * productivity_mod)
+	new digResult(src, round(5 + productivity_mod))
 	icon_plating = "[environment_type]_dug"
 	icon_state = "[environment_type]_dug"
 	SSblackbox.record_feedback("tally", "ore_mined", 5, "[digResult]")

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -95,24 +95,24 @@
 		if(do_after(user, mine_time * P.toolspeed, target = src))
 			if(ismineralturf(src)) //sanity check against turf being deleted during digspeed delay
 				to_chat(user, "<span class='notice'>You finish cutting into the rock.</span>")
-				gets_drilled(user, productivity_mult = P.bit_productivity_mod)
+				gets_drilled(user, productivity_mod = P.bit_productivity_mod)
 				SSblackbox.record_feedback("tally", "pick_used_mining", 1, P.name)
 
 		return FINISH_ATTACK
 	else
 		return attack_hand(user)
 
-/turf/simulated/mineral/proc/mine_ore(mob/user, triggered_by_explosion, productivity_mult = 1)
+/turf/simulated/mineral/proc/mine_ore(mob/user, triggered_by_explosion, productivity_mod = 1)
 	if(!ore)
 		return MINERAL_ALLOW_DIG
 
 	for(var/obj/effect/temp_visual/mining_overlay/M in src)
 		qdel(M)
 
-	return ore.on_mine(src, user, triggered_by_explosion, productivity_mult)
+	return ore.on_mine(src, user, triggered_by_explosion, productivity_mod)
 
-/turf/simulated/mineral/proc/gets_drilled(mob/user, triggered_by_explosion = FALSE, productivity_mult = 1)
-	if(mine_ore(user, triggered_by_explosion, productivity_mult) == MINERAL_PREVENT_DIG)
+/turf/simulated/mineral/proc/gets_drilled(mob/user, triggered_by_explosion = FALSE, productivity_mod = 1)
+	if(mine_ore(user, triggered_by_explosion, productivity_mod) == MINERAL_PREVENT_DIG)
 		return
 
 	ChangeTurf(turf_type, defer_change)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Changes the productivity bit to add more instead of act as a multiplier.

## Why It's Good For The Game

Too many minerals makes mining dull.

## Testing

Created best possible productivity bit. Mined ore. Saw increased values but not insane multiplied ones.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Fixed over-production from productivity bits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
