### PR TITLE
Various enhanced tracker fixes

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai_life.dm
+++ b/code/modules/mob/living/silicon/ai/ai_life.dm
@@ -27,13 +27,14 @@
 		check_holopad_eye()
 
 	// Enhanced Tracking
-	if(enhanced_tracking && tracked_mob)
+	if(enhanced_tracking && tracked_mob && !tracker_alert_cooldown)
 		if(can_see(tracked_mob))
 			var/area/A = get_area(tracked_mob)
 			if(A)
 				addtimer(CALLBACK(src, PROC_REF(raise_tracking_alert), A, tracked_mob), enhanced_tracking_delay)
-				// To prevent spam, immediately unset tracking.
-				tracked_mob = null
+				// To prevent spam, start a cooldown.
+				tracker_alert_cooldown = TRUE
+				addtimer(CALLBACK(src, PROC_REF(reset_tracker_cooldown)), tracking_alert_interval)
 
 	if(malfhack && malfhack.aidisabled)
 		to_chat(src, "<span class='danger'>ERROR: APC access disabled, hack attempt canceled.</span>")

--- a/code/modules/mob/living/silicon/ai/ai_mob.dm
+++ b/code/modules/mob/living/silicon/ai/ai_mob.dm
@@ -87,6 +87,10 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 	var/mob/tracked_mob
 	/// The current delay on enhanced tracking
 	var/enhanced_tracking_delay = 10 SECONDS
+	/// Interval between camera pings to prevent spammed alerts
+	var/tracking_alert_interval = 30 SECONDS
+	/// Is the interval active
+	var/tracker_alert_cooldown = FALSE
 
 	//MALFUNCTION
 	var/datum/module_picker/malf_picker

--- a/code/modules/mob/living/silicon/ai/ai_programs.dm
+++ b/code/modules/mob/living/silicon/ai/ai_programs.dm
@@ -1046,11 +1046,11 @@
 		return
 	user.enhanced_tracking = TRUE
 	user.alarms_listened_for += "Tracking"
-	user.enhanced_tracking_delay = initial(user.enhanced_tracking_delay) - (upgrade_level * 2 SECONDS)
+	user.enhanced_tracking_delay = initial(user.enhanced_tracking_delay) - (upgrade_level * 1 SECONDS)
 
 /datum/ai_program/enhanced_tracker/downgrade(mob/living/silicon/ai/user)
 	..()
-	user.enhanced_tracking_delay = initial(user.enhanced_tracking_delay) - (upgrade_level * 2 SECONDS)
+	user.enhanced_tracking_delay = initial(user.enhanced_tracking_delay) - (upgrade_level * 1 SECONDS)
 
 /datum/ai_program/enhanced_tracker/uninstall(mob/living/silicon/ai/user)
 	..()
@@ -1073,6 +1073,9 @@
 		return
 	// Pick a mob to track
 	var/target_name = tgui_input_list(user, "Pick a trackable target...", "AI", user.trackable_mobs())
+	if(!target_name)
+		user.tracked_mob = null
+		return
 	user.tracked_mob = (isnull(user.track.humans[target_name]) ? user.track.others[target_name] : user.track.humans[target_name])
 
 /mob/living/silicon/ai/proc/raise_tracking_alert(area/A, mob/target)
@@ -1088,6 +1091,9 @@
 	if(GLOB.alarm_manager.trigger_alarm("Tracking", A, A.cameras, closest_camera))
 		// Cancel alert after 1 minute
 		addtimer(CALLBACK(GLOB.alarm_manager, TYPE_PROC_REF(/datum/alarm_manager, cancel_alarm), "Tracking", A, closest_camera), 1 MINUTES)
+
+/mob/living/silicon/ai/proc/reset_tracker_cooldown()
+	tracker_alert_cooldown = FALSE
 
 // Pointer - Lets you put down a holographic reticle to draw attention to things
 /datum/ai_program/pointer


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes three issues with the enhanced tracker:
- The enhanced tracker auto-resetting when it locks the first time
- The enhanced tracker not properly resetting the tracked mob when the menu is cancelled
- The enhanced tracker scaling the upgrades twice as fast as intended

## Why It's Good For The Game

Bugs are bad. Oversights are bad. Bad numbers are bad.

## Testing

Spawned as AI. Bought enhanced tracker. Tracked pun pun. 

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed enhanced tracker auto-resetting
fix: Fixed enhanced tracker scaling twice as fast as it should
fix: Fixed enhanced tracker not resetting when tracking menu is canceled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
