### PR TITLE
fix carp mouth overlays

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -66,7 +66,6 @@
 /mob/living/simple_animal/hostile/carp/Initialize(mapload)
 	. = ..()
 	carp_randomify(rarechance)
-	update_icons()
 	AddComponent(/datum/component/swarming)
 
 /mob/living/simple_animal/hostile/carp/proc/carp_randomify(rarechance)
@@ -78,21 +77,7 @@
 		else
 			our_color = pick(carp_colors)
 			add_atom_colour(carp_colors[our_color], FIXED_COLOUR_PRIORITY)
-		regenerate_icons()
-
-/mob/living/simple_animal/hostile/carp/proc/add_carp_overlay()
-	if(!random_color)
-		return
-	var/mutable_appearance/base_overlay = mutable_appearance(icon, "base_mouth")
-	base_overlay.appearance_flags = RESET_COLOR
-	add_overlay(base_overlay)
-
-/mob/living/simple_animal/hostile/carp/proc/add_dead_carp_overlay()
-	if(!random_color)
-		return
-	var/mutable_appearance/base_dead_overlay = mutable_appearance(icon, "base_dead_mouth")
-	base_dead_overlay.appearance_flags = RESET_COLOR
-	add_overlay(base_dead_overlay)
+		update_icon()
 
 /mob/living/simple_animal/hostile/carp/Process_Spacemove(movement_dir = 0, continuous_move = FALSE)
 	return TRUE	//No drifting in space for space carp!	//original comments do not steal
@@ -107,20 +92,18 @@
 	. = ..()
 	if(!random_color || gibbed)
 		return
-	regenerate_icons()
+	update_icon()
 
 /mob/living/simple_animal/hostile/carp/revive()
 	..()
-	regenerate_icons()
+	update_icon()
 
-/mob/living/simple_animal/hostile/carp/regenerate_icons()
-	..()
+/mob/living/simple_animal/hostile/carp/update_overlays()
+	. = ..()
 	if(!random_color)
 		return
-	if(stat != DEAD)
-		add_carp_overlay()
-	else
-		add_dead_carp_overlay()
+
+	. += mutable_appearance(icon, "base_[stat == DEAD ? "dead_" : ""]mouth", appearance_flags = RESET_COLOR)
 
 // We do not want mobs moving through space carp, we as such we block it if the mob is not dense
 /mob/living/simple_animal/hostile/carp/CanPass(atom/movable/mover, border_dir)


### PR DESCRIPTION
## What Does This PR Do
This PR fixes overlays for carp mouths.
## Why It's Good For The Game
Bugfix.
## Testing
### Before
![2025_05_07__23_59_07__Paradise Station 13](https://github.com/user-attachments/assets/ffcb1681-1bbe-4a67-907c-622911772d4c)
### After
![2025_05_09__12_10_13__Paradise Station 13](https://github.com/user-attachments/assets/14b3ba86-3372-4828-b697-03d3cd1b2f23)
![2025_05_09__12_16_03__Paradise Station 13](https://github.com/user-attachments/assets/08d978bb-8761-4ff3-a6e5-e859be0a5097)
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Space carps now properly update their mouth sprite when dead.
/:cl: