### PR TITLE
fix permissions panel table row formatting

### DIFF
--- a/html/search.js
+++ b/html/search.js
@@ -23,7 +23,7 @@ function updateSearch() {
 			}
 			if (found == 0) row.style.display = 'none';
 			else {
-				row.style.display = 'block';
+				row.style.display = 'table-row';
 				row.className = alt_style;
 				if (alt_style == 'alt') alt_style = 'norm';
 				else alt_style = 'alt';


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the width in the admin permissions browserUI window. I have no idea why this javascript is setting the display property of the row but whatever. This search.js file is only used on that window so nothing else is affected.
## Why It's Good For The Game
Bugfix.
## Images of changes
### Before
![2025_05_26__01_54_57__Paradise Station 13](https://github.com/user-attachments/assets/b4001883-7923-43d9-af1e-85ea19122308)
### After
![2025_05_26__01_51_35__Paradise Station 13](https://github.com/user-attachments/assets/43085185-27e6-4251-b263-c03810966ec1)
## Testing
Visual inspection. Also ensured search still worked as expected.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC