### PR TITLE
Nukes Round Extension Vote - Makes it an Admin Verb

### DIFF
--- a/code/controllers/subsystem/SSticker.dm
+++ b/code/controllers/subsystem/SSticker.dm
@@ -120,8 +120,7 @@ SUBSYSTEM_DEF(ticker)
 					sample_biohazard_population(biohazard)
 
 			if(world.time > next_autotransfer)
-				SSvote.start_vote(new /datum/vote/crew_transfer)
-				next_autotransfer = world.time + GLOB.configuration.vote.autotransfer_interval_time
+				init_shift_change(null, TRUE)
 
 			var/game_finished = SSshuttle.emergency.mode >= SHUTTLE_ENDGAME || mode.station_was_nuked
 			if(GLOB.configuration.gamemode.disable_certain_round_early_end)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -69,6 +69,7 @@ GLOBAL_LIST_INIT(admin_verbs_admin, list(
 	/client/proc/ccbdb_lookup_ckey,
 	/client/proc/view_instances,
 	/client/proc/start_vote,
+	/client/proc/extend_round,
 	/client/proc/ping_all_admins,
 	/client/proc/show_watchlist,
 	/client/proc/debugstatpanel,
@@ -636,6 +637,21 @@ GLOBAL_LIST_INIT(view_runtimes_verbs, list(
 	holder.Secrets()
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Secrets") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return
+
+
+/client/proc/extend_round()
+	set name = "Extend Round"
+	set category = "Admin"
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	if(tgui_alert(usr, "Are you sure you want to extend the round?", "Round Extension", list("No", "Yes")) == "Yes")
+		SSticker.next_autotransfer = world.time + GLOB.configuration.vote.autotransfer_interval_time
+		log_admin("[key_name(usr)] has extended the round!")
+		message_admins("[key_name_admin(usr)] has extended the round!")
+		SSblackbox.record_feedback("tally", "admin_verb", 1, "Extend Round")
+		return
 
 /client/proc/getStealthKey()
 	return GLOB.stealthminID[ckey]


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

The shuttle call vote no longer exists. It is automatically called at the 2 hour mark. Admins can extend the round manually with a new admin verb. The vote template still exists so admins can manually call the vote.

## Why It's Good For The Game

Rounds that get extended are pure pain for the majority of living crew. By the time two hours has passed, most crew are starting to burn out. The vast vast majority of time that rounds get extended, they are extended for the purpose of a late-roll biohazard, mostly voted in by DChat. This PR makes it so admins can extend/manually call the shuttle vote as need be.

## Testing

Started game. Extended round with new verb. De-adminned. Verb gone.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
![image](https://github.com/user-attachments/assets/6d156c6c-496e-4dcc-a7f7-adba6b718666)

  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Added round extension verb to admins
del: Removed end round vote
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
