### PR TITLE
Smith Polish: Fixes secondary goal turn in

### DIFF
--- a/code/modules/station_goals/secondary/supply/random_smithed_item.dm
+++ b/code/modules/station_goals/secondary/supply/random_smithed_item.dm
@@ -105,7 +105,7 @@
 	if(!istype(product, product_type))
 		return FALSE
 	// Quality doesn't match
-	if(product.quality != quality)
+	if(!istype(product.quality, quality))
 		return FALSE
 	// Material doesn't match
 	if(product.material != material)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes #29152

When a smith item is created, quality is a new datum while mineral is a type reference. The quality needed to be an istype instead of an equals as a result

## Why It's Good For The Game

Bugs bad

## Testing

Smithed items manually instead of var edit. Items successfully turned in for secondary goals.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Fixes turning in secondary goals for smith
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
