### PR TITLE
Thermite won't create fake plating anymore

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -226,7 +226,7 @@
 /turf/simulated/wall/burn_down()
 	if(istype(sheet_type, /obj/item/stack/sheet/mineral/diamond))
 		return
-	ChangeTurf(/turf/simulated/floor)
+	ChangeTurf(/turf/simulated/floor/plating)
 
 /turf/simulated/wall/proc/thermitemelt(mob/user as mob, speed)
 	if(melting)
@@ -255,7 +255,6 @@
 		burn_down()
 		var/turf/simulated/floor/F = src
 		F.burn_tile()
-		F.icon_state = "plating"
 		if(O)	qdel(O)
 		return
 
@@ -267,7 +266,6 @@
 
 			var/turf/simulated/floor/F = src
 			F.burn_tile()
-			F.icon_state = "plating"
 			break
 		take_damage(30)
 		playsound(src, 'sound/items/welder.ogg', 100, TRUE)


### PR DESCRIPTION
## What Does This PR Do
Makes thermite create actual plating instead of a fake floor with the plating icon. Fixes #29234
## Why It's Good For The Game
The fake default floor is confusing and refuses to be interacted with.
## Testing
Burned down walls with fast acting thermite C4 and with thermite from a beaker. It produced Real Genuine plating.
### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Thermite will no longer produce fake floor.
/:cl: