### PR TITLE
Allows cult fall to have more cultists on lowpop

### DIFF
--- a/code/modules/antagonists/cult/team_cult.dm
+++ b/code/modules/antagonists/cult/team_cult.dm
@@ -165,7 +165,7 @@ RESTRICT_TYPE(/datum/team/cult)
 
 	if(cult_ascendant)
 		// The cult only falls if below 1/2 of the rising, usually pretty low. e.g. 5% on highpop, 10% on lowpop
-		if(cult_players < (rise_number / 2))
+		if(cult_players <= CEILING(rise_number / 2))
 			cult_fall()
 		return
 

--- a/code/modules/antagonists/cult/team_cult.dm
+++ b/code/modules/antagonists/cult/team_cult.dm
@@ -165,7 +165,7 @@ RESTRICT_TYPE(/datum/team/cult)
 
 	if(cult_ascendant)
 		// The cult only falls if below 1/2 of the rising, usually pretty low. e.g. 5% on highpop, 10% on lowpop
-		if(cult_players <= CEILING(rise_number / 2))
+		if(cult_players <= ceil(rise_number / 2))
 			cult_fall()
 		return
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Allows cult fall to have more cultists on lowpop. When a cult would rise at 5, and fall it 1, it instead falls at 3.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Lowpop cult falling is REALLY unforgiving, because it expects there to be a higher population for the percentage.

## Testing

<!-- How did you test the PR, if at all? -->
It compiles

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
![image](https://github.com/user-attachments/assets/85ccc372-0d46-4597-9116-a336f4a7911c)

## Changelog

:cl:
tweak: Allows cult fall to have more cultists on lowpop
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
