### PR TITLE
Fixes components staying hot after completion

### DIFF
--- a/code/modules/smithing/smith_component.dm
+++ b/code/modules/smithing/smith_component.dm
@@ -38,7 +38,7 @@
 	update_icon(UPDATE_ICON_STATE)
 
 /obj/item/smithed_item/component/proc/cool_off()
-	heat--
+	heat = max(heat - 1, 0)
 	if(heat)
 		addtimer(CALLBACK(src, PROC_REF(cool_off)), cool_time)
 	else


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes #29393

## Why It's Good For The Game

Bugs bad

## Testing

Made component. Was not hot after completion.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed smith components staying hot after completion
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
