### PR TITLE
fix lavaland anomalous crystal shuttle floors

### DIFF
--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -473,3 +473,25 @@
 /turf/simulated/floor/plating/nitrogen
 	oxygen = 0
 	nitrogen = MOLES_N2STANDARD + MOLES_O2STANDARD
+
+/// Used in situations like the anomalous crystal where we want
+/// floors that look and act like asteroid floors but aren't.
+/// This doesn't allow you to dig sand out of it but whatever.
+/turf/simulated/floor/plating/false_asteroid
+	gender = PLURAL
+	name = "volcanic floor"
+	baseturf = /turf/simulated/floor/plating/false_asteroid
+	icon_state = "basalt"
+	icon_plating = "basalt"
+	footstep = FOOTSTEP_SAND
+	barefootstep = FOOTSTEP_SAND
+	clawfootstep = FOOTSTEP_SAND
+	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
+	var/environment_type = "basalt"
+	var/turf_type = /turf/simulated/floor/plating/false_asteroid
+	var/floor_variance = 20 //probability floor has a different icon state
+
+/turf/simulated/floor/plating/false_asteroid/AfterChange(ignore_air, keep_cabling)
+	. = ..()
+	if(prob(floor_variance))
+		icon_plating = "[environment_type][rand(0,12)]"

--- a/code/modules/mining/lavaland/loot/colossus_loot.dm
+++ b/code/modules/mining/lavaland/loot/colossus_loot.dm
@@ -101,8 +101,8 @@
 	. = ..()
 	terrain_theme = pick("lavaland","winter","jungle","alien")
 	switch(terrain_theme)
-		if("lavaland")//Depressurizes the place... and free cult metal, I guess.
-			NewTerrainFloors = /turf/simulated/floor/plating/asteroid/basalt // Needs to be updated after turf update
+		if("lavaland")//Free cult metal, I guess.
+			NewTerrainFloors = /turf/simulated/floor/plating/false_asteroid
 			NewTerrainWalls = /turf/simulated/wall/cult
 			NewFlora = list(/mob/living/simple_animal/hostile/asteroid/goldgrub)
 			florachance = 1
@@ -135,13 +135,13 @@
 				if(isturf(Stuff))
 					var/turf/T = Stuff
 					if((isspaceturf(T) || isfloorturf(T)) && NewTerrainFloors)
-						var/turf/simulated/O = T.ChangeTurf(NewTerrainFloors)
+						var/turf/simulated/O = T.ChangeTurf(NewTerrainFloors, keep_icon = FALSE)
 						if(prob(florachance) && length(NewFlora) && !is_blocked_turf(O))
 							var/atom/Picked = pick(NewFlora)
 							new Picked(O)
 						continue
 					if(iswallturf(T) && NewTerrainWalls && !istype(T, /turf/simulated/wall/indestructible))
-						T.ChangeTurf(NewTerrainWalls)
+						T.ChangeTurf(NewTerrainWalls, keep_icon = FALSE)
 						continue
 				if(istype(Stuff, /obj/structure/chair) && NewTerrainChairs)
 					var/obj/structure/chair/Original = Stuff


### PR DESCRIPTION
## What Does This PR Do
This PR makes a fake version of asteroid floors for use with the anomalous crystal theme warp for Lavaland. This ensures the floors will still count as floors for the purposes of shuttle transit.

It also removes a comment about the lavaland theme warp "depressurizing" the area that gets transformed; even when Lavaland was first added that wouldn't have been true due to how Lavaland was ported over from /tg/.
## Why It's Good For The Game
This fixes a serious regression that is caused when used on shuttles.
## Testing
![2025_04_30__13_14_13__Paradise Station 13](https://github.com/user-attachments/assets/f308c902-186e-44b7-bab6-83e068a773d9)
![2025_04_30__13_14_28__Paradise Station 13](https://github.com/user-attachments/assets/fe448d13-00ba-499c-9e5a-c8a8083e0d2a)
![2025_04_30__13_14_35__Paradise Station 13](https://github.com/user-attachments/assets/cf0c9a0a-db88-49ee-81d5-e20c920bb293)
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Anomalous crystals which theme warp areas to "Lavaland" will generate the correct floors and work as expected on shuttles.
/:cl: