### PR TITLE
Fixes Changeling runtime

### DIFF
--- a/code/modules/antagonists/changeling/powers/transform.dm
+++ b/code/modules/antagonists/changeling/powers/transform.dm
@@ -26,6 +26,6 @@
 		user.update_handcuffed()
 	cling.update_languages()
 	var/datum/action/changeling/augmented_eyesight/eyesight = locate() in user.actions
-	eyesight.update_eyes(user)
+	eyesight?.update_eyes(user)
 	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]"))
 	return TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a runtime that occurs when a Changeling uses Transform without having the Augmented Eyes ability that was accidentally added by #28582. Offending lines of code:

```js
var/datum/action/changeling/augmented_eyesight/eyesight = locate() in user.actions
eyesight.update_eyes(user)
```

These lines run every time the transform action is used. `locate() in user.actions` will return `null` if `augmented_eyesight` does not exist in the `actions` list. I have added a nullcheck so that `update_eyes(user)` does not execute when `eyesight` is `null`.

```
[2025-05-26T21:30:05] Runtime in code/modules/antagonists/changeling/powers/transform.dm:29: Cannot execute null.update eyes().
   proc name: sting action (/datum/action/changeling/transform/sting_action)
   usr: [censored] (/mob/living/carbon/human)
   usr.loc: The plating (131,90,2) (/turf/simulated/floor/plating)
   src: Transform (/datum/action/changeling/transform)
   call stack:
   Transform (/datum/action/changeling/transform): sting_action
   Transform (/datum/action/changeling/transform): try_to_sting
   Transform (/datum/action/changeling/transform): Trigger
   Transform (/atom/movable/screen/movable/action_button): fire_action
   Transform (/atom/movable/screen/movable/action_button): Click
```

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Runtimes that prevent ability logging are bad!
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

<!-- How did you test the PR, if at all? -->
Confirmed the runtime no longer occurs with the nullcheck.
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->



<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
