### PR TITLE
add admin verb for log access by round ID

### DIFF
--- a/code/__DEFINES/misc_defines.dm
+++ b/code/__DEFINES/misc_defines.dm
@@ -742,3 +742,6 @@ do { \
 ///  Economy account defines
 #define BANK_PIN_MIN 10000
 #define BANK_PIN_MAX 99999
+
+//! The number of seconds between the start of the UNIX and BYOND epochs.
+#define BYOND_EPOCH_UNIX 946702800

--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -34,8 +34,11 @@
 	return text
 
 /client/proc/browse_files(root="data/logs/", max_iterations=10, list/valid_extensions=list("txt", "log", "htm", "json"))
-	// wow why was this ever a parameter
-	root = "data/logs/"
+	if(!dd_hasprefix(root, "data/logs/") || findtext(root, "../"))
+		message_admins("/client/browse_files was called with a non-log or relative root `[root]`, please inform a headcoder!")
+		log_admin("/client/browse_files was called with a non-log or relative root `[root]`!")
+
+		return
 	var/path = root
 
 	for(var/i=0, i<max_iterations, i++)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -23,6 +23,7 @@ GLOBAL_LIST_INIT(admin_verbs_admin, list(
 	/client/proc/cmd_admin_check_contents,	/*displays the contents of an instance*/
 	/client/proc/cmd_admin_open_logging_view,
 	/client/proc/getserverlogs,			/*allows us to fetch server logs (diary) for other days*/
+	/client/proc/get_server_logs_by_round_id,
 	/client/proc/Getmob,				/*teleports a mob to our location*/
 	/client/proc/Getkey,				/*teleports a mob with a certain ckey to our location*/
 	/client/proc/jump_to,				/*Opens a menu for jumping to an Area, Mob, Key or Coordinate*/

--- a/code/modules/admin/verbs/getlogs.dm
+++ b/code/modules/admin/verbs/getlogs.dm
@@ -4,6 +4,9 @@
 	set desc = "View/retrieve logfiles."
 	set category = "Admin"
 
+	if(!check_rights(R_ADMIN))
+		return
+
 	access_file_by_browsing_path(usr, "data/logs/")
 
 /// This proc allows download of past server logs saved within the data/logs/ folder by specifying a specific round ID.
@@ -11,6 +14,9 @@
 	set name = "Get Round Logs"
 	set desc = "View/retrieve logfiles for a given round."
 	set category = "Admin"
+
+	if(!check_rights(R_ADMIN))
+		return
 
 	var/round_id = input(usr, "Enter a round ID.", "Enter Round ID", "[GLOB.round_id]") as null|text
 	if(isnull(round_id))

--- a/code/modules/admin/verbs/getlogs.dm
+++ b/code/modules/admin/verbs/getlogs.dm
@@ -13,7 +13,7 @@
 	set category = "Admin"
 
 	var/round_id = input(usr, "Enter a round ID.", "Enter Round ID", "[GLOB.round_id]") as null|text
-	if(!round_id)
+	if(isnull(round_id))
 		return
 
 	var/round_path = "[GLOB.log_directory]/"

--- a/code/modules/admin/verbs/getlogs.dm
+++ b/code/modules/admin/verbs/getlogs.dm
@@ -1,41 +1,63 @@
-/*
-	HOW DO I LOG RUNTIMES?
-	Firstly, start dreamdeamon if it isn't already running. Then select "world>Log Session" (or press the F3 key)
-	navigate the popup window to the data/logs/runtime/ folder from where your tgstation .dmb is located.
-	(you may have to make this folder yourself)
-
-	OPTIONAL: 	you can select the little checkbox down the bottom to make dreamdeamon save the log everytime you
-				start a world. Just remember to repeat these steps with a new name when you update to a new revision!
-
-	Save it with the name of the revision your server uses (e.g. r3459.txt).
-	Game Masters will now be able to grant access any runtime logs you have archived this way!
-	This will allow us to gather information on bugs across multiple servers and make maintaining the TG
-	codebase for the entire /TG/station commuity a TONNE easier :3 Thanks for your help!
-*/
-
-
-//This proc allows download of past server logs saved within the data/logs/ folder.
+/// This proc allows download of past server logs saved within the data/logs/ folder.
 /client/proc/getserverlogs()
 	set name = "Get Server Logs"
 	set desc = "View/retrieve logfiles."
 	set category = "Admin"
 
-	var/path = browse_files("data/logs/")
-	if(!path)
+	access_file_by_browsing_path(usr, "data/logs/")
+
+/// This proc allows download of past server logs saved within the data/logs/ folder by specifying a specific round ID.
+/client/proc/get_server_logs_by_round_id()
+	set name = "Get Round Logs"
+	set desc = "View/retrieve logfiles for a given round."
+	set category = "Admin"
+
+	var/round_id = input(usr, "Enter a round ID.", "Enter Round ID", "[GLOB.round_id]") as null|text
+	if(!round_id)
 		return
 
-	if(file_spam_check())
+	var/round_path = "[GLOB.log_directory]/"
+	if(round_id != "[GLOB.round_id]")
+		var/datum/db_query/query = SSdbcore.NewQuery(
+			"SELECT UNIX_TIMESTAMP(initialize_datetime) AS dt FROM round WHERE id = :id",
+			list(id = round_id)
+		)
+		if(!query.warn_execute())
+			qdel(query)
+			to_chat(usr, "Could not check database for round [round_id].")
+			return
+
+		if(!query.NextRow())
+			qdel(query)
+			to_chat(usr, "Could not find round [round_id] in database.")
+			return
+
+		// convert unix timestamp in seconds to byond timestamp in deciseconds
+		var/round_datetime = (query.item[1] - BYOND_EPOCH_UNIX) * 10
+		round_path = "data/logs/[time2text(round_datetime, "YYYY/MM-Month/DD-Day")]/round-[round_id]/"
+		qdel(query)
+
+	access_file_by_browsing_path(usr, round_path)
+
+/proc/access_file_by_browsing_path(mob/user, path)
+	if(!user.client)
 		return
 
-	message_admins("[key_name_admin(src)] accessed file: [path]")
-	switch(alert("View (in game), Open (in your system's text editor), or Download?", path, "View", "Open", "Download"))
+	var/filename = user.client.browse_files(path)
+	if(!filename)
+		return
+
+	if(user.client.file_spam_check())
+		return
+
+	message_admins("[key_name_admin(user)] accessed file: [filename]")
+	switch(alert("View (in game), Open (in your system's text editor), or Download?", filename, "View", "Open", "Download"))
 		if("View")
-			src << browse("<pre style='word-wrap: break-word;'>[html_encode(wrap_file2text(wrap_file(path)))]</pre>", list2params(list("window" = "viewfile.[path]")))
+			user << browse("<pre style='word-wrap: break-word;'>[html_encode(wrap_file2text(wrap_file(filename)))]</pre>", list2params(list("window" = "viewfile.[filename]")))
 		if("Open")
-			src << run(wrap_file(path))
+			user << run(wrap_file(filename))
 		if("Download")
-			src << ftp(wrap_file(path))
+			user << ftp(wrap_file(filename))
 		else
 			return
-	to_chat(src, "Attempting to send [path], this may take a fair few minutes if the file is very large.")
-	return
+	to_chat(user, "Attempting to send [filename], this may take a fair few minutes if the file is very large.")


### PR DESCRIPTION
## What Does This PR Do
This PR adds an admin command for accessing logs for rounds by entering their ID. It defaults to the current round but will look up the log directory based on the date time of the inputted round in the database. Kind of fiddly but does the job.
## Why It's Good For The Game
Admin request.
## Images of changes
https://github.com/user-attachments/assets/33f8c0b2-59b3-4c82-803c-aa1ca916ad2c
## Testing
See above
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC