### PR TITLE
fix inability to climb over railings

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -109,6 +109,7 @@
 		return
 	climbers -= user
 	UnregisterSignal(user, COMSIG_PARENT_QDELETING)
+	return TRUE
 
 /obj/structure/proc/remove_climber(mob/living/climber)
 	SIGNAL_HANDLER // COMSIG_PARENT_QDELETING


### PR DESCRIPTION
## What Does This PR Do
This PR makes it possible to climb over railings from both sides again. Fixes #23529.
## Why It's Good For The Game
Bugfix.
## Testing
Climbed over railing from both sides, ensured it worked.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Fixed inability to climb over railings from both sides.
/:cl: