### PR TITLE
Oneliner to make RSC CDN work.

### DIFF
--- a/code/controllers/subsystem/SStgui.dm
+++ b/code/controllers/subsystem/SStgui.dm
@@ -30,6 +30,13 @@ SUBSYSTEM_DEF(tgui)
 	polyfill = "<script>\n[polyfill]\n</script>"
 	basehtml = replacetextEx(basehtml, "<!-- tgui:inline-polyfill -->", polyfill)
 
+/datum/controller/subsystem/tgui/can_vv_get(var_name)
+	if(var_name == "basehtml")
+		return FALSE // No security implication here, it just spams the fuck out of the UI
+
+	return ..()
+
+
 /datum/controller/subsystem/tgui/Shutdown()
 	close_all_uis()
 

--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -340,6 +340,7 @@
           var node = document.createElement('link');
           node.type = 'text/css';
           node.rel = 'stylesheet';
+          node.crossOrigin = 'anonymous';
           node.href = url;
           // Temporarily set media to something inapplicable
           // to ensure it'll fetch without blocking render


### PR DESCRIPTION
## What Does This PR Do
So turns out the issue is chrome now cares about CORS for stylesheets and we needed to go "dont worry about this just allow it fam", hence the change to `tgui.html`.

Also removes `basehtml` from the TGUI VV list. There isnt a security risk here, it just bloats the everliving fuck out of the VV window.

## Why It's Good For The Game
RSC CDN Assets good.

## Images of changes
![image](https://github.com/user-attachments/assets/ee2e273b-d2d6-4401-8cf5-58dc30a7697e)

Notice how the assets are infact working

## Testing
See above

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl: AffectedArc07
fix: Fixed CSS for RSC CDN assets
/:cl:
