### PR TITLE
Ports pneumatic cannon to new attack chain

### DIFF
--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -97,6 +97,14 @@
 	fire(user, target)
 	return ITEM_INTERACT_COMPLETE
 
+/obj/item/pneumatic_cannon/interact_with_atom(atom/target, mob/living/user, list/modifiers)
+	if(get_turf(user) == get_turf(target))
+		return ..()
+	if(user.a_intent != INTENT_HELP) // I know this seems backwards but other guns also have point blank shooting being locked to help intent
+		return ..()
+	fire(user, target)
+	return ITEM_INTERACT_COMPLETE
+
 /obj/item/pneumatic_cannon/proc/fire(mob/living/carbon/human/user, atom/target)
 	if(!istype(user) && !target)
 		return

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -10,6 +10,7 @@
 	lefthand_file = 'icons/mob/inhands/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/guns_righthand.dmi'
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, RAD = 0, FIRE = 60, ACID = 50)
+	new_attack_chain = TRUE
 	///The max weight of items that can fit into the cannon
 	var/max_weight_class = 20
 	///The weight of items currently in the cannon
@@ -75,32 +76,26 @@
 		pressure_setting++
 	to_chat(user, "<span class='notice'>You tweak [src]'s pressure output to [pressure_setting].</span>")
 
-/obj/item/pneumatic_cannon/attackby__legacy__attackchain(obj/item/W, mob/user, params)
-	..()
-	if(istype(W, /obj/item/tank/internals) && !tank)
-		if(istype(W, /obj/item/tank/internals/emergency_oxygen))
-			to_chat(user, "<span class='warning'>[W] is too small for [src].</span>")
-			return
-		add_tank(W, user)
-		return
-	if(W.type == type)
+/obj/item/pneumatic_cannon/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	if(istype(used, /obj/item/tank/internals) && !tank)
+		if(istype(used, /obj/item/tank/internals/emergency_oxygen))
+			to_chat(user, "<span class='warning'>[used] is too small for [src].</span>")
+			return ITEM_INTERACT_COMPLETE
+		add_tank(used, user)
+		return ITEM_INTERACT_COMPLETE
+	if(used.type == type)
 		to_chat(user, "<span class='warning'>You're fairly certain that putting a pneumatic cannon inside another pneumatic cannon would cause a spacetime disruption.</span>")
-		return
-	load_item(W, user)
+		return ITEM_INTERACT_COMPLETE
+	load_item(used, user)
+	return ..()
 
 /obj/item/pneumatic_cannon/screwdriver_act(mob/living/user, obj/item/I)
 	remove_tank(user)
 	return TRUE
 
-/obj/item/pneumatic_cannon/afterattack__legacy__attackchain(atom/target, mob/living/carbon/human/user, flag, params)
-	if(isstorage(target)) //So you can store it in backpacks
-		return ..()
-	if(istype(target, /obj/structure/rack)) //So you can store it on racks
-		return ..()
-	if(!istype(user))
-		return ..()
+/obj/item/pneumatic_cannon/ranged_interact_with_atom(atom/target, mob/living/user, list/modifiers)
 	fire(user, target)
-
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/pneumatic_cannon/proc/fire(mob/living/carbon/human/user, atom/target)
 	if(!istype(user) && !target)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Title
## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
More updated attack chains is good


## Testing

<!-- How did you test the PR, if at all? -->
Put a tank on a pneumatic cannon, stuffed it with things until I couldn't anymore, fired. Tried to put cannon in bag, tried to fire cannon point-blank on both harm and help intent, properly bashed the target when on harm intent.
## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
:cl:
tweak: Pneumatic cannon will now only fire point-blank on help intent, like other guns
/:cl: