### PR TITLE
Fix some chameleon items display no on-mob sprite on non-human species

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -194,11 +194,9 @@
 		I.color = initial(picked_item.color)
 
 		I.icon_override = initial(picked_item.icon_override)
-		if(initial(picked_item.sprite_sheets))
-			// Species-related variables are lists, which can not be retrieved using initial(). As such, we need to instantiate the picked item.
-			var/obj/item/P = new picked_item(null)
-			I.sprite_sheets = P.sprite_sheets
-			qdel(P)
+		var/obj/item/P = new picked_item(null)
+		I.sprite_sheets = P.sprite_sheets ? P.sprite_sheets.Copy() : null
+		qdel(P)
 
 		if(isclothing(I) && isclothing(picked_item))
 			var/obj/item/clothing/CL = I

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -194,10 +194,13 @@
 		I.color = initial(picked_item.color)
 
 		I.icon_override = initial(picked_item.icon_override)
-		// lists can't be copied that easy, we need to instantiate the picked item.
-		var/obj/item/P = new picked_item(null)
-		I.sprite_sheets = P.sprite_sheets ? P.sprite_sheets.Copy() : null
-		qdel(P)
+		if(initial(picked_item.sprite_sheets))
+			// Species-related variables are lists, which can not be retrieved using initial(). As such, we need to instantiate the picked item.
+			var/obj/item/P = new picked_item(null)
+			I.sprite_sheets = P.sprite_sheets
+			qdel(P)
+		else
+			I.sprite_sheets = null
 
 		if(isclothing(I) && isclothing(picked_item))
 			var/obj/item/clothing/CL = I

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -194,6 +194,7 @@
 		I.color = initial(picked_item.color)
 
 		I.icon_override = initial(picked_item.icon_override)
+		// lists can't be copied that easy, we need to instantiate the picked item.
 		var/obj/item/P = new picked_item(null)
 		I.sprite_sheets = P.sprite_sheets ? P.sprite_sheets.Copy() : null
 		qdel(P)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes an issue when you could select something like holo cigar as a tajaran and there would be no sprite on your mob at all

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

fix

some items have `sprite_sheets` set to null, and if they do, chameleon mask doesn't take that into account and keeps its old `sprite_sheets`. so that's what causes the issue

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

compiled, spawned chameleon mask, equipped as tajaran, switched between ~10 different looks, `sprite_sheets` always updated correctly. Did the same with drask and human

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Fixed an issue when chameleon clothing couldn't render on-mob sprite if you weren't a human.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
