### PR TITLE
Fixes slime management console runtime

### DIFF
--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -345,13 +345,13 @@
 /datum/action/innate/hotkey_help/Activate()
 	if(!target || !isliving(owner))
 		return
-	var/obj/machinery/computer/camera_advanced/xenobio/X = owner.machine
+	var/obj/machinery/computer/camera_advanced/xenobio/console = target
 	to_chat(owner, "<b>Click shortcuts:</b>")
 	to_chat(owner, "Shift-click a slime to pick it up, or the floor to drop all held slimes.")
 	to_chat(owner, "Ctrl-click a slime to scan it.")
 	to_chat(owner, "Alt-click a slime to feed it a potion.")
 	to_chat(owner, "Ctrl-click or a dead monkey to recycle it, or the floor to place a new monkey.")
-	to_chat(owner, "[X] now has [X.monkeys] monkeys left.")
+	to_chat(owner, "[console] now has [console.monkeys] monkeys left.")
 
 //
 // Alternate clicks for slime, monkey and open turf if using a xenobio console


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
#26306 forgot to clean up a use of `owner.machine` in a slime management console action when refactoring the parent `/obj/machinery/computer/camera_advanced` type. `owner.machine` will always be null and `src.target` should have been used instead. 
```
[2025-05-27T02:16:47] Runtime in code/modules/research/xenobiology/xenobio_camera.dm:354: Cannot read null.monkeys
   proc name: Activate (/datum/action/innate/hotkey_help/Activate)
   usr: [censored] (tsunat) (/mob/living/carbon/human)
   usr.loc: The floor (99,52,2) (/turf/simulated/floor/plasteel/white)
   src: Hotkey Help (/datum/action/innate/hotkey_help)
   call stack:
   Hotkey Help (/datum/action/innate/hotkey_help): Activate
   Hotkey Help (/datum/action/innate/hotkey_help): Trigger
   Hotkey Help (/atom/movable/screen/movable/action_button): fire_action
   Hotkey Help (/atom/movable/screen/movable/action_button): Click
   [censored] (/client): Click
```
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
You just lost The Game.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
Runtime didn't trigger after the change.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->



<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
