### PR TITLE
fix meat/chickensteak recipe collision

### DIFF
--- a/code/__DEFINES/cooking_defines.dm
+++ b/code/__DEFINES/cooking_defines.dm
@@ -49,6 +49,7 @@
 #define PCWJ_USE_STOVE(temperature, time, options...) new/datum/cooking/recipe_step/use_machine/stovetop(temperature, time, list(##options))
 #define PCWJ_USE_ICE_CREAM_MIXER(time, options...) new/datum/cooking/recipe_step/use_machine/ice_cream_mixer(time, list(##options))
 #define PCWJ_USE_DEEP_FRYER(time, options...) new/datum/cooking/recipe_step/use_machine/deepfryer(time, list(##options))
+#define PCWJ_ADD_MEATHUNK(options...) new/datum/cooking/recipe_step/add_item/meathunk(list(##options))
 
 #define PCWJ_CONTAINER_AVAILABLE 1
 #define PCWJ_CONTAINER_BUSY 2

--- a/code/modules/cooking/recipes/deep_fryer_recipes.dm
+++ b/code/modules/cooking/recipes/deep_fryer_recipes.dm
@@ -332,7 +332,7 @@
 	catalog_category = COOKBOOK_CATEGORY_DONUTS
 	steps = list(
 		PCWJ_ADD_ITEM(/obj/item/food/cookiedough),
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
+		PCWJ_ADD_MEATHUNK(),
 		PCWJ_ADD_REAGENT("ketchup", 5),
 		PCWJ_USE_DEEP_FRYER(20 SECONDS),
 	)

--- a/code/modules/cooking/recipes/grill_recipes.dm
+++ b/code/modules/cooking/recipes/grill_recipes.dm
@@ -12,8 +12,8 @@
 	product_type = /obj/item/food/bbqribs
 	catalog_category = COOKBOOK_CATEGORY_MEAT
 	steps = list(
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
+		PCWJ_ADD_MEATHUNK(),
+		PCWJ_ADD_MEATHUNK(),
 		PCWJ_ADD_REAGENT("bbqsauce", 5),
 		PCWJ_USE_GRILL(J_MED, 10 SECONDS),
 	)
@@ -98,8 +98,8 @@
 	catalog_category = COOKBOOK_CATEGORY_MEAT
 	steps = list(
 		PCWJ_ADD_ITEM(/obj/item/stack/rods),
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
+		PCWJ_ADD_MEATHUNK(),
+		PCWJ_ADD_MEATHUNK(),
 		PCWJ_USE_GRILL(J_MED, 10 SECONDS),
 	)
 
@@ -108,7 +108,7 @@
 	product_type = /obj/item/food/meatsteak
 	catalog_category = COOKBOOK_CATEGORY_MEAT
 	steps = list(
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
+		PCWJ_ADD_MEATHUNK(),
 		PCWJ_ADD_REAGENT("sodiumchloride", 1),
 		PCWJ_ADD_REAGENT("blackpepper", 1),
 		PCWJ_USE_GRILL(J_MED, 10 SECONDS),
@@ -221,33 +221,12 @@
 		PCWJ_USE_GRILL(J_MED, 10 SECONDS),
 	)
 
-/datum/cooking/recipe/syntisteak
-	container_type = /obj/item/reagent_containers/cooking/grill_grate
-	product_type = /obj/item/food/meatsteak
-	catalog_category = COOKBOOK_CATEGORY_MEAT
-	steps = list(
-		PCWJ_ADD_ITEM(/obj/item/food/meat/syntiflesh),
-		PCWJ_ADD_REAGENT("sodiumchloride", 1),
-		PCWJ_ADD_REAGENT("blackpepper", 1),
-		PCWJ_USE_GRILL(J_MED, 10 SECONDS),
-	)
-
-/datum/cooking/recipe/syntitelebacon
-	container_type = /obj/item/reagent_containers/cooking/grill_grate
-	product_type = /obj/item/food/telebacon
-	catalog_category = COOKBOOK_CATEGORY_MEAT
-	steps = list(
-		PCWJ_ADD_ITEM(/obj/item/food/meat/syntiflesh),
-		PCWJ_ADD_ITEM(/obj/item/assembly/signaler),
-		PCWJ_USE_GRILL(J_MED, 10 SECONDS),
-	)
-
 /datum/cooking/recipe/telebacon
 	container_type = /obj/item/reagent_containers/cooking/grill_grate
 	product_type = /obj/item/food/telebacon
 	catalog_category = COOKBOOK_CATEGORY_MEAT
 	steps = list(
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
+		PCWJ_ADD_MEATHUNK(),
 		PCWJ_ADD_ITEM(/obj/item/assembly/signaler),
 		PCWJ_USE_GRILL(J_MED, 10 SECONDS),
 	)

--- a/code/modules/cooking/recipes/oven_recipes.dm
+++ b/code/modules/cooking/recipes/oven_recipes.dm
@@ -540,7 +540,7 @@
 		PCWJ_ADD_ITEM(/obj/item/food/sliced/cheesewedge),
 		PCWJ_ADD_ITEM(/obj/item/food/sliced/pineapple),
 		PCWJ_ADD_ITEM(/obj/item/food/sliced/pineapple),
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
+		PCWJ_ADD_MEATHUNK(),
 		PCWJ_ADD_PRODUCE(/obj/item/food/grown/tomato),
 		PCWJ_USE_OVEN(J_MED, 15 SECONDS),
 	)
@@ -576,8 +576,8 @@
 	product_type = /obj/item/food/lasagna
 	catalog_category = COOKBOOK_CATEGORY_PIZZAS
 	steps = list(
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
+		PCWJ_ADD_MEATHUNK(),
+		PCWJ_ADD_MEATHUNK(),
 		PCWJ_ADD_ITEM(/obj/item/food/sliced/cheesewedge),
 		PCWJ_ADD_ITEM(/obj/item/food/sliced/cheesewedge),
 		PCWJ_ADD_ITEM(/obj/item/food/sliced/cheesewedge),
@@ -665,9 +665,9 @@
 		PCWJ_ADD_ITEM(/obj/item/food/dough),
 		PCWJ_ADD_ITEM(/obj/item/food/dough),
 		PCWJ_ADD_ITEM(/obj/item/food/dough),
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
+		PCWJ_ADD_MEATHUNK(),
+		PCWJ_ADD_MEATHUNK(),
+		PCWJ_ADD_MEATHUNK(),
 		PCWJ_ADD_ITEM(/obj/item/food/sliced/cheesewedge),
 		PCWJ_ADD_ITEM(/obj/item/food/sliced/cheesewedge),
 		PCWJ_ADD_ITEM(/obj/item/food/sliced/cheesewedge),
@@ -680,7 +680,7 @@
 	catalog_category = COOKBOOK_CATEGORY_MEAT
 	steps = list(
 		PCWJ_ADD_ITEM(/obj/item/food/sliceable/flatdough),
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
+		PCWJ_ADD_MEATHUNK(),
 		PCWJ_USE_OVEN(J_MED, 10 SECONDS),
 	)
 
@@ -690,9 +690,9 @@
 	catalog_category = COOKBOOK_CATEGORY_PIZZAS
 	steps = list(
 		PCWJ_ADD_ITEM(/obj/item/food/sliceable/flatdough),
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
+		PCWJ_ADD_MEATHUNK(),
+		PCWJ_ADD_MEATHUNK(),
+		PCWJ_ADD_MEATHUNK(),
 		PCWJ_ADD_ITEM(/obj/item/food/sliced/cheesewedge),
 		PCWJ_ADD_PRODUCE(/obj/item/food/grown/tomato),
 		PCWJ_USE_OVEN(J_MED, 15 SECONDS),
@@ -1059,10 +1059,10 @@
 	product_type = /obj/item/food/sliceable/turkey
 	catalog_category = COOKBOOK_CATEGORY_MEAT
 	steps = list(
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
+		PCWJ_ADD_MEATHUNK(),
+		PCWJ_ADD_MEATHUNK(),
+		PCWJ_ADD_MEATHUNK(),
+		PCWJ_ADD_MEATHUNK(),
 		PCWJ_ADD_ITEM(/obj/item/food/stuffing),
 		PCWJ_ADD_ITEM(/obj/item/food/stuffing),
 		PCWJ_USE_OVEN(J_MED, 15 SECONDS),

--- a/code/modules/cooking/recipes/stove_recipes.dm
+++ b/code/modules/cooking/recipes/stove_recipes.dm
@@ -51,7 +51,7 @@
 	product_type = /obj/item/food/soup/chicken_noodle_soup
 	catalog_category = COOKBOOK_CATEGORY_SOUPS
 	steps = list(
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
+		PCWJ_ADD_MEATHUNK(),
 		PCWJ_ADD_ITEM(/obj/item/food/boiledspaghetti),
 		PCWJ_ADD_PRODUCE(/obj/item/food/grown/carrot),
 		PCWJ_ADD_REAGENT("water", 10),
@@ -88,7 +88,7 @@
 	product_type = /obj/item/food/soup/coldchili
 	catalog_category = COOKBOOK_CATEGORY_SOUPS
 	steps = list(
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
+		PCWJ_ADD_MEATHUNK(),
 		PCWJ_ADD_PRODUCE(/obj/item/food/grown/icepepper),
 		PCWJ_ADD_PRODUCE(/obj/item/food/grown/tomato),
 		PCWJ_USE_STOVE(J_MED, 20 SECONDS),
@@ -178,7 +178,7 @@
 	product_type = /obj/item/food/soup/hotchili
 	catalog_category = COOKBOOK_CATEGORY_SOUPS
 	steps = list(
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
+		PCWJ_ADD_MEATHUNK(),
 		PCWJ_ADD_PRODUCE(/obj/item/food/grown/chili),
 		PCWJ_ADD_PRODUCE(/obj/item/food/grown/tomato),
 		PCWJ_USE_STOVE(J_MED, 20 SECONDS),
@@ -326,7 +326,7 @@
 	product_type = /obj/item/food/soup/stew
 	catalog_category = COOKBOOK_CATEGORY_SOUPS
 	steps = list(
-		PCWJ_ADD_ITEM(/obj/item/food/meat),
+		PCWJ_ADD_MEATHUNK(),
 		PCWJ_ADD_PRODUCE(/obj/item/food/grown/tomato),
 		PCWJ_ADD_PRODUCE(/obj/item/food/grown/potato),
 		PCWJ_ADD_PRODUCE(/obj/item/food/grown/carrot),

--- a/code/modules/cooking/steps/recipe_step_add_meathunk.dm
+++ b/code/modules/cooking/steps/recipe_step_add_meathunk.dm
@@ -1,0 +1,20 @@
+RESTRICT_TYPE(/datum/cooking/recipe_step/add_item/meathunk)
+
+/// A specialized add-item step for specific meat subtypes
+/datum/cooking/recipe_step/add_item/meathunk
+	/// A list of subtypes of meat which aren't appropriate substitutes for the generic "hunk of meat" base type in recipes
+	var/list/exclude_meat_subtypes = list(
+		/obj/item/food/meat/chicken,
+		/obj/item/food/meat/patty_raw,
+		/obj/item/food/meat/patty,
+		/obj/item/food/meat/raw_meatball,
+	)
+
+/datum/cooking/recipe_step/add_item/meathunk/New(options)
+	..(/obj/item/food/meat, options)
+
+/datum/cooking/recipe_step/add_item/meathunk/check_conditions_met(obj/added_item, datum/cooking/recipe_tracker/tracker)
+	if(is_type_in_list(added_item, exclude_meat_subtypes))
+		return PCWJ_CHECK_INVALID
+
+	return ..()

--- a/paradise.dme
+++ b/paradise.dme
@@ -1960,6 +1960,7 @@
 #include "code\modules\cooking\recipes\sushi_mat_recipes.dm"
 #include "code\modules\cooking\steps\recipe_step.dm"
 #include "code\modules\cooking\steps\recipe_step_add_item.dm"
+#include "code\modules\cooking\steps\recipe_step_add_meathunk.dm"
 #include "code\modules\cooking\steps\recipe_step_add_produce.dm"
 #include "code\modules\cooking\steps\recipe_step_add_reagent.dm"
 #include "code\modules\cooking\steps\recipe_step_use_machine.dm"


### PR DESCRIPTION
## What Does This PR Do
This PR fixes a collision between chicken- and meat-steak recipes, and provides a custom add-item recipe step specifically for meat, because it has about a dozen subtypes which are appropriate for use as a "generic hunk of meat" in recipes (ham, synthflesh, human flesh, etc.), and about a half dozen subtypes which aren't (raw chicken, etc.). Fixes #29321, and removes some recipes that are redundant as a result of the refactor.
## Why It's Good For The Game
Fixes a broken recipe and makes recipes more consistent.
## Testing
Attempted to make steak recipes with various meat subtypes, ensured things were working as expected, ensured autochef continued to work with meat steak recipe.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Chicken and meat steak recipes now work properly
tweak: Food recipes which require some kind of meat hunk will no longer accept certain unexpected types of items such as raw chicken.
/:cl: