### PR TITLE
Make using wirecutters on an open modsuit open the wire interaction interface

### DIFF
--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -294,6 +294,14 @@
 
 			add_fingerprint(M)
 
+/obj/item/mod/control/wirecutter_act(mob/living/user, obj/item/I)
+	if(open)
+		if(seconds_electrified && get_charge() && shock(user))
+			return TRUE
+		wires.Interact(user)
+		return TRUE
+	return ..()
+
 /obj/item/mod/control/wrench_act(mob/living/user, obj/item/wrench)
 	if(..())
 		return TRUE


### PR DESCRIPTION
## What Does This PR Do
Using wirecutters on an unscrewed mod control unit will open a wire interaction menu (akin to the multitool). Fixes #29396
## Why It's Good For The Game
You should be able to access an open modsuits wires with a wirecutter.
## Testing
Put wirecutters in a closed modsuit, cut wires in an open modsuit, got shocked by an electrified open modsuit, didnt get shocked by an electrified closed modsuit.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Using wirecutters on an unscrewed modsuit will open a wire interface.
/:cl: