### PR TITLE
Allows back-slot item to be rendered above head layer

### DIFF
--- a/code/modules/mob/living/carbon/human/human_inventory.dm
+++ b/code/modules/mob/living/carbon/human/human_inventory.dm
@@ -120,6 +120,7 @@
 			update_hair()	//rebuild hair
 			update_fhair()
 			update_head_accessory()
+			update_inv_back()
 		// Bandanas and paper hats go on the head but are not head clothing
 		if(istype(target, /obj/item/clothing/head))
 			var/obj/item/clothing/head/hat = target
@@ -148,6 +149,7 @@
 			update_hair()	//rebuild hair
 			update_fhair()
 			update_head_accessory()
+			update_inv_back()
 		if(internal && !get_organ_slot("breathing_tube"))
 			internal = null
 		if(target.flags_inv & HIDEEARS)
@@ -224,6 +226,7 @@
 				update_hair()	//rebuild hair
 				update_fhair()
 				update_head_accessory()
+				update_inv_back()
 			if(length(hud_list))
 				sec_hud_set_ID()
 				malf_hud_set_status()
@@ -297,6 +300,7 @@
 				update_hair()	//rebuild hair
 				update_fhair()
 				update_head_accessory()
+				update_inv_back()
 			// paper + bandanas
 			if(istype(I, /obj/item/clothing/head))
 				var/obj/item/clothing/head/hat = I

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -1095,6 +1095,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	..()
 	remove_overlay(BACK_LAYER)
 	if(back)
+		var/actual_layer = ((head?.flags & BLOCKHAIR) || (wear_mask?.flags & BLOCKHAIR)) ? HEAD_LAYER - 0.01 : BACK_LAYER
 		update_hud_back(back)
 		//determine the icon to use
 		var/t_state = back.item_state
@@ -1102,11 +1103,11 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 			t_state = back.icon_state
 		var/mutable_appearance/standing
 		if(back.icon_override)
-			standing = mutable_appearance(back.icon_override, "[back.icon_state]", layer = -BACK_LAYER)
+			standing = mutable_appearance(back.icon_override, "[back.icon_state]", layer = -actual_layer)
 		else if(back.sprite_sheets && back.sprite_sheets[dna.species.sprite_sheet_name])
-			standing = mutable_appearance(back.sprite_sheets[dna.species.sprite_sheet_name], "[t_state]", layer = -BACK_LAYER)
+			standing = mutable_appearance(back.sprite_sheets[dna.species.sprite_sheet_name], "[t_state]", layer = -actual_layer)
 		else
-			standing = mutable_appearance('icons/mob/clothing/back.dmi', "[t_state]", layer = -BACK_LAYER)
+			standing = mutable_appearance('icons/mob/clothing/back.dmi', "[t_state]", layer = -actual_layer)
 
 		//create the image
 		standing.alpha = back.alpha


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

If helmet blocks your hair (has a `BLOCKHAIR` flag), then your back-slot item will be rendered above your helmet. 
The only reason why it shouldn't be always rendered above - hair should cover your back-slot, otherwise it looks weird. But if there is no hair, then we can render it above the helmet!

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

I was in the middle of porting new winter coats and noticed that issue (hood is rendered above back-slot):

![image](https://github.com/user-attachments/assets/97682b42-f57e-45a3-8662-fd82cfe5203c)

With the changes, it's gone:

![image](https://github.com/user-attachments/assets/d111595f-9a7d-4673-8611-f7412c1d4cd1)

Don't know if there is any other clothing that would face the same issue

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Overlays update correctly whenever i put/remove a backpack/helmet

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Some head-slot items won't anymore be shown above your back-slot items.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
