### PR TITLE
Fix prayer bread runtiming on mindless mobs

### DIFF
--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -653,8 +653,10 @@
 
 /obj/item/nullrod/rosary/bread/process()
 	var/mob/living/carbon/human/holder = loc
-	//would like to make the holder mime if they have it in on thier person in general
+	//would like to make the holder mime if they have it in on their person in general
 	for(var/mob/living/carbon/human/H in range(5, loc))
+		if(!H.mind)
+			continue
 		if(H.mind.assigned_role == "Clown" && !LAZYACCESS(smited_clowns, H))
 			LAZYSET(smited_clowns, H, TRUE)
 			H.Silence(20 SECONDS)

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -653,7 +653,7 @@
 
 /obj/item/nullrod/rosary/bread/process()
 	var/mob/living/carbon/human/holder = loc
-	//would like to make the holder mime if they have it in on their person in general
+	// would like to make the holder mime if they have it in on their person in general
 	for(var/mob/living/carbon/human/H in range(5, loc))
 		if(!H.mind)
 			continue


### PR DESCRIPTION
## What Does This PR Do
Adds a mind check to prayer bread

## Why It's Good For The Game
Fixes #29162

## Images of changes
![bread](https://github.com/user-attachments/assets/cc5f10d4-66cf-48db-b4b5-3946d4ab0fe3)

## Testing
Spawned as a mime, bread, and a regular human mob. Looked for runtimes.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
NPFC
