### PR TITLE
Fix FLASH_PROTECTION trait not protecting against flashes.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -817,7 +817,7 @@
 
 //Checks for anything other than eye protection that would stop flashing. Overridden in carbon.dm and human.dm
 /mob/living/proc/can_be_flashed(intensity = 1, override_blindness_check = 0)
-	if(check_eye_prot() >= intensity || (!override_blindness_check && (HAS_TRAIT(src, TRAIT_BLIND) || HAS_TRAIT(src, TRAIT_FLASH_PROTECTION))))
+	if((check_eye_prot() >= intensity) || (!override_blindness_check && (HAS_TRAIT(src, TRAIT_BLIND))) || HAS_TRAIT(src, TRAIT_FLASH_PROTECTION))
 		return FALSE
 
 	return TRUE


### PR DESCRIPTION
## What Does This PR Do
Splits up the if check in `living/can_be_flashed`. Something was going wrong with it, which caused it to not check for the flash protection trait. Fixes #29513
## Why It's Good For The Game
Traits should work.
## Testing
Flashed myself without any protection, with sunglasses, when blind and with the trait. All worked as they're supposed to.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Flash protection trait will protect from flashes again.
/:cl: