### PR TITLE
Makes antidrop implant release its items regardless which slot theyre in

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -261,10 +261,6 @@
 	if(!istype(W))
 		return FALSE
 
-	if(W.flags & NODROP)
-		to_chat(src, "<span class='warning'>[W] is stuck to your hand!</span>")
-		return FALSE
-
 	if(!W.mob_can_equip(src, slot, disable_warning))
 		if(del_on_fail)
 			qdel(W)

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -115,9 +115,9 @@
 
 /obj/item/organ/internal/cyberimp/brain/anti_drop/proc/release_items()
 	active = FALSE
-	if(!l_hand_ignore && l_hand_obj && (l_hand_obj == owner.l_hand))
+	if(!l_hand_ignore && l_hand_obj)
 		l_hand_obj.flags &= ~NODROP
-	if(!r_hand_ignore && r_hand_obj && (r_hand_obj == owner.r_hand))
+	if(!r_hand_ignore && r_hand_obj)
 		r_hand_obj.flags &= ~NODROP
 
 /obj/item/organ/internal/cyberimp/brain/anti_drop/remove(mob/living/carbon/M, special = 0)

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -103,12 +103,12 @@
 	release_items()
 	..()
 	if(L_item)
-		A = pick(oview(range))
+		A = pick(oview(range, owner))
 		L_item.throw_at(A, range, 2)
 		to_chat(owner, "<span class='notice'>Your left arm spasms and throws [L_item]!</span>")
 		l_hand_obj = null
 	if(R_item)
-		A = pick(oview(range))
+		A = pick(oview(range, owner))
 		R_item.throw_at(A, range, 2)
 		to_chat(owner, "<span class='notice'>Your right arm spasms and throws [R_item]!</span>")
 		r_hand_obj = null

--- a/code/tests/game_tests.dm
+++ b/code/tests/game_tests.dm
@@ -23,6 +23,7 @@
 #include "jobs\test_job_globals.dm"
 #include "test_aicard_icons.dm"
 #include "test_announcements.dm"
+#include "test_anti_drop.dm"
 #include "test_apc_construction.dm"
 #include "test_components.dm"
 #include "test_config_sanity.dm"

--- a/code/tests/test_anti_drop.dm
+++ b/code/tests/test_anti_drop.dm
@@ -4,39 +4,46 @@
 	var/obj/item/autosurgeon/organ/syndicate/autosurg = player.spawn_obj_in_hand(/obj/item/autosurgeon/organ/syndicate)
 
 	autosurg.insert_organ(anti_drop)
-	TEST_ASSERT(autosurg.storedorgan == anti_drop, "failed to inser antidrop in autosurgeon")
+	TEST_ASSERT(autosurg.storedorgan == anti_drop, "failed to insert antidrop in autosurgeon")
 	player.use_item_in_hand()
 	TEST_ASSERT(anti_drop in player.puppet.internal_organs, "failed to insert anti_drop in player")
 	qdel(autosurg)
 
-	var/obj/item/belt = player.spawn_obj_in_hand(/obj/item/storage/belt)
 	var/obj/item/screwdriver = player.spawn_obj_in_hand(/obj/item/screwdriver)
 	anti_drop.ui_action_click()
-	TEST_ASSERT_LAST_CHATLOG(player, "hand's")
-	TEST_ASSERT((belt.flags & NODROP) && (screwdriver.flags & NODROP), "nodrop failed to apply")
-	// TEST_ASSERT(screwdriver.flags & NODROP, "nodrop failed to apply")
-
-	var/left_hand = player.puppet.l_hand
-	var/right_hand = player.puppet.r_hand
-
-
-	anti_drop.emp_act()
-	TEST_ASSERT(!player.puppet.l_hand && !player.puppet.r_hand, "player failed to throw items")
-	TEST_ASSERT_ANY_CHATLOG(player, "arm spasms")
-	TEST_ASSERT(!(belt.flags & NODROP) && !(screwdriver.flags & NODROP), "emp throw failed to remove NODROP")
-
-	belt.forceMove(get_turf(player))
-	player.click_on(belt)
-	TEST_ASSERT(belt in get_both_hands(player), "player failed to pick up belt")
-
-	player.puppet.equip_to_appropriate_slot(belt)
-	player.puppet.drop_item_to_ground(belt)
-	TEST_ASSERT(belt.loc = player, "belt removed with NODROP")
+	TEST_ASSERT((screwdriver.flags & NODROP), "nodrop failed to apply")
+	anti_drop.ui_action_click()
+	TEST_ASSERT(!(screwdriver.flags & NODROP), "nodrop failed to get removed")
 
 	anti_drop.ui_action_click()
+	anti_drop.emp_act()
+	TEST_ASSERT(!(screwdriver in get_both_hands(player.puppet)), "player failed to throw items")
+	TEST_ASSERT(!(screwdriver.flags & NODROP), "emp throw failed to remove NODROP")
+	player.rejuvenate()
+
+	var/obj/item/belt = player.spawn_obj_in_hand(/obj/item/storage/belt)
+	anti_drop.ui_action_click()
+	player.puppet.equip_to_appropriate_slot(belt)
 	player.puppet.drop_item_to_ground(belt)
-	TEST_ASSERT(belt.loc != player, "failed to remove belt after disabling NODROP")
+	TEST_ASSERT(player.puppet.get_item_by_slot(ITEM_SLOT_BELT), "belt removed with NODROP")
+	anti_drop.ui_action_click()
+	player.puppet.drop_item_to_ground(belt)
+	TEST_ASSERT(!player.puppet.get_item_by_slot(ITEM_SLOT_BELT), "failed to remove belt after disabling NODROP")
 
+	var/obj/item/butcher_chainsaw/saw = player.spawn_obj_in_hand(/obj/item/butcher_chainsaw)
+	player.use_item_in_hand()
+	anti_drop.ui_action_click()
+	anti_drop.ui_action_click()
+	TEST_ASSERT(saw.flags & NODROP, "anti_drop removed unique item NODROP")
 
+	player.use_item_in_hand()
+	anti_drop.ui_action_click()
+	player.puppet.put_in_r_hand(saw)
+	TEST_ASSERT(player.puppet.r_hand = saw, "player failed to put saw in right hand")
+	var/obj/item/organ/external/right_hand = player.puppet.get_organ(BODY_ZONE_R_ARM)
+	right_hand.droplimb()
+	TEST_ASSERT(!(saw.flags & NODROP), "limb dismemberment failed to remove NODROP")
 
-
+	player.puppet.put_in_hands(saw)
+	anti_drop.ui_action_click()
+	TEST_ASSERT(!(saw.flags & NODROP), "picking item up with antidrop active applied NODROP")

--- a/code/tests/test_anti_drop.dm
+++ b/code/tests/test_anti_drop.dm
@@ -1,0 +1,42 @@
+/datum/game_test/anti_drop_implant/Run()
+	var/datum/test_puppeteer/player = new(src)
+	var/obj/item/organ/internal/cyberimp/brain/anti_drop/anti_drop = new/obj/item/organ/internal/cyberimp/brain/anti_drop
+	var/obj/item/autosurgeon/organ/syndicate/autosurg = player.spawn_obj_in_hand(/obj/item/autosurgeon/organ/syndicate)
+
+	autosurg.insert_organ(anti_drop)
+	TEST_ASSERT(autosurg.storedorgan == anti_drop, "failed to inser antidrop in autosurgeon")
+	player.use_item_in_hand()
+	TEST_ASSERT(anti_drop in player.puppet.internal_organs, "failed to insert anti_drop in player")
+	qdel(autosurg)
+
+	var/obj/item/belt = player.spawn_obj_in_hand(/obj/item/storage/belt)
+	var/obj/item/screwdriver = player.spawn_obj_in_hand(/obj/item/screwdriver)
+	anti_drop.ui_action_click()
+	TEST_ASSERT_LAST_CHATLOG(player, "hand's")
+	TEST_ASSERT((belt.flags & NODROP) && (screwdriver.flags & NODROP), "nodrop failed to apply")
+	// TEST_ASSERT(screwdriver.flags & NODROP, "nodrop failed to apply")
+
+	var/left_hand = player.puppet.l_hand
+	var/right_hand = player.puppet.r_hand
+
+
+	anti_drop.emp_act()
+	TEST_ASSERT(!player.puppet.l_hand && !player.puppet.r_hand, "player failed to throw items")
+	TEST_ASSERT_ANY_CHATLOG(player, "arm spasms")
+	TEST_ASSERT(!(belt.flags & NODROP) && !(screwdriver.flags & NODROP), "emp throw failed to remove NODROP")
+
+	belt.forceMove(get_turf(player))
+	player.click_on(belt)
+	TEST_ASSERT(belt in get_both_hands(player), "player failed to pick up belt")
+
+	player.puppet.equip_to_appropriate_slot(belt)
+	player.puppet.drop_item_to_ground(belt)
+	TEST_ASSERT(belt.loc = player, "belt removed with NODROP")
+
+	anti_drop.ui_action_click()
+	player.puppet.drop_item_to_ground(belt)
+	TEST_ASSERT(belt.loc != player, "failed to remove belt after disabling NODROP")
+
+
+
+


### PR DESCRIPTION
## What Does This PR Do
Fixes #29226
Let's #29225 be closed.
Undoes my previous fix and lets antidrop implants remove `NODROP` from its items regardless which slot theyre in.
## Why It's Good For The Game
Prevents items getting glued permanently when using anti drop implants.
## Testing
Manually tested the implant and edge cases. Wrote a unit test for it.
### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Belts will no longer get stuck to you when using the anti drop implant.
/:cl: