### PR TITLE
Fixes Egun Frame Cast Examine Runtime

### DIFF
--- a/code/modules/smithing/machinery/casting_basin.dm
+++ b/code/modules/smithing/machinery/casting_basin.dm
@@ -52,7 +52,6 @@
 			qdel(temp_product)
 		else if(istype(cast, /obj/item/smithing_cast/misc) && !produced_item)
 			var/obj/item/temp_product = new cast.selected_product(src) // This is necessary due to selected_product being a type
-			var/obj/item/smithing_cast/component/comp_cast = cast
 			. += "<span class='notice'>Required Resources:</span>"
 			var/MAT
 			// Get the materials the item needs and display

--- a/code/modules/smithing/smithing_cast.dm
+++ b/code/modules/smithing/smithing_cast.dm
@@ -171,9 +171,6 @@
 /obj/item/smithing_cast/misc/AltClick(mob/user, modifiers)
 	return
 
-/obj/item/smithing_cast/misc/examine(mob/user)
-	. = desc
-
 /obj/item/smithing_cast/misc/egun_parts
 	name = "energy gun parts cast"
 	icon_state = "egun_parts_cast"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes a runtime error when examining an egun parts cast. Also gets rid of an extra var.

## Why It's Good For The Game

Bugs bad.

## Testing

Examined the cast.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed a runtime in examining egun parts casts
fix: Purged an extra var that was doing nothing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
