### PR TITLE
Fix: Queen bees with reagents causing runtime errors by adding null c…

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -262,7 +262,8 @@
 	if(. && beegent && isliving(target))
 		var/mob/living/L = target
 		beegent.reaction_mob(L, REAGENT_TOUCH)
-		L.reagents.add_reagent(beegent.id, rand(1, 5))
+		if(L.reagents)
+			L.reagents.add_reagent(beegent.id, rand(1, 5))
 
 //PEASENT BEES
 /mob/living/simple_animal/hostile/poison/bees/queen/pollinate()


### PR DESCRIPTION
## What does this PR do?
Adds a null check before adding reagents to ensure the target has a valid reagents container. This fixes the runtime error 'Cannot execute null.add reagent()' when queen bees with special reagents attack targets without reagent containers.

## Why is it good for the game?
Prevents runtime errors that occur when bees with custom reagents (like "Iced Beer") attack targets that don't have reagent containers.

Adds a null check before adding reagents to ensure the target has a valid reagents container. This fixes the runtime error 'Cannot execute null.add reagent()' when queen bees with special reagents attack targets without reagent containers.

<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What does this PR do?
Adds a null check before adding reagents to ensure the target has a valid reagents container. This fixes the runtime error 'Cannot execute null.add reagent()' when queen bees with special reagents attack targets without reagent containers.

## Why is it good for the game?
Prevents runtime errors that occur when bees with custom reagents (like "Iced Beer") attack targets that don't have reagent containers.

## Images/Videos (if applicable)
N/A

## Changelog
:cl:
fix: Added null check in queen bee code to prevent runtime errors when targeting objects without reagent containers
/:cl:

## Declaration

- [ ] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:

fix: Fixed a few things

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->