### PR TITLE
removes 1 tile chasm potential from summoning ritual ruin

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
@@ -309,7 +309,7 @@ a
 a
 d
 e
-B
+Z
 s
 B
 b
@@ -317,7 +317,7 @@ b
 b
 B
 s
-B
+Z
 s
 d
 a
@@ -330,7 +330,7 @@ a
 a
 a
 b
-Z
+Q
 b
 a
 a

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
@@ -77,6 +77,12 @@
 "B" = (
 /turf/simulated/floor/lava/mapping_lava,
 /area/ruin/unpowered/misc_lavaruin)
+"Q" = (
+/turf/simulated/floor/lava/lava_land_surface/plasma,
+/area/ruin/unpowered/misc_lavaruin)
+"Z" = (
+/turf/simulated/floor/lava/lava_land_surface,
+/area/ruin/unpowered/misc_lavaruin)
 
 (1,1,1) = {"
 a
@@ -86,7 +92,7 @@ a
 a
 a
 b
-B
+Q
 b
 a
 a
@@ -99,7 +105,7 @@ a
 a
 d
 e
-B
+Z
 s
 B
 b
@@ -107,7 +113,7 @@ b
 b
 B
 s
-B
+Z
 s
 d
 a
@@ -131,7 +137,7 @@ a
 "}
 (4,1,1) = {"
 a
-B
+Q
 s
 B
 B
@@ -143,7 +149,7 @@ B
 B
 B
 e
-B
+Q
 a
 "}
 (5,1,1) = {"
@@ -198,7 +204,7 @@ b
 b
 "}
 (8,1,1) = {"
-B
+Z
 b
 g
 b
@@ -212,7 +218,7 @@ b
 b
 g
 b
-B
+Z
 "}
 (9,1,1) = {"
 b
@@ -267,7 +273,7 @@ a
 "}
 (12,1,1) = {"
 a
-B
+Q
 s
 B
 B
@@ -279,7 +285,7 @@ B
 B
 B
 e
-B
+Q
 a
 "}
 (13,1,1) = {"
@@ -324,7 +330,7 @@ a
 a
 a
 b
-B
+Z
 b
 a
 a


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Changes the 1 tile random lava to alternating plasma / lava tiles.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

For a ruin for cosmetic loot (unless you are a cult I guess), the 1 tile random tiles potentially being chasms is a bit punishing. As such, we change them to be the lava / plasma tiles.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
before

![image](https://github.com/user-attachments/assets/c0ca15a8-2b16-4e59-aa15-ff942724bdf6)

after

![image](https://github.com/user-attachments/assets/9d540ef8-5d2e-4440-98d4-b2662868ee4d)

after with no darksight

![image](https://github.com/user-attachments/assets/1293dab1-e6d6-4348-8412-8db7589f767d)


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

see above, even missed tiles originally

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: removes 1 tile chasm potential from summoning ritual ruin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
