### PR TITLE
fix too-long oven recipes

### DIFF
--- a/code/modules/cooking/recipes/oven_recipes.dm
+++ b/code/modules/cooking/recipes/oven_recipes.dm
@@ -358,7 +358,7 @@
 		PCWJ_ADD_PRODUCE(/obj/item/food/grown/banana),
 		PCWJ_ADD_REAGENT("milk", 5),
 		PCWJ_ADD_REAGENT("sugar", 15),
-		PCWJ_USE_OVEN(J_MED, 50 SECONDS),
+		PCWJ_USE_OVEN(J_MED, 30 SECONDS),
 	)
 
 /datum/cooking/recipe/cookies
@@ -618,7 +618,7 @@
 		PCWJ_ADD_PRODUCE(/obj/item/food/grown/berries),
 		PCWJ_ADD_REAGENT("milk", 5),
 		PCWJ_ADD_REAGENT("sugar", 15),
-		PCWJ_USE_OVEN(J_MED, 50 SECONDS),
+		PCWJ_USE_OVEN(J_MED, 30 SECONDS),
 	)
 
 /datum/cooking/recipe/limecake


### PR DESCRIPTION
## What Does This PR Do
This PR fixes #29179.
## Why It's Good For The Game
Recipes should work.
## Testing
Completed both recipes in-game.
![2025_04_30__12_04_27__Paradise Station 13](https://github.com/user-attachments/assets/fd8f6052-f89a-45ac-82dc-fe1b69da63f9)
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: The bake times for strawberry chocolate cake and clown cake have been fixed to not cause a burnt mess.
/:cl: