### PR TITLE
Quicksilver form no longer allows item useage

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -1008,8 +1008,18 @@
 	return ..()
 
 /datum/status_effect/quicksilver_form/on_apply()
+	var/obj/item/item_one = owner.get_active_hand()
+	if(item_one)
+		item_one.equip_to_best_slot(owner)
+	var/obj/item/item_two = owner.get_inactive_hand()
+	if(item_two)
+		// Equip to best slot only works for the item in the active hand. As such, if we detect an item, we swap, equip, then swap back
+		owner.swap_hand()
+		item_two.equip_to_best_slot(owner)
+		owner.swap_hand()
 	if(should_deflect)
 		ADD_TRAIT(owner, TRAIT_DEFLECTS_PROJECTILES, UNIQUE_TRAIT_SOURCE(src))
+	ADD_TRAIT(owner, TRAIT_HANDS_BLOCKED, "[id]")
 	temporary_flag_storage = owner.pass_flags
 	owner.pass_flags |= (PASSTABLE | PASSGRILLE | PASSMOB | PASSFENCE | PASSGIRDER | PASSGLASS | PASSTAKE | PASSBARRICADE)
 	owner.add_atom_colour(COLOR_ALUMINIUM, TEMPORARY_COLOUR_PRIORITY)
@@ -1017,6 +1027,7 @@
 
 /datum/status_effect/quicksilver_form/on_remove()
 	REMOVE_TRAIT(owner, TRAIT_DEFLECTS_PROJECTILES, UNIQUE_TRAIT_SOURCE(src))
+	REMOVE_TRAIT(owner, TRAIT_HANDS_BLOCKED, "[id]")
 	owner.pass_flags = temporary_flag_storage
 	owner.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, COLOR_ALUMINIUM)
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Quicksiver form grants TRAIT_HANDS_BLOCKED for the duration. This means the flayer cannot attack during this time, however most abilties still work.
This will cause items that cannot be stored to be dropped (unless antidrop). The ability will **attempt** to store the items you have in hand like you pressed E, starting with  the item in active hand.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

We do not allow guns with carp. Qani can dodge bullets, but not deflect them, takes a moderate portion of tc, a 5 minute cooldown, and a *lot* of heart damage.

Quicksilver form lasts 10 or 20 seconds, giving it up to ***50%*** uptime (since it has a 40 second cooldown), of which the flayer can shoot you down, be reflecting your ranged attacks, and pass through windows and mobs.
As such, it reaaaally doesn't need the ability to attack at the same time.

## Testing
Use quicksilver form.
Have storing items fail.
Fiddle with the codes, impliment swap hands solution.
Test again.
Works properly.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

![image](https://github.com/user-attachments/assets/d795b456-4f47-40f1-8654-dcb8cb9fecbb)


## Changelog

:cl:
tweak: Quicksilver form no longer allows item useage during it's active period.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
