### PR TITLE
NSS Cerebron (Metastation), renamed two supply cameras to their proper rooms

### DIFF
--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -34397,9 +34397,8 @@
 /area/station/hallway/primary/starboard/east)
 "dTf" = (
 /obj/machinery/camera{
-	c_tag = "AI Satellite Atmospherics";
-	dir = 4;
-	network = list("SS13","MiniSat")
+	c_tag = "Smiths Office";
+	dir = 4
 	},
 /obj/machinery/newscaster/directional/west,
 /obj/machinery/status_display/supply_display{
@@ -60067,9 +60066,8 @@
 "nhC" = (
 /obj/machinery/suit_storage_unit/expedition,
 /obj/machinery/camera{
-	c_tag = "AI Satellite Atmospherics";
-	dir = 4;
-	network = list("SS13","MiniSat")
+	c_tag = "Expedition Room";
+	dir = 4
 	},
 /obj/machinery/newscaster/directional/west,
 /turf/simulated/floor/plasteel{


### PR DESCRIPTION
## What Does This PR Do

Renames the expedition camera and smith cameras to proper names and removes them from sciences camera network

## Why It's Good For The Game
Science shouldn't be stalking the smith. proper names for cameras is nice as well.
## Testing
Spawned as RD, scanned the cameras for smiths' office and expedition room. Not on list.
Spawned as Security Officer, searched "smith", seen the smiths office
Searched "expe", seen expedition room
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: NSS Cerebron, the Research director can no longer watch the smith by cameras.
/:cl: