### PR TITLE
Fixes casting basin access not properly denying

### DIFF
--- a/code/modules/smithing/machinery/casting_basin.dm
+++ b/code/modules/smithing/machinery/casting_basin.dm
@@ -33,7 +33,7 @@
 	for(var/obj/machinery/magma_crucible/crucible in view(2, src))
 		linked_crucible = crucible
 		linked_crucible.linked_machines |= src
-		return 
+		return
 
 /obj/machinery/smithing/casting_basin/examine(mob/user)
 	. = ..()
@@ -150,6 +150,7 @@
 /obj/machinery/smithing/casting_basin/attack_hand(mob/user)
 	if(!allowed(user) && !isobserver(user))
 		to_chat(user, "<span class='warning'>Access denied.</span>")
+		return FINISH_ATTACK
 	if(!we_are_open)
 		to_chat(user, "<span class='notice'>You open [src].</span>")
 		we_are_open = TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes issue where casting basins denying access is in warning only.

## Why It's Good For The Game

Bugs bad

## Testing

Tried to use casting basin without access. Was actually denied instead of warned.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed casting basin access bug
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
