### PR TITLE
fix supply console BSOD

### DIFF
--- a/code/modules/supply/supply_order.dm
+++ b/code/modules/supply/supply_order.dm
@@ -27,10 +27,9 @@
 	orderedbyaccount = account
 	RegisterSignal(orderedbyaccount, COMSIG_PARENT_QDELETING, PROC_REF(clear_request))
 
-/// Clear the request from the request list and delete it
+/// Clear the request from the request list so it's not permanently stuck in the console
 /datum/supply_order/proc/clear_request()
 	SSeconomy.request_list -= src
-	qdel(src)
 
 /datum/supply_order/proc/createObject(atom/_loc, errors = 0)
 	if(!object)


### PR DESCRIPTION
## What Does This PR Do
This PR fixes #27449 maybe. This runtime first started occurring a week or so after #27190, and I suspect the issue is that orders being deleted after a person cryos have already made it into either SSeconomy.delivery_list or SSeconomy.shopping_list, causing them to become null entries in those lists, because I don't see any other way for null entries to end up in those lists.

I could remove the `as anything` in the loops for the ui_data, or do some other bookkeeping and remove qdeleted items from the list somewhere, but I'd rather prevent the problem from happening altogether.
## Why It's Good For The Game
BSOD on supply consoles is bad.
## Testing
I can't reproduce the original issue so we'll just TM it and see. It will be easy to spot if it was fixed because it can happen like 50 times a day some days.
![2025_05_20__12_56_50__Runtimes - Elastic](https://github.com/user-attachments/assets/9e97f012-057f-447e-8621-8dd580b6ffd2)

## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: The supply console will no longer bluescreen under certain conditions.
/:cl: