### PR TITLE
check z-levels exist for volcanic weather

### DIFF
--- a/code/datums/weather/weather_types/lavaland_weather.dm
+++ b/code/datums/weather/weather_types/lavaland_weather.dm
@@ -162,7 +162,7 @@
 	. = ..()
 
 /datum/weather/volcano/area_act()
-	if(prob(1) && !generated_river)
+	if(prob(1) && !generated_river && length(levels_by_trait(ORE_LEVEL)))
 		generated_river = TRUE
 		var/datum/river_spawner/new_river = new /datum/river_spawner(pick(levels_by_trait(ORE_LEVEL)))
 		new_river.generate(nodes = 4, ignore_bridges = TRUE, warning = TRUE)


### PR DESCRIPTION
## What Does This PR Do
This PR adds a check to make sure lavaland levels exist when volcanic weather tries to place a river.
## Why It's Good For The Game
This proc can runtime in unit tests if the list is empty.
## Testing
Visual inspection.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC