### PR TITLE
Makes knuckledusters visible on strip menu

### DIFF
--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -325,7 +325,7 @@
 		var/list/result
 
 		var/obj/item/item = item_data.get_item(owner)
-		if(item && (item.flags & ABSTRACT || HAS_TRAIT(item, TRAIT_NO_STRIP) || HAS_TRAIT(item, TRAIT_SKIP_EXAMINE)))
+		if(item && (item.flags & ABSTRACT || HAS_TRAIT(item, TRAIT_NO_STRIP)))
 			items[strippable_key] = result
 			continue
 

--- a/code/game/objects/items/weapons/knuckledusters.dm
+++ b/code/game/objects/items/weapons/knuckledusters.dm
@@ -23,16 +23,19 @@
 	if(!gripped)
 		gripped = TRUE
 		to_chat(user, "You tighten your grip on [src], ensuring you won't drop it.")
-		flags |= (NODROP | ABSTRACT)
+		flags |= NODROP
+		ADD_TRAIT(src, TRAIT_SKIP_EXAMINE, "knuckledusters")
 	else
 		gripped = FALSE
 		to_chat(user, "You relax your grip on [src].")
-		flags &= ~(NODROP | ABSTRACT)
+		flags &= ~NODROP
+		REMOVE_TRAIT(src, TRAIT_SKIP_EXAMINE, "knuckledusters")
 
 /obj/item/melee/knuckleduster/dropped(mob/user, silent)
 	. = ..()
 	gripped = FALSE
-	flags &= ~(NODROP | ABSTRACT)
+	flags &= ~NODROP
+	REMOVE_TRAIT(src, TRAIT_SKIP_EXAMINE, "knuckledusters")
 
 /obj/item/melee/knuckleduster/attack__legacy__attackchain(mob/living/target, mob/living/user)
 	. = ..()


### PR DESCRIPTION
## What Does This PR Do
Makes items with `TRAIT_SKIP_EXAMINE` visible on strip menu.
Removes the `ABSTRACT` flag from knuckledusters and replaces it with `TRAIT_SKIP_EXAMINE`. Knuckledusters are now always visible in strip menu. Knuckledusters are visible in examine when ungripped , invisible when gripped. Fixes #29247

I'll probably make them invisible on strip again, but that'd be after NODROP is made into a trait and non-attached NODROP items lose the flag on death. (ETA whenever I finish testing it)
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
An invisible and undroppable item that occasionally is a high value target is weird.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Ungripped knuckledusters
![image](https://github.com/user-attachments/assets/3ef5c3f4-5cce-4683-a9db-0264da712e0c)
Gripped knuckledusters
![image](https://github.com/user-attachments/assets/c9f106a3-4aa7-4fcf-bc62-939363ceca9c)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Images. Local instance, strip and examine mob with ungripped dusters and with gripped dusters.
<!-- How did you test the PR, if at all? -->

## Declaration
![image](https://github.com/user-attachments/assets/6979ccdf-e6d4-4e8d-b1d5-e896a0316909)
![image](https://github.com/user-attachments/assets/ff443f0a-ab00-486a-b9a5-0664656ef373)
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Knuckledusters will show on strip menu when gripped.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
