### PR TITLE
[LORE] Cybersun Lore Polishing + Small Implant Updates

### DIFF
--- a/code/game/objects/items/theft_items.dm
+++ b/code/game/objects/items/theft_items.dm
@@ -46,7 +46,7 @@
 //nuke core box, for carrying the core
 /obj/item/nuke_core_container
 	name = "nuke core container"
-	desc = "A solid container for radioactive objects."
+	desc = "A lead-lined secure container produced by Cybersun Industries, ostensibly for hazardous waste disposal. Strangely, the interior dimensions seem to be a near-perfect match for Nanotrasen-standard plutonium cores."
 	icon = 'icons/obj/nuke_tools.dmi'
 	icon_state = "core_container_empty"
 	item_state = "metal"
@@ -75,7 +75,7 @@
 	else if(dented) // Not cracked, but dented.
 		. += "<span class='notice'>[src] looks dented. Perhaps a bigger explosion may break it.</span>"
 	else // Not cracked or dented.
-		. += "Fine print on the box reads \"Cybersun Industries secure container, guaranteed thermite proof, assistant proof, and explosive resistant.\""
+		. += "Fine print on the box reads \"Cybersun Industries secure hazardous waste container. Guaranteed thermite proof, assistant proof, and explosive resistant.\""
 
 /obj/item/nuke_core_container/attack_hand(mob/user)
 	if(cracked && core)
@@ -253,7 +253,7 @@
 
 /obj/item/nuke_core_container/supermatter
 	name = "supermatter bin"
-	desc = "A tiny receptacle that releases an inert hyper-noblium mix upon sealing, allowing a sliver of a supermatter crystal to be safely stored."
+	desc = "A modified Cybersun Industries secure hazardous waste container, with an experimental alloy interior designed to hold Supermatter crystals."
 	var/obj/item/nuke_core/supermatter_sliver/sliver
 
 /obj/item/nuke_core_container/supermatter/Destroy()

--- a/code/game/objects/items/weapons/bio_chips/bio_chip_fluff.dm
+++ b/code/game/objects/items/weapons/bio_chips/bio_chip_fluff.dm
@@ -14,31 +14,32 @@
 /datum/implant_fluff/abductor
 	name = "GC$X9%D#G"
 	life = "Unknown."
-	notes = "Appears to contain highly advanced bluespace technology."
+	notes = "(FATAL ERROR 310) Unidentified object detected in bio-chip receptacle. Please contact your system administrator!"
+	function = "(FATAL ERROR 310) Unidentified object detected in bio-chip receptacle. Please contact your system administrator!"
 
 /datum/implant_fluff/adrenaline
 	name = "Cybersun Industries RX-2 Adrenaline Bio-chip"
-	life = "Five days."
-	notes = "One of Cybersun Industries' oldest and simplest implants, it is rumoured to be among their best-selling products."
-	function = "Subjects injected with this bio-chip can activate an injection of medical cocktails that removes stuns, increases speed, and has mild healing effects."
+	life = "Indefinite lifespan. Three uses."
+	notes = "One of Cybersun's most popular bio-chips, seeing extensive use within the Trans-Solar Armed Forces and wealthy PMCs."
+	function = "Injects a cocktail of powerful stimulants and regenerative agents that removes stuns, increases speed, and heals minor injuries. The internal reservoir holds three doses."
 
 /datum/implant_fluff/basic_adrenalin
 	name = "Cybersun Industries RX-1 Adrenaline Bio-chip"
-	life = "Five days or after 1 use."
+	life = "Indefinite lifespan. One use."
 	notes = "A reduced-size version of Cybersun Industries' hugely popular RX-2 biochip, designed to offer the same robust jolt of energy for the budget-conscious consumer. Single use only."
 	function = "Subjects injected with this bio-chip can activate an injection of medical cocktails that removes stuns, increases speed, and has mild healing effects."
 
 /datum/implant_fluff/proto_adrenaline
-	name = "Cybersun Industries FX-1 Proto-Adrenaline Bio-chip"
-	life = "5 days, destroyed after 1 use."
+	name = "Cybersun Industries RX-1P Proto-Adrenaline Bio-chip"
+	life = "Approximately three month lifespan. One use."
 	notes = "An ultra-minimalist version of Cybersun Industries' hugely popular RX-2 biochip, for those operating on a shoestring budget."
-	function = "Injects a mixture of adrenaline, noradrenaline, and cortisol into the subject, giving them a very quick burst of energy that will clear all stunning effects and allow them to rise to their feet. The effect is extremely short lived and lacks any staying power."
+	function = "Injects a mixture of adrenaline, noradrenaline, and cortisol into the subject, giving them a very quick burst of energy that will clear all stunning effects and allow them to quickly regain their footing. The effect is extremely short lived and lacks any staying power."
 
 /datum/implant_fluff/supercharge
 	name = "Cybersun Industries RX-4 Synthetic Supercharge Bio-chip"
-	life = "Known to last for up to a year."
-	notes = "A complex bio-chip utilizing a multitude of synthetic chemicals invented by Cybersun Industries. It's rumored that synthetic rights groups maintain stockpiles of these."
-	function = "Synthetic subjects injected with this bio-chip can activate an injection of lubricants, coolants, and positronic patching fluid."
+	life = "Indefinite lifespan. One use."
+	notes = "A modification of the acclaimed RX-2 biochip, the RX-4 is specialized for IPC use, and sees extensive service within Cybersun's synthetic security units."
+	function = "Deploys a mixture of lubricants, coolants, and positronic patching fluid directly into an IPC's vital systems, replicating the effects of an RX-2 biochip."
 
 /datum/implant_fluff/chem
 	name = "Bishop Cybernetics Chemical Injection Bio-chip"
@@ -52,10 +53,10 @@
 	function = "Contains a compact radio signaler that triggers when the host's lifesigns cease."
 
 /datum/implant_fluff/dust
-	name = "Cybersun Industries Dust Bio-chip"
-	life = "Unknown, attempts to retrieve a sample of the bio-chip have often led to the destruction of the bio-chip... and user."
-	notes = "Activates upon death or from manual activation by the user."
-	function = "Contains a compact, electrically activated heat source that turns its host to ash upon activation, or their death."
+	name = "Cybersun Industries RX-70 Dust Bio-chip"
+	life = "Indefinite. Destroyed upon use, along with the user."
+	notes = "A specialist biochip developed by Cybersun for sale to special operations units and intelligence agencies, the RX-70 has also seen success within criminal groups seeking quick corpse-disposal methods."
+	function = "Contains a compact, electrically activated thermite charge that turns its host to ash upon activation, or their death."
 
 /datum/implant_fluff/emp
 	name = "Cybersun Industries RX-22 Electromagnetic Pulse Emitter Bio-chip"
@@ -64,15 +65,15 @@
 	function = "Upon detonization the bio-chip will release an EMP affecting the immediate area around the user."
 
 /datum/implant_fluff/explosive
-	name = "Cybersun Industries RX-78 Employee Management Bio-chip"
+	name = "Cybersun Industries RX-78 Self-Destruction Bio-chip"
 	life = "Destroyed upon activation."
-	notes = "Appears to contain a small, dense explosive device wired to a signaller chip. The serial number on the side is scratched out."
+	notes = "Designed for its military customers only, the RX-78 has seen substantial success within intelligence agencies for deep-cover operatives."
 	function = "Contains a compact, electrically detonated explosive that detonates upon receiving a specially encoded signal or upon host death."
 
 /datum/implant_fluff/explosive_macro
-	name = "Cybersun Industries RX-79 Employee Management Bio-chip"
+	name = "Cybersun Industries RX-78E Self-Destruction Bio-chip"
 	life = "Destroyed upon activation."
-	notes = "Compared to its predecessor, the RX-79 contains a much larger explosive; sometimes you just need a bigger boom. Due to its bulkiness, it has been known to press into the user's frontal lobe, impairing judgement."
+	notes = "A questionably stable modification of the Cybersun RX-78, the RX-78E, as it is known, rigs a large fuel-air explosive in place of the original plastique payload, dramatically increasing blast size."
 	function = "Contains a bulky, electrically triggered explosive that detonates upon receiving a specially encoded signal or upon host death."
 
 /datum/implant_fluff/freedom
@@ -82,7 +83,7 @@
 	function = "Uses a mixture of cybernetic nanobots, bone regrowth chemicals, and radio signals to quickly break the user out of restraints."
 
 /datum/implant_fluff/protofreedom
-	name = "Cybersun Industries X-92 Quick Escape Bio-chip"
+	name = "Cybersun Industries RX-91 Quick Escape Bio-chip"
 	life = "Destroyed after 1 use."
 	notes = "A bio-chip that is illegal in many systems. This is the early prototype version of the RX-92. It's significantly cheaper than its newer version."
 	function = "Uses a mixture of cheap cybernetic nanobots, bone regrowth chemicals, and radio signals to quickly break the user out of restraints."
@@ -95,9 +96,9 @@
 
 /datum/implant_fluff/mindshield
 	name = "Nanotrasen Type 3 Mindshield Bio-chip"
-	life = "Studies have shown the bio-chip to last up to 10 years."
-	notes = "This is the third iteration of a bio-chip that has garnered attention from many galactic humanoid rights groups over concerns of self autonomy. Allegedly, it used to force the user to be completely loyal to Nanotrasen."
-	function = "Personnel injected with this device can better resist mental compulsions such as brainwashing and mindslaving."
+	life = "Indefinite."
+	notes = "An advanced neural shielding chip, the Type 3 Mindshield uses low-frequency radio pulses and defensive nanites to ensure the mental safety of Nanotrasen officers and security personnel."
+	function = "Personnel injected with this device can better resist mental compulsions such as brainwashing and mindslaving. The hardened shell prevents damage or interference from EMPs."
 
 /datum/implant_fluff/storage
 	name = "Cybersun Industries RX-16 Collapsible Body Cavity Bio-chip"

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -837,7 +837,7 @@
 
 /obj/item/clothing/gloves/color/black/pyro_claws
 	name = "Fusion gauntlets"
-	desc = "Cybersun Industries developed these gloves after a grifter fought one of their soldiers, who attached a pyro core to an energy sword, and found it mostly effective."
+	desc = "A pair of heavy combat gauntlets that project lethal energy claws via the power of captive pyroclastic anomaly core."
 	item_state = "pyro"
 	item_color = "pyro" // I will kill washing machines one day
 	icon_state = "pyro"

--- a/code/modules/economy/economy_events/economy_events.dm
+++ b/code/modules/economy/economy_events/economy_events.dm
@@ -71,7 +71,7 @@
 			if(RANDOM_STORY_PIRATES)
 				newMsg.body = "[pick("Pirates","Criminal elements","A [pick("Syndicate","Donk Co.","Waffle Co.","\'REDACTED\'")] strike force")] have [pick("raided","blockaded","attempted to blackmail","attacked")] [affected_dest.name] today. Security has been tightened, but many valuable minerals were taken."
 			if(RANDOM_STORY_CORPORATE_ATTACK)
-				newMsg.body = "A small [pick("pirate","Cybersun Industries","Gorlex Marauders","Syndicate")] fleet has precise-jumped into proximity with [affected_dest.name], [pick("for a smash-and-grab operation","in a hit and run attack","in an overt display of hostilities")]. Much damage was done, and security has been tightened since the incident."
+				newMsg.body = "A small [pick("pirate","Gorlex Marauders","Syndicate")] fleet has precise-jumped into proximity with [affected_dest.name], [pick("for a smash-and-grab operation","in a hit and run attack","in an overt display of hostilities")]. Much damage was done, and security has been tightened since the incident."
 			if(RANDOM_STORY_ALIEN_RAIDERS)
 				if(prob(20))
 					newMsg.body = "The Tiger Co-operative have raided [affected_dest.name] today, no doubt on orders from their enigmatic masters. Stealing wildlife, farm animals, medical research materials and kidnapping civilians. Nanotrasen authorities are standing by to counter attempts at bio-terrorism."

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -35,7 +35,7 @@
 
 /datum/event/prison_break/announce(false_alarm)
 	if(length(areas) || false_alarm)
-		GLOB.minor_announcement.Announce("[pick("Gr3y.T1d3 virus", "S.E.L.F program", "Malignant trojan", "Runtime error", "Cybersun worm", "[pick("Castle", "Felix", "Fractal", "Paradox", "Rubiks", "Portcullis", "Hammer", "Lockpick", "Faust", "Dream")][pick(" 2.0","")] Daemon")] detected in [station_name()] [(eventDept == "Security")? "imprisonment":"containment"] subroutines. Secure any compromised areas immediately. Station AI involvement is recommended.", "[eventDept] Alert")
+		GLOB.minor_announcement.Announce("[pick("Gr3y.T1d3 virus", "S.E.L.F program", "Malignant trojan", "Runtime error", "Hostile worm", "[pick("Castle", "Felix", "Fractal", "Paradox", "Rubiks", "Portcullis", "Hammer", "Lockpick", "Faust", "Dream")][pick(" 2.0","")] Daemon")] detected in [station_name()] [(eventDept == "Security")? "imprisonment":"containment"] subroutines. Secure any compromised areas immediately. Station AI involvement is recommended.", "[eventDept] Alert")
 
 /datum/event/prison_break/start()
 	for(var/area/A in world)

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -303,9 +303,10 @@
 	origin_tech = "biotech=4;programming=4;syndicate=2"
 	syndiemmi = TRUE
 	mmi_item_name = "Syndicate Man-Machine Interface"
-	extended_desc = "Before the development of the mindslave implant by Cybersun, they first prototyped the technology using test subjects in MMIs. The unfettered access given to the user's brain made the task of delivering the memetic payloads trivial, allowing Cybersun's R&D to perfect their brainwashing techniques before moving on to a miniaturised implant. \
-	Whilst these specialty MMIs are rarely used owing to the far greater applicability and convenience of the mindslave implant, they do see occasional employment by undercover agents that wish to stealthily convert the AI-slaved cyborgs of Nanotrasen. \
-	Just like the mindslave implant, these are extremely illegal in most regions of space. Simple possession (to say nothing of actual use) generally warrants a very long prison sentence."
+	extended_desc = "Before the development of the mindslave implant, the mind-controlling technology was first prototyped using existing MMI systems. The unfettered access given to the user's brain made the task of delivering the memetic payloads trivial, allowing for brainwashing techniques to be perfected before moving on to a miniaturised implant. \
+		Whilst these specialty MMIs are rarely used owing to the far greater applicability and convenience of the mindslave implant, they do see occasional employment by undercover agents that wish to stealthily convert the AI-slaved cyborgs of Nanotrasen. \
+		Just like the mindslave implant, these are extremely illegal in most regions of space. Simple possession (to say nothing of actual use) generally warrants a very long prison sentence. \
+		The manufacturer of these devices remains unknown, though indepdent observers have noted similarities in the design to contemporary Cybersun electronics. The company, naturally, denies all such associations."
 
 /obj/item/mmi/syndie/attackby__legacy__attackchain(obj/item/O, mob/user, params)
 	if(!master_uid && ishuman(user) && user.mind && istype(O,/obj/item/organ/internal/brain))

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -56,9 +56,9 @@
 
 /obj/item/mod/module/storage/large_capacity
 	name = "MOD expanded storage module"
-	desc = "Reverse engineered by Cybersun Industries from Donk Corporation designs, this system of hidden compartments \
-		is entirely within the suit, distributing items and weight evenly to ensure a comfortable experience for the user; \
-		whether smuggling, or simply hauling."
+	desc = "A collaborative effort between Cybersun Industries and Donk Corporation, this system of hidden compartments, attachment points, and pouches \
+		fits entirely within the suit, distributing items and weight evenly to ensure a comfortable carrying experience for the user \
+		in all manner of hauling tasks."
 	icon_state = "storage_large"
 	max_combined_w_class = 21
 	max_items = 14
@@ -115,9 +115,9 @@
 ///Ion Jetpack - Lets the user fly freely through space using battery charge.
 /obj/item/mod/module/jetpack
 	name = "MOD ion jetpack module"
-	desc = "A series of electric thrusters installed across the suit, this is a module highly anticipated by trainee Engineers. \
-		Rather than using gasses for combustion thrust, these jets are capable of accelerating ions using \
-		charge from the suit's charge. Some say this isn't Cybersun Industries's first foray into jet-enabled suits."
+	desc = "A series of electric thrusters installed across the suit, allowing for precision movement in zero-G environments. \
+		Rather than using gasses for combustion thrust, this modules uses lightweight ion thrusters connected directly to the suit's energy cell, \
+		removing any reliance on external fuel systems. This does, however, mean that the thrusters are useless outside of zero-G, as any heavy weight will easily overwhelm the ion engines."
 	icon_state = "jetpack"
 	module_type = MODULE_TOGGLE
 	complexity = 3

--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -156,9 +156,9 @@
 ///Ore Bag - Lets you pick up ores and drop them from the suit.
 /obj/item/mod/module/orebag
 	name = "MOD ore bag module"
-	desc = "An integrated ore storage system installed into the suit, \
-		this utilizes precise electromagnets and storage compartments to automatically collect and deposit ore. \
-		It's recommended by Cybersun Industries to actually deposit that ore at local refineries."
+	desc = "An integrated ore storage system installed into the suit, developed in-house by Nanotrasen for its plasma mining operations.\
+		Utilizing precise electromagnets and modular storage compartments, the module automatically collects and sorts extracted ores. \
+		Nanotrasen reminds users of the system to actually deposit that ore at local refineries."
 	icon_state = "ore"
 	module_type = MODULE_USABLE
 	complexity = 1


### PR DESCRIPTION
## What Does This PR Do
Goes through a bunch of objects and things mentioning Cybersun to ensure lore consistency.

Also updates some descriptions for biochips while I was there.

## Why It's Good For The Game
Cybersun has a mildly bipolar representation in game, seemingly going from Evil Inc. to a normal company with a dark secret on a whim. Standardizing to the latter is in the interest of LT.

Descriptions are also good.

## Testing

Hopped in, read words.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
 

## Changelog

:cl:
tweak: Updated Cybersun and bio-chip lore.
/:cl:

