### PR TITLE
Make mob capsules respect collar names

### DIFF
--- a/code/modules/mining/equipment/lazarus_injector.dm
+++ b/code/modules/mining/equipment/lazarus_injector.dm
@@ -104,9 +104,13 @@
 	else
 		if("neutral" in S.faction)
 			S.forceMove(src)
-			S.name = "[M.name]'s [initial(S.name)]"
+			var/obj/item/petcollar/collar = S.get_item_by_slot(ITEM_SLOT_COLLAR)
+			if(collar)
+				name = "Lazarus Capsule: [S.name]"
+			else
+				S.name = "[M.name]'s [initial(S.name)]"
+				name = "Lazarus Capsule: [initial(S.name)]"
 			S.cancel_camera()
-			name = "Lazarus Capsule: [initial(S.name)]"
 			to_chat(M, "<span class='notice'>You placed a [S.name] inside the Lazarus Capsule!</span>")
 			captured = S
 		else


### PR DESCRIPTION
## What Does This PR Do
This PR makes mob capsules respect pet collar names, both for the capsule name and the mob's name.
## Why It's Good For The Game
Pokemon
## Images of changes
https://github.com/user-attachments/assets/5fc60178-6fb8-40fd-816c-5758e51a0e64
## Testing
Captured a migo without a collar and it's name updated appropriately.
Captured a migo with a Hatsune Mi'Go collar and it's name remained Hatsune Mi'Go. Capsule was named Hatsune Mi'Go as well.
### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: mob capsules will respect pet collar names.
/:cl: