### PR TITLE
Smith Polish: Fixes Radiation

### DIFF
--- a/code/modules/smithing/components/trim.dm
+++ b/code/modules/smithing/components/trim.dm
@@ -7,7 +7,7 @@
 /obj/item/smithed_item/component/trim/Initialize(mapload)
 	. = ..()
 	if((material == /datum/smith_material/uranium || istype(material, /datum/smith_material/uranium)) && quality)
-		var/datum/component/inherent_radioactivity/radioactivity = AddComponent(/datum/component/inherent_radioactivity, 50 * quality.stat_mult, 2.5 * quality.stat_mult, 0, 1.5)
+		var/datum/component/inherent_radioactivity/radioactivity = AddComponent(/datum/component/inherent_radioactivity, 50 * quality.stat_mult, 0, 0, 1.5)
 		START_PROCESSING(SSradiation, radioactivity)
 
 /obj/item/smithed_item/component/trim/set_name()

--- a/code/modules/smithing/components/trim.dm
+++ b/code/modules/smithing/components/trim.dm
@@ -4,6 +4,12 @@
 	desc = "Debug smithed component part of any smithed item. If you see this, notify the development team."
 	part_type = PART_TRIM
 
+/obj/item/smithed_item/component/trim/Initialize(mapload)
+	. = ..()
+	if((material == /datum/smith_material/uranium || istype(material, /datum/smith_material/uranium)) && quality)
+		var/datum/component/inherent_radioactivity/radioactivity = AddComponent(/datum/component/inherent_radioactivity, 50 * quality.stat_mult, 2.5 * quality.stat_mult, 0, 1.5)
+		START_PROCESSING(SSradiation, radioactivity)
+
 /obj/item/smithed_item/component/trim/set_name()
 	if(!quality)
 		return

--- a/code/modules/smithing/smith_item.dm
+++ b/code/modules/smithing/smith_item.dm
@@ -28,6 +28,9 @@
 	return
 
 /obj/item/smithed_item/proc/set_stats()
+	if((material == /datum/smith_material/uranium || istype(material, /datum/smith_material/uranium)) && quality)
+		var/datum/component/inherent_radioactivity/radioactivity = AddComponent(/datum/component/inherent_radioactivity, 100 * quality.stat_mult, 5 * quality.stat_mult, 0, 1.5)
+		START_PROCESSING(SSradiation, radioactivity)
 	return
 
 /obj/item/smithed_item/proc/set_name()

--- a/code/modules/smithing/smith_item.dm
+++ b/code/modules/smithing/smith_item.dm
@@ -29,7 +29,7 @@
 
 /obj/item/smithed_item/proc/set_stats()
 	if((material == /datum/smith_material/uranium || istype(material, /datum/smith_material/uranium)) && quality)
-		var/datum/component/inherent_radioactivity/radioactivity = AddComponent(/datum/component/inherent_radioactivity, 100 * quality.stat_mult, 5 * quality.stat_mult, 0, 1.5)
+		var/datum/component/inherent_radioactivity/radioactivity = AddComponent(/datum/component/inherent_radioactivity, 100 * quality.stat_mult, 0, 0, 1.5)
 		START_PROCESSING(SSradiation, radioactivity)
 	return
 

--- a/code/modules/smithing/smithed_items/inserts.dm
+++ b/code/modules/smithing/smithed_items/inserts.dm
@@ -22,6 +22,7 @@
 	var/obj/item/clothing/suit/attached_suit
 
 /obj/item/smithed_item/insert/set_stats()
+	..()
 	brute_armor = initial(brute_armor) * quality.stat_mult * material.brute_armor_mult
 	burn_armor = initial(burn_armor) * quality.stat_mult * material.burn_armor_mult
 	laser_armor = initial(laser_armor) * quality.stat_mult * material.laser_armor_mult

--- a/code/modules/smithing/smithed_items/lens.dm
+++ b/code/modules/smithing/smithed_items/lens.dm
@@ -26,6 +26,7 @@
 	var/obj/item/gun/energy/attached_gun
 
 /obj/item/smithed_item/lens/set_stats()
+	..()
 	durability = initial(durability) * material.durability_mult
 	max_durability = durability
 	power_mult = 1 + (base_power_mult * quality.stat_mult * material.power_draw_mult)

--- a/code/modules/smithing/smithed_items/tool_bits.dm
+++ b/code/modules/smithing/smithed_items/tool_bits.dm
@@ -32,6 +32,7 @@
 		return ITEM_INTERACT_COMPLETE
 
 /obj/item/smithed_item/tool_bit/set_stats()
+	..()
 	durability = initial(durability) * material.durability_mult
 	max_durability = durability
 	size_mod = initial(size_mod) + material.size_mod


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes uranium upgrade and part radioactivity.

## Why It's Good For The Game

Intended side effects should be there.

## Testing

Made uranium parts. Checked radioactivity. Saw healthy glow.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Fixes smith upgrade and part radioactivity
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
