### PR TITLE
fix bapping rd console with disks

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -182,17 +182,18 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 /obj/machinery/computer/rdconsole/item_interaction(mob/living/user, obj/item/used, list/modifiers)
 	//Loading a disk into it.
 	if(istype(used, /obj/item/disk))
+		. = ITEM_INTERACT_COMPLETE
 		if(t_disk || d_disk)
 			to_chat(user, "A disk is already loaded into the machine.")
-			return ITEM_INTERACT_COMPLETE
+			return
 
 		if(istype(used, /obj/item/disk/tech_disk)) t_disk = used
 		else if(istype(used, /obj/item/disk/design_disk)) d_disk = used
 		else
 			to_chat(user, "<span class='danger'>Machine cannot accept disks in that format.</span>")
-			return ITEM_INTERACT_COMPLETE
+			return
 		if(!user.drop_item())
-			return ITEM_INTERACT_COMPLETE
+			return
 		used.loc = src
 		to_chat(user, "<span class='notice'>You add the disk to the machine!</span>")
 	else if(!(linked_analyzer && linked_analyzer.busy) && !(linked_lathe && linked_lathe.busy) && !(linked_imprinter && linked_imprinter.busy))


### PR DESCRIPTION
## What Does This PR Do
This PR fixes bapping the R&D console with tech disks when trying to insert them.
## Why It's Good For The Game
Regression fix.
## Testing
Spawned in, spawned tech disk, used tech disk on console, ensured no bap.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: An attack animation will no longer play when inserting tech disks into the R&D console.
/:cl: