### PR TITLE
fix persistent wizard immovable rod

### DIFF
--- a/code/datums/spells/rod_form.dm
+++ b/code/datums/spells/rod_form.dm
@@ -40,13 +40,16 @@
 	notify = FALSE
 
 /obj/effect/immovablerod/wizard/Move()
+	. = ..()
 	if(get_dist(start_turf, get_turf(src)) >= max_distance)
 		qdel(src)
-	..()
 
 /obj/effect/immovablerod/wizard/Destroy()
 	if(wizard)
 		wizard.status_flags &= ~GODMODE
 		wizard.notransform = FALSE
 		wizard.forceMove(get_turf(src))
+		wizard = null
+
+	start_turf = null
 	return ..()


### PR DESCRIPTION
## What Does This PR Do
This PR fixes wizard immovable rods becoming invisible impassible barriers on tiles after turning back into wizards. Fixes #29386. Also cleans up some references on the rod for sanity's sake.
## Why It's Good For The Game
Bugfix.
## Testing
Spawned in as wizard, used rod form, ensured that it was qdel'd properly and was not located in-game.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Wizard's rod form should no longer leave behind invisible impassible obstacles.
/:cl: