### PR TITLE
fix hermit in admin equip menu

### DIFF
--- a/code/modules/ruins/lavalandruin_code/hermit.dm
+++ b/code/modules/ruins/lavalandruin_code/hermit.dm
@@ -45,6 +45,7 @@
 	return ..()
 
 /datum/outfit/hermit
+	name = "Lavaland Hermit"
 	suit = /obj/item/clothing/suit/space/syndicate/orange
 	head = /obj/item/clothing/head/helmet/space/syndicate/orange
 	shoes = /obj/item/clothing/shoes/black


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the name of the lavaland hermit in the admin equip menu so it doesn't say "SOMEBODY FORGOT TO SET A NAME, NOTIFY A CODER" anymore.
## Why It's Good For The Game
SOMEBODY FORGOT TO SET A REASON, NOTIFY A CODER
## Images of changes
SOMEBODY FORGOT TO SET IMAGES OF CHANGES, NOTIFY A CODER
## Testing
SOMEBODY FORGOT TO SET TESTING, NOTIFY A CODER
## Declaration
- [X] SOMEBODY FORGOT TO SET A DECLARATION, NOTIFY A CODER
## Changelog
SOMEBODY FORGOT TO SET A CHANGELOG, NOTIFY A CODER