### PR TITLE
Prevent shotguns leaving a ghost of their slug if reloaded with no gravity

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -208,9 +208,7 @@
 				break
 	if(istype(A, /obj/item/ammo_casing))
 		var/obj/item/ammo_casing/AC = A
-		if(give_round(AC, replace_spent))
-			user.drop_item()
-			AC.loc = src
+		if(give_round(AC, replace_spent) && user.transfer_item_to(AC, src))
 			num_loaded++
 		else
 			to_chat(user, "<span class='notice'>You are unable to fit [AC] into \the [src].</span>")


### PR DESCRIPTION
## What Does This PR Do
Changes the drop and loc to `transfer_item_to`. Slugs will now go inside of their magazine without leaving a ghost. The ghost slug isn't duplicated and only hogs space in the shotgun if used several times.
## Why It's Good For The Game
Bug no good.
## Testing
Loaded, unloaded and shot a shotgun in gravity. Repeated the same in no gravity.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Shotguns won't leave ghost slugs if reloaded in zero gravity.
/:cl: