### PR TITLE
Prevent reagent container transfer amounts from being set if a user is incapacitated, unconscious or not next to the container.

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -36,7 +36,7 @@
 	if(!length(possible_transfer_amounts))
 		// Nothing to configure.
 		return FALSE
-	return TRUE
+	return is_valid_interaction(user)
 
 /obj/item/reagent_containers/proc/is_valid_interaction(mob/user)
 	if(isrobot(user) && src.loc == user)


### PR DESCRIPTION
## What Does This PR Do
Reagent containers `can_set_transfer_amount` will return `is_valid_interaction` after it checks for possible transfer amounts. Fixes #29492
## Why It's Good For The Game
Wireless emissions are harmful and must be prevented. Also doesn't make sense why its possible.
## Testing
Set transfer amounts as a human, set transfer amounts of personal beaker as a robot.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: You can no longer wirelessly set reagent container transfer amounts.
/:cl: