### PR TITLE
Prevent disks from getting duplicated if inserted in the RnD console when there's no gravity.

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -192,9 +192,9 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		else
 			to_chat(user, "<span class='danger'>Machine cannot accept disks in that format.</span>")
 			return
-		if(!user.drop_item())
+		if(!user.transfer_item_to(used, src))
 			return
-		used.loc = src
+		playsound(src, used.drop_sound, DROP_SOUND_VOLUME, ignore_walls = FALSE) // Highly important auditory feedback
 		to_chat(user, "<span class='notice'>You add the disk to the machine!</span>")
 	else if(!(linked_analyzer && linked_analyzer.busy) && !(linked_lathe && linked_lathe.busy) && !(linked_imprinter && linked_imprinter.busy))
 		return ..()


### PR DESCRIPTION
## What Does This PR Do
Changes disk insertion to use `transfer_item_to` rather than `drop_item`. Plays the drop sound for auditory feedback. Fixes #29463
## Why It's Good For The Game
Duplication is bad.
## Testing
Inserted disks with gravity, turned gravity off, inserted disks without gravity. Disk did not get duplicated.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Disks will no longer get duplicated by the RnD console without gravity.
/:cl: