### PR TITLE
Fixes deconstructing shocked devices without consequence

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -320,6 +320,9 @@
 	if(busy)
 		to_chat(user, "<span class='alert'>The autolathe is busy. Please wait for completion of previous operation.</span>")
 		return
+	if(shocked && !(stat & NOPOWER))
+		if(shock(user, 50))
+			return
 	if(panel_open)
 		default_deconstruction_crowbar(user, I)
 

--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -520,6 +520,8 @@
 	if(tilted)
 		to_chat(user, "<span class='warning'>You'll need to right it first!</span>")
 		return
+	if(seconds_electrified != 0 && shock(user, 100))
+		return
 	default_deconstruction_crowbar(user, I)
 
 /obj/machinery/economy/vending/multitool_act(mob/user, obj/item/I)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Attempting to deconstruct a shocked vendor or autolathe with a crowbar or crowbar-adjacent will try to shock you now instead of deconstruct the device. You can still deconstruct the shocked device with insuls.

## Why It's Good For The Game

Metal objects should be conductive.

## Testing

Shocked a vendor. Tried to crowbar it apart. Got zapped again.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
![image](https://github.com/user-attachments/assets/5aafdeed-5577-46c7-87f8-deed79850ed4)

  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
Tweak: Stopped being able to deconstruct shocked devices without getting shocked.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
