### PR TITLE
Sorta revert of #29402

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -175,6 +175,7 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 
 /obj/machinery/door/airlock/Destroy()
 	SStgui.close_uis(wires)
+	QDEL_LIST_CONTENTS(fillers)
 	QDEL_NULL(electronics)
 	QDEL_NULL(wires)
 	QDEL_NULL(note)
@@ -1267,9 +1268,13 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 	update_icon(AIRLOCK_OPENING, 1)
 	sleep(1)
 	set_opacity(0)
+	if(width > 1)
+		set_fillers_opacity(0)
 	update_freelook_sight()
 	sleep(4)
 	density = FALSE
+	if(width > 1)
+		set_fillers_density(FALSE)
 	sleep(1)
 	layer = OPEN_DOOR_LAYER
 	update_icon(AIRLOCK_OPEN, 1)
@@ -1309,12 +1314,16 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 	if(!override)
 		sleep(1)
 	density = TRUE
+	if(width > 1)
+		set_fillers_density(TRUE)
 	if(!override)
 		sleep(4)
 	if(!safe)
 		crush()
 	if((visible && !glass) || polarized_on)
 		set_opacity(1)
+		if(width > 1)
+			set_fillers_opacity(1)
 	update_freelook_sight()
 	sleep(1)
 	update_icon(AIRLOCK_CLOSED, 1)
@@ -1498,9 +1507,9 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 	if(!(flags & NODECONSTRUCT))
 		var/obj/structure/door_assembly/DA
 		if(assemblytype)
-			DA = new assemblytype(loc, dir)
+			DA = new assemblytype(loc)
 		else
-			DA = new /obj/structure/door_assembly(loc, dir)
+			DA = new /obj/structure/door_assembly(loc)
 			//If you come across a null assemblytype, it will produce the default assembly instead of disintegrating.
 		DA.reinforced_glass = src.reinforced_glass //tracks whether there's rglass in
 		DA.anchored = TRUE
@@ -1531,6 +1540,7 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 			electronics = null
 			ae.forceMove(loc)
 			ae.is_installed = FALSE
+	QDEL_LIST_CONTENTS(fillers)
 	qdel(src)
 
 /obj/machinery/door/airlock/proc/note_type() //Returns a string representing the type of note pinned to this airlock

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1507,9 +1507,9 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 	if(!(flags & NODECONSTRUCT))
 		var/obj/structure/door_assembly/DA
 		if(assemblytype)
-			DA = new assemblytype(loc)
+			DA = new assemblytype(loc, dir)
 		else
-			DA = new /obj/structure/door_assembly(loc)
+			DA = new /obj/structure/door_assembly(loc, dir)
 			//If you come across a null assemblytype, it will produce the default assembly instead of disintegrating.
 		DA.reinforced_glass = src.reinforced_glass //tracks whether there's rglass in
 		DA.anchored = TRUE

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -671,3 +671,86 @@ MAPPING_DIRECTIONAL_HELPERS_MULTITILE(/obj/machinery/door/airlock/multi_tile/gla
 /obj/machinery/door/airlock/multi_tile/glass
 	opacity = FALSE
 	glass = TRUE
+
+/obj/airlock_filler_object
+	name = "airlock fluff"
+	desc = "You shouldn't be able to see this fluff!"
+	icon = null
+	icon_state = null
+	density = TRUE
+	opacity = TRUE
+	anchored = TRUE
+	invisibility = INVISIBILITY_MAXIMUM
+	obj_integrity = INFINITY // our parent airlock/assembly will handle that
+	//atmos_canpass = CANPASS_DENSITY
+	/// The door/airlock this fluff panel is attached to
+	var/obj/machinery/door/filled_airlock
+	/// The assembly this fluff panel is attached to
+	var/obj/structure/door_assembly/filled_assembly
+
+/obj/airlock_filler_object/Bumped(atom/A)
+	if(filled_airlock)
+		return filled_airlock.Bumped(A)
+	if(filled_assembly)
+		return filled_assembly.Bumped(A)
+	else
+		stack_trace("Someone bumped into an airlock filler with no parent airlock/assembly specified!")
+
+/obj/airlock_filler_object/Destroy()
+	filled_airlock = null
+	filled_assembly = null
+	return ..()
+
+/obj/airlock_filler_object/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = TRUE, attack_dir, armour_penetration_flat = 0, armour_penetration_percentage = 0)
+	if(filled_airlock)
+		filled_airlock.take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir)
+	else if(filled_assembly)
+		filled_assembly.take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir)
+	return ..()
+
+/obj/airlock_filler_object/ex_act(severity)
+	if(filled_airlock)
+		filled_airlock.ex_act(severity)
+	else if(filled_assembly)
+		filled_assembly.ex_act(severity)
+	return ..()
+
+/// Multi-tile airlocks pair with a filler panel, if one goes so does the other.
+/obj/airlock_filler_object/proc/pair_airlock(obj/machinery/door/parent_airlock)
+	if(isnull(parent_airlock))
+		stack_trace("Attempted to pair an airlock filler with no parent airlock specified!")
+
+	filled_airlock = parent_airlock
+	RegisterSignal(filled_airlock, COMSIG_PARENT_QDELETING, PROC_REF(no_airlock))
+
+/obj/airlock_filler_object/proc/pair_assembly(obj/structure/door_assembly/parent_assembly)
+	if(isnull(parent_assembly))
+		stack_trace("Attempted to pair an airlock filler with no parent assembly specified!")
+
+	filled_assembly = parent_assembly
+	RegisterSignal(filled_assembly, COMSIG_PARENT_QDELETING, PROC_REF(no_assembly))
+
+/obj/airlock_filler_object/proc/no_airlock()
+	UnregisterSignal(filled_airlock)
+	qdel(src)
+
+/obj/airlock_filler_object/proc/no_assembly()
+	UnregisterSignal(filled_assembly)
+	qdel(src)
+
+/// Multi-tile airlocks (using a filler panel) have special handling for movables with PASS_FLAG_GLASS
+/obj/airlock_filler_object/CanPass(atom/movable/mover, border_dir)
+	if(mover == filled_assembly)
+		return TRUE
+	. = ..()
+	if(.)
+		return
+
+	if(istype(mover))
+		return !density
+
+/obj/airlock_filler_object/singularity_act()
+	return
+
+/obj/airlock_filler_object/singularity_pull(S, current_size)
+	return

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -688,14 +688,6 @@ MAPPING_DIRECTIONAL_HELPERS_MULTITILE(/obj/machinery/door/airlock/multi_tile/gla
 	/// The assembly this fluff panel is attached to
 	var/obj/structure/door_assembly/filled_assembly
 
-/obj/airlock_filler_object/Bumped(atom/A)
-	if(filled_airlock)
-		return filled_airlock.Bumped(A)
-	if(filled_assembly)
-		return filled_assembly.Bumped(A)
-	else
-		stack_trace("Someone bumped into an airlock filler with no parent airlock/assembly specified!")
-
 /obj/airlock_filler_object/Destroy()
 	filled_airlock = null
 	filled_assembly = null
@@ -747,7 +739,7 @@ MAPPING_DIRECTIONAL_HELPERS_MULTITILE(/obj/machinery/door/airlock/multi_tile/gla
 		return
 
 	if(istype(mover))
-		return !density
+		return !opacity
 
 /obj/airlock_filler_object/singularity_act()
 	return

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -588,7 +588,7 @@
 	LAZYINITLIST(fillers)
 
 	var/obj/last_filler = src
-	for(var/i in 1 to width)
+	for(var/i in 1 to width - 1)
 		var/obj/airlock_filler_object/filler
 
 		if(length(fillers) < i)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -37,6 +37,8 @@
 	var/unres_sides = 0
 	//Multi-tile doors
 	var/width = 1
+	/// List. Player view blocking fillers for multi-tile doors.
+	var/list/fillers
 	//Whether nonstandard door sounds (cmag laughter) are off cooldown.
 	var/sound_ready = TRUE
 	var/sound_cooldown = 1 SECONDS
@@ -53,6 +55,7 @@
 	var/superconductivity = DOOR_HEAT_TRANSFER_COEFFICIENT
 	/// So explosion doesn't deal extra damage for multitile airlocks
 	COOLDOWN_DECLARE(explosion_cooldown)
+
 
 /obj/machinery/door/Initialize(mapload)
 	. = ..()
@@ -88,7 +91,7 @@
 	update_icon()
 
 /obj/machinery/door/ex_act()
-	if(width > 1)
+	if(width > 1 && fillers)
 		if(!COOLDOWN_FINISHED(src, explosion_cooldown))
 			return
 		COOLDOWN_START(src, explosion_cooldown, 1 SECONDS)
@@ -382,12 +385,18 @@
 	recalculate_atmos_connectivity()
 	do_animate("opening")
 	set_opacity(0)
+	if(width > 1)
+		set_fillers_opacity(0)
 	sleep(5)
 	density = FALSE
+	if(width > 1)
+		set_fillers_density(FALSE)
 	sleep(5)
 	layer = initial(layer)
 	update_icon()
 	set_opacity(0)
+	if(width > 1)
+		set_fillers_opacity(0)
 	operating = NONE
 	update_freelook_sight()
 	if(autoclose)
@@ -414,10 +423,14 @@
 	layer = closingLayer
 	sleep(5)
 	density = TRUE
+	if(width > 1)
+		set_fillers_density(TRUE)
 	sleep(5)
 	update_icon()
 	if(!glass || polarized_on)
 		set_opacity(TRUE)
+		if(width > 1)
+			set_fillers_opacity(TRUE)
 	operating = NONE
 	recalculate_atmos_connectivity()
 	update_freelook_sight()
@@ -429,12 +442,9 @@
 
 /obj/machinery/door/proc/get_airlock_turfs()
 	var/list/airlock_turfs = list(get_turf(src))
-	if(width > 1)
-		var/turf/last_turf = get_turf(src)
-		for(var/i in width - 1)
-			var/turf/next_turf = get_step(last_turf, dir)
-			airlock_turfs |= next_turf
-			last_turf = next_turf
+	if(width > 1 && fillers)
+		for(var/obj/F in fillers)
+			airlock_turfs |= get_turf(F)
 	return airlock_turfs
 
 /obj/machinery/door/proc/check_for_mobs()
@@ -542,10 +552,14 @@
 /**
  * Sets the bounds of the airlock. For use with multi-tile airlocks.
  * If the airlock is multi-tile, it will set the bounds to be the size of the airlock.
+ * If the airlock doesn't already have fillers, it will create them.
+ * If the airlock already has fillers, it will move them to the correct location.
  */
 /obj/machinery/door/proc/update_bounds()
 	if(width <= 1)
 		return
+
+	QDEL_LIST_CONTENTS(fillers)
 
 	if(dir in list(EAST, WEST))
 		bound_width = width * world.icon_size
@@ -570,6 +584,39 @@
 		else
 			bound_y = 0
 			pixel_y = 0
+
+	LAZYINITLIST(fillers)
+
+	var/obj/last_filler = src
+	for(var/i in 1 to width)
+		var/obj/airlock_filler_object/filler
+
+		if(length(fillers) < i)
+			filler = new(src)
+			filler.pair_airlock(src)
+			fillers.Add(filler)
+		else
+			filler = fillers[i]
+
+		filler.loc = get_step(last_filler, dir)
+		filler.density = density
+		filler.set_opacity(opacity)
+
+		last_filler = filler
+
+/obj/machinery/door/proc/set_fillers_density(density)
+	if(!length(fillers))
+		return
+
+	for(var/obj/airlock_filler_object/filler as anything in fillers)
+		filler.density = density
+
+/obj/machinery/door/proc/set_fillers_opacity(opacity)
+	if(!length(fillers))
+		return
+
+	for(var/obj/airlock_filler_object/filler as anything in fillers)
+		filler.set_opacity(opacity)
 
 #define MAX_FOAM_LEVEL 5
 // Adds foam to the airlock, which will block it from being opened

--- a/code/game/objects/structures/door_assembly_types.dm
+++ b/code/game/objects/structures/door_assembly_types.dm
@@ -142,8 +142,10 @@
 	glass_type = /obj/machinery/door/airlock/multi_tile/glass
 	material_amt = 8
 
-/obj/structure/door_assembly/multi_tile/Initialize(mapload)
+/obj/structure/door_assembly/multi_tile/Initialize(mapload, direction)
 	. = ..()
+	if(direction)
+		setDir(direction)
 	update_bounds()
 
 /obj/structure/door_assembly/multi_tile/Move(new_loc, new_dir)

--- a/code/game/objects/structures/door_assembly_types.dm
+++ b/code/game/objects/structures/door_assembly_types.dm
@@ -150,20 +150,6 @@
 	. = ..()
 	update_bounds()
 
-/obj/structure/door_assembly/multi_tile/start_pulling(atom/movable/AM, state, force, show_message)
-	. = ..()
-	if(fillers)
-		for(var/i in 1 to width)
-			var/obj/airlock_filler_object/filler = fillers[i]
-			filler.density = FALSE
-
-/obj/structure/door_assembly/multi_tile/stop_pulling()
-	. = ..()
-	if(fillers)
-		for(var/i in 1 to width)
-			var/obj/airlock_filler_object/filler = fillers[i]
-			filler.density = TRUE
-
 /obj/structure/door_assembly/multi_tile/proc/update_bounds()
 	if(width <= 1)
 		return
@@ -196,7 +182,7 @@
 	LAZYINITLIST(fillers)
 
 	var/obj/last_filler = src
-	for(var/i in 1 to width)
+	for(var/i in 1 to width - 1)
 		var/obj/airlock_filler_object/filler
 
 		if(length(fillers) < i)

--- a/code/game/objects/structures/door_assembly_types.dm
+++ b/code/game/objects/structures/door_assembly_types.dm
@@ -136,20 +136,33 @@
 	icon = 'icons/obj/doors/airlocks/glass_large/glass_large.dmi'
 	base_name = "large airlock"
 	overlays_file = 'icons/obj/doors/airlocks/glass_large/overlays.dmi'
+	var/width = 2
+	var/list/fillers
 	airlock_type = /obj/machinery/door/airlock/multi_tile
 	glass_type = /obj/machinery/door/airlock/multi_tile/glass
 	material_amt = 8
-	var/width = 2
 
-/obj/structure/door_assembly/multi_tile/Initialize(mapload, direction)
+/obj/structure/door_assembly/multi_tile/Initialize(mapload)
 	. = ..()
-	if(direction)
-		setDir(direction)
 	update_bounds()
 
 /obj/structure/door_assembly/multi_tile/Move(new_loc, new_dir)
 	. = ..()
 	update_bounds()
+
+/obj/structure/door_assembly/multi_tile/start_pulling(atom/movable/AM, state, force, show_message)
+	. = ..()
+	if(fillers)
+		for(var/i in 1 to width)
+			var/obj/airlock_filler_object/filler = fillers[i]
+			filler.density = FALSE
+
+/obj/structure/door_assembly/multi_tile/stop_pulling()
+	. = ..()
+	if(fillers)
+		for(var/i in 1 to width)
+			var/obj/airlock_filler_object/filler = fillers[i]
+			filler.density = TRUE
 
 /obj/structure/door_assembly/multi_tile/proc/update_bounds()
 	if(width <= 1)
@@ -178,6 +191,25 @@
 		else
 			bound_y = 0
 			pixel_y = 0
+
+	QDEL_LIST_CONTENTS(fillers)
+	LAZYINITLIST(fillers)
+
+	var/obj/last_filler = src
+	for(var/i in 1 to width)
+		var/obj/airlock_filler_object/filler
+
+		if(length(fillers) < i)
+			filler = new(src)
+			filler.pair_assembly(src)
+			fillers += filler
+		else
+			filler = fillers[i]
+
+		filler.loc = get_step(last_filler, dir)
+		filler.set_opacity(opacity)
+
+		last_filler = filler
 
 /obj/structure/door_assembly/door_assembly_cult
 	name = "cult airlock assembly"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Reverts most of the #29402
Keeps the fixes
Fixes that some glass airlocks couldn't let the lasers pass through them

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

They are not 100% useless as i thought
Fixes are good

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Tested on test tiny that they are fine

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Multitile glass airlocks will let the energy projectiles pass through them once again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
