### PR TITLE
IPCs can be colorblind

### DIFF
--- a/code/modules/mob/mob_misc_procs.dm
+++ b/code/modules/mob/mob_misc_procs.dm
@@ -81,7 +81,7 @@
 	if(istype(worn_glasses) && worn_glasses.color_view) //Check to see if they got those magic glasses and they're augmenting the colour of what the wearer sees. If they're not, color_view should be null.
 		return worn_glasses.color_view
 	else if(eyes) //If they're not, check to see if their eyes got one of them there colour matrices. Will be null if eyes are robotic/the mob isn't colourblind and they have no default colour matrix.
-		return eyes.get_colourmatrix()
+		return eyes.get_colormatrix()
 
 /**
   * Flash up a color as an overlay on a player's screen, then fade back to normal.

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -6,8 +6,8 @@
 	parent_organ = "head"
 	slot = "eyes"
 	var/eye_color = "#000000" // Should never be null
-	var/list/colourmatrix = null
-	var/list/colourblind_matrix = MATRIX_GREYSCALE //Special colourblindness parameters. By default, it's black-and-white.
+	var/list/colormatrix = null
+	var/list/colorblind_matrix = MATRIX_GREYSCALE //Special colourblindness parameters. By default, it's black-and-white.
 	var/list/replace_colours = GREYSCALE_COLOR_REPLACE
 	var/dependent_disabilities = list() //Gets set by eye-dependent disabilities such as colourblindness so the eyes can transfer the disability during transplantation.
 	var/weld_proof = FALSE //If set, the eyes will not take damage during welding. eg. IPC optical sensors do not take damage when they weld things while all other eyes will.
@@ -18,6 +18,8 @@
 	var/flash_protect = FLASH_PROTECTION_NONE
 	var/see_invisible = SEE_INVISIBLE_LIVING
 	var/lighting_alpha = LIGHTING_PLANE_ALPHA_VISIBLE
+	/// If someone with the colorblind trait who has these eyes will actually be colorblind
+	var/can_be_colorblind = TRUE
 
 /obj/item/organ/internal/eyes/proc/update_colour()
 	dna.write_eyes_attributes(src)
@@ -31,11 +33,11 @@
 
 	return eyes_icon
 
-/obj/item/organ/internal/eyes/proc/get_colourmatrix() //Returns a special colour matrix if the eyes are organic and the mob is colourblind, otherwise it uses the current one.
-	if(!is_robotic() && HAS_TRAIT(owner, TRAIT_COLORBLIND))
-		return colourblind_matrix
+/obj/item/organ/internal/eyes/proc/get_colormatrix() //Returns a special colour matrix if the eyes are organic and the mob is colourblind, otherwise it uses the current one.
+	if(can_be_colorblind && HAS_TRAIT(owner, TRAIT_COLORBLIND))
+		return colorblind_matrix
 	else
-		return colourmatrix
+		return colormatrix
 
 /obj/item/organ/internal/eyes/proc/shine()
 	if(is_robotic() || (see_in_dark > EYE_SHINE_THRESHOLD))
@@ -101,7 +103,7 @@
 	icon_state = "burning_eyes"
 
 /obj/item/organ/internal/eyes/robotize(make_tough)
-	colourmatrix = null
+	colormatrix = null
 	..() //Make sure the organ's got the robotic status indicators before updating the client colour.
 	if(owner)
 		owner.update_client_colour(0) //Since mechanical eyes give see_in_dark of 2 and full colour vision atm, just having this here is fine.
@@ -112,6 +114,7 @@
 	desc = "An electronic device designed to mimic the functions of a pair of human eyes. It has no benefits over organic eyes, but is easy to produce."
 	origin_tech = "biotech=4"
 	status = ORGAN_ROBOT
+	can_be_colorblind = FALSE // I PRINTED 400 PAIRS OF NEW EYES TO CURE COLORBLIND KIDS! -Space Beast
 	var/flash_intensity = 1
 
 /obj/item/organ/internal/eyes/cybernetic/emp_act(severity)
@@ -362,7 +365,7 @@
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	flash_protect = FLASH_PROTECTION_VERYVUNERABLE //Flashing is it's weakness. I don't care how many protections you have up
 	owner?.client?.color = LIGHT_COLOR_PURE_CYAN
-	colourmatrix = list(0, 0, 0,\
+	colormatrix = list(0, 0, 0,\
 						0, 1, 0,\
 						0, 0, 1)
 	owner.update_sight()
@@ -376,7 +379,7 @@
 	lighting_alpha = initial(lighting_alpha)
 	flash_protect = initial(flash_protect)
 	owner?.client?.color = null
-	colourmatrix = null
+	colormatrix = null
 	owner.update_sight()
 	owner.update_eyes_overlay_layer()
 

--- a/code/modules/surgery/organs/subtypes/tajaran_organs.dm
+++ b/code/modules/surgery/organs/subtypes/tajaran_organs.dm
@@ -6,14 +6,14 @@
 /obj/item/organ/internal/eyes/tajaran
 	icon = 'icons/obj/species_organs/tajaran.dmi'
 	name = "tajaran eyeballs"
-	colourblind_matrix = MATRIX_TAJ_CBLIND //The colour matrix and darksight parameters that the mob will receive when they get the disability.
+	colorblind_matrix = MATRIX_TAJ_CBLIND //The colour matrix and darksight parameters that the mob will receive when they get the disability.
 	replace_colours = TRITANOPIA_COLOR_REPLACE
 	see_in_dark = 3
 
 /// Being the lesser form of Tajara, Farwas have an utterly incurable version of their colourblindness.
 /obj/item/organ/internal/eyes/tajaran/farwa
 	name = "farwa eyeballs"
-	colourmatrix = MATRIX_TAJ_CBLIND
+	colormatrix = MATRIX_TAJ_CBLIND
 	see_in_dark = 3
 	replace_colours = TRITANOPIA_COLOR_REPLACE
 

--- a/code/modules/surgery/organs/subtypes/vulpkanin_organs.dm
+++ b/code/modules/surgery/organs/subtypes/vulpkanin_organs.dm
@@ -6,14 +6,14 @@
 /obj/item/organ/internal/eyes/vulpkanin
 	name = "vulpkanin eyeballs"
 	icon = 'icons/obj/species_organs/vulpkanin.dmi'
-	colourblind_matrix = MATRIX_VULP_CBLIND //The colour matrix and darksight parameters that the mob will receive when they get the disability.
+	colorblind_matrix = MATRIX_VULP_CBLIND //The colour matrix and darksight parameters that the mob will receive when they get the disability.
 	replace_colours = PROTANOPIA_COLOR_REPLACE
 	see_in_dark = 3
 
 /// Being the lesser form of Vulpkanin, Wolpins have an utterly incurable version of their colourblindness.
 /obj/item/organ/internal/eyes/vulpkanin/wolpin
 	name = "wolpin eyeballs"
-	colourmatrix = MATRIX_VULP_CBLIND
+	colormatrix = MATRIX_VULP_CBLIND
 	see_in_dark = 3
 	replace_colours = PROTANOPIA_COLOR_REPLACE
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Changes it so IPCs are fully affected by colorblindness instead of just with pulsing wires. Also changes a few instances of "colour" to "color".
## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
If you choose the colorblind disability, you should be colorblind. They already have the colorblind version of door wires, so this keeps the behavior consistent. Also keeping coding standards up to date a bit more.
## Testing

<!-- How did you test the PR, if at all? -->
Spawned in as human with colorblind, and IPC with colorblind. Replaced both eyes with cybernetics and colorblindness was properly cured.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: IPCs are fully affected by colorblindness
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
