### PR TITLE
NSS NSS Farragus, moves a double wide airlock to its correct spot

### DIFF
--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -45478,12 +45478,6 @@
 	icon_state = "blue"
 	},
 /area/station/hallway/primary/fore/north)
-"iwy" = (
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/multi_tile/glass/directional/south,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/station/service/bar)
 "iwD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb{
@@ -59850,6 +59844,12 @@
 /obj/structure/table/wood,
 /turf/simulated/floor/wood,
 /area/station/public/vacant_office)
+"lGh" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/multi_tile/glass/directional/south,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/wood,
+/area/station/service/bar)
 "lGj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -129430,8 +129430,8 @@ aZZ
 aZZ
 aZZ
 bjn
+lGh
 xOB
-iwy
 bjn
 aZZ
 aZZ


### PR DESCRIPTION
## What Does This PR Do
Moves the bar double wide airlock to the correct spot
## Why It's Good For The Game
Airlock being in window looks bad
## Images of changes
![image](https://github.com/user-attachments/assets/304f991a-1126-4382-b676-868a05688895)
## Testing
I launched a server and looked at the now moved airlock
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
fix: nudged farragus's bar double wide airlock into frame
/:cl:
