### PR TITLE
Second package of skin tone fixes

### DIFF
--- a/code/__HELPERS/mob_helpers.dm
+++ b/code/__HELPERS/mob_helpers.dm
@@ -118,7 +118,7 @@
 
 /// Returns a purely random tint for specific color
 /proc/tint_color(color, range = 25)
-	if(!istext(color) || length(color) < 7 || copytext(color, 1, 2) != "#") // if it's not a hex color
+	if(!is_color_text(color)) // if it's not a hex color
 		return color // just leave it as it is
 
 	var/R = clamp(color2R(color) + rand(-range, range), 0, 255)
@@ -218,54 +218,12 @@
 
 /// Randomises skin tone, specifically for each species that has a skin tone. Otherwise keeps a default of 1
 /proc/random_skin_tone(species = "Human")
-	switch(species)
-		if("Human")
-			return rand(1, 13)
-		if("Drask")
-			return rand(1, 220)
-		if("Nian")
-			return rand(1, 4)
-		if("Vox")
-			return rand(1, 8)
+	var/datum/species/species_selected = GLOB.all_species[species]
+	if(species_selected?.bodyflags & HAS_SKIN_TONE)
+		return rand(1, 220)
+	else if(species_selected?.bodyflags & HAS_ICON_SKIN_TONE)
+		return rand(1, length(species_selected.icon_skin_tones))
 	return 1
-
-/proc/skintone2racedescription(tone, species = "Human")
-	if(species == "Human")
-		switch(tone)
-			if(30 to INFINITY)		return "albino"
-			if(20 to 30)			return "pale"
-			if(5 to 15)				return "light skinned"
-			if(-10 to 5)			return "white"
-			if(-25 to -10)			return "tan"
-			if(-45 to -25)			return "darker skinned"
-			if(-65 to -45)			return "brown"
-			if(-INFINITY to -65)	return "black"
-			else					return "unknown"
-	else if(species == "Vox")
-		switch(tone)
-			if(2)					return "plum"
-			if(3)					return "brown"
-			if(4)					return "gray"
-			if(5)					return "emerald"
-			if(6)					return "azure"
-			if(7)					return "crimson"
-			if(8)					return "nebula"
-			else					return "lime"
-	else
-		return "unknown"
-
-/proc/age2agedescription(age)
-	switch(age)
-		if(0 to 1)			return "infant"
-		if(1 to 3)			return "toddler"
-		if(3 to 13)			return "child"
-		if(13 to 19)		return "teenager"
-		if(19 to 30)		return "young adult"
-		if(30 to 45)		return "adult"
-		if(45 to 60)		return "middle-aged"
-		if(60 to 70)		return "aging"
-		if(70 to INFINITY)	return "elderly"
-		else				return "unknown"
 
 /proc/set_criminal_status(mob/living/user, datum/data/record/target_records , criminal_status, comment, user_rank, list/authcard_access = list(), user_name)
 	var/status = criminal_status

--- a/code/modules/client/preference/character.dm
+++ b/code/modules/client/preference/character.dm
@@ -32,7 +32,7 @@
 	var/f_style = "Shaved"				//Facial hair type
 	var/f_colour = "#000000"			//Facial hair color
 	var/f_sec_colour = "#000000"		//Secondary facial hair color
-	var/s_tone = 0						//Skin tone
+	var/s_tone = 1						//Skin tone
 	var/s_colour = "#000000"			//Skin color
 	var/e_colour = "#000000"			//Eye color
 	var/alt_head = "None"				//Alt head style.
@@ -619,7 +619,9 @@
 	socks = random_socks(body_type, species)
 	if(length(GLOB.body_accessory_by_species[species]))
 		body_accessory = random_body_accessory(species, S.optional_body_accessory)
-	if(S.bodyflags & (HAS_SKIN_TONE|HAS_ICON_SKIN_TONE))
+	if(S.bodyflags & HAS_SKIN_TONE)
+		s_tone = 35 - random_skin_tone(species)
+	else if(S.bodyflags & HAS_ICON_SKIN_TONE)
 		s_tone = random_skin_tone(species)
 	h_style = random_hair_style(gender, species, robohead)
 	f_style = random_facial_hair_style(gender, species, robohead)

--- a/code/modules/client/preference/link_processing.dm
+++ b/code/modules/client/preference/link_processing.dm
@@ -151,8 +151,10 @@
 				if("eyes")
 					active_character.e_colour = rand_hex_color()
 				if("s_tone")
-					if(S.bodyflags & (HAS_SKIN_TONE|HAS_ICON_SKIN_TONE))
-						active_character.s_tone = random_skin_tone()
+					if(S.bodyflags & HAS_SKIN_TONE)
+						active_character.s_tone = 35 - random_skin_tone(active_character.species)
+					else if(S.bodyflags & HAS_ICON_SKIN_TONE)
+						active_character.s_tone = random_skin_tone(active_character.species)
 				if("s_color")
 					if(S.bodyflags & HAS_SKIN_COLOR)
 						active_character.s_colour = rand_hex_color()
@@ -246,10 +248,12 @@
 							active_character.socks = random_socks(active_character.body_type, active_character.species)
 
 						//reset skin tone and colour
-						if(NS.bodyflags & (HAS_SKIN_TONE|HAS_ICON_SKIN_TONE))
-							random_skin_tone(active_character.species)
+						if(NS.bodyflags & HAS_SKIN_TONE)
+							active_character.s_tone = 35 - random_skin_tone(active_character.species)
+						else if(NS.bodyflags & HAS_ICON_SKIN_TONE)
+							active_character.s_tone = random_skin_tone(active_character.species)
 						else
-							active_character.s_tone = 0
+							active_character.s_tone = 1
 
 						if(!(NS.bodyflags & HAS_SKIN_COLOR))
 							active_character.s_colour = "#000000"
@@ -639,18 +643,18 @@
 					active_character.e_colour = new_eyes
 
 				if("s_tone")
+					var/new_s_tone
 					if(S.bodyflags & HAS_SKIN_TONE)
-						var/new_s_tone = input(user, "Choose your character's skin-tone:\n(Light 1 - 220 Dark)", "Character Preference")  as num|null
+						new_s_tone = tgui_input_number(user, "Choose your character's skin-tone:\n(Light 1 - 220 Dark)", "Character Preference", -active_character.s_tone + 35, 220, 1)
 						if(isnull(new_s_tone))
 							return
-						active_character.s_tone = 35 - max(min(round(new_s_tone), 220), 1)
+						active_character.s_tone = 35 - new_s_tone
 					else if(S.bodyflags & HAS_ICON_SKIN_TONE)
-						var/const/MAX_LINE_ENTRIES = 4
 						var/prompt = "Choose your character's skin tone: 1-[length(S.icon_skin_tones)]\n(Light to Dark)"
-						var/skin_c = tgui_input_number(user, prompt, "Character Preference", active_character.s_tone, length(S.icon_skin_tones), 1)
-						if(isnull(skin_c))
+						new_s_tone = tgui_input_number(user, prompt, "Character Preference", active_character.s_tone, length(S.icon_skin_tones), 1)
+						if(isnull(new_s_tone))
 							return
-						active_character.s_tone = skin_c
+						active_character.s_tone = new_s_tone
 
 				if("skin")
 					if((S.bodyflags & HAS_SKIN_COLOR) || GLOB.body_accessory_by_species[active_character.species] || check_rights(R_ADMIN, 0, user))

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -132,8 +132,8 @@
 		if(H.dna.species.bodyflags & (HAS_SKIN_TONE | HAS_ICON_SKIN_TONE))
 			H.change_skin_tone(-115, TRUE)
 		else if(H.dna.species.bodyflags & HAS_SKIN_COLOR)
-			var/list/hsl = list(rgb2hsl(hex2num(copytext(H.skin_colour, 2, 4)), hex2num(copytext(H.skin_colour, 4, 6)), hex2num(copytext(color, 6, 8))))
-			hsl[3] = min(hsl[3], 0.05) // makes their current skin color very dark, setting its lightness to max 5%
+			var/list/hsl = rgb2hsl(hex2num(copytext(H.skin_colour, 2, 4)), hex2num(copytext(H.skin_colour, 4, 6)), hex2num(copytext(color, 6, 8)))
+			hsl[3] = min(hsl[3], 0.15) // makes their current skin color dark, setting its lightness to max of 15%
 			var/list/rgb = hsl2rgb(arglist(hsl))
 			var/new_color = "#[num2hex(rgb[1], 2)][num2hex(rgb[2], 2)][num2hex(rgb[3], 2)]"
 			H.change_skin_color(new_color)

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -129,8 +129,14 @@
 /obj/item/fluff/bird_painter/attack_self__legacy__attackchain(mob/user)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		H.s_tone = -115
-		H.regenerate_icons()
+		if(H.dna.species.bodyflags & (HAS_SKIN_TONE | HAS_ICON_SKIN_TONE))
+			H.change_skin_tone(-115, TRUE)
+		else if(H.dna.species.bodyflags & HAS_SKIN_COLOR)
+			var/list/hsl = list(rgb2hsl(hex2num(copytext(H.skin_colour, 2, 4)), hex2num(copytext(H.skin_colour, 4, 6)), hex2num(copytext(color, 6, 8))))
+			hsl[3] = min(hsl[3], 0.05) // makes their current skin color very dark, setting its lightness to max 5%
+			var/list/rgb = hsl2rgb(arglist(hsl))
+			var/new_color = "#[num2hex(rgb[1], 2)][num2hex(rgb[2], 2)][num2hex(rgb[3], 2)]"
+			H.change_skin_color(new_color)
 		to_chat(user, "You use [src] on yourself.")
 		qdel(src)
 

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -318,18 +318,18 @@
 	return TRUE
 
 
-/mob/living/carbon/human/proc/change_skin_color(colour = "#000000")
-	if(colour == skin_colour || !(dna.species.bodyflags & HAS_SKIN_COLOR))
+/mob/living/carbon/human/proc/change_skin_color(color = "#000000")
+	if(!is_color_text(color) || color == skin_colour || !(dna.species.bodyflags & HAS_SKIN_COLOR))
 		return
 
-	skin_colour = colour
+	skin_colour = color
 
 	force_update_limbs()
 	return TRUE
 
 /// Tone must be between -185 and 220. commonly used in 1 to 220, see `random_skin_tone()` for species-specific values
 /mob/living/carbon/human/proc/change_skin_tone(tone, override = FALSE)
-	if(s_tone == tone || !((dna.species.bodyflags & HAS_SKIN_TONE) || (dna.species.bodyflags & HAS_ICON_SKIN_TONE)))
+	if(!isnum(tone) || !((dna.species.bodyflags & HAS_SKIN_TONE) || (dna.species.bodyflags & HAS_ICON_SKIN_TONE)))
 		return
 
 	if(tone in -185 to 220)

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -20,7 +20,7 @@
 	var/list/m_colours = DEFAULT_MARKING_COLOURS //All colours set to #000000.
 	var/list/m_styles = DEFAULT_MARKING_STYLES //All markings set to None.
 
-	var/s_tone = 0	//Skin tone
+	var/s_tone = 1	//Skin tone
 
 	//Skin colour
 	var/skin_colour = "#000000"

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1176,8 +1176,8 @@
 	else
 		skin_colour = "#000000"
 
-	if(!(dna.species.bodyflags & HAS_SKIN_TONE))
-		s_tone = 0
+	if(!(dna.species.bodyflags & (HAS_SKIN_TONE|HAS_ICON_SKIN_TONE)))
+		s_tone = 1
 
 	var/list/thing_to_check = list(ITEM_SLOT_MASK, ITEM_SLOT_HEAD, ITEM_SLOT_SHOES, ITEM_SLOT_GLOVES, ITEM_SLOT_LEFT_EAR, ITEM_SLOT_RIGHT_EAR, ITEM_SLOT_EYES, ITEM_SLOT_LEFT_HAND, ITEM_SLOT_RIGHT_HAND, ITEM_SLOT_NECK)
 	var/list/kept_items[0]

--- a/code/modules/mob/living/carbon/superheroes.dm
+++ b/code/modules/mob/living/carbon/superheroes.dm
@@ -218,7 +218,7 @@
 	if(istype(head_organ))
 		head_organ.h_style = "Bald"
 		head_organ.f_style = "Shaved"
-	target.s_tone = 35
+	target.change_skin_tone(1)
 	// No `update_dna=0` here because the character is being over-written
 	target.change_eye_color(1,1,1)
 	for(var/obj/item/W in target.get_all_slots())

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -803,7 +803,9 @@
 
 /datum/reagent/spraytan/proc/set_skin_color(mob/living/carbon/human/H)
 	if(H.dna.species.bodyflags & HAS_SKIN_TONE)
-		H.change_skin_tone(max(H.s_tone - 10, -195))
+		H.change_skin_tone(min(-H.s_tone + 45, 220)) // adjusts our skin tone by 10
+	else if(H.dna.species.bodyflags & HAS_ICON_SKIN_TONE)
+		H.change_skin_tone(min(H.s_tone + 1, length(H.dna.species.icon_skin_tones))) // adjusts our skin tone by 1
 
 	if(H.dna.species.bodyflags & HAS_SKIN_COLOR) //take current alien color and darken it slightly
 		H.change_skin_color("#9B7653")

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -803,11 +803,18 @@
 
 /datum/reagent/spraytan/proc/set_skin_color(mob/living/carbon/human/H)
 	if(H.dna.species.bodyflags & HAS_SKIN_TONE)
-		H.change_skin_tone(min(-H.s_tone + 45, 220)) // adjusts our skin tone by 10
+		H.change_skin_tone(min(-H.s_tone + 45, 220)) // adjusts our skin tone by 10 - makes it darker
 	else if(H.dna.species.bodyflags & HAS_ICON_SKIN_TONE)
-		H.change_skin_tone(min(H.s_tone + 1, length(H.dna.species.icon_skin_tones))) // adjusts our skin tone by 1
-
-	if(H.dna.species.bodyflags & HAS_SKIN_COLOR) //take current alien color and darken it slightly
+		switch(H.dna.species.name)
+			if("Human")
+				H.change_skin_tone(max(H.s_tone, 10)) // bronze - `icons/mob/human_races/human_skintones/r_human_bronzed.dmi`
+			if("Vox")
+				H.change_skin_tone(3) // brown - `icons/mob/human_races/vox/r_voxbrn.dmi`
+			if("Nian")
+				H.change_skin_tone(1) // default - `icons/mob/human_races/nian/r_moth.dmi`
+			if("Grey")
+				H.change_skin_tone(4) // red - `icons/mob/human_races/grey/r_grey_red.dmi`
+	else if(H.dna.species.bodyflags & HAS_SKIN_COLOR) // take current alien color and darken it slightly
 		H.change_skin_color("#9B7653")
 
 /datum/reagent/admin_cleaner

--- a/code/modules/tgui/modules/appearance_changer.dm
+++ b/code/modules/tgui/modules/appearance_changer.dm
@@ -47,28 +47,15 @@
 
 		if("skin_tone")
 			if(can_change_skin_tone())
-				var/new_s_tone = null
+				var/new_s_tone
 				if(owner.dna.species.bodyflags & HAS_SKIN_TONE)
-					new_s_tone = input(usr, "Choose your character's skin tone:\n(Light 1 - 220 Dark)", "Skin Tone", owner.s_tone) as num|null
-					if(isnum(new_s_tone) && (!..()))
-						new_s_tone = max(min(round(new_s_tone), 220),1)
+					new_s_tone = tgui_input_number(usr, "Choose your character's skin-tone:\n(Light 1 - 220 Dark)", "Character Preference", owner.s_tone, 220, 1)
 				else if(owner.dna.species.bodyflags & HAS_ICON_SKIN_TONE)
-					var/const/MAX_LINE_ENTRIES = 4
-					var/prompt = "Choose your character's skin tone: 1-[length(owner.dna.species.icon_skin_tones)]\n("
-					for(var/i in 1 to length(owner.dna.species.icon_skin_tones))
-						if(i > MAX_LINE_ENTRIES && !((i - 1) % MAX_LINE_ENTRIES))
-							prompt += "\n"
-						prompt += "[i] = [owner.dna.species.icon_skin_tones[i]]"
-						if(i != length(owner.dna.species.icon_skin_tones))
-							prompt += ", "
-					prompt += ")"
+					var/prompt = "Choose your character's skin tone: 1-[length(owner.dna.species.icon_skin_tones)]\n(Light to Dark)"
+					new_s_tone = tgui_input_number(usr, prompt, "Character Preference", owner.s_tone, length(owner.dna.species.icon_skin_tones), 1)
 
-					new_s_tone = input(usr, prompt, "Skin Tone", owner.s_tone) as num|null
-					if(isnum(new_s_tone) && (!..()))
-						new_s_tone = max(min(round(new_s_tone), length(owner.dna.species.icon_skin_tones)), 1)
-
-				if(new_s_tone)
-					owner.change_skin_tone(new_s_tone)
+				if(!isnull(new_s_tone) && (!..()) && owner.change_skin_tone(new_s_tone))
+					update_dna()
 
 		if("skin_color")
 			if(can_change_skin_color())


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Sets default skin tone to 1 rather than 0, cos any skin tone starts with 1 whether it's `ICON_SKIN_TONE` or just a `SKIN_TONE`

Fixes negative skin tones on `randomise()` for drasks in character menu; allows greys to randomise their skin tone

Changes `random_skin_tone()` to work based on `species.bodyflags` and `list/icon_skin_tones`, which allows not to update it every single time there is another skin tone added or some flags being changed for the species

`random_skin_tone()` and `random_skin_color()`, `tint_color()` now only accept num/color values appropriate, you can't send `null` or something weird anymore

Converts some regular inputs into tgui inputs and fixes them by separating flags of `HAS_ICON_SKIN_TONE` and `HAS_SKIN_TONE` (they act in different ways)

Removes `skintone2racedescription()` and `age2agedescription()` from code - they are not used by anything

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Fixes and code improvements

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Tested bird painter interactions for humans, drasks and vulps
Tested spray tan interactions for humans, drasks and vulps
Tested randomising characters for humans, drasks and greys - skin tones are within a correct range

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Greys now can randomise their skin tone in character creation menu.
fix: Drasks now properly randomise their skin tone in character creation menu.
fix: Spray tan now properly affects skin tones.
fix: Bird painter now properly affects skin tones and colors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
