### PR TITLE
fix coffee/drgibb jelly bean recipes

### DIFF
--- a/code/modules/cooking/recipes/midway_recipes.dm
+++ b/code/modules/cooking/recipes/midway_recipes.dm
@@ -410,7 +410,7 @@
 
 /datum/cooking/recipe/jellybean_coffee
 	container_type = /obj/item/reagent_containers/cooking/mould/bean
-	product_type = /obj/item/food/candy/jellybean/cola
+	product_type = /obj/item/food/candy/jellybean/coffee
 	catalog_category = COOKBOOK_CATEGORY_CANDY
 	steps = list(
 		PCWJ_ADD_REAGENT("sugar", 5),
@@ -434,7 +434,7 @@
 
 /datum/cooking/recipe/jellybean_drgibb
 	container_type = /obj/item/reagent_containers/cooking/mould/bean
-	product_type = /obj/item/food/candy/jellybean/cola
+	product_type = /obj/item/food/candy/jellybean/drgibb
 	catalog_category = COOKBOOK_CATEGORY_CANDY
 	steps = list(
 		PCWJ_ADD_REAGENT("sugar", 5),


### PR DESCRIPTION
## What Does This PR Do
This PR sets the proper outputs of the related jelly bean recipes. Fixes #29311.
## Why It's Good For The Game
Bugfix.
## Testing
Created fixed recipes, ensured the product was the correct type.
![2025_05_13__11_59_33__Paradise Station 13](https://github.com/user-attachments/assets/8bdcbff4-0313-4dda-a336-1ec68bf5bdf1)

## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Recipes for Dr Gibbs- and coffee-flavored jelly beans produce the correct output.
/:cl: