### PR TITLE
Nerf Spectral Blade

### DIFF
--- a/code/modules/mining/lavaland/loot/ashdragon_loot.dm
+++ b/code/modules/mining/lavaland/loot/ashdragon_loot.dm
@@ -167,7 +167,7 @@
 	force = 0
 	var/ghost_counter = length(orbs)
 
-	force = clamp((ghost_counter * 4), 0, 50)
+	force = clamp((ghost_counter * 3), 0, 50)
 	user.visible_message("<span class='danger'>[user] strikes with the force of [ghost_counter] vengeful spirit\s!</span>")
 	..()
 

--- a/code/modules/mining/lavaland/loot/ashdragon_loot.dm
+++ b/code/modules/mining/lavaland/loot/ashdragon_loot.dm
@@ -53,14 +53,14 @@
 	register_signals(src)
 	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 	GLOB.poi_list |= src
-	parry_comp = AddComponent(/datum/component/parry, _stamina_constant = 2, _stamina_coefficient = 1, _parryable_attack_types = NON_PROJECTILE_ATTACKS, _parry_cooldown = (7 / 3) SECONDS)
+	parry_comp = AddComponent(/datum/component/parry, _stamina_constant = 2, _stamina_coefficient = 1, _parryable_attack_types = NON_PROJECTILE_ATTACKS, _parry_cooldown = (10 / 3) SECONDS)
 
 /obj/item/melee/ghost_sword/proc/update_parry(orbs)
 	var/counter = length(orbs)
 	// scaling stamina coeff. 0 ghosts being 1, 20 being 0.5
 	parry_comp.stamina_coefficient = 1 - clamp(counter * 0.025, 0, 0.5)
 	// scaling uptime. 0 ghosts being 30%, 20 ghosts being 70%
-	parry_comp.parry_cooldown = ((7 / 3) - clamp(counter * 0.0715, 0, 1.43)) SECONDS
+	parry_comp.parry_cooldown = ((10 / 3) - clamp(counter * 0.095, 0, 1.9)) SECONDS
 
 /obj/item/melee/ghost_sword/Destroy()
 	for(var/mob/dead/observer/G in ghosts)

--- a/code/modules/mining/lavaland/loot/ashdragon_loot.dm
+++ b/code/modules/mining/lavaland/loot/ashdragon_loot.dm
@@ -45,13 +45,14 @@
 	/// List of ghosts currently orbiting us.
 	var/list/mob/dead/observer/ghosts
 
-/obj/item/melee/ghost_sword/New()
-	..()
+/obj/item/melee/ghost_sword/Initialize(mapload)
+	. = ..()
 	ghosts = list()
 	orbs = list()
 	register_signals(src)
 	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 	GLOB.poi_list |= src
+	AddComponent(/datum/component/parry, _stamina_constant = 2, _stamina_coefficient = 0.7, _parryable_attack_types = ALL_ATTACK_TYPES, _parry_cooldown = (7 / 3) SECONDS)
 
 /obj/item/melee/ghost_sword/Destroy()
 	for(var/mob/dead/observer/G in ghosts)

--- a/code/modules/mining/lavaland/loot/ashdragon_loot.dm
+++ b/code/modules/mining/lavaland/loot/ashdragon_loot.dm
@@ -167,16 +167,9 @@
 	force = 0
 	var/ghost_counter = length(orbs)
 
-	force = clamp((ghost_counter * 4), 0, 75)
+	force = clamp((ghost_counter * 4), 0, 50)
 	user.visible_message("<span class='danger'>[user] strikes with the force of [ghost_counter] vengeful spirit\s!</span>")
 	..()
-
-/obj/item/melee/ghost_sword/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	var/ghost_counter = length(orbs)
-	final_block_chance += clamp((ghost_counter * 5), 0, 75)
-	owner.visible_message("<span class='danger'>[owner] is protected by a ring of [ghost_counter] ghost\s!</span>")
-	return ..()
-
 
 /obj/effect/wisp/ghost
 	name = "mischievous wisp"

--- a/code/modules/mining/lavaland/loot/ashdragon_loot.dm
+++ b/code/modules/mining/lavaland/loot/ashdragon_loot.dm
@@ -52,7 +52,7 @@
 	register_signals(src)
 	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 	GLOB.poi_list |= src
-	AddComponent(/datum/component/parry, _stamina_constant = 2, _stamina_coefficient = 0.7, _parryable_attack_types = NON_PROJECTILE_ATTACKS, _parry_cooldown = (7 / 3) SECONDS)
+	AddComponent(/datum/component/parry, _stamina_constant = 2, _stamina_coefficient = 0.7, _parryable_attack_types = NON_PROJECTILE_ATTACKS, _parry_cooldown = (10 / 3) SECONDS)
 
 /obj/item/melee/ghost_sword/Destroy()
 	for(var/mob/dead/observer/G in ghosts)

--- a/code/modules/mining/lavaland/loot/ashdragon_loot.dm
+++ b/code/modules/mining/lavaland/loot/ashdragon_loot.dm
@@ -52,7 +52,7 @@
 	register_signals(src)
 	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 	GLOB.poi_list |= src
-	AddComponent(/datum/component/parry, _stamina_constant = 2, _stamina_coefficient = 0.7, _parryable_attack_types = ALL_ATTACK_TYPES, _parry_cooldown = (7 / 3) SECONDS)
+	AddComponent(/datum/component/parry, _stamina_constant = 2, _stamina_coefficient = 0.7, _parryable_attack_types = NON_PROJECTILE_ATTACKS, _parry_cooldown = (7 / 3) SECONDS)
 
 /obj/item/melee/ghost_sword/Destroy()
 	for(var/mob/dead/observer/G in ghosts)

--- a/code/modules/mining/lavaland/loot/ashdragon_loot.dm
+++ b/code/modules/mining/lavaland/loot/ashdragon_loot.dm
@@ -53,14 +53,14 @@
 	register_signals(src)
 	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 	GLOB.poi_list |= src
-	parry_comp = AddComponent(/datum/component/parry, _stamina_constant = 2, _stamina_coefficient = 1, _parryable_attack_types = NON_PROJECTILE_ATTACKS, _parry_cooldown = (10 / 3) SECONDS)
+	parry_comp = AddComponent(/datum/component/parry, _stamina_constant = 2, _stamina_coefficient = 1, _parryable_attack_types = NON_PROJECTILE_ATTACKS, _parry_cooldown = (7 / 3) SECONDS)
 
 /obj/item/melee/ghost_sword/proc/update_parry(orbs)
 	var/counter = length(orbs)
 	// scaling stamina coeff. 0 ghosts being 1, 20 being 0.5
 	parry_comp.stamina_coefficient = 1 - clamp(counter * 0.025, 0, 0.5)
 	// scaling uptime. 0 ghosts being 30%, 20 ghosts being 70%
-	parry_comp.parry_cooldown = ((10 / 3) - clamp(counter * 0.095, 0, 1.9)) SECONDS
+	parry_comp.parry_cooldown = ((7 / 3) - clamp(counter * 0.0715, 0, 1.43)) SECONDS
 
 /obj/item/melee/ghost_sword/Destroy()
 	for(var/mob/dead/observer/G in ghosts)


### PR DESCRIPTION
## What Does This PR Do
Removes spectral blades' flat block chance
Adds a parry that scales with ghosts. Starts out with a `stamina_coefficient` of 1 and 30% uptime, at 20 ghosts it reaches stam_coeff of 0.5 and 70% uptime. It cannot parry projectiles.
Lowers the damage per ghost 4 -> 3.
Lowers spectral blade dmg cap 75 -> 50
## Why It's Good For The Game
With it's block and damage, it's an oppressive weapon that enables antags. Despite that, the item is interesting and I do not wish to see it completely removed.
## Testing
Compiled. Number adjustment. Tested parrying by orbiting my character and VV-ing the parry values. They updated accordingly to my ghost.
<!-- How did you test the PR, if at all? -->
### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
![image](https://github.com/user-attachments/assets/fbabc2e2-681e-4d7e-99aa-bca1427d4a38)
![image](https://github.com/user-attachments/assets/776d4973-9d21-4dc5-b558-7c724f1f92ff)
## Changelog
:cl:
tweak: spectral blade damage caps out at 50,
tweak: spectral blade now gets 3 damage per ghost.
tweak: spectral blade now uses a parry that scales with ghosts.
/:cl: