### PR TITLE
fix a bad typecast with collar element

### DIFF
--- a/code/datums/elements/wears_collar.dm
+++ b/code/datums/elements/wears_collar.dm
@@ -55,7 +55,7 @@
 	SIGNAL_HANDLER // COMSIG_ATOM_EXITED
 
 	var/obj/item/petcollar/collar = moved
-	if(!istype(moved))
+	if(!istype(collar))
 		return
 
 	if(collar.tagname)


### PR DESCRIPTION
## What Does This PR Do
This PR fixes a typo in a typecast for pet collars.
## Why It's Good For The Game
You can get in this situation when e.g. Poly drops an item they're holding, and this will runtime. Runtimes bad.
## Testing
Visual inspection.
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC