### PR TITLE
IPC monitors no longer reset to a default after reattachment

### DIFF
--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -175,13 +175,6 @@
 	if(!(E.dna) && E.is_robotic() && target.dna)
 		E.set_dna(target.dna)
 	..()
-	if(E.limb_name == BODY_ZONE_HEAD)
-		var/obj/item/organ/external/head/H = target.get_organ(BODY_ZONE_HEAD)
-		var/datum/robolimb/robohead = GLOB.all_robolimbs[H.model]
-		if(robohead.is_monitor) //Ensures that if an IPC gets a head that's got a human hair wig attached to their body, the hair won't wipe.
-			H.h_style = "Bald"
-			H.f_style = "Shaved"
-			target.m_styles["head"] = "None"
 
 
 /datum/surgery_step/limb/connect

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -176,13 +176,6 @@
 		C.update_body()
 		C.updatehealth()
 		C.UpdateDamageIcon()
-		if(limb_name == BODY_ZONE_HEAD)
-			var/obj/item/organ/external/head/H = C.get_organ(BODY_ZONE_HEAD)
-			var/datum/robolimb/robohead = GLOB.all_robolimbs[H.model]
-			if(robohead.is_monitor) //Ensures that if an IPC gets a head that's got a human hair wig attached to their body, the hair won't wipe.
-				H.h_style = "Bald"
-				H.f_style = "Shaved"
-				C.m_styles["head"] = "None"
 		user.visible_message(
 			"<span class='notice'>[user] has attached [C]'s [src] to the [amputation_point].</span>",
 			"<span class='notice'>You have attached [C]'s [src] to the [amputation_point].</span>")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Title
## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It always seemed very arbitrary to me that the style reset like that. It bothered me so I imagine it probably bothered someone else.

## Testing

<!-- How did you test the PR, if at all? -->
Decapitated myself, recapitated myself, I looked exactly the same
## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Putting an IPC's head back on no longer resets the style to default
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
