### PR TITLE
Adds a warning if you attempt to call with an unlinked scryer + moves modsuit wire interact before the scryer imprinting

### DIFF
--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -317,6 +317,11 @@
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
+	if(open)
+		if(seconds_electrified && get_charge() && shock(user))
+			return TRUE
+		wires.Interact(user)
+		return TRUE
 	if(!I.multitool_check_buffer(user))
 		return
 	var/obj/item/multitool/M = I
@@ -428,11 +433,6 @@
 		user.drop_item()
 		attacking_core.install(src)
 		update_charge_alert()
-		return TRUE
-	else if(istype(attacking_item, /obj/item/multitool) && open)
-		if(seconds_electrified && get_charge() && shock(user))
-			return TRUE
-		wires.Interact(user)
 		return TRUE
 	else if(open && attacking_item.GetID())
 		update_access(user, attacking_item.GetID())

--- a/code/modules/mod/mod_link.dm
+++ b/code/modules/mod/mod_link.dm
@@ -499,6 +499,7 @@
 
 /proc/call_link(mob/user, datum/mod_link/calling_link)
 	if(!calling_link.frequency)
+		to_chat(user, "<span class='warning'>The frequency isn't set!</span>")
 		return
 	var/list/callers = list()
 	for(var/id in GLOB.mod_link_ids)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a warning message if you try to call with an unlinked scryer, moves the modsuit wire interact before the scryer imprinting interaction.
## Why It's Good For The Game
Having a call fail with zero feedback doesn't feel good. Using a multitool on an open modsuit should result in a wire interface.
## Testing
Tried calling with an unlinked scryer, I got a warning message. Used multitool on modsuit with it's panel closed and it imprinted. Opened the modsuit, it resulted in a wire interface.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Multitools will show a wire interface when interacting with open modsuits again.
tweak: Unlinked scryers now have a fail message when trying to call someone.
/:cl: