### PR TITLE
fix dynamic airlock linker runtime

### DIFF
--- a/code/modules/mapping/dynamic_airlock_linker.dm
+++ b/code/modules/mapping/dynamic_airlock_linker.dm
@@ -123,9 +123,9 @@ RESTRICT_TYPE(/datum/dynamic_airlock_linker)
 /// this process are qdel'd so they don't attempt to assign access to anything
 /// else later.
 /datum/dynamic_airlock_linker/proc/consume_access_helpers(obj/effect/map_effect/dynamic_airlock/helper)
-	for(var/obj/effect/mapping_helpers/airlock/access/any/any_helper as anything in get_turf(helper))
+	for(var/obj/effect/mapping_helpers/airlock/access/any/any_helper in get_turf(helper))
 		req_one_access |= any_helper.access
 		qdel(any_helper)
-	for(var/obj/effect/mapping_helpers/airlock/access/all/all_helper as anything in get_turf(helper))
+	for(var/obj/effect/mapping_helpers/airlock/access/all/all_helper in get_turf(helper))
 		req_access |= all_helper.access
 		qdel(all_helper)


### PR DESCRIPTION
## What Does This PR Do
This PR fixes a runtime caused by dynamic airlock helpers. These loops iterate over anything on the turf, so we can't ignore the type cast.
## Why It's Good For The Game
Fewer runtimes.
## Testing
Started server with drug lab ruin, ensured that no runtimes occurred.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC