### PR TITLE
Fixes brainless mobs runtiming when in crit

### DIFF
--- a/code/modules/mob/living/carbon/human/human_life.dm
+++ b/code/modules/mob/living/carbon/human/human_life.dm
@@ -625,7 +625,7 @@
 	var/guaranteed_death_threshold = health + (getOxyLoss() * 0.5) - (getFireLoss() * 0.67) - (getBruteLoss() * 0.67)
 
 	var/obj/item/organ/internal/brain = get_int_organ(/obj/item/organ/internal/brain)
-	if(brain?.damage >= brain.max_damage || (guaranteed_death_threshold) <= -500)
+	if(brain?.damage >= brain?.max_damage || guaranteed_death_threshold <= -500)
 		death()
 		return
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a missing null check in `/mob/living/carbon/human/handle_critical_condition()`. 

Rarely, mobs can enter crit with a null brain (usually happens with zombies). A missing null check in this proc would cause a runtime that triggered 20 times per second until the long overdue death of the brainless mob. 
```
[2025-05-26T22:26:55] Runtime in code/modules/mob/living/carbon/human/human_life.dm:628: Cannot read null.max_damage
   proc name: handle critical condition (/mob/living/carbon/human/handle_critical_condition)
   src: Unknown (/mob/living/carbon/human)
   src.loc: the floor (135,95,2) (/turf/simulated/floor/plasteel)
   call stack:
   Unknown (/mob/living/carbon/human): handle_critical_condition
   Unknown (/mob/living/carbon/human): Life
   Unknown (/mob/living/carbon/human): Life
   Unknown (/mob/living/carbon/human): Life
   Mobs (/datum/controller/subsystem/mobs): fire
   Mobs (/datum/controller/subsystem/mobs): ignite
   Master (/datum/controller/master): RunQueue
   Master (/datum/controller/master): Loop
   Master (/datum/controller/master): StartProcessing
   (This error will now be silenced for 10 minutes)
```
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Runtime bad
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
Runtime didn't happen after the fix.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->



<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
