### PR TITLE
switch spawn pools from using IDs to typerefs

### DIFF
--- a/code/game/objects/effects/spawners/random/pool/lavaland_pools.dm
+++ b/code/game/objects/effects/spawners/random/pool/lavaland_pools.dm
@@ -8,21 +8,19 @@
 	)
 
 /datum/spawn_pool/lavaland_fauna
-	id = "lavaland_fauna_spawn_pool"
 
 /datum/spawn_pool/lavaland_fauna/New()
 	. = ..()
 	available_points = rand(100, 150)
 
 /datum/spawn_pool/lavaland_megafauna
-	id = "lavaland_megafauna_spawn_pool"
 
 /datum/spawn_pool/lavaland_megafauna/New()
 	. = ..()
 	available_points = roll("8d3")
 
 /obj/effect/spawner/random/pool/lavaland_fauna
-	spawn_pool_id = "lavaland_fauna_spawn_pool"
+	spawn_pool = /datum/spawn_pool/lavaland_fauna
 	record_spawn = TRUE
 
 	var/fauna_scan_range = 12
@@ -70,7 +68,7 @@
 	return ..()
 
 /obj/effect/spawner/random/pool/lavaland_fauna/megafauna
-	spawn_pool_id = "lavaland_megafauna_spawn_pool"
+	spawn_pool = /datum/spawn_pool/lavaland_megafauna
 	point_value = 1
 	loot = list(
 		/mob/living/simple_animal/hostile/megafauna/dragon = 4,
@@ -104,14 +102,13 @@
 	)
 
 /datum/spawn_pool/tendrils
-	id = "lavaland_tendril_spawn_pool"
 
 /datum/spawn_pool/tendrils/New()
 	. = ..()
 	available_points = roll("5d4") + roll("1d6")
 
 /obj/effect/spawner/random/pool/tendril_spawner
-	spawn_pool_id = "lavaland_tendril_spawn_pool"
+	spawn_pool = /datum/spawn_pool/tendrils
 	point_value = 1
 	loot = list(
 		/obj/structure/spawner/lavaland,

--- a/code/game/objects/effects/spawners/random/pool/misc_pools.dm
+++ b/code/game/objects/effects/spawners/random/pool/misc_pools.dm
@@ -1,10 +1,9 @@
 /datum/spawn_pool/whiteship_mobs
-	id = "whiteship_mobs_spawn_pool"
 	available_points = 0
 
 /obj/effect/spawner/random/pool/whiteship_mob
 	icon_state = "giftbox"
-	spawn_pool_id = "whiteship_mobs_spawn_pool"
+	spawn_pool = /datum/spawn_pool/whiteship_mobs
 	unique_picks = TRUE
 	guaranteed = TRUE
 	point_value = 0

--- a/code/game/objects/effects/spawners/random/pool/pool_spawner.dm
+++ b/code/game/objects/effects/spawners/random/pool/pool_spawner.dm
@@ -10,8 +10,8 @@
 	var/unique_picks = FALSE
 	/// Guaranteed spawners will always proc, and always proc first.
 	var/guaranteed = FALSE
-	/// The ID of the spawn pool. Must match the pool's [/datum/spawn_pool/var/id].
-	var/spawn_pool_id
+	/// The type of the spawn pool.
+	var/spawn_pool
 
 /obj/effect/spawner/random/pool/Initialize(mapload)
 	// short-circuit atom init machinery since we won't be around long
@@ -19,7 +19,7 @@
 		stack_trace("Warning: [src]([type]) initialized multiple times!")
 	initialized = TRUE
 
-	if(!spawn_pool_id)
+	if(!spawn_pool)
 		stack_trace("No spawn pool ID provided to [src]([type])")
 
 	if(GLOB.spawn_pool_manager.finalized)
@@ -29,9 +29,9 @@
 		qdel(src)
 		return
 
-	var/datum/spawn_pool/pool = GLOB.spawn_pool_manager.get(spawn_pool_id)
+	var/datum/spawn_pool/pool = GLOB.spawn_pool_manager.get(spawn_pool)
 	if(!pool)
-		stack_trace("Could not find spawn pool with ID [spawn_pool_id]")
+		stack_trace("Could not find spawn pool [spawn_pool]")
 
 	if(unique_picks && !(type in pool.unique_spawners))
 		pool.unique_spawners[type] = loot.Copy()
@@ -42,9 +42,9 @@
 		pool.known_spawners |= src
 
 /obj/effect/spawner/random/pool/generate_loot_list()
-	var/datum/spawn_pool/pool = GLOB.spawn_pool_manager.get(spawn_pool_id)
+	var/datum/spawn_pool/pool = GLOB.spawn_pool_manager.get(spawn_pool)
 	if(!pool)
-		stack_trace("Could not find spawn pool with ID [spawn_pool_id]")
+		stack_trace("Could not find spawn pool [spawn_pool]")
 
 	if(unique_picks)
 		var/list/unique_loot = pool.unique_spawners[type]
@@ -62,9 +62,9 @@
 
 	var/is_safe = FALSE
 	var/deduct_points = TRUE
-	var/datum/spawn_pool/pool = GLOB.spawn_pool_manager.get(spawn_pool_id)
+	var/datum/spawn_pool/pool = GLOB.spawn_pool_manager.get(spawn_pool)
 	if(!pool)
-		stack_trace("Could not find spawn pool with ID [spawn_pool_id]")
+		stack_trace("Could not find spawn pool [spawn_pool]")
 
 	if(ispath(type_path_to_make, /obj/effect/spawner/random/pool))
 		return TRUE

--- a/code/game/objects/effects/spawners/random/pool/space_loot.dm
+++ b/code/game/objects/effects/spawners/random/pool/space_loot.dm
@@ -1,9 +1,8 @@
 /datum/spawn_pool/spaceloot
-	id = "space_loot_spawn_pool"
 	available_points = 1700
 
 /obj/effect/spawner/random/pool/spaceloot
-	spawn_pool_id = "space_loot_spawn_pool"
+	spawn_pool = /datum/spawn_pool/spaceloot
 	record_spawn = TRUE
 
 /obj/effect/spawner/random/pool/spaceloot/record_item(type_path_to_make)

--- a/code/game/objects/effects/spawners/random/pool/spawn_pool.dm
+++ b/code/game/objects/effects/spawners/random/pool/spawn_pool.dm
@@ -2,8 +2,6 @@
 /// spawners that need to keep track globally of the number of any specific item
 /// that they spawn.
 /datum/spawn_pool
-	/// The ID of the spawn pool. All spawners registered to this pool must use this ID.
-	var/id
 	/// The number of points left for the spawner to use. Starts at its initial value.
 	var/available_points = 0
 	/// A list of all spawners registered to this pool.
@@ -56,6 +54,6 @@
 
 		qdel(spawner)
 
-	log_game("finished spawner [id] with [length(known_spawners)] remaining spawners and [available_points] points remaining.")
+	log_game("finished spawner [type] with [length(known_spawners)] remaining spawners and [available_points] points remaining.")
 
 	QDEL_LIST_CONTENTS(known_spawners)

--- a/code/game/objects/effects/spawners/random/pool/spawn_pool_manager.dm
+++ b/code/game/objects/effects/spawners/random/pool/spawn_pool_manager.dm
@@ -10,10 +10,10 @@ GLOBAL_DATUM_INIT(spawn_pool_manager, /datum/spawn_pool_manager, new)
 /datum/spawn_pool_manager/New()
 	for(var/spawn_pool_type in subtypesof(/datum/spawn_pool))
 		var/datum/spawn_pool/pool = new spawn_pool_type
-		spawn_pools[pool.id] = pool
+		spawn_pools[spawn_pool_type] = pool
 
-/datum/spawn_pool_manager/proc/get(id)
-	return spawn_pools[id]
+/datum/spawn_pool_manager/proc/get(spawn_pool)
+	return spawn_pools[spawn_pool]
 
 /datum/spawn_pool_manager/proc/process_pools()
 	for(var/pool_id in spawn_pools)

--- a/docs/mapping/spawn_pools.md
+++ b/docs/mapping/spawn_pools.md
@@ -28,7 +28,6 @@ explorer loot to a pool, we first need to create the pool as a distinct
 
 ```dm
 /datum/spawn_pool/space_loot
-	id = "space_loot_pool"
 	available_points = 200
 ```
 
@@ -37,7 +36,7 @@ And then we create the spawners we want, all subtypes of
 
 ```dm
 /obj/effect/spawner/random/pool/space_loot
-	spawn_pool_id = "space_loot_pool"
+	spawn_pool = /datum/spawn_pool/space_loot
 
 /obj/effect/spawner/random/pool/space_loot/tier1
 	point_value = 5


### PR DESCRIPTION
## What Does This PR Do
This PR switches spawn pools from using string IDs to just datum references. I should have done it this way in the first place.
## Why It's Good For The Game
Cleaner, less risk of typos fucking things up.
## Testing
Visual inspection.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC