### PR TITLE
add siegedlab loot, add research paper noticeboard

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/sieged_lab.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/sieged_lab.dmm
@@ -56,7 +56,6 @@
 /area/ruin/space/sieged_lab)
 "dy" = (
 /obj/structure/table/wood,
-/obj/item/paper/sieged_lab_research_paper,
 /turf/simulated/floor/carpet/royalblue,
 /area/ruin/space/sieged_lab)
 "dE" = (
@@ -558,6 +557,12 @@
 	icon_state = "yellow"
 	},
 /area/ruin/space/sieged_lab)
+"AB" = (
+/obj/structure/noticeboard,
+/obj/item/paper/sieged_lab_research_paper,
+/obj/item/paper/sieged_lab_research_paper,
+/turf/simulated/wall/indestructible/riveted,
+/area/ruin/space/sieged_lab)
 "AC" = (
 /obj/structure/sign/directions/engineering{
 	pixel_x = 32;
@@ -850,6 +855,12 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
+/area/ruin/space/sieged_lab)
+"PF" = (
+/obj/structure/safe/floor,
+/obj/effect/spawner/random/pool/spaceloot/syndicate/rare/sieged_lab,
+/obj/effect/spawner/random/pool/spaceloot/syndicate/rare/sieged_lab,
+/turf/simulated/floor/carpet/royalblue,
 /area/ruin/space/sieged_lab)
 "PI" = (
 /obj/machinery/space_heater,
@@ -3250,9 +3261,9 @@ GU
 Fc
 Fc
 KP
-SP
+AB
 GY
-GY
+PF
 dy
 GY
 Gh

--- a/code/modules/awaymissions/mission_code/ruins/sieged_lab.dm
+++ b/code/modules/awaymissions/mission_code/ruins/sieged_lab.dm
@@ -175,3 +175,6 @@ GLOBAL_LIST_INIT(ruin_sieged_lab_research_loot, list(
 
 /obj/effect/mine/sieged_lab/mineEffect(mob/living/victim)
 	explosion(loc, 1, 0, 0, 1) // devastate the tile you are on, but leave everything else untouched
+
+/obj/effect/spawner/random/pool/spaceloot/syndicate/rare/sieged_lab
+	guaranteed = TRUE


### PR DESCRIPTION
## What Does This PR Do
This PR puts the two research papers in the sieged lab executive room on a noticeboard, and puts a safe under the floor containing two guaranteed space loot pool spawners.
## Why It's Good For The Game
The sieged lab gets depressurized often due to mines and things and the research papers were getting constantly blown off the table and lost. The syndicate loot isn't ingenious or anything but sieged lab loot is awful right now and at least people will get used to looking for a floor safe so we can add something else to it later. I got some more interesting feedback about things which may come later.
## Images of changes
![2025_05_02__18_52_42__paradise dme  sieged_lab dmm  - StrongDMM](https://github.com/user-attachments/assets/2df2fc03-7f89-4879-aef0-7243b3fe8056)
![2025_05_02__19_08_42__Paradise Station 13](https://github.com/user-attachments/assets/07186da5-c17f-4175-90ed-91f9b98ca3a5)
## Testing
Spawned in, ensured I could get the papers off the noticeboard. Took off carpet, ensured that safe contained spawned contents.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
![2025_05_02__21_05_52__#balance_chat _ Paradise Station - Discord](https://github.com/user-attachments/assets/5ef96de0-8c7e-476f-9709-b49ef17909d5)

## Changelog
:cl:
add: The sieged lab executive suite now contains a safe with potentially valuable Syndicate goodies.
fix: The sieged lab research papers are now affixed to a noticeboard, so they won't fly off and get lost.
/:cl: