### PR TITLE
integrate tg's restore_or_install_byond github action

### DIFF
--- a/.github/actions/restore_or_install_byond/action.yml
+++ b/.github/actions/restore_or_install_byond/action.yml
@@ -1,0 +1,41 @@
+# This action attempts to restore BYOND from a cache, or to install it otherwise.
+name: Restore or Install BYOND
+description: Attempts to restore a specified BYOND version from cache; if it can't, it installs it.
+
+inputs:
+  release:
+    description: "The release channel of BYOND to install. Either STABLE or BETA."
+    required: false
+    type: string
+    default: "STABLE"
+
+runs:
+  using: composite
+  steps:
+    - name: Configure BYOND version from _build_dependencies.sh
+      shell: bash
+      run: |
+        source _build_dependencies.sh
+        echo "BYOND_MAJOR=$${{ inputs.release }}_BYOND_MAJOR" >> $GITHUB_ENV
+        echo "BYOND_MINOR=$${{ inputs.release }}_BYOND_MINOR" >> $GITHUB_ENV
+
+    # The use of `actions/cache/restore` and `actions/cache/save` here is deliberate, as we want to
+    # save the BYOND install to a cache as early as possible. If we used just `actions/cache`, it
+    # would only attempt to save the cache at the end of a job. This ensures that if a workflow run
+    # is cancelled, we already have a cache to restore from.
+    - name: Restore BYOND cache
+      id: restore_byond_cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/BYOND
+        key: ${{ runner.os }}-byond-${{ env.BYOND_MAJOR }}-${{ env.BYOND_MINOR }}
+    - name: Install BYOND
+      if: ${{ !steps.restore_byond_cache.outputs.cache-hit }}
+      shell: bash
+      run: bash tools/ci/install_byond.sh
+    - name: Save BYOND cache
+      if: ${{ !steps.restore_byond_cache.outputs.cache-hit }}
+      uses: actions/cache/save@v4
+      with:
+        path: ~/BYOND
+        key: ${{ steps.restore_byond_cache.outputs.cache-primary-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,11 +85,10 @@ jobs:
         byondtype: ['STABLE', 'BETA']
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Cache
-        uses: actions/cache@v4
+      - name: Restore BYOND from Cache
+        uses: ./.github/actions/restore_or_install_byond
         with:
-          path: ~/BYOND
-          key: ${{ runner.os }}-byond-${{ matrix.byondtype }}
+          release: ${{ matrix.byondtype }}
       # We test PARADISE_PRODUCTION_HARDWARE here because we dont in station_mapload_tests
       - name: Compile All Maps
         run: |
@@ -108,11 +107,10 @@ jobs:
         byondtype: ['STABLE', 'BETA']
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Cache
-        uses: actions/cache@v4
+      - name: Restore BYOND from Cache
+        uses: ./.github/actions/restore_or_install_byond
         with:
-          path: ~/BYOND
-          key: ${{ runner.os }}-byond-${{ matrix.byondtype }}
+          release: ${{ matrix.byondtype }}
       - name: Install RUST_G Deps
         run: |
           sudo dpkg --add-architecture i386
@@ -136,11 +134,10 @@ jobs:
         byondtype: ['STABLE', 'BETA']
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Cache
-        uses: actions/cache@v4
+      - name: Restore BYOND from Cache
+        uses: ./.github/actions/restore_or_install_byond
         with:
-          path: ~/BYOND
-          key: ${{ runner.os }}-byond-${{ matrix.byondtype }}
+          release: ${{ matrix.byondtype }}
       - name: Setup & Validate DB
         run: |
           sudo systemctl start mysql

--- a/tools/ci/install_byond.sh
+++ b/tools/ci/install_byond.sh
@@ -13,7 +13,7 @@ else
   rm -rf "$HOME/BYOND"
   mkdir -p "$HOME/BYOND"
   cd "$HOME/BYOND"
-  curl "http://www.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -o byond.zip
+  curl "http://www.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -H "User-Agent: ParadiseSS13/Paradise CI" -o byond.zip
   unzip byond.zip
   rm byond.zip
   cd byond

--- a/tools/ci/install_byond.sh
+++ b/tools/ci/install_byond.sh
@@ -3,6 +3,19 @@ set -euo pipefail
 
 if [ -z "${BYOND_MAJOR+x}" ]; then
   source _build_dependencies.sh
+  # if some other build step hasn't specified the specific BYOND version we're not
+  # gonna get it straight from _build_dependencies.sh so one more fallback here
+  BYOND_MAJOR=$STABLE_BYOND_MAJOR
+  BYOND_MINOR=$STABLE_BYOND_MINOR
+
+  if [ -z "$1" ]; then
+    echo "No arg specified. Assuming STABLE."
+  else
+    if [ "$1" == "BETA" ]; then
+      BYOND_MAJOR=$BETA_BYOND_MAJOR
+      BYOND_MINOR=$BETA_BYOND_MINOR
+    fi
+  fi
 fi
 
 if [ -d "$HOME/BYOND/byond/bin" ] && grep -Fxq "${BYOND_MAJOR}.${BYOND_MINOR}" $HOME/BYOND/version.txt;

--- a/tools/ci/install_byond.sh
+++ b/tools/ci/install_byond.sh
@@ -1,21 +1,11 @@
 #!/bin/bash
-set -eo pipefail
+set -euo pipefail
 
-source _build_dependencies.sh
-
-TARGET_MAJOR=$STABLE_BYOND_MAJOR
-TARGET_MINOR=$STABLE_BYOND_MINOR
-
-if [ -z "$1" ]; then
-	echo "No arg specified. Assuming STABLE."
-else
-	if [ "$1" == "BETA" ]; then
-		TARGET_MAJOR=$BETA_BYOND_MAJOR
-		TARGET_MINOR=$BETA_BYOND_MINOR
-	fi
+if [ -z "${BYOND_MAJOR+x}" ]; then
+  source _build_dependencies.sh
 fi
 
-if [ -d "$HOME/BYOND/byond/bin" ] && grep -Fxq "${TARGET_MAJOR}.${TARGET_MINOR}" $HOME/BYOND/version.txt;
+if [ -d "$HOME/BYOND/byond/bin" ] && grep -Fxq "${BYOND_MAJOR}.${BYOND_MINOR}" $HOME/BYOND/version.txt;
 then
   echo "Using cached directory."
 else
@@ -23,11 +13,11 @@ else
   rm -rf "$HOME/BYOND"
   mkdir -p "$HOME/BYOND"
   cd "$HOME/BYOND"
-  curl "http://www.byond.com/download/build/${TARGET_MAJOR}/${TARGET_MAJOR}.${TARGET_MINOR}_byond_linux.zip" -H "User-Agent: ParadiseSS13/Paradise CI" -o byond.zip
+  curl "http://www.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -o byond.zip
   unzip byond.zip
   rm byond.zip
   cd byond
   make here
-  echo "$TARGET_MAJOR.$TARGET_MINOR" > "$HOME/BYOND/version.txt"
+  echo "$BYOND_MAJOR.$BYOND_MINOR" > "$HOME/BYOND/version.txt"
   cd ~/
 fi

--- a/tools/tgs_scripts/PreCompile.sh
+++ b/tools/tgs_scripts/PreCompile.sh
@@ -9,7 +9,7 @@ set -x
 #need to switch to game dir for Dockerfile weirdness
 original_dir=$PWD
 cd "$1"
-. _build_dependencies.sh
+. dependencies.sh
 cd "$original_dir"
 
 git config --global user.name

--- a/tools/tgs_scripts/PreCompile.sh
+++ b/tools/tgs_scripts/PreCompile.sh
@@ -9,7 +9,7 @@ set -x
 #need to switch to game dir for Dockerfile weirdness
 original_dir=$PWD
 cd "$1"
-. dependencies.sh
+. _build_dependencies.sh
 cd "$original_dir"
 
 git config --global user.name


### PR DESCRIPTION
## What Does This PR Do
This PR attempts to integrate TG's GitHub action for installing and caching BYOND in CI.
## Why It's Good For The Game
Even though #29282 properly caches BYOND, some unknown stupidity with the install script is still refusing to see it.
## Testing
Let's find out
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC