### PR TITLE
NSS Cyberiad (Boxstation) reinforces a single regular table on the bridge

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -55323,7 +55323,6 @@
 	},
 /area/station/hallway/secondary/entry)
 "hsH" = (
-/obj/structure/table,
 /obj/item/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
@@ -55333,6 +55332,7 @@
 /obj/structure/closet/fireaxecabinet{
 	pixel_y = -32
 	},
+/obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "blue"


### PR DESCRIPTION
## What Does This PR Do
Reinforces a table with plasteel
## Why It's Good For The Game
Aestetically pleasing and unreasonable for the table to not be reinforced
## Images of changes
![image](https://github.com/user-attachments/assets/87abcf94-3153-47cd-b492-c2418702f98b)
## Testing
Loaded up the cyberiad.
Spawned as captain.
Inspected the table.
moved the pen on the table and placed a sheet of paper on the table.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: NSS Cyberiad, replaces a metal table with a reinforced table on the bridge.
/:cl: