### PR TITLE
Smith Polish: Fast-Click Lens Durability Fix

### DIFF
--- a/code/modules/projectiles/guns/energy_guns.dm
+++ b/code/modules/projectiles/guns/energy_guns.dm
@@ -173,9 +173,9 @@
 /obj/item/gun/energy/process_fire(atom/target, mob/living/user, message = 1, params, zone_override, bonus_spread = 0)
 	if(!chambered && can_shoot())
 		process_chamber()
+	..()
 	if(current_lens)
 		current_lens.damage_lens()
-	return ..()
 
 /obj/item/gun/energy/proc/select_fire(mob/living/user)
 	select++

--- a/code/modules/projectiles/guns/energy_guns.dm
+++ b/code/modules/projectiles/guns/energy_guns.dm
@@ -173,6 +173,9 @@
 /obj/item/gun/energy/process_fire(atom/target, mob/living/user, message = 1, params, zone_override, bonus_spread = 0)
 	if(!chambered && can_shoot())
 		process_chamber()
+	return ..()
+
+/obj/item/gun/energy/shoot_live_shot(mob/living/user, atom/target, pointblank = FALSE, message = TRUE)
 	..()
 	if(current_lens)
 		current_lens.damage_lens()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes an issue where, if you're clicking faster than the gun can shoot, durability damage is still applied to the lens.

## Why It's Good For The Game

Bugs bad.

## Testing

Spawned a lens. Shot gun. Watched durability in VV.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Fixed lenses taking extra damage if clicking faster than the fire rate of the gun
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
