### PR TITLE
increases garment bag slots to 27

### DIFF
--- a/code/game/objects/items/weapons/storage/garment.dm
+++ b/code/game/objects/items/weapons/storage/garment.dm
@@ -7,7 +7,7 @@
 	max_w_class = WEIGHT_CLASS_NORMAL
 	display_contents_with_number = FALSE
 	max_combined_w_class = 200
-	storage_slots = 21
+	storage_slots = 27
 	resistance_flags = FLAMMABLE
 	can_hold = list(/obj/item/clothing)
 	cant_hold = list(


### PR DESCRIPTION
## What Does This PR Do
Increases the garment bag slots to 27. Fixes #29236
## Why It's Good For The Game
Captains bag has 27 items. Taking an item out results in not being able to put it back in.
## Testing
Tried to put in a 28th item. Bag full.
Took an item out, put it back in.
### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: Garment bags now have 27 slots.
/:cl: