### PR TITLE
fix putting things/beakers in grinders in zero-gravity

### DIFF
--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -168,12 +168,8 @@
 			to_chat(user, "<span class='warning'>There's already a container inside.</span>")
 		else if(panel_open)
 			to_chat(user, "<span class='warning'>Close the maintenance panel first.</span>")
-		else
-			if(!user.drop_item())
-				return ITEM_INTERACT_COMPLETE
-
-			beaker =  used
-			beaker.loc = src
+		else if(user.transfer_item_to(used, src))
+			beaker = used
 			update_icon(UPDATE_ICON_STATE)
 			SStgui.update_uis(src)
 		return ITEM_INTERACT_COMPLETE
@@ -225,8 +221,7 @@
 			to_chat(user, "<span class='warning'>Cannot refine into a reagent!</span>")
 			return ITEM_INTERACT_COMPLETE
 
-	if(user.drop_item())
-		used.loc = src
+	if(user.transfer_item_to(used, src))
 		holdingitems += used
 		SStgui.update_uis(src)
 		return ITEM_INTERACT_COMPLETE


### PR DESCRIPTION
## What Does This PR Do
This PR fixes #29530 by swapping drop_item with transfer_item_to for reagent grinder interactions.
## Why It's Good For The Game
Bugfix.
## Testing
Placed wheat and beaker in grinder in zero-g, ensured there was no visual duplicate.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Items and beakers placed in grinders will no longer have a visual duplicate bug in zero-gravity.
/:cl: