### PR TITLE
fix putthing shells/rounds in mags in zero-g

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -209,8 +209,7 @@
 	if(istype(A, /obj/item/ammo_casing))
 		var/obj/item/ammo_casing/AC = A
 		if(give_round(AC, replace_spent))
-			user.drop_item()
-			AC.loc = src
+			user.transfer_item_to(AC, src)
 			num_loaded++
 		else
 			to_chat(user, "<span class='notice'>You are unable to fit [AC] into \the [src].</span>")

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -285,8 +285,7 @@
 	if(istype(A, /obj/item/ammo_casing))
 		var/obj/item/ammo_casing/AC = A
 		if(give_round(AC))
-			user.drop_item()
-			AC.loc = src
+			user.transfer_item_to(AC, src)
 			return
 	if(istype(A, /obj/item/ammo_box/wt550) || istype(A, /obj/item/ammo_box/magazine/wt550m9))
 		to_chat(user, "<span class='notice'>You begin to load the magazine with [A].</span>")


### PR DESCRIPTION
## What Does This PR Do
This PR fixes visual dupe bugs for shells and rounds when inserting them into mags in zero-g.
## Why It's Good For The Game
Bugfix.
## Testing
Emptied bulldog and WT magazines in zero-g and reloaded them.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: WT rounds and shells placed in magazines will no longer have a duplicate visual bug in zero gravity.
/:cl: