### PR TITLE
Smith Polish: Adds access requirements to smith machines

### DIFF
--- a/code/modules/smithing/machinery/casting_basin.dm
+++ b/code/modules/smithing/machinery/casting_basin.dm
@@ -153,6 +153,9 @@
 	update_icon(UPDATE_OVERLAYS)
 
 /obj/machinery/smithing/casting_basin/attack_hand(mob/user)
+	if(!allowed(user) && !isobserver(user))
+		to_chat(user, "<span class='warning'>Access denied.</span>")
+		return FINISH_ATTACK
 	if(produced_item)
 		if(produced_item.burn_check(user))
 			produced_item.burn_user(user)

--- a/code/modules/smithing/machinery/kinetic_assembler.dm
+++ b/code/modules/smithing/machinery/kinetic_assembler.dm
@@ -174,6 +174,9 @@
 		return ITEM_INTERACT_COMPLETE
 
 /obj/machinery/smithing/kinetic_assembler/attack_hand(mob/user)
+	if(!allowed(user) && !isobserver(user))
+		to_chat(user, "<span class='warning'>Access denied.</span>")
+		return FINISH_ATTACK
 	if(!primary)
 		to_chat(user, "<span class='warning'>[src] lacks a primary component!</span>")
 		return FINISH_ATTACK
@@ -246,6 +249,7 @@
 	bound_width = 32
 	bound_y = 0
 	operation_sound = 'sound/items/welder.ogg'
+	req_one_access = list(ACCESS_TOX, ACCESS_XENOBIOLOGY, ACCESS_SMITH)
 	/// Slime extract for the egun
 	var/obj/item/slime_extract/slime_core
 	/// The gun frame
@@ -351,6 +355,9 @@
 	return ITEM_INTERACT_COMPLETE
 
 /obj/machinery/smithing/scientific_assembler/attack_hand(mob/user)
+	if(!allowed(user) && !isobserver(user))
+		to_chat(user, "<span class='warning'>Access denied.</span>")
+		return FINISH_ATTACK
 	if(!slime_core)
 		to_chat(user, "<span class='warning'>[src] lacks a slime core!</span>")
 		return FINISH_ATTACK

--- a/code/modules/smithing/machinery/lava_furnace.dm
+++ b/code/modules/smithing/machinery/lava_furnace.dm
@@ -58,6 +58,9 @@
 
 /obj/machinery/smithing/lava_furnace/attack_hand(mob/user)
 	. = ..()
+	if(!allowed(user) && !isobserver(user))
+		to_chat(user, "<span class='warning'>Access denied.</span>")
+		return FINISH_ATTACK
 	if(operating)
 		to_chat(user, "<span class='warning'>[src] is currently operating!</span>")
 		return

--- a/code/modules/smithing/machinery/power_hammer.dm
+++ b/code/modules/smithing/machinery/power_hammer.dm
@@ -79,6 +79,9 @@
 
 /obj/machinery/smithing/power_hammer/attack_hand(mob/user)
 	. = ..()
+	if(!allowed(user) && !isobserver(user))
+		to_chat(user, "<span class='warning'>Access denied.</span>")
+		return FINISH_ATTACK
 	if(operating)
 		to_chat(user, "<span class='warning'>[src] is currently operating!</span>")
 		return

--- a/code/modules/smithing/smith_machinery.dm
+++ b/code/modules/smithing/smith_machinery.dm
@@ -12,6 +12,7 @@
 	anchored = TRUE
 	density = TRUE
 	resistance_flags = FIRE_PROOF
+	req_one_access = list(ACCESS_SMITH)
 	/// How many loops per operation
 	var/operation_time = 10
 	/// Is this active
@@ -65,6 +66,14 @@
 		working_component = used
 		return ITEM_INTERACT_COMPLETE
 	return ..()
+
+/obj/machinery/smithing/emag_act(user as mob)
+	if(!emagged)
+		playsound(get_turf(src), 'sound/effects/sparks4.ogg', 75, 1)
+		req_one_access = list()
+		emagged = TRUE
+		to_chat(user, "<span class='notice'>You disable the security protocols</span>")
+		return TRUE
 
 /obj/machinery/smithing/proc/operate(loops, mob/living/user)
 	operating = TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Locks smith machines (casting basin, power hammer, lava furnace, and kinetic assembler) to ACCESS_SMITH or ACCESS_MINING. The Scientific Assembler requires either ACCESS_TOX or ACCESS_XENOBIOLOGY. An emag can be used to short out these requirements.

## Why It's Good For The Game

Generally, the intention behind the smith is for the departments to have their own machines to incentivize working together, not having one department build a monolith. This helps enforce that.

## Testing

Tried to use smith machines as scientist. Could not. Was able to as the smith. Emagged the machine and could then use it as the scientist.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Smith machines now are access locked.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
