### PR TITLE
[DNM] remove zombie from whiteship submap

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/submaps/whiteship_submaps.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/submaps/whiteship_submaps.dmm
@@ -634,7 +634,6 @@
 /area/template_noop)
 "Nr" = (
 /obj/structure/bed,
-/obj/effect/mob_spawn/human/alive/zombie/non_infectious,
 /obj/effect/decal/cleanable/blood,
 /obj/item/restraints/handcuffs/cable/zipties/used,
 /obj/item/stack/sheet/cloth,


### PR DESCRIPTION
## What Does This PR Do
This PR removes the zombie from the "quarantine" whiteship medbay submap.
## Why It's Good For The Game
This zombie is meant to be non-infectious, but has somehow spread despite initial bugfixes. Temporarily removing while we see if we can truly neutralize this. This is not a balance decision, this is to ensure that the course of rounds are not unintentionally or maliciously altered by bugs allowing players to transmit the zombie disease from this host.
## Testing
Visual infection.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
del: A PR marked DO NOT MERGE was merged. Please inform a headcoder.
/:cl:
