### PR TITLE
fix connect_range/container runtimes

### DIFF
--- a/code/datums/components/connect_containers.dm
+++ b/code/datums/components/connect_containers.dm
@@ -33,7 +33,7 @@
 /datum/component/connect_containers/proc/set_tracked(atom/movable/new_tracked)
 	if(tracked)
 		UnregisterSignal(tracked, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING))
-		unregister_signals(tracked.loc)
+		unregister_signals(tracked)
 	tracked = new_tracked
 	if(!tracked)
 		return

--- a/code/datums/components/connect_range.dm
+++ b/code/datums/components/connect_range.dm
@@ -75,14 +75,12 @@
 		turfs = list()
 		return
 
-	if(ismovable(target.loc))
+	var/loc_is_movable = ismovable(target.loc)
+	if(loc_is_movable)
 		if(!works_in_containers)
 			unregister_signals(old_loc, turfs)
 			turfs = list()
 			return
-		//Keep track of possible movement of all movables the target is in.
-		for(var/atom/movable/container as anything in get_nested_locs(target))
-			RegisterSignal(container, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
 
 	//Only register/unregister turf signals if it's moved to a new turf.
 	if(current_turf == get_turf(old_loc))
@@ -91,6 +89,11 @@
 	var/list/old_turfs = turfs
 	turfs = RANGE_TURFS(range, current_turf)
 	unregister_signals(old_loc, old_turfs - turfs)
+	if(loc_is_movable)
+		//Keep track of possible movement of all movables the target is in.
+		for(var/atom/movable/container as anything in get_nested_locs(target))
+			RegisterSignal(container, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
+
 	for(var/turf/target_turf as anything in turfs - old_turfs)
 		for(var/signal in connections)
 			parent.RegisterSignal(target_turf, signal, connections[signal])

--- a/code/modules/assembly/assembly_holder.dm
+++ b/code/modules/assembly/assembly_holder.dm
@@ -175,12 +175,10 @@
 			return FALSE
 		user.unequip(src, force = TRUE)
 		if(a_left)
-			a_left.holder = null
-			a_left.forceMove(T)
+			a_left.on_detach()
 			user.put_in_active_hand(a_left)
 		if(a_right) // Right object is the secondary item, hence put in inactive hand
-			a_right.holder = null
-			a_right.forceMove(T)
+			a_right.on_detach()
 			user.put_in_inactive_hand(a_right)
 		qdel(src)
 


### PR DESCRIPTION
## What Does This PR Do
This PR fixes several runtimes related to proximity monitors, and a bug that caused the parts from disassembled assemblies to work properly, as well as a bug that was causing prox sensor assemblies to "remember" the original location they were placed and continue to proc when that location sensed movement. I'm not 100% sure this fixes all the runtimes but this appears to prevent the ones I was able to reproduce locally... in fact based on the sheer frequency of the runtimes I'm almost positive this doesn't fix all of them, but at least this will help narrow things down.
## Why It's Good For The Game
Bugfixes and runtime cleanups.
## Testing
Build an assembly with a prox sensor and an igniter, disassemble it and put it back together. Arm it, walk away, then walk over to it, pick it up/drop it/put it in a bag several times, and hold it again. (kind of requires some monkey testing and waiting around between steps)
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Assemblies with proximity sensors in them will work as expected if made from parts from a disassembled assembly.
fix: Assemblies with proximity sensors in them will properly update their sensor range when picked up and moved.
/:cl: