### PR TITLE
use ~ instead of shellenv HOME for CI cache paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Cache
         uses: actions/cache@v4
         with:
-          path: $HOME/SpacemanDMM
+          path: ~/SpacemanDMM
           key: ${{ runner.os }}-spacemandmm
 
       - name: Install Tools
@@ -84,7 +84,7 @@ jobs:
       - name: Setup Cache
         uses: actions/cache@v4
         with:
-          path: $HOME/BYOND
+          path: ~/BYOND
           key: ${{ runner.os }}-byond
       # We test PARADISE_PRODUCTION_HARDWARE here because we dont in station_mapload_tests
       - name: Compile All Maps
@@ -107,7 +107,7 @@ jobs:
       - name: Setup Cache
         uses: actions/cache@v4
         with:
-          path: $HOME/BYOND
+          path: ~/BYOND
           key: ${{ runner.os }}-byond
       - name: Install RUST_G Deps
         run: |
@@ -135,7 +135,7 @@ jobs:
       - name: Setup Cache
         uses: actions/cache@v4
         with:
-          path: $HOME/BYOND
+          path: ~/BYOND
           key: ${{ runner.os }}-byond
       - name: Setup & Validate DB
         run: |


### PR DESCRIPTION
## What Does This PR Do
This PR swaps uses `~` instead of `$HOME` for cache paths in CI.
## Why It's Good For The Game
Considering this is what the official documentation uses, and the error we're seeing on failed cache saves:
![2025_05_10__12_59_35__Ports deer to basic mobs and adds some behaviors · ParadiseSS13_Paradise@4a8257e](https://github.com/user-attachments/assets/f1c97a64-ab18-4c22-8754-c03ff1440e48)
This is my first hunch of what might be going wrong with our cache misses.
## Testing
Let's find out
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC