### PR TITLE
remove cigarette debugging message

### DIFF
--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -67,7 +67,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 
 	if(lit)
 		extinguish_cigarette(user)
-	
+
 /obj/item/clothing/mask/cigarette/item_interaction(mob/living/user, obj/item/used, list/modifiers)
 	if(used.cigarette_lighter_act(user, user, src))
 		return ITEM_INTERACT_COMPLETE
@@ -306,7 +306,6 @@ LIGHTERS ARE IN LIGHTERS.DM
 		to_chat(M, "<span class='notice'>Your [name] goes out.</span>")
 		// Only put the butt in the user's mouth if there's already a cig there.
 		if(M.wear_mask == src)
-			to_chat(M, "<span class='userdanger'>Butt in your mouth!</span>")
 			M.drop_item_to_ground(src, force = TRUE) //Force the un-equip so the overlays update
 			butt.slot_flags |= ITEM_SLOT_MASK // Temporarily allow it to go on masks
 			M.equip_to_slot_if_possible(butt, ITEM_SLOT_MASK)


### PR DESCRIPTION
## What Does This PR Do
This PR removes a debugging message from cigarettes.
## Why It's Good For The Game
Not supposed to be there.
## Testing
Visual inspection.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: You'll no longer receive a warning message when a lit cigarette in your mouth goes out.
/:cl: