### PR TITLE
Fix examine broadcast sending the wrong messages

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -720,6 +720,13 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 		return
 	return ..()
 
+/mob/living/silicon/ai/broadcast_examine(atom/examined)
+	var/mob/living/silicon/ai/ai = src
+	// Only show the AI's examines if they're in a holopad
+	if(istype(ai.current, /obj/machinery/hologram/holopad))
+		return ..()
+
+
 /mob/living/carbon/human/broadcast_examine(atom/examined)
 	var/obj/item/glasses = get_item_by_slot(ITEM_SLOT_EYES)
 	if(glasses && (HAS_TRAIT(glasses, TRAIT_HIDE_EXAMINE)))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -720,13 +720,6 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 		return
 	return ..()
 
-/mob/living/silicon/ai/broadcast_examine(atom/examined)
-	var/mob/living/silicon/ai/ai = src
-	// Only show the AI's examines if they're in a holopad
-	if(istype(ai.current, /obj/machinery/hologram/holopad))
-		return ..()
-
-
 /mob/living/carbon/human/broadcast_examine(atom/examined)
 	var/obj/item/glasses = get_item_by_slot(ITEM_SLOT_EYES)
 	if(glasses && (HAS_TRAIT(glasses, TRAIT_HIDE_EXAMINE)))
@@ -748,6 +741,13 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 
 /mob/dead/broadcast_examine(atom/examined)
 	return //Observers arent real the government is lying to you
+
+/mob/living/silicon/ai/broadcast_examine(atom/examined)
+	var/mob/living/silicon/ai/ai = src
+	// Only show the AI's examines if they're in a holopad
+	if(istype(ai.current, /obj/machinery/hologram/holopad))
+		return ..()
+
 
 /mob/proc/ret_grab(obj/effect/list_container/mobl/L as obj, flag)
 	if((!istype(l_hand, /obj/item/grab) && !istype(r_hand, /obj/item/grab)))


### PR DESCRIPTION
## What Does This PR Do
Fixes #29190
Examine broadcasts will now send the appropriate messages. If the examined atom is not visible to the user, it will not send an examine message.
## Why It's Good For The Game
Feature wasn't working as intended.
## Testing
In an instance with 2 clients:
- [x] Player 1 examined an atom that neither can see. No examine message was sent to either player.
- [x] Player 1 examined an atom an atom that only player 1 can see. Player 1 received an exact examine message, Player 2 received a vague message.
- [x] Player 1 examined an atom that only Player 2 can see. No message was sent to either player.
- [x] Player 1 examined an atom that both players can see. Both players received an exact examine message.
- [x] Player 1 examined an item it was wearing. Both players received a detailed message.
- [x] Player 1 examined an item in its pockets. Both players received a vague message about "in pockets".
- [x] Player 1 examined an item in its backpack. Player 1 received an exact message, Player 2 received a vague message about "in backpack".
- [x] Player 1 examined an item in a backpack on the floor. Both players received a message about "in backpack"
### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Examines will now send the appropriate message in chat.
/:cl: