### PR TITLE
Adds an oven dish and a cutting board to ghostbar kitchen

### DIFF
--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -8118,6 +8118,7 @@
 /area/tdome/tdomeadmin)
 "Dk" = (
 /obj/machinery/cooking/oven/upgraded,
+/obj/item/reagent_containers/cooking/oven,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -8624,6 +8625,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/item/reagent_containers/cooking/board,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},


### PR DESCRIPTION
## What Does This PR Do
Adds an oven dish and a cutting board to the Ghostbar kitchen.
## Why It's Good For The Game
Currently, the ghostbar kitchen has an oven, but no oven dish - so you can't really use the oven. This PR makes is so you can.
And a cutting board just because.
## Images of changes
<img width="290" alt="Screenshot 2025-05-06 at 7 39 17 AM" src="https://github.com/user-attachments/assets/ef7aff88-6bd0-4ce4-a9cb-c86f7cbe3c69" />

(oven dish is on top of the oven)

## Testing
Took the above screenshot.
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl: Baton4ik220
add: Added an oven dish and a cutting board to ghostbar kitchen
/:cl: