### PR TITLE
fix runtime in grill

### DIFF
--- a/code/modules/cooking/machines/grill.dm
+++ b/code/modules/cooking/machines/grill.dm
@@ -72,7 +72,8 @@
 	for(var/datum/cooking_surface/surface in surfaces)
 		if(surface.on)
 			if(!stored_wood)
-				SEND_SIGNAL(surface.container, COMSIG_COOK_GRILL_NO_FUEL)
+				if(surface.container)
+					SEND_SIGNAL(surface.container, COMSIG_COOK_GRILL_NO_FUEL)
 				surface.turn_off()
 			else
 				stored_wood = max(0, stored_wood - wood_consumption_rate)


### PR DESCRIPTION
## What Does This PR Do
This PR fixes a runtime caused by grills running out of fuel when no cooking container is on them.
## Why It's Good For The Game
Getting rid of runtime spam.
## Testing
Visual inspection.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC