### PR TITLE
modify default vsc settings to insert final newlines on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,6 +50,7 @@
 	},
 
 	"editor.formatOnSave": true,
+	"files.insertFinalNewline": true,
 	"gitlens.advanced.blame.customArguments": [
 		"--ignore-revs-file",
 		"${workspaceRoot}/.git-blame-ignore-revs"


### PR DESCRIPTION
## What Does This PR Do
This PR enables the VSC setting for adding a final newline to files on save to the default editor settings.
## Why It's Good For The Game
So people don't have to worry/care about this or set it manually
## Testing
Visual inspection
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC