### PR TITLE
fix empty list length check in volcano

### DIFF
--- a/code/datums/weather/weather_types/lavaland_weather.dm
+++ b/code/datums/weather/weather_types/lavaland_weather.dm
@@ -173,9 +173,7 @@
 		for(var/turf/T in get_area_turfs(/area/lavaland/surface/outdoors))
 			if(istype(T, /turf/simulated/floor/)) // dont waste our time hitting walls
 				valid_targets += T
-		while(hits <= 150) //sling a bunch of rocks around the map
-			if(!valid_targets) // god forbid we run out of spots to sling rocks
-				break
+		while(hits <= 150 && length(valid_targets)) //sling a bunch of rocks around the map
 			target = pick(valid_targets)
 			new /obj/effect/temp_visual/rock_target(target)
 			hits++


### PR DESCRIPTION
## What Does This PR Do
This PR changes a check in volcano's area_act to check for a list length instead of truthiness.
## Why It's Good For The Game
Fixes a runtime.
## Testing
Visual inspection.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC
