### PR TITLE
Makes Morgues deconstructable, constructable, and anchorable.

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -79,6 +79,7 @@ GLOBAL_LIST_INIT(metal_recipes, list(
 	new /datum/stack_recipe("computer frame", /obj/structure/computerframe, 5, time = 2.5 SECONDS, one_per_turf = TRUE, on_floor = TRUE),
 	new /datum/stack_recipe("wall girders", /obj/structure/girder, 2, time = 5 SECONDS, one_per_turf = TRUE, on_floor = TRUE),
 	new /datum/stack_recipe("machine frame", /obj/structure/machine_frame, 5, time = 2.5 SECONDS, one_per_turf = TRUE, on_floor = TRUE),
+	new /datum/stack_recipe("morgue tray", /obj/structure/morgue, 5, time = 8 SECONDS, one_per_turf = TRUE, on_floor = TRUE),
 	new /datum/stack_recipe("turret frame", /obj/machinery/porta_turret_construct, 5, time = 2.5 SECONDS, one_per_turf = TRUE, on_floor = TRUE),
 	new /datum/stack_recipe("firelock frame", /obj/structure/firelock_frame, 3, time = 5 SECONDS, one_per_turf = TRUE, on_floor = TRUE),
 	new /datum/stack_recipe("meatspike frame", /obj/structure/kitchenspike_frame, 5, time = 5 SECONDS, one_per_turf = TRUE, on_floor = TRUE),

--- a/code/game/objects/items/stacks/stack_recipe.dm
+++ b/code/game/objects/items/stacks/stack_recipe.dm
@@ -147,6 +147,12 @@
 	if(istype(result, /obj/item/restraints/handcuffs/cable))
 		result.color = S.color
 	..()
+/datum/stack_recipe
+/datum/stack_recipe/post_build(mob/user, obj/item/stack/S, obj/result)
+	if(istype(result, /obj/structure/morgue))
+		var/obj/structure/morgue/M = result
+		M.anchored = FALSE
+	..()
 
 /datum/stack_recipe/dangerous
 /datum/stack_recipe/dangerous/post_build(mob/user, obj/item/stack/S, obj/result)


### PR DESCRIPTION
## What Does This PR Do
Makes morgues more dynamic by allowing them to be deconstructed, moved around, and constructed.
## Why It's Good For The Game
Allows the coroner to modify their morgues to their hearts content. Also allows them to rebuild morgues if they get destroyed.
## Testing
Spawned as CE in the morgue,
Opened and closed the morgues,
Dropped cable coils in a morgue tray,
Closed the morgue,
Tried to unwrench the morgue with coils, couldnt unwrench
Opened the morgue, took the cables out
Closed the morgue, and unwrenched it
Tried to open and close the morgue that was unanchored, couldnt do that
Welded the morgue, It fully deconstructed

Picked up the metal, constructed a new morgue with it
Dragged the morgue around to prove it spawned unanchored
Rotated the morgue with altclick
Tried to open the morgue, it was still unachored
Wrenched the morgue into place, tried to rotate and couldnt
Opened and closed the morgue successfully

Ran to the cremator
Tried to unwrench and weld the cremator, couldnt.
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
![image](https://github.com/user-attachments/assets/b68a06ed-4d05-4b4b-854e-3493cdfb8de7)
## Changelog
:cl:
add: Allows Morgues, not the room the object, to be constructed deconstructed and unanchored.
/:cl: