### PR TITLE
fix flooring of whiteship submaps

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/submaps/whiteship_submaps.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/submaps/whiteship_submaps.dmm
@@ -492,7 +492,7 @@
 "Dm" = (
 /obj/machinery/door/airlock/titanium/glass,
 /obj/effect/mapping_helpers/airlock/c_foam/three,
-/turf/template_noop,
+/turf/simulated/floor/plating/airless,
 /area/template_noop)
 "Dv" = (
 /obj/machinery/light/small{
@@ -699,7 +699,10 @@
 /area/template_noop)
 "Ri" = (
 /obj/machinery/door/airlock/security/glass,
-/turf/template_noop,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkred"
+	},
 /area/template_noop)
 "RE" = (
 /obj/structure/shuttle/engine/heater{


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Plating now is under the destroyed room's door instead of wood.
Security colored flooring instead of wood to the armory room.

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

![image](https://github.com/user-attachments/assets/e7094de6-add0-44aa-8ad1-a475aca03f73)


## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fix whiteship flooring of 2 layouts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
