### PR TITLE
make space goliaths, hivelords, and basilisks spacewalk

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/abandoned_engi_sat.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/abandoned_engi_sat.dmm
@@ -199,7 +199,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/abandoned_engi_sat)
 "fs" = (
-/mob/living/simple_animal/hostile/asteroid/hivelord,
+/mob/living/simple_animal/hostile/asteroid/hivelord/space,
 /turf/simulated/floor/wood/airless,
 /area/ruin/space/abandoned_engi_sat)
 "fA" = (
@@ -953,7 +953,7 @@
 	},
 /area/ruin/space/abandoned_engi_sat)
 "FN" = (
-/mob/living/simple_animal/hostile/asteroid/hivelord,
+/mob/living/simple_animal/hostile/asteroid/hivelord/space,
 /turf/simulated/floor/carpet/airless,
 /area/ruin/space/abandoned_engi_sat)
 "FQ" = (
@@ -1147,7 +1147,7 @@
 	},
 /area/ruin/space/abandoned_engi_sat)
 "OW" = (
-/mob/living/simple_animal/hostile/asteroid/hivelord,
+/mob/living/simple_animal/hostile/asteroid/hivelord/space,
 /turf/simulated/floor/plating,
 /area/ruin/space/abandoned_engi_sat)
 "OZ" = (
@@ -1261,7 +1261,7 @@
 /area/ruin/space/abandoned_engi_sat)
 "RV" = (
 /obj/effect/mapping_helpers/turfs/damage,
-/mob/living/simple_animal/hostile/asteroid/hivelord,
+/mob/living/simple_animal/hostile/asteroid/hivelord/space,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/abandoned_engi_sat)
 "Sa" = (
@@ -1338,7 +1338,7 @@
 /area/ruin/space/abandoned_engi_sat)
 "Xq" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/asteroid/hivelord,
+/mob/living/simple_animal/hostile/asteroid/hivelord/space,
 /turf/simulated/floor/plating,
 /area/ruin/space/abandoned_engi_sat)
 "XP" = (
@@ -1346,7 +1346,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/abandoned_engi_sat)
 "Ye" = (
-/mob/living/simple_animal/hostile/asteroid/hivelord,
+/mob/living/simple_animal/hostile/asteroid/hivelord/space,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/abandoned_engi_sat)
 "Yz" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -112,7 +112,7 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "as" = (
-/mob/living/simple_animal/hostile/asteroid/basilisk,
+/mob/living/simple_animal/hostile/asteroid/basilisk/space,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "at" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroid2.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroid2.dmm
@@ -12,7 +12,7 @@
 /turf/simulated/mineral/random/high_chance/space,
 /area/ruin/space/unpowered)
 "t" = (
-/obj/structure/spawner/mining/basilisk,
+/obj/structure/spawner/mining/basilisk/space,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "C" = (
@@ -20,7 +20,7 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "R" = (
-/obj/structure/spawner/mining/goliath,
+/obj/structure/spawner/mining/goliath/space,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "V" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroid3.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroid3.dmm
@@ -27,11 +27,11 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "v" = (
-/obj/structure/spawner/mining/basilisk,
+/obj/structure/spawner/mining/basilisk/space,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "N" = (
-/obj/structure/spawner/mining/hivelord,
+/obj/structure/spawner/mining/hivelord/space,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroid5.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroid5.dmm
@@ -12,7 +12,7 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "f" = (
-/obj/structure/spawner/mining/goliath,
+/obj/structure/spawner/mining/goliath/space,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "o" = (
@@ -27,11 +27,11 @@
 /turf/template_noop,
 /area/template_noop)
 "U" = (
-/obj/structure/spawner/mining/basilisk,
+/obj/structure/spawner/mining/basilisk/space,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "Y" = (
-/obj/structure/spawner/mining/hivelord,
+/obj/structure/spawner/mining/hivelord/space,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroidmining2.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroidmining2.dmm
@@ -15,11 +15,11 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "A" = (
-/obj/structure/spawner/mining/hivelord,
+/obj/structure/spawner/mining/hivelord/space,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "S" = (
-/obj/structure/spawner/mining/basilisk,
+/obj/structure/spawner/mining/basilisk/space,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "V" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroidmining3.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroidmining3.dmm
@@ -15,18 +15,18 @@
 /turf/space,
 /area/ruin/space/unpowered)
 "s" = (
-/obj/structure/spawner/mining/hivelord,
+/obj/structure/spawner/mining/hivelord/space,
 /turf/simulated/floor/plating/asteroid,
 /area/ruin/space/unpowered)
 "w" = (
-/mob/living/simple_animal/hostile/asteroid/basilisk,
+/mob/living/simple_animal/hostile/asteroid/basilisk/space,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "y" = (
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "E" = (
-/obj/structure/spawner/mining/basilisk,
+/obj/structure/spawner/mining/basilisk/space,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "L" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict4.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict4.dmm
@@ -91,7 +91,7 @@
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/unpowered)
 "K" = (
-/obj/structure/spawner/mining/basilisk,
+/obj/structure/spawner/mining/basilisk/space,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "Z" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict5.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict5.dmm
@@ -52,7 +52,7 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/space/unpowered)
 "gx" = (
-/obj/structure/spawner/mining/basilisk,
+/obj/structure/spawner/mining/basilisk/space,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "hG" = (
@@ -235,7 +235,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
 "KW" = (
-/obj/structure/spawner/mining/hivelord,
+/obj/structure/spawner/mining/hivelord/space,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "Li" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/emptyshell.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/emptyshell.dmm
@@ -37,7 +37,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
 "p" = (
-/mob/living/simple_animal/hostile/asteroid/hivelord,
+/mob/living/simple_animal/hostile/asteroid/hivelord/space,
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
 "t" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
@@ -463,7 +463,7 @@
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/syndicate_listening_station/asteroid)
 "Ie" = (
-/obj/structure/spawner/mining/basilisk,
+/obj/structure/spawner/mining/basilisk/space,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/syndicate_listening_station/asteroid)
 "Il" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/way_home.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/way_home.dmm
@@ -15,7 +15,7 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered/no_grav/way_home)
 "g" = (
-/obj/structure/spawner/mining/hivelord,
+/obj/structure/spawner/mining/hivelord/space,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered/no_grav/way_home)
 "n" = (
@@ -26,7 +26,7 @@
 /turf/template_noop,
 /area/template_noop)
 "z" = (
-/obj/structure/spawner/mining/basilisk,
+/obj/structure/spawner/mining/basilisk/space,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered/no_grav/way_home)
 "O" = (

--- a/code/game/objects/structures/monster_spawner.dm
+++ b/code/game/objects/structures/monster_spawner.dm
@@ -66,15 +66,24 @@
 	desc = "A den housing a nest of goliaths, oh god why?"
 	mob_types = list(/mob/living/simple_animal/hostile/asteroid/goliath)
 
+/obj/structure/spawner/mining/goliath/space
+	mob_types = list(/mob/living/simple_animal/hostile/asteroid/goliath/space)
+
 /obj/structure/spawner/mining/hivelord
 	name = "hivelord den"
 	desc = "A den housing a nest of hivelords."
 	mob_types = list(/mob/living/simple_animal/hostile/asteroid/hivelord)
 
+/obj/structure/spawner/mining/hivelord/space
+	mob_types = list(/mob/living/simple_animal/hostile/asteroid/hivelord/space)
+
 /obj/structure/spawner/mining/basilisk
 	name = "basilisk den"
 	desc = "A den housing a nest of basilisks, bring a coat."
 	mob_types = list(/mob/living/simple_animal/hostile/asteroid/basilisk)
+
+/obj/structure/spawner/mining/basilisk/space
+	mob_types = list(/mob/living/simple_animal/hostile/asteroid/basilisk/space)
 
 /obj/structure/spawner/sentient
 	var/role_name = "A sentient mob"

--- a/code/modules/mob/living/simple_animal/hostile/mining/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/basilisk.dm
@@ -63,6 +63,11 @@
 		if(3)
 			adjustBruteLoss(110)
 
+/mob/living/simple_animal/hostile/asteroid/basilisk/space
+
+/mob/living/simple_animal/hostile/asteroid/basilisk/space/Process_Spacemove(movement_dir, continuous_move)
+	return TRUE
+
 //Watcher
 /mob/living/simple_animal/hostile/asteroid/basilisk/watcher
 	name = "watcher"

--- a/code/modules/mob/living/simple_animal/hostile/mining/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/goliath.dm
@@ -192,3 +192,8 @@
 	icon_state = "Goliath_tentacle_retract"
 	deltimer(timerid)
 	timerid = QDEL_IN(src, 7)
+
+/mob/living/simple_animal/hostile/asteroid/goliath/space
+
+/mob/living/simple_animal/hostile/asteroid/goliath/space/Process_Spacemove(movement_dir, continuous_move)
+	return TRUE

--- a/code/modules/mob/living/simple_animal/hostile/mining/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/hivelord.dm
@@ -57,6 +57,12 @@
 		return FALSE
 	mouse_opacity = MOUSE_OPACITY_ICON
 
+/mob/living/simple_animal/hostile/asteroid/hivelord/space
+	brood_type = /mob/living/simple_animal/hostile/asteroid/hivelordbrood/space
+
+/mob/living/simple_animal/hostile/asteroid/hivelord/space/Process_Spacemove(movement_dir, continuous_move)
+	return TRUE
+
 //A fragile but rapidly produced creature
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood
 	name = "hivelord brood"
@@ -92,6 +98,11 @@
 	. = ..()
 	addtimer(CALLBACK(src, PROC_REF(death)), 100)
 	AddComponent(/datum/component/swarming)
+
+/mob/living/simple_animal/hostile/asteroid/hivelordbrood/space
+
+/mob/living/simple_animal/hostile/asteroid/hivelordbrood/space/Process_Spacemove(movement_dir, continuous_move)
+	return TRUE
 
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/blood
 	name = "blood brood"
@@ -179,6 +190,8 @@
 	var/dwarf_mob = FALSE
 	var/mob/living/carbon/human/stored_mob
 
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion/Process_Spacemove(movement_dir, continuous_move)
+	return FALSE
 
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion/dwarf
 	name = "dwarf legion"


### PR DESCRIPTION
## What Does This PR Do
This PR makes it so that all spawners and mobs in SpaceRuins for goliaths, hivelords, and basilisks create mobs which can spacewalk. This does not affect tendrils or mobs on Lavaland.
## Why It's Good For The Game
Impromptu goliath migration waves descending upon the station are ~~hilarious~~ very bad.
## Testing
Spawned space ruins, ensured that affected mobs could spacewalk as expected.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: Basilisks, goliaths, and hivelords found in space ruins all now have the ability to spacewalk.
/:cl: