### PR TITLE
makes non-required ruin placement failures a log, not a runtime

### DIFF
--- a/code/datums/ruins/ruin_placer.dm
+++ b/code/datums/ruins/ruin_placer.dm
@@ -169,7 +169,7 @@
 			for(var/datum/map_template/ruin/R in ruins_available)
 				if(R.id == current_pick.id)
 					ruins_available -= R
-			stack_trace("failed to place ruin [current_pick.suffix]")
+			log_debug("failed ruin placement `[current_pick.suffix]` length(z_levels)=[length(z_levels)] budget=[ruin_budget]")
 
 		//Update the available list
 		for(var/datum/map_template/ruin/R in ruins_available)


### PR DESCRIPTION
## What Does This PR Do
This PR makes ruin placement failures (for non-required ruins) a debug log statement instead of a stack trace, and adds a bit more useful info to the message.
## Why It's Good For The Game
A failure here isn't the end of the world, it just means there was an overall mismatch between available space and ruin rolls. One less noisy runtime.
## Testing
Visual inspection.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC