### PR TITLE
fix lingering office chair repath

### DIFF
--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -46574,7 +46574,7 @@
 	},
 /area/station/medical/virology)
 "inr" = (
-/obj/structure/chair/office/light,
+/obj/structure/chair/office,
 /turf/simulated/floor/wood,
 /area/station/public/vacant_office)
 "inv" = (
@@ -58829,7 +58829,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/chair/office/light{
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -76551,7 +76551,7 @@
 /turf/space,
 /area/station/engineering/solar/fore_port)
 "tpn" = (
-/obj/structure/chair/office/light{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/simulated/floor/wood,


### PR DESCRIPTION
## What Does This PR Do
This PR fixes a remaining office chair repath that must have slipped in after #29156 
## Why It's Good For The Game
Bugfix
## Testing
Visual inspection and CI
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Cerebron should properly load.
/:cl: