### PR TITLE
QOL tweaks for RPED

### DIFF
--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -60,3 +60,8 @@
 
 /proc/cmp_changeling_power_category_asc(datum/changeling_power_category/a, datum/changeling_power_category/b)
 	return initial(a.priority) - initial(b.priority)
+
+///Sorts stock parts based on tier
+/proc/cmp_rped_sort(obj/item/first_item, obj/item/second_item)
+	///even though stacks aren't stock parts, get_part_rating() is defined on the item level (see /obj/item/proc/get_part_rating()) and defaults to returning 0.
+	return second_item.get_part_rating() - first_item.get_part_rating()

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -128,6 +128,10 @@
 	materials = list(MAT_GLASS = 1000)
 	var/obj/item/assembly_holder/assembly = null
 	var/can_assembly = 1
+	var/rating = 1
+
+/obj/item/reagent_containers/glass/beaker/get_part_rating()
+	return rating
 
 /obj/item/reagent_containers/glass/beaker/Initialize(mapload)
 	. = ..()
@@ -227,6 +231,7 @@
 	icon_state = "beakerlarge"
 	materials = list(MAT_GLASS=2500)
 	volume = 100
+	rating = 2
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5,10,15,25,30,50,100)
 	container_type = OPENCONTAINER
@@ -274,6 +279,7 @@
 	icon_state = "beakerbluespace"
 	materials = list(MAT_GLASS=3000)
 	volume = 300
+	rating = 4
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5,10,15,25,30,50,100,300)
 	container_type = OPENCONTAINER


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

RPED moved to new attack chain
RPED now always applies top tier component parts first instead of applying just 1-2 tiers above the existing ones
RPED now drops only lowest tier component parts from itself when you use it in hand
BSRPED now can add components to machine frames from a distance
If you try to add a rigged cell from a distance using BSRPED - it will explode at max charge

Mostly just a copypaste from TG's RPEDs

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

QOL

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Spawned some machines, deconstructed some of them to frames, spawned tier 2-4 comp parts and shuffled them inside RPED. RPED always applied top-tier components first
Tested when RPED is empty or there is no component parts required for the machine/frame
Tested interactions with rigged power cells

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: RPED now always applies top tier components first, no need to spam it multiple times anymore.
tweak: RPED now drops only lowest tier components when you use it in hand. You can still empty it completely by mouse dragging it onto floor.
tweak: BSRPED now can add components to machine frames from a distance.
tweak: Rigged power cells now explode if you try to transfer them from BSRPED to machinery or its frame.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
