### PR TITLE
admin log surplus crate purchases and contents

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -687,7 +687,9 @@
 	for(var/item in bought_items)
 		var/obj/purchased = new item(src)
 		U.purchase_log += "<BIG>[bicon(purchased)]</BIG>"
-	log_game("[key_name(usr)] purchased a surplus crate with [jointext(itemlog, ", ")]")
+	var/item_list = jointext(sortList(itemlog), ", ")
+	log_game("[key_name(user)] purchased a surplus crate with [item_list]")
+	user.create_log(MISC_LOG, "Surplus crate purchase with spawned items [item_list]")
 
 /obj/structure/closet/crate/surplus/proc/generate_refund(amount)
 	var/changing_amount = amount


### PR DESCRIPTION
## What Does This PR Do
This PR adds a user log for the contents of surplus bundles they purchase.
## Why It's Good For The Game
Logs for surplus bundles were only in admin logs, not player logs. This ensures they show up in both, similarly to other uplink purchases.
## Images of changes
![2025_04_26__20_47_09__](https://github.com/user-attachments/assets/d7bfbd21-081f-46a1-8f24-d3f7a7012e2a)
## Testing
See above.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC