### PR TITLE
Fixes Powerhammer Runtime

### DIFF
--- a/code/modules/smithing/machinery/power_hammer.dm
+++ b/code/modules/smithing/machinery/power_hammer.dm
@@ -47,6 +47,9 @@
 	operation_time = max(ROUND_UP(initial(operation_time) * (1.3 - operation_mult)), 2)
 
 /obj/machinery/smithing/power_hammer/operate(loops, mob/living/user)
+	if(!working_component)
+		to_chat(user, "<span class='notice'>There is no component in the machine.</span>")
+		return
 	if(!working_component.heat)
 		to_chat(user, "<span class='notice'>[working_component] is too cold to properly shape.</span>")
 		return


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Adds a check for if something is inserted to stop operations.

## Why It's Good For The Game

Runtimes bad.

## Testing

Interacted with power hammer. Was told there was nothing inside instead of runtiming.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Fixed a powerhammer runtime
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
