### PR TITLE
Wizard spells spelling/grammar fixes

### DIFF
--- a/code/datums/spells/bloodcrawl.dm
+++ b/code/datums/spells/bloodcrawl.dm
@@ -159,7 +159,7 @@
 		L.adjustOxyLoss(-1000)
 		L.adjustToxLoss(-1000)
 	else if((ishuman(victim) || isrobot(victim)))
-		to_chat(L, "<span class='warning'>You devour [victim], but their lack of intelligence renders their flesh dull and unappetising, leaving you wanting for more.</span>")
+		to_chat(L, "<span class='warning'>You devour [victim], but their lack of intelligence renders their flesh dull and unappetizing, leaving you wanting for more.</span>")
 		L.adjustBruteLoss(-50)
 		if(!isslaughterdemon(L))
 			L.adjustFireLoss(-50)

--- a/code/datums/spells/conjure.dm
+++ b/code/datums/spells/conjure.dm
@@ -1,5 +1,5 @@
 /datum/spell/aoe/conjure
-	desc = "This spell conjures objs of the specified types in range."
+	desc = "This spell conjures objects of the specified types in range."
 
 	var/list/summon_type = list() //determines what exactly will be summoned
 	//should be text, like list("/mob/simple_animal/bot/ed209")

--- a/code/datums/spells/construct_spells.dm
+++ b/code/datums/spells/construct_spells.dm
@@ -156,8 +156,8 @@
 	weaken = 0
 
 /datum/spell/smoke/disable
-	name = "Paralysing Smoke"
-	desc = "This spell spawns a cloud of paralysing smoke."
+	name = "Paralyzing Smoke"
+	desc = "This spell spawns a cloud of paralyzing smoke."
 	action_icon_state = "parasmoke"
 	action_background_icon_state = "bg_cult"
 	base_cooldown = 200

--- a/code/datums/spells/horsemask.dm
+++ b/code/datums/spells/horsemask.dm
@@ -39,7 +39,7 @@
 	magichead.flags_inv = null	//so you can still see their face
 	magichead.voicechange = TRUE	//NEEEEIIGHH
 	target.visible_message(	"<span class='danger'>[target]'s face  lights up in fire, and after the event a horse's head takes its place!</span>", \
-							"<span class='danger'>Your face burns up, and shortly after the fire you realise you have the face of a horse!</span>")
+							"<span class='danger'>Your face burns up, and shortly after the fire you realize you have the face of a horse!</span>")
 	if(!target.drop_item_to_ground(target.wear_mask))
 		qdel(target.wear_mask)
 	target.equip_to_slot_if_possible(magichead, ITEM_SLOT_MASK, TRUE, TRUE)

--- a/code/datums/spells/magnet.dm
+++ b/code/datums/spells/magnet.dm
@@ -1,6 +1,6 @@
 /datum/spell/charge_up/bounce/magnet
 	name = "Magnetic Pull"
-	desc = "Pulls metalic objects from enemies hands with the power of MAGNETS."
+	desc = "Pulls metallic objects from enemies hands with the power of MAGNETS."
 	action_icon_state = "magnet"
 	base_cooldown	= 30 SECONDS
 	clothes_req = FALSE

--- a/code/datums/spells/mime_malaise.dm
+++ b/code/datums/spells/mime_malaise.dm
@@ -1,6 +1,6 @@
 /datum/spell/touch/mime_malaise
 	name = "Mime Malaise"
-	desc = "A spell popular with theater nerd wizards and contrarian pranksters, this spell will put on a mime costume on the target, \
+	desc = "A spell popular with theater nerd wizards and contrarian pranksters. This spell will put on a mime costume on the target, \
 		stun them so that they may contemplate Art, and silence them. \
 		Warning : Effects are permanent on non-wizards."
 	hand_path = /obj/item/melee/touch_attack/mime_malaise

--- a/code/datums/spells/wizard_spells.dm
+++ b/code/datums/spells/wizard_spells.dm
@@ -37,7 +37,7 @@
 
 /datum/spell/projectile/honk_missile
 	name = "Honk Missile"
-	desc = "This spell fires several, slow moving, magic bikehorns at nearby targets."
+	desc = "This spell fires several, slow moving, magic bike horns at nearby targets."
 
 	base_cooldown = 6 SECONDS
 	clothes_req = FALSE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Spelling and grammar fixes for wizard spells

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

I cast spel

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

I cast reading

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
spellcheck: Fixed spelling/grammar issues in wizard spells
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
