### PR TITLE
Fixes destroyed turrets being invincible

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -104,7 +104,7 @@
 				Gun.current_lens.on_attached(Gun)
 			Gun.update_icon()
 		if(prob(50))
-			new /obj/item/stack/sheet/metal(loc, rand(1,4))
+			new /obj/item/stack/sheet/metal(loc, rand(1, 4))
 		if(prob(50))
 			new /obj/item/assembly/prox_sensor(loc)
 	return ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes #29483 by handling turrets better.

All turrets gained +50 HP, and become broken at 50 hitpoints (no change to actual durability). The remaining 50 hitpoints is held for the broken state - dealing 50 damage to the broken turret destroys it.

## Why It's Good For The Game

Destroyed turrets should be destructable.

## Testing

Shot AI turrets. Shot Syndicate turrets. Shot nukie turrets. All turrets broke when expected and behaved as expected when broken and destroyed.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixes turrets being unable to be fully destroyed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
