### PR TITLE
some food tray improvements

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -361,7 +361,11 @@
 	flags = CONDUCT
 	slot_flags = null
 	materials = list(MAT_METAL=3000)
-	cant_hold = list(/obj/item/disk/nuclear) // Prevents some cheesing
+	can_hold = list(
+		/obj/item/food,
+		/obj/item/reagent_containers/drinks,
+		/obj/item/reagent_containers/condiment,
+	)
 
 /obj/item/storage/bag/tray/attack__legacy__attackchain(mob/living/M, mob/living/user)
 	..()

--- a/code/modules/food_and_drinks/food_base.dm
+++ b/code/modules/food_and_drinks/food_base.dm
@@ -330,7 +330,7 @@
 		if(istype(I, /obj/item/kitchen/knife) || istype(I, /obj/item/scalpel))
 			inaccurate = FALSE
 	else
-		return TRUE
+		return ..()
 	if(!isturf(loc) || !(locate(/obj/structure/table) in loc) && \
 			!(locate(/obj/machinery/optable) in loc) && !(locate(/obj/item/storage/bag/tray) in loc))
 		to_chat(user, "<span class='warning'>You cannot slice [src] here! You need a table or at least a tray to do it.</span>")


### PR DESCRIPTION
## What Does This PR Do
This PR:
- restricts the items food trays can pick up to food and reagent condiment containers
- fixes not being able to pick up sliceable foods like pizzas by clicking on them with a food tray
## Why It's Good For The Game
Yes, technically it's just a tray, there's no reason why you couldn't put anything on it, but its practical usage in game is for storing food. Trying to use it on cluttered kitchen tables to get things into a food and drink cart or the counters is an exercise in frustration because it literally picks up everything that can fit on it, forcing you to constantly pick things off of it to fit the actual things you want. This makes it more useful for its actual job.
## Testing
Used food tray on above items as well as others, ensured it behaved as expected.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: Food trays now only pick up food, reagent containers, and condiment containers.
fix: Sliceable food like pizza can now properly be picked up by clicking on them with a food tray.
/:cl: