### PR TITLE
Gives Medical Cyborgs a Holo Stretcher Upgrade

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -423,6 +423,20 @@
 	items_to_replace = list(/obj/item/rsf = /obj/item/rsf/executive)
 
 /***********************/
+// MARK: Medical
+/***********************/
+
+/obj/item/borg/upgrade/holo_stretcher
+	name = "holo stretcher rack upgrade"
+	desc = "An upgrade that allows medical cyborgs to carry holo stretchers in addition to basic roller beds"
+	icon = 'icons/obj/rollerbed.dmi'
+	icon_state = "holo_retracted"
+	origin_tech = "magnets=3;biotech=4;powerstorage=3"
+	require_module = TRUE
+	module_type = /obj/item/robot_module/medical
+	items_to_replace = list(/obj/item/roller_holder = /obj/item/roller_holder/holo)
+
+/***********************/
 // MARK: Syndicate
 /***********************/
 

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -190,30 +190,27 @@
 	icon = 'icons/obj/rollerbed.dmi'
 	icon_state = "folded"
 	w_class = WEIGHT_CLASS_BULKY
+	new_attack_chain = TRUE
 	var/extended = /obj/structure/bed/roller
 
-/obj/item/roller/attack_self__legacy__attackchain(mob/user)
+/obj/item/roller/activate_self(mob/user)
+	if(..())
+		return
+
 	var/obj/structure/bed/roller/R = new extended(user.loc)
 	R.add_fingerprint(user)
 	qdel(src)
 
-/obj/item/roller/afterattack__legacy__attackchain(atom/target, mob/user, proximity, params)
-	if(!proximity)
-		return
-	if(isturf(target))
-		var/turf/T = target
-		if(!T.density)
-			var/obj/structure/bed/roller/R = new extended(T)
-			R.add_fingerprint(user)
-			qdel(src)
+/obj/item/roller/interact_with_atom(atom/target, mob/living/user, list/modifiers)
+	if(!isturf(target))
+		return ..()
 
-/obj/item/roller/attackby__legacy__attackchain(obj/item/W as obj, mob/user as mob, params)
-	if(istype(W, /obj/item/roller_holder))
-		var/obj/item/roller_holder/RH = W
-		if(!RH.held)
-			user.visible_message("<span class='notice'>[user] collects \the [name].</span>", "<span class='notice'>You collect \the [name].</span>")
-			forceMove(RH)
-			RH.held = src
+	var/turf/T = target
+	if(!T.density)
+		var/obj/structure/bed/roller/R = new extended(T)
+		R.add_fingerprint(user)
+		qdel(src)
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/roller/holo
 	name = "holo stretcher"
@@ -222,9 +219,6 @@
 	w_class = WEIGHT_CLASS_SMALL
 	origin_tech = "magnets=3;biotech=4;powerstorage=3"
 	extended = /obj/structure/bed/roller/holo
-
-/obj/item/roller/holo/attackby__legacy__attackchain(obj/item/W, mob/user, params)
-	return
 
 /obj/structure/bed/roller/MouseDrop(over_object, src_location, over_location)
 	if(over_object == usr && Adjacent(usr) && (in_range(src, usr) || usr.contents.Find(src)))
@@ -243,21 +237,56 @@
 	desc = "A rack for carrying a collapsed roller bed."
 	icon = 'icons/obj/rollerbed.dmi'
 	icon_state = "folded"
+	new_attack_chain = TRUE
 	var/obj/item/roller/held
+	var/obj/carry_holo = FALSE
 
 /obj/item/roller_holder/New()
 	..()
 	held = new /obj/item/roller(src)
 
-/obj/item/roller_holder/attack_self__legacy__attackchain(mob/user as mob)
-	if(!held)
-		to_chat(user, "<span class='notice'>The rack is empty.</span>")
+/obj/item/roller_holder/interact_with_atom(atom/target, mob/living/user, list/modifiers)
+	if(!istype(target, /obj/item/roller))
+		return ..()
+	
+	if(istype(target, /obj/item/roller/holo) && !carry_holo)
+		return ITEM_INTERACT_COMPLETE
+
+	if(held)
+		to_chat(user, "<span class='warning'>[src] is already full!</span>")
+		return ITEM_INTERACT_COMPLETE
+
+	var/obj/item/roller/bed = target
+	user.visible_message(
+		"<span class='notice'>[user] collects [target].</span>",
+		"<span class='notice'>You collect [target].</span>"
+	)
+	bed.forceMove(src)
+	held = target
+	return ITEM_INTERACT_COMPLETE
+
+/obj/item/roller_holder/activate_self(mob/user)
+	if(..())
 		return
 
-	to_chat(user, "<span class='notice'>You deploy the roller bed.</span>")
-	var/obj/structure/bed/roller/R = new /obj/structure/bed/roller(user.loc)
+	if(!held)
+		to_chat(user, "<span class='warning'>[src] is empty!</span>")
+		return
+
+	to_chat(user, "<span class='notice'>You deploy [held].</span>")
+	var/obj/structure/bed/roller/R = new held.extended(user.loc)
 	R.add_fingerprint(user)
 	QDEL_NULL(held)
+
+/obj/item/roller_holder/holo
+	name = "holo stretcher rack"
+	desc = "A rack for carrying an undeployed holo stretcher. It can also support a basic roller bed in a pinch."
+	icon_state = "holo_retracted"
+	carry_holo = TRUE
+
+/obj/item/roller_holder/holo/New()
+	..()
+	held = new /obj/item/roller/holo(src)
 
 /*
  * Dog beds

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1323,6 +1323,16 @@
 	construction_time = 12 SECONDS
 	category = list("Cyborg Upgrades")
 
+/datum/design/borg_upgrade_holo_stretcher
+	name = "Cyborg Upgrade (Holo Stretcher Rack Upgrade)"
+	id = "borg_upgrade_holo_stretcher"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/holo_stretcher
+	req_tech = list("magnets" = 5, "powerstorage" = 4)
+	materials = list(MAT_METAL = 1000, MAT_SILVER = 500, MAT_GLASS = 500, MAT_DIAMOND = 200)
+	construction_time = 12 SECONDS
+	category = list("Cyborg Upgrades")
+
 // IPC
 
 /datum/design/ipc_head


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gives medical cyborgs access to a holo stretcher rack upgrade. It can hold both holo stretchers and roller beds. It has the same tech requirements and material costs as a roller bed.

Also migrates the roller bed rack and roller bed item to the new attack chain.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Medical borgs finally get their own upgrade (not dependent on abductors existing). There's no reason why they shouldn't be able to use them if the rest of the crew can.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in. Printed the upgrade from a mech fabricator. Installed it into a borg. They had the new rack.
Tried to pick up holo stretchers with the basic roller bed rack, was unable. Worked with basic roller bed.
Tried to pick up holo stretchers and roller beds with the holo stretcher rack. Was successful.
Repeated the above with an already filled rack, couldn't grab an extra.
Ensured that the deployed bed was of the correct type.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Added the holo stretcher rack upgrade for medical cyborgs. It can hold both roller beds and holo stretchers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
