### PR TITLE
refactor is_blocked_turf

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -641,23 +641,6 @@ Returns 1 if the chain up to the area contains the given typepath
 
 	return 1
 
-/proc/is_blocked_turf(turf/T, exclude_mobs, list/excluded_objs)
-	if(T.density)
-		return TRUE
-	if(locate(/mob/living/silicon/ai) in T) //Prevents jaunting onto the AI core cheese, AI should always block a turf due to being a dense mob even when unanchored
-		return TRUE
-	if(!exclude_mobs)
-		for(var/mob/living/L in T)
-			if(L.density)
-				return TRUE
-	var/any_excluded_objs = length(excluded_objs)
-	for(var/obj/O in T)
-		if(any_excluded_objs && (O in excluded_objs))
-			continue
-		if(O.density)
-			return TRUE
-	return FALSE
-
 //Returns: all the areas in the world
 /proc/return_areas()
 	var/list/area/areas = list()

--- a/code/controllers/subsystem/SSshuttles.dm
+++ b/code/controllers/subsystem/SSshuttles.dm
@@ -361,7 +361,7 @@ SUBSYSTEM_DEF(shuttle)
 
 	if(!length(supply_shuttle_turfs))
 		for(var/turf/simulated/T in supply.areaInstance)
-			if(is_blocked_turf(T))
+			if(T.is_blocked_turf())
 				continue
 			supply_shuttle_turfs += T
 	if(!length(supply_shuttle_turfs)) // In case some nutjob walled the supply shuttle 10 minutes into the round

--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
@@ -115,7 +115,7 @@
 		var/turf/target_turf = get_step(our_turf, direction)
 		if(isnull(target_turf))
 			continue
-		if(is_blocked_turf(target_turf) || get_dist(target_turf, target) > get_dist(living_pawn, target))
+		if(target_turf.is_blocked_turf() || get_dist(target_turf, target) > get_dist(living_pawn, target))
 			continue
 		possible_turfs += target_turf
 

--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/run_away_from_target.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/run_away_from_target.dm
@@ -52,7 +52,7 @@
 	var/turf/return_turf
 	for(var/i in 1 to run_distance)
 		var/turf/test_destination = get_ranged_target_turf_direct(source, target, range = i, offset = angle)
-		if(is_blocked_turf(test_destination, excluded_objs = GLOB.airlocks + src))
+		if(test_destination.is_blocked_turf(source_atom = source, ignore_atoms = GLOB.airlocks))
 			break
 		return_turf = test_destination
 	return return_turf

--- a/code/datums/components/shelved.dm
+++ b/code/datums/components/shelved.dm
@@ -59,9 +59,13 @@
 	for(var/turf/turf_in_view in view(2, get_turf(structure_parent)))
 		if(!isfloorturf(turf_in_view))
 			continue
+		var/blocked_los = FALSE
 		for(var/turf/potential_blockage as anything in get_line(get_turf(structure_parent), turf_in_view))
-			if(!is_blocked_turf(potential_blockage, exclude_mobs = TRUE, excluded_objs = list(parent)))
-				nearby_empty_tiles += turf_in_view
+			if(potential_blockage.is_blocked_turf(exclude_mobs = TRUE, source_atom = parent))
+				blocked_los = TRUE
+				break
+		if(!blocked_los)
+			nearby_empty_tiles += turf_in_view
 
 	var/itemcount = 1
 	for(var/obj/item/I in structure_parent.loc)

--- a/code/datums/spells/ethereal_jaunt.dm
+++ b/code/datums/spells/ethereal_jaunt.dm
@@ -61,7 +61,7 @@
 	sleep(jaunt_in_time)
 	qdel(holder)
 	if(!QDELETED(target))
-		if(is_blocked_turf(mobloc, TRUE))
+		if(mobloc.is_blocked_turf(exclude_mobs = TRUE))
 			for(var/turf/T in orange(7))
 				if(isspaceturf(T))
 					continue

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1053,7 +1053,7 @@
 
 	var/has_tried_to_move = FALSE
 
-	if(is_blocked_turf(target_turf, TRUE, excluded_objs = list(src)))
+	if(target_turf.is_blocked_turf(exclude_mobs = TRUE, ignore_atoms = list(src)))
 		has_tried_to_move = TRUE
 		if(!Move(target_turf, crush_dir))
 			// we'll try to move, and if we didn't end up going anywhere, then we do nothing.

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -710,7 +710,7 @@
 		to_chat(src, "<span class='warning'>You don't have camera vision of this location!</span>")
 		addtimer(CALLBACK(src, PROC_REF(remove_transformer_image), client, I, deploylocation), 3 SECONDS)
 		return FALSE
-	if(is_blocked_turf(deploylocation))
+	if(deploylocation.is_blocked_turf())
 		to_chat(src, "<span class='warning'>That area must be clear of objects!</span>")
 		addtimer(CALLBACK(src, PROC_REF(remove_transformer_image), client, I, deploylocation), 3 SECONDS)
 		return FALSE

--- a/code/game/gamemodes/wizard/magic_tarot.dm
+++ b/code/game/gamemodes/wizard/magic_tarot.dm
@@ -384,7 +384,7 @@
 /datum/tarot/the_emperor/activate(mob/living/target)
 	var/list/L = list()
 	for(var/turf/T in get_area_turfs(/area/station/command/bridge))
-		if(is_blocked_turf(T))
+		if(T.is_blocked_turf())
 			continue
 		L.Add(T)
 
@@ -576,7 +576,7 @@
 /datum/tarot/the_stars/activate(mob/living/target)
 	var/list/L = list()
 	for(var/turf/T in get_area_turfs(/area/station/security/evidence))
-		if(is_blocked_turf(T))
+		if(T.is_blocked_turf())
 			continue
 		L.Add(T)
 
@@ -1007,7 +1007,7 @@
 /datum/tarot/reversed/the_world/activate(mob/living/target)
 	var/list/L = list()
 	for(var/turf/T in get_area_turfs(/area/mine/outpost)) //Lavaland is the abyss, but also too hot to send people too. Mining base should be fair!
-		if(is_blocked_turf(T))
+		if(T.is_blocked_turf())
 			continue
 		L.Add(T)
 

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -209,20 +209,20 @@
 	new /obj/structure/barricade/security(get_turf(loc))
 	switch(mode)
 		if(VERTICAL)
-			var/target_turf = get_step(src, NORTH)
-			if(!(is_blocked_turf(target_turf)))
+			var/turf/target_turf = get_step(src, NORTH)
+			if(!(target_turf.is_blocked_turf()))
 				new /obj/structure/barricade/security(target_turf)
 
-			var/target_turf2 = get_step(src, SOUTH)
-			if(!(is_blocked_turf(target_turf2)))
+			var/turf/target_turf2 = get_step(src, SOUTH)
+			if(!(target_turf2.is_blocked_turf()))
 				new /obj/structure/barricade/security(target_turf2)
 		if(HORIZONTAL)
-			var/target_turf = get_step(src, EAST)
-			if(!(is_blocked_turf(target_turf)))
+			var/turf/target_turf = get_step(src, EAST)
+			if(!(target_turf.is_blocked_turf()))
 				new /obj/structure/barricade/security(target_turf)
 
-			var/target_turf2 = get_step(src, WEST)
-			if(!(is_blocked_turf(target_turf2)))
+			var/turf/target_turf2 = get_step(src, WEST)
+			if(!(target_turf2.is_blocked_turf()))
 				new /obj/structure/barricade/security(target_turf2)
 	qdel(src)
 
@@ -367,12 +367,12 @@
 
 	var/dir_left = turn(direction, -90)
 	var/dir_right = turn(direction, 90)
-	var/target_turf = get_step(src, dir_left)
-	if(!is_blocked_turf(target_turf))
+	var/turf/target_turf = get_step(src, dir_left)
+	if(!target_turf.is_blocked_turf())
 		connected_shields += new barricade_type(target_turf, src, FALSE, direction, dir_left)
 
-	var/target_turf2 = get_step(src, dir_right)
-	if(!is_blocked_turf(target_turf2))
+	var/turf/target_turf2 = get_step(src, dir_right)
+	if(!target_turf2.is_blocked_turf())
 		connected_shields += new barricade_type(target_turf2, src, FALSE, direction, dir_right)
 
 

--- a/code/game/objects/effects/spawners/random/random_spawner.dm
+++ b/code/game/objects/effects/spawners/random/random_spawner.dm
@@ -180,7 +180,7 @@
 
 /obj/effect/spawner/random/proc/has_unblocked_line(destination)
 	for(var/turf/potential_blockage as anything in get_line(get_turf(src), destination))
-		if(!is_blocked_turf(potential_blockage, exclude_mobs = TRUE))
+		if(!potential_blockage.is_blocked_turf(exclude_mobs = TRUE))
 			continue
 		return FALSE
 	return TRUE

--- a/code/game/objects/items/weapons/caution.dm
+++ b/code/game/objects/items/weapons/caution.dm
@@ -82,7 +82,7 @@
 		return
 	var/turf/T = get_turf(target)
 
-	if(is_blocked_turf(T, TRUE)) //can't put mines on a tile that has dense stuff
+	if(T.is_blocked_turf(exclude_mobs = TRUE)) //can't put mines on a tile that has dense stuff
 		to_chat(user, "<span class='notice'>The space is occupied! You cannot place a mine there!</span>")
 		return
 	if(!use(1)) //Can't place a landmine if you don't have a landmine

--- a/code/game/objects/items/weapons/holosign_projector.dm
+++ b/code/game/objects/items/weapons/holosign_projector.dm
@@ -28,7 +28,7 @@
 			to_chat(user, "<span class='notice'>You use [src] to deactivate [H].</span>")
 			qdel(H)
 		else
-			if(!is_blocked_turf(T, TRUE)) //can't put holograms on a tile that has dense stuff
+			if(!T.is_blocked_turf(exclude_mobs = TRUE)) //can't put holograms on a tile that has dense stuff
 				if(holocreator_busy)
 					to_chat(user, "<span class='notice'>[src] is busy creating a hologram.</span>")
 					return
@@ -42,7 +42,7 @@
 						holocreator_busy = FALSE
 						if(length(signs) >= max_signs)
 							return
-						if(is_blocked_turf(T, TRUE)) //don't try to sneak dense stuff on our tile during the wait.
+						if(T.is_blocked_turf(exclude_mobs = TRUE)) //don't try to sneak dense stuff on our tile during the wait.
 							return
 					H = new holosign_type(get_turf(target), src)
 					to_chat(user, "<span class='notice'>You create [H] with [src].</span>")

--- a/code/game/objects/items/weapons/melee/melee_misc.dm
+++ b/code/game/objects/items/weapons/melee/melee_misc.dm
@@ -512,7 +512,7 @@
 			return
 		var/list/turfs = list()
 		for(var/turf/T in orange(1, get_turf(target)))
-			if(is_blocked_turf(T, TRUE))
+			if(T.is_blocked_turf(exclude_mobs = TRUE))
 				continue
 			turfs += T
 

--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -50,7 +50,7 @@
 	var/list/L = list()
 
 	for(var/turf/T in get_area_turfs(thearea.type))
-		if(is_blocked_turf(T))
+		if(T.is_blocked_turf())
 			continue
 		L.Add(T)
 

--- a/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/syndicate_contract.dm
@@ -534,7 +534,7 @@
 /datum/syndicate_contract/proc/handle_target_return(mob/living/M)
 	var/list/turf/possible_turfs = list()
 	for(var/turf/T in contract.extraction_zone.contents)
-		if(!isspaceturf(T) && !is_blocked_turf(T))
+		if(!isspaceturf(T) && !T.is_blocked_turf())
 			possible_turfs += T
 
 	var/turf/destination = length(possible_turfs) ? pick(possible_turfs) : pick(GLOB.latejoin)

--- a/code/modules/events/anomaly_event.dm
+++ b/code/modules/events/anomaly_event.dm
@@ -25,7 +25,7 @@
 		var/list/candidate_turfs = get_area_turfs(impact_area)
 		while(length(candidate_turfs))
 			var/turf/candidate = pick_n_take(candidate_turfs)
-			if(!is_blocked_turf(candidate,TRUE))
+			if(!candidate.is_blocked_turf(exclude_mobs = TRUE))
 				target_turf = candidate
 				break
 		if(target_turf)

--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -37,7 +37,7 @@
 			if(!destination)
 				continue
 			for(var/turf/simulated/floor/F in destination.contents)
-				if(!is_blocked_turf(F))
+				if(!F.is_blocked_turf())
 					turfs += F
 			if(length(turfs))
 				spawn_area_type = area_type

--- a/code/modules/events/tear.dm
+++ b/code/modules/events/tear.dm
@@ -23,7 +23,7 @@
 	var/list/area_turfs = get_area_turfs(impact_area)
 	while(length(area_turfs))
 		var/turf/T = pick_n_take(area_turfs)
-		if(is_blocked_turf(T))
+		if(T.is_blocked_turf())
 			continue
 
 		// Give ghosts some time to jump there before it begins.

--- a/code/modules/hallucinations/effects/major.dm
+++ b/code/modules/hallucinations/effects/major.dm
@@ -95,7 +95,7 @@
 
 	var/list/locs = list()
 	for(var/turf/T in oview(world.view, target))
-		if(!is_blocked_turf(T))
+		if(!T.is_blocked_turf())
 			locs += T
 	if(!length(locs))
 		qdel(src)
@@ -124,7 +124,7 @@
 	// Find a spot for the scientist to spawn
 	var/list/locs = list()
 	for(var/turf/T in orange(1, target))
-		if(!is_blocked_turf(T))
+		if(!T.is_blocked_turf())
 			locs += T
 	locs -= get_turf(agent)
 	if(!length(locs))
@@ -278,7 +278,7 @@
 
 	var/list/locs = list()
 	for(var/turf/T in oview(world.view / 2, target))
-		if(!is_blocked_turf(T))
+		if(!T.is_blocked_turf())
 			locs += T
 	if(!length(locs))
 		qdel(src)
@@ -357,7 +357,7 @@
 	var/list/locs = list()
 	for(var/turf/T in oview(world.view / 2, target))
 		var/light_amount = T.get_lumcount()
-		if(!is_blocked_turf(T) && light_amount <= 0.5)
+		if(!T.is_blocked_turf() && light_amount <= 0.5)
 			locs += T
 	if(!length(locs))
 		return INITIALIZE_HINT_QDEL

--- a/code/modules/hallucinations/effects/moderate.dm
+++ b/code/modules/hallucinations/effects/moderate.dm
@@ -81,7 +81,7 @@
 
 	var/list/locs = list()
 	for(var/turf/T in oview(world.view, target))
-		if(!is_blocked_turf(T))
+		if(!T.is_blocked_turf())
 			locs += T
 	if(!length(locs))
 		qdel(src)
@@ -195,7 +195,7 @@
 	// Let's check if we can spawn somewhere first
 	var/list/locs = list()
 	for(var/turf/T in oview(world.view, target))
-		if(isfloorturf(T) && !is_blocked_turf(T))
+		if(isfloorturf(T) && !T.is_blocked_turf())
 			locs += T
 	if(!length(locs))
 		qdel(src)
@@ -257,7 +257,8 @@
 
 	var/list/vents = list()
 	for(var/obj/machinery/atmospherics/unary/vent_pump/vent in oview(world.view, target))
-		if(!is_blocked_turf(vent) && !vent.welded)
+		var/turf/vent_turf = get_turf(vent)
+		if(!vent_turf.is_blocked_turf() && !vent.welded)
 			vents += vent
 	if(!length(vents))
 		qdel(src)
@@ -320,7 +321,7 @@
 
 	var/list/locs = list()
 	for(var/turf/T in oview(world.view, target))
-		if(isfloorturf(T) && !is_blocked_turf(T))
+		if(isfloorturf(T) && !T.is_blocked_turf())
 			locs += T
 	if(!length(locs))
 		qdel(src)
@@ -512,7 +513,7 @@
 
 	var/list/locs = list()
 	for(var/turf/T in oview(world.view / 2, target))
-		if(!is_blocked_turf(T))
+		if(!T.is_blocked_turf())
 			locs += T
 	if(!length(locs))
 		return INITIALIZE_HINT_QDEL

--- a/code/modules/mining/lavaland/loot/colossus_loot.dm
+++ b/code/modules/mining/lavaland/loot/colossus_loot.dm
@@ -117,7 +117,7 @@
 					var/turf/T = Stuff
 					if((isspaceturf(T) || isfloorturf(T)) && NewTerrainFloors)
 						var/turf/simulated/O = T.ChangeTurf(NewTerrainFloors, keep_icon = FALSE)
-						if(prob(florachance) && length(NewFlora) && !is_blocked_turf(O))
+						if(prob(florachance) && length(NewFlora) && !O.is_blocked_turf())
 							var/atom/Picked = pick(NewFlora)
 							new Picked(O)
 						continue

--- a/code/modules/mining/lavaland/loot/hierophant_loot.dm
+++ b/code/modules/mining/lavaland/loot/hierophant_loot.dm
@@ -167,7 +167,8 @@
 	if(is_in_teleport_proof_area(beacon))
 		to_chat(user, "<span class='warning'>[src] sparks and fizzles.</span>")
 		return
-	if(is_blocked_turf(get_turf(beacon), TRUE))
+	var/turf/beacon_turf = get_turf(beacon)
+	if(beacon_turf.is_blocked_turf(exclude_mobs = TRUE))
 		to_chat(user, "<span class='warning'>The beacon is blocked by something, preventing teleportation!</span>")
 		return
 	if(!isturf(user.loc))
@@ -184,7 +185,7 @@
 	if(do_after(user, 40, target = user) && user && beacon)
 		var/turf/T = get_turf(beacon)
 		var/turf/source = get_turf(user)
-		if(is_blocked_turf(T, TRUE))
+		if(T.is_blocked_turf(exclude_mobs = TRUE))
 			teleporting = FALSE
 			to_chat(user, "<span class='warning'>The beacon is blocked by something, preventing teleportation!</span>")
 			user.update_action_buttons_icon()
@@ -205,7 +206,7 @@
 			if(beacon)
 				beacon.icon_state = "hierophant_tele_off"
 			return
-		if(is_blocked_turf(T, TRUE))
+		if(T.is_blocked_turf(exclude_mobs = TRUE))
 			teleporting = FALSE
 			to_chat(user, "<span class='warning'>The beacon is blocked by something, preventing teleportation!</span>")
 			user.update_action_buttons_icon()
@@ -240,7 +241,7 @@
 
 /obj/item/hierophant_club/proc/teleport_mob(turf/source, mob/M, turf/target, mob/user)
 	var/turf/turf_to_teleport_to = get_step(target, get_dir(source, M)) //get position relative to caster
-	if(!turf_to_teleport_to || is_blocked_turf(turf_to_teleport_to, TRUE))
+	if(!turf_to_teleport_to || turf_to_teleport_to.is_blocked_turf(exclude_mobs = TRUE))
 		return
 	if(SEND_SIGNAL(M, COMSIG_MOVABLE_TELEPORTING, turf_to_teleport_to) & COMPONENT_BLOCK_TELEPORT)
 		return FALSE

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -680,7 +680,7 @@
 	for(var/distance in 0 to 8)
 		var/turf/current_dash_target = dash_target
 		current_dash_target = get_step(current_dash_target, user.dir)
-		if(!is_blocked_turf(current_dash_target, TRUE))
+		if(!current_dash_target.is_blocked_turf(exclude_mobs = TRUE))
 			dash_target = current_dash_target
 		else
 			break

--- a/code/modules/mob/living/basic/farm_animals/deer_ai.dm
+++ b/code/modules/mob/living/basic/farm_animals/deer_ai.dm
@@ -133,7 +133,7 @@
 	var/list/possible_turfs = get_adjacent_open_turfs(target)
 	shuffle_inplace(possible_turfs)
 	for(var/turf/possible_turf as anything in possible_turfs)
-		if(!is_blocked_turf(possible_turf))
+		if(!possible_turf.is_blocked_turf())
 			set_movement_target(controller, possible_turf)
 			return TRUE
 	return FALSE

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -133,7 +133,7 @@
 				adjustToxLoss(-3)
 
 		T = get_step(T, dir)
-		if(is_blocked_turf(T))
+		if(T.is_blocked_turf())
 			break
 
 /mob/living/carbon/gib()

--- a/code/modules/mob/living/carbon/human/npcs.dm
+++ b/code/modules/mob/living/carbon/human/npcs.dm
@@ -65,7 +65,7 @@
 	for(var/turf/T in target_turfs)
 		if(isspaceturf(T))
 			continue
-		if(is_blocked_turf(T))
+		if(T.is_blocked_turf())
 			continue
 		if(T.x > world.maxx - 5 || T.x < 5)
 			continue	//putting them at the edge is dumb

--- a/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
@@ -118,7 +118,8 @@
 			movable_target.forceMove(src)
 			return COMPONENT_CANCEL_ATTACK_CHAIN
 
-		if(isturf(target) && !is_blocked_turf(target) && LAZYLEN(crates_in_hand))
+		var/turf/target_turf = target
+		if(istype(target_turf) && !target_turf.is_blocked_turf() && LAZYLEN(crates_in_hand))
 			drop_random_crate(target)
 			return COMPONENT_CANCEL_ATTACK_CHAIN
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -246,7 +246,7 @@ Difficulty: Medium
 		if(get_dist(src, O) >= MINER_DASH_RANGE && turf_dist_to_target <= self_dist_to_target && !islava(O) && !ischasm(O))
 			var/valid = TRUE
 			for(var/turf/T in get_line(own_turf, O))
-				if(is_blocked_turf(T, TRUE))
+				if(T.is_blocked_turf(exclude_mobs = TRUE))
 					valid = FALSE
 					continue
 			if(valid)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -896,7 +896,7 @@
 
 		H.forceMove(P)
 	else			// if wasn't a pipe, then set loc to turf
-		if(is_blocked_turf(T))
+		if(T.is_blocked_turf())
 			H.forceMove(loc)
 		else
 			H.forceMove(T)

--- a/code/modules/supply/supply_packs/pack_shuttle.dm
+++ b/code/modules/supply/supply_packs/pack_shuttle.dm
@@ -120,7 +120,7 @@
 	GLOB.major_announcement.Announce("We were unable to find an orderer. We have sent the beacon placer to the Cargo Office.", "Shuttle Purchase Receipt")
 	var/list/L = list()
 	for(var/turf/T in get_area_turfs(/area/station/supply/office))
-		if(is_blocked_turf(T))
+		if(T.is_blocked_turf())
 			continue
 		L.Add(T)
 

--- a/code/tests/_game_test_puppeteer.dm
+++ b/code/tests/_game_test_puppeteer.dm
@@ -22,7 +22,7 @@
 
 /datum/test_puppeteer/proc/spawn_puppet_nearby(carbon_type = /mob/living/carbon/human)
 	for(var/turf/T in RANGE_TURFS(1, puppet.loc))
-		if(!is_blocked_turf(T, exclude_mobs = FALSE))
+		if(!T.is_blocked_turf())
 			return new/datum/test_puppeteer(origin_test, carbon_type, T)
 
 	origin_test.Fail("could not spawn puppeteer near [src]")
@@ -40,7 +40,7 @@
 		T = get_step(puppet, direction)
 	else
 		for(var/turf/nearby in RANGE_TURFS(1, puppet.loc))
-			if(!is_blocked_turf(nearby, exclude_mobs = FALSE))
+			if(!nearby.is_blocked_turf())
 				T = nearby
 
 	if(T)
@@ -75,7 +75,7 @@
 
 /datum/test_puppeteer/proc/spawn_mob_nearby(mob_type)
 	for(var/turf/T in RANGE_TURFS(1, puppet))
-		if(!is_blocked_turf(T, exclude_mobs = FALSE))
+		if(!T.is_blocked_turf())
 			var/mob/new_mob = origin_test.allocate(mob_type, T)
 			return new_mob
 


### PR DESCRIPTION
## What Does This PR Do
This PR pulls our implementation of /proc/is_blocked_turf more in line with /tg/'s /turf/proc/is_blocked_turf.
## Why It's Good For The Game
The argument names and behavior of these two different procs is just different enough to be confusing when porting things like AI behavior subtrees, so better to avoid any confusion on how to properly handle the discrepancies.
## Testing
Compiles, will request TM as well.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC