### PR TITLE
Hides morph ventcrawl cogbar

### DIFF
--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -513,7 +513,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 	if(!client)
 		return
 #endif
-	if(!do_after(src, ventcrawl_delay, target = src))
+	if(!do_after(src, ventcrawl_delay, target = src, hidden = TRUE))
 		return
 
 	if(!vent_found.can_crawl_through())

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -513,8 +513,11 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 	if(!client)
 		return
 #endif
-	if(!do_after(src, ventcrawl_delay, target = src, hidden = TRUE))
+	if(ismorph(src))
+		if(!do_after(src, ventcrawl_delay, target = src, hidden = TRUE))
 		return
+	else
+		if(!do_after(src, ventcrawl_delay, target = src))
 
 	if(!vent_found.can_crawl_through())
 		to_chat(src, "<span class='warning'>You can't vent crawl through that!</span>")

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -515,10 +515,10 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 #endif
 	if(ismorph(src))
 		if(!do_after(src, ventcrawl_delay, target = src, hidden = TRUE))
-		return
+			return
 	else
 		if(!do_after(src, ventcrawl_delay, target = src))
-
+			return
 	if(!vent_found.can_crawl_through())
 		to_chat(src, "<span class='warning'>You can't vent crawl through that!</span>")
 		return


### PR DESCRIPTION
## What Does This PR Do
Hides morphs ventcrawl cogbar. Fixes #28835
## Why It's Good For The Game
For something that can mimick anything, it doesnt make sense to blatantly announce sinking into a vent.
## Images of changes
![image](https://github.com/user-attachments/assets/b240f582-9bbb-429d-9482-4aa5067b79b7)
## Testing
Loaded server with 2 clients, observed morph from 2nd client.
### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Hides morph ventcrawl cogbar
/:cl: