### PR TITLE
Smith Polish - Nerfs gun parts material costs

### DIFF
--- a/code/modules/smithing/smithed_items/misc_smithed.dm
+++ b/code/modules/smithing/smithed_items/misc_smithed.dm
@@ -3,5 +3,5 @@
 	name = "energy gun parts"
 	desc = "Smithed component of an energy gun."
 	icon_state = "egun_parts"
-	materials = list(MAT_TITANIUM = 10000, MAT_PLASMA = 10000)
+	materials = list(MAT_TITANIUM = 50000, MAT_PLASMA = 50000, MAT_PALLADIUM = 4000, MAT_PLATINUM = 4000, MAT_IRIDIUM = 4000)
 	hammer_time = 6


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Increases cost of egun parts to 25 titanium, 25 plasma, and 2 of the space ores.

## Why It's Good For The Game

Balance bandaid.

## Testing

Compiled numbers change.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
![image](https://github.com/user-attachments/assets/4942abe5-71b0-4c94-8792-2d95c44d2929)

  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Changes mineral cost for egun parts significantly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
