### PR TITLE
add admin logging for pulls of mobs, canisters, and reagent tanks

### DIFF
--- a/code/_globalvars/misc_globals.dm
+++ b/code/_globalvars/misc_globals.dm
@@ -71,3 +71,10 @@ GLOBAL_VAR_INIT(sparks_active, 0)
 #define GLOBAL_SMOKE_LIMIT 200
 ///Counter for the current amount of smoke
 GLOBAL_VAR_INIT(smokes_active, 0)
+
+/// A list of types of objects we want to record in admin logs when
+/// a player starts pulling them. Mobs are handled separately.
+GLOBAL_LIST_INIT(log_pulltypes, list(
+	/obj/structure/reagent_dispensers,
+	/obj/machinery/atmospherics/portable/canister,
+))

--- a/code/_globalvars/misc_globals.dm
+++ b/code/_globalvars/misc_globals.dm
@@ -73,8 +73,9 @@ GLOBAL_VAR_INIT(sparks_active, 0)
 GLOBAL_VAR_INIT(smokes_active, 0)
 
 /// A list of types of objects we want to record in admin logs when
-/// a player starts pulling them. Mobs are handled separately.
+/// a player starts pulling them.
 GLOBAL_LIST_INIT(log_pulltypes, list(
+	/mob/living,
 	/obj/structure/reagent_dispensers,
 	/obj/machinery/atmospherics/portable/canister,
 ))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -265,13 +265,10 @@
 	if(pulling)
 		var/atom/pullee = pulling
 		..()
-		if(isliving(pullee))
-			create_log(MISC_LOG, "Stopped pulling [key_name_admin(pullee)]")
-		else
-			for(var/log_pulltype in GLOB.log_pulltypes)
-				if(istype(pullee, log_pulltype))
-					create_log(MISC_LOG, "Stopped pulling [pullee]")
-					break
+		for(var/log_pulltype in GLOB.log_pulltypes)
+			if(istype(pullee, log_pulltype))
+				create_log(MISC_LOG, "Stopped pulling", pullee)
+				break
 	if(pullin)
 		pullin.update_icon(UPDATE_ICON_STATE)
 
@@ -1022,13 +1019,10 @@
 	if(pullin)
 		pullin.update_icon(UPDATE_ICON_STATE)
 
-	if(isliving(AM))
-		create_log(MISC_LOG, "Started pulling [key_name_admin(AM)]")
-	else
-		for(var/log_pulltype in GLOB.log_pulltypes)
-			if(istype(AM, log_pulltype))
-				create_log(MISC_LOG, "Started pulling [AM]")
-				break
+	for(var/log_pulltype in GLOB.log_pulltypes)
+		if(istype(AM, log_pulltype))
+			create_log(MISC_LOG, "Started pulling", AM)
+			break
 
 /mob/living/proc/check_pull()
 	if(pulling && !pulling.Adjacent(src))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -262,7 +262,16 @@
 		stop_pulling()
 
 /mob/living/stop_pulling()
-	..()
+	if(pulling)
+		var/atom/pullee = pulling
+		..()
+		if(isliving(pullee))
+			create_log(MISC_LOG, "Stopped pulling [key_name_admin(pullee)]")
+		else
+			for(var/log_pulltype in GLOB.log_pulltypes)
+				if(istype(pullee, log_pulltype))
+					create_log(MISC_LOG, "Stopped pulling [pullee]")
+					break
 	if(pullin)
 		pullin.update_icon(UPDATE_ICON_STATE)
 
@@ -1012,6 +1021,14 @@
 	AM.pulledby = src
 	if(pullin)
 		pullin.update_icon(UPDATE_ICON_STATE)
+
+	if(isliving(AM))
+		create_log(MISC_LOG, "Started pulling [key_name_admin(AM)]")
+	else
+		for(var/log_pulltype in GLOB.log_pulltypes)
+			if(istype(AM, log_pulltype))
+				create_log(MISC_LOG, "Started pulling [AM]")
+				break
 
 /mob/living/proc/check_pull()
 	if(pulling && !pulling.Adjacent(src))


### PR DESCRIPTION
## What Does This PR Do
This PR adds user logs for when players start and stop pulling mobs, atmos canisters, and reagent tanks.
## Why It's Good For The Game
Improved admin logging, will help to see who is dragging around fuel tanks to welderbomb, if people are taking SSD players somewhere that isn't cryo, etc, etc.
## Images of changes
![2025_05_09__08_16_19__Paradise Station 13](https://github.com/user-attachments/assets/2b1ef6fa-23a2-4f4e-b0ad-957d769f469f)

## Testing
See above
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC