### PR TITLE
Fix: Reset smithing machinery operation state when power is lost

### DIFF
--- a/code/modules/smithing/smith_machinery.dm
+++ b/code/modules/smithing/smith_machinery.dm
@@ -36,6 +36,9 @@
 /obj/machinery/smithing/power_change()
 	if(!..())
 		return
+	// If power is lost during operation, reset the operating flag to prevent the machine from getting stuck
+	if(stat & NOPOWER && operating)
+		operating = FALSE
 	update_icon(UPDATE_ICON_STATE)
 
 /obj/machinery/smithing/item_interaction(mob/living/user, obj/item/used, list/modifiers)
@@ -71,6 +74,8 @@
 	update_icon(ALL)
 	for(var/i in 1 to loops)
 		if(stat & (NOPOWER|BROKEN))
+			operating = FALSE
+			update_icon(ALL)
 			return FALSE
 		use_power(500)
 		if(operation_sound)


### PR DESCRIPTION
### What does this PR do?
Fixes #29403  where smithing equipment gets stuck if power is cut during operation. Previously, the operating state wouldn't reset when power was lost, leading to equipment that couldn't be used or deconstructed when power returned.

This PR adds code to:
1. Reset the operating flag in power_change() when power is lost
2. Ensure the operating flag is reset in operate() if power is lost during operation
3. Update the visual state of the machine appropriately

### Why is it good for the game?
Prevents runtime errors that occur when bees with custom reagents (like "Iced Beer") attack targets that don't have reagent containers.

### Declaration
 I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
 
### Changelog
🆑
fix: Fixes an issue where smithing equipment gets stuck if power is cut during operation.
/:cl:
