### PR TITLE
Cooking machines logic tweak

### DIFF
--- a/code/modules/cooking/machines/cooking_machine.dm
+++ b/code/modules/cooking/machines/cooking_machine.dm
@@ -60,9 +60,11 @@ RESTRICT_TYPE(/obj/machinery/cooking)
 /obj/machinery/cooking/RefreshParts()
 	. = ..()
 	var/man_rating = 0
+	var/part_count = 0
 	for(var/obj/item/stock_parts/stock_part in component_parts)
 		man_rating += stock_part.rating
-	quality_mod = round(man_rating / 2)
+		part_count++
+	quality_mod = floor(man_rating / part_count)
 
 /// Retrieve which burning surface on the machine is being accessed.
 /obj/machinery/cooking/proc/clickpos_to_surface(modifiers)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the logic to calculate the average of the machine parts rating, rather than just their sum. This is done to fix the problem with the unimproved grill producing too much stuff, because it has more parts than other machines and thus it's machine rating is higher.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Cooking machines logic is now more universal, grill doesn't make two steaks out of one slab of meat and so on.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Made a bunch of stuff with an improved grill, then changed the parts for the best ones and did it again.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Tweaked cooking machines logic now doesn't allow the grill to produce matter out of thin air.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
