### PR TITLE
support running saved sdql scripts

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -240,7 +240,8 @@ GLOBAL_LIST_INIT(admin_verbs_dev, list(
 GLOBAL_LIST_INIT(admin_verbs_proccall, list(
 	/client/proc/callproc,
 	/client/proc/callproc_datum,
-	/client/proc/SDQL2_query
+	/client/proc/SDQL2_query,
+	/client/proc/load_sdql2_query,
 ))
 GLOBAL_LIST_INIT(admin_verbs_ticket, list(
 	/client/proc/openAdminTicketUI,

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -28,6 +28,14 @@
 	if(!query_text || length(query_text) < 1)
 		return
 
+	run_sdql2_query(query_text)
+
+/client/proc/run_sdql2_query(query_text)
+	if(!check_rights(R_PROCCALL))  //Shouldn't happen... but just to be safe.
+		message_admins("<span class='danger'>ERROR: Non-admin [key_name_admin(usr)] attempted to execute a SDQL query!</span>")
+		log_admin("Non-admin [key_name(usr)] attempted to execute an SDQL query: [query_text]")
+		return
+
 //	to_chat(world, query_text)
 
 	var/list/query_list = SDQL2_tokenize(query_text)

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -32,7 +32,7 @@
 
 /client/proc/run_sdql2_query(query_text)
 	if(!check_rights(R_PROCCALL))  //Shouldn't happen... but just to be safe.
-		message_admins("<span class='danger'>ERROR: Non-admin [key_name_admin(usr)] attempted to execute a SDQL query!</span>")
+		message_admins("<span class='danger'>ERROR: Non-admin [key_name_admin(usr)] attempted to execute an SDQL query!</span>")
 		log_admin("Non-admin [key_name(usr)] attempted to execute an SDQL query: [query_text]")
 		return
 

--- a/code/modules/admin/verbs/SDQL2/sdql2_verbs.dm
+++ b/code/modules/admin/verbs/SDQL2/sdql2_verbs.dm
@@ -1,0 +1,19 @@
+/client/proc/load_sdql2_query()
+	set category = "Debug"
+	set name = "Load SDQL2 Query"
+
+	if(!check_rights(R_PROCCALL))
+		return
+
+	var/list/choices = flist("data/sdql/")
+	var/choice = input(src, "Choose an SDQL script to run:", "Load SDQL Query", null) as null|anything in choices
+	if(isnull(choice))
+		return
+
+	var/script_text = return_file_text("data/sdql/[choice]")
+	script_text = input(usr, "SDQL2 query", "", script_text) as message
+
+	if(!script_text || length(script_text) < 1)
+		return
+
+	run_sdql2_query(script_text)

--- a/paradise.dme
+++ b/paradise.dme
@@ -1599,6 +1599,7 @@
 #include "code\modules\admin\verbs\toggledebugverbs.dm"
 #include "code\modules\admin\verbs\tripAI.dm"
 #include "code\modules\admin\verbs\view_instances.dm"
+#include "code\modules\admin\verbs\SDQL2\sdql2_verbs.dm"
 #include "code\modules\admin\verbs\SDQL2\SDQL_2.dm"
 #include "code\modules\admin\verbs\SDQL2\SDQL_2_parser.dm"
 #include "code\modules\admin\verbs\SDQL2\useful_procs.dm"


### PR DESCRIPTION
## What Does This PR Do
This PR adds support for running saved SDQL queries from the `data/sdql` directory. Incredibly basic and straightforward, no-frills. Once you choose a file it loads it up into the SDQL2 query prompt so you can inspect, modify, and run it.
## Why It's Good For The Game
Convenience method for developers/admins.
## Images of changes
![2025_05_29__17_55_03__Paradise Station 13](https://github.com/user-attachments/assets/7d4323f8-41e8-48a1-a200-f0ec3ba62486)
![2025_05_29__17_37_24__Paradise Station 13](https://github.com/user-attachments/assets/73f0491e-0d15-4e7f-9b00-a7a38c295e4f)
## Testing
Loaded and ran scripts, ensured they worked as expected.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC