### PR TITLE
Restores the "malfunctioning" screen state for the ai

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai_mob.dm
+++ b/code/modules/mob/living/silicon/ai/ai_mob.dm
@@ -506,7 +506,8 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 		"NAD Burn",
 		"Borb",
 		"Bee",
-		"Catamari"
+		"Catamari",
+		"Malfunctioning",
 		)
 	if(custom_sprite)
 		display_choices += "Custom"
@@ -613,6 +614,8 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 			icon_state = "ai-bee"
 		if("Catamari")
 			icon_state = "ai-catamari"
+		if("Malfunctioning")
+			icon_state = "ai-malf"
 		else
 			icon_state = "ai"
 


### PR DESCRIPTION
## What Does This PR Do
Lets the AI pick the "malfunctioning" screen display again
## Why It's Good For The Game
Was unintentionally removed as an option back in 2013
## Images of changes
![Code_TrFNzYb1Gf](https://github.com/user-attachments/assets/436edcfd-2234-4407-b65d-1396f589afc1)
(this doesn't add any sprites, just the selection but heres what it looks like)
## Testing
compiled. spawned a ai core possessed the ai core chose the "malfunctioning" option, icon properly changed
### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
add: Added back the "malfunctioning" as an optional screen state for the ai
/:cl: