### PR TITLE
Fixes captains spare ID getting deleted

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -347,7 +347,7 @@
 	for(var/obj/item/I in items)
 		if(istype(I, /obj/item/pda))
 			var/obj/item/pda/P = I
-			QDEL_NULL(P.id)
+			P.id = null
 			qdel(P)
 			continue
 		if(istype(I, /obj/item/storage/backpack/modstorage)) //Best place for me to put it.


### PR DESCRIPTION
## What Does This PR Do
Fixes #29210
The cryopod would qdel the PDA id, resulting in the spare getting deleted. The PDA id slot is now simply set to null and ID card deletion is handled like normal items (captains spare being the sole exclusion)
## Why It's Good For The Game
Important item go kaput no good
## Testing
Put spare ID in PDA, cryod. Respawned and dispensed the spare ID. Regular ID was not kept, PDA was not kept.
### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Captain's spare ID will no longer get eaten by the cryopod.
/:cl: