### PR TITLE
[TM ONLY] Asset CDN debugging utility

### DIFF
--- a/code/controllers/subsystem/non_firing/SSassets.dm
+++ b/code/controllers/subsystem/non_firing/SSassets.dm
@@ -37,3 +37,32 @@ SUBSYSTEM_DEF(assets)
 			continue
 
 		load_asset_datum(type)
+
+
+
+// Debug shite
+/client/proc/dump_all_assets()
+	set name = "Upload All Assets"
+	set category = "Debug"
+
+	if(ckey != "affectedarc07")
+		to_chat(usr, "This is only for the host - its a temporary verb lol")
+		return
+
+	var/datum/asset_transport/webroot/wat = new() // this stands for webroot asset transport not my confusion I swear
+
+
+	var/assets_to_process = length(SSassets.cache)
+	var/done = 0
+
+	to_chat(usr, "Starting mass asset dump - [assets_to_process] to do")
+	var/watch = start_watch()
+	for(var/key in SSassets.cache)
+		if(TICK_CHECK)
+			to_chat(usr, "Sleeping for 1 tick - [done]/[assets_to_process] done")
+			CHECK_TICK
+		var/datum/asset/A = SSassets.cache[key]
+		wat.save_asset_to_webroot(A)
+		done++
+
+	to_chat(usr, "Done within [stop_watch(watch)]s")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -186,6 +186,7 @@ GLOBAL_LIST_INIT(admin_verbs_debug, list(
 	/client/proc/debug_atom_init,
 	/client/proc/debug_bloom,
 	/client/proc/cmd_mass_screenshot,
+	/client/proc/dump_all_assets,
 	))
 GLOBAL_LIST_INIT(admin_verbs_possess, list(
 	/proc/possess,


### PR DESCRIPTION
## What Does This PR Do
Adds a verb that dumps all the current assets to the webroot.

Why?

So I am trying to make asset CDN stuff work to reduce lag and other stuff like that, but testing it is a royal pain in the arse because its all or nothing, and if I try and run a round with it I break assets for the entire server.

The plan here is to make a verb I can run on prod to copy all items to the prod webroot assets folder then point my local client at that so I can debug it in peace.

This should only ever be TM'd because this verb is the hackiest of hacks. It also means when I test this I need to be on the same commit as the server since the TGUI assets and stuff may change their MD5. This is pain.

## Why It's Good For The Game
See above.

## Testing
I pressed the button, files appeared.
![image](https://github.com/user-attachments/assets/a6bb395f-ccc3-4e4a-9367-3b21e24872cb)

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl: AffectedArc07
experiment: Someone merged a TM only PR. 
/:cl: