### PR TITLE
Fix repeat kill objective rerolls

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -119,7 +119,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	for(var/datum/mind/M in get_owners())
 		if(possible_target == M)
 			return TARGET_INVALID_IS_OWNER
-		if(possible_target in M.targets)
+		if(possible_target in holder.get_targets())
 			return TARGET_INVALID_IS_TARGET
 	if(SEND_SIGNAL(src, COMSIG_OBJECTIVE_CHECK_VALID_TARGET, possible_target) & OBJECTIVE_INVALID_TARGET)
 		return TARGET_INVALID_BLACKLISTED

--- a/code/game/gamemodes/objective_holder.dm
+++ b/code/game/gamemodes/objective_holder.dm
@@ -56,6 +56,12 @@
 	return objectives
 
 /**
+ * Get all of our targets
+ */
+/datum/objective_holder/proc/get_targets()
+	return assigned_targets
+
+/**
  * Replace old_objective with new_objective
  */
 /datum/objective_holder/proc/replace_objective(datum/objective/old_objective, datum/objective/new_objective, datum/original_target_department, list/original_steal_list)


### PR DESCRIPTION
## What Does This PR Do
Fixes #29065
Adds a proc to `objective_holder` which will return the list of assigned targets. Changed the target validity check to use the returned list.
## Why It's Good For The Game
Bug bad. Objectives should reroll into valid targets or not at all.
## Images of changes
![image](https://github.com/user-attachments/assets/95a9c955-8238-4113-a73f-58394fa551ad)
![image](https://github.com/user-attachments/assets/3d83afab-8c42-4163-a931-ccbd71b1ba25)
![image](https://github.com/user-attachments/assets/5497fc0e-5a5e-4d8e-b89f-3d86811d7a0e)

## Testing
As shown on the images, the round had a total of 3 crew, 2 valid targets. Upon cryoing of one target, there's now only 2 crew.  The objective tried to reroll, but due to a lack of valid targets (the sole existing one already being a target), it removed the objective.
### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Objectives will no longer reroll repeats.
/:cl: