### PR TITLE
fix new golem ship docking port dimensions

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -153,6 +153,7 @@
 /obj/machinery/door/airlock/external,
 /obj/docking_port/mobile/free_golem,
 /obj/structure/fans/tiny,
+/obj/docking_port/stationary/golem/lavaland,
 /turf/simulated/floor/plating,
 /area/shuttle/freegolem)
 "oD" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/golemtarget.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/golemtarget.dmm
@@ -9,14 +9,7 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "S" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 8;
-	height = 20;
-	id = "freegolem_space";
-	name = "The middle of space";
-	width = 16
-	},
+/obj/docking_port/stationary/golem/space,
 /turf/template_noop,
 /area/template_noop)
 

--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
@@ -6786,14 +6786,7 @@
 /turf/template_noop,
 /area/ruin/space/derelict/solar_control)
 "sm" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 8;
-	height = 20;
-	id = "freegolem_ussp";
-	name = "Near USSP Station";
-	width = 16
-	},
+/obj/docking_port/stationary/golem/ussp,
 /turf/template_noop,
 /area/template_noop)
 "sn" = (

--- a/code/modules/awaymissions/mission_code/ruins/freegolems.dm
+++ b/code/modules/awaymissions/mission_code/ruins/freegolems.dm
@@ -133,3 +133,39 @@
 	desc = "Used to recall the Golem Ship."
 	possible_destinations = "freegolem_lavaland"
 	resistance_flags = INDESTRUCTIBLE
+
+#define FREE_GOLEM_SHIP_WIDTH 18
+#define FREE_GOLEM_SHIP_HEIGHT 19
+
+/obj/docking_port/mobile/free_golem
+	name = "Free Golem Ship"
+	dir = 8
+	id = "freegolem"
+	dwidth = FREE_GOLEM_SHIP_WIDTH / 2
+	height = FREE_GOLEM_SHIP_HEIGHT
+	width = FREE_GOLEM_SHIP_WIDTH
+	preferred_direction = WEST
+	port_direction = SOUTH
+
+/obj/docking_port/stationary/golem
+	dir = 8
+	height = FREE_GOLEM_SHIP_HEIGHT
+	width = FREE_GOLEM_SHIP_WIDTH
+	dwidth = FREE_GOLEM_SHIP_WIDTH / 2
+
+/obj/docking_port/stationary/golem/space
+	name = "The middle of space"
+	id = "freegolem_space"
+
+/obj/docking_port/stationary/golem/ussp
+	name = "Near USSP Station"
+	id = "freegolem_ussp"
+
+/obj/docking_port/stationary/golem/lavaland
+	name = "Lavaland Surface"
+	id = "freegolem_lavaland"
+	area_type = /area/ruin/powered/golem_ship
+	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
+
+#undef FREE_GOLEM_SHIP_WIDTH
+#undef FREE_GOLEM_SHIP_HEIGHT

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -13,11 +13,16 @@
 	anchored = TRUE
 
 	var/id
-	dir = NORTH		//this should point -away- from the dockingport door, ie towards the ship
-	var/width = 0	//size of covered area, perpendicular to dir
-	var/height = 0	//size of covered area, paralell to dir
-	var/dwidth = 0	//position relative to covered area, perpendicular to dir
-	var/dheight = 0	//position relative to covered area, parallel to dir
+	/// This should point *away* from the docking port door, i.e. towards the ship.
+	dir = NORTH
+	/// Size of covered area, perpendicular to direction.
+	var/width = 0
+	/// Size of covered area, paralell to direction.
+	var/height = 0
+	/// Position relative to covered area, perpendicular to direction.
+	var/dwidth = 0
+	/// Position relative to covered area, parallel to direction.
+	var/dheight = 0
 
 	// A timid shuttle will not register itself with the shuttle subsystem
 	// All shuttle templates are timid
@@ -906,16 +911,6 @@
 	id = "syndicate"
 	name = "syndicate infiltrator"
 	width = 18
-
-/obj/docking_port/mobile/free_golem
-	dir = 8
-	dwidth = 8
-	height = 20
-	id = "freegolem"
-	name = "Free Golem Ship"
-	width = 16
-	preferred_direction = WEST
-	port_direction = SOUTH
 
 /obj/docking_port/mobile/whiteship
 	dir = 8

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -17,7 +17,7 @@
 	dir = NORTH
 	/// Size of covered area, perpendicular to direction.
 	var/width = 0
-	/// Size of covered area, paralell to direction.
+	/// Size of covered area, parallel to direction.
 	var/height = 0
 	/// Position relative to covered area, perpendicular to direction.
 	var/dwidth = 0


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the dimensions of the docking ports for the new golem ship.
## Why It's Good For The Game
Bugfix.
## Testing
![2025_05_17__19_44_34__Paradise Station 13](https://github.com/user-attachments/assets/ec475af6-622c-4095-8c84-7a372c0bcb24)
![2025_05_17__19_45_09__Paradise Station 13](https://github.com/user-attachments/assets/39632386-02a0-4495-a057-9199383c7fc2)
![2025_05_17__19_45_48__Paradise Station 13](https://github.com/user-attachments/assets/c6be713d-f611-4c4c-8342-b139148aa081)
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: The new golem ship now properly docks and undocks at all its available locations.
/:cl: