### PR TITLE
space loot pool update: trader stock

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/abandoned_engi_sat.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/abandoned_engi_sat.dmm
@@ -364,7 +364,7 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/ripped/directional/north,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating,
 /area/ruin/space/abandoned_engi_sat)
 "kT" = (
@@ -504,7 +504,7 @@
 	pixel_y = -24;
 	name = "south bump"
 	},
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/abandoned_engi_sat)
 "oL" = (
@@ -548,7 +548,7 @@
 /area/ruin/space/abandoned_engi_sat)
 "pX" = (
 /obj/structure/closet/secure_closet/engineering_personal/empty,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/wood/airless,
 /area/ruin/space/abandoned_engi_sat)
 "qu" = (
@@ -707,7 +707,7 @@
 	pixel_y = 32
 	},
 /obj/structure/closet/crate/internals,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel{
 	icon_state = "bot";
 	dir = 1
@@ -932,7 +932,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
 	dir = 5

--- a/_maps/map_files/RandomRuins/SpaceRuins/abandoned_sec_shuttle.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/abandoned_sec_shuttle.dmm
@@ -115,7 +115,7 @@
 /obj/item/gun/projectile/automatic/pistol/enforcer,
 /obj/item/grenade/flashbang,
 /obj/item/storage/firstaid/regular,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/sec_shuttle)
 "F" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/abandonedtele.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/abandonedtele.dmm
@@ -90,7 +90,7 @@
 /area/ruin/space/abandtele)
 "w" = (
 /obj/structure/closet,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/abandtele)
 "x" = (
@@ -107,7 +107,7 @@
 /obj/item/weldingtool,
 /obj/item/wrench,
 /obj/item/circuitboard/teleporter,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/abandtele)
 "z" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroid1.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroid1.dmm
@@ -10,7 +10,7 @@
 /turf/simulated/mineral/random/high_chance/space,
 /area/ruin/space/unpowered)
 "l" = (
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "V" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroid2.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroid2.dmm
@@ -16,7 +16,7 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "C" = (
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "R" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroid3.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroid3.dmm
@@ -23,7 +23,7 @@
 /turf/simulated/mineral/random/low_chance/space,
 /area/ruin/space/unpowered)
 "r" = (
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "v" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroid4.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroid4.dmm
@@ -51,7 +51,7 @@
 /turf/simulated/floor/mineral/titanium/blue,
 /area/ruin/space/unpowered)
 "p" = (
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
 "Q" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroid5.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroid5.dmm
@@ -16,7 +16,7 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "o" = (
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered)
 "A" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/blowntcommsat.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/blowntcommsat.dmm
@@ -53,7 +53,7 @@
 /area/ruin/space/tcommsat)
 "cl" = (
 /obj/structure/rack,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "dark"
 	},
@@ -488,7 +488,7 @@
 /area/ruin/space/tcommsat)
 "Go" = (
 /obj/structure/table,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/tcommsat)
 "GG" = (
@@ -599,7 +599,7 @@
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/tcommsat)
 "NC" = (
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/tcommsat)
 "NJ" = (
@@ -644,7 +644,7 @@
 	dir = 8
 	},
 /obj/structure/closet/firecloset,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/tcommsat)
 "PZ" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/casino.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/casino.dmm
@@ -290,7 +290,7 @@
 /area/ruin/space/powered/casino/security)
 "hv" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/carpet/black,
 /area/ruin/space/powered/casino/floor)
 "hJ" = (
@@ -319,8 +319,8 @@
 	icon_state = "4-8"
 	},
 /obj/item/stack/spacecash/c1000,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/rare/casino,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/rare/casino,
+/obj/effect/spawner/random/pool/spaceloot/casino,
+/obj/effect/spawner/random/pool/spaceloot/casino,
 /turf/simulated/floor/mineral/plastitanium,
 /area/ruin/space/powered/casino/security)
 "in" = (
@@ -380,7 +380,7 @@
 /area/ruin/space/powered/casino/arrivals)
 "jz" = (
 /obj/structure/closet/cabinet,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating,
 /area/ruin/space/powered/casino/floor)
 "jJ" = (
@@ -657,7 +657,7 @@
 "rh" = (
 /obj/structure/grille/broken,
 /obj/structure/closet/crate/trashcart,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating,
 /area/ruin/space/powered/casino/maints)
 "rp" = (
@@ -796,7 +796,7 @@
 	dir = 8
 	},
 /obj/effect/mob_spawn/human/corpse/random_species/gambler,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel/freezer,
 /area/ruin/space/powered/casino/hall)
 "wo" = (
@@ -1108,7 +1108,7 @@
 /area/ruin/space/powered/casino/arrivals)
 "EK" = (
 /obj/structure/table,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -1310,7 +1310,7 @@
 "Nh" = (
 /obj/structure/table/reinforced,
 /obj/item/tank/internals/oxygen,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/ruin/space/powered/casino/docked_ships)
 "Nj" = (
@@ -1371,7 +1371,7 @@
 /area/ruin/space/powered/casino/security)
 "OZ" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},

--- a/_maps/map_files/RandomRuins/SpaceRuins/clownmime.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/clownmime.dmm
@@ -73,7 +73,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/mineral/tranquillite,
 /area/ruin/space/powered)
 "fS" = (
@@ -737,7 +737,7 @@
 /obj/effect/mapping_helpers/turfs/damage,
 /obj/effect/mapping_helpers/turfs/burn,
 /obj/item/stack/sheet/wood,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/mineral/plastitanium,
 /area/ruin/space/clown_mime_ruin)
 "Pt" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/debris1.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/debris1.dmm
@@ -150,7 +150,7 @@
 /turf/simulated/floor/plating/burnt/airless,
 /area/ruin)
 "QL" = (
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating/burnt/airless,
 /area/ruin)
 

--- a/_maps/map_files/RandomRuins/SpaceRuins/debris2.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/debris2.dmm
@@ -131,7 +131,7 @@
 /area/ruin/unpowered)
 "Di" = (
 /obj/effect/mapping_helpers/turfs/burn,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel/airless,
 /area/ruin/unpowered)
 

--- a/_maps/map_files/RandomRuins/SpaceRuins/debris3.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/debris3.dmm
@@ -129,7 +129,7 @@
 /turf/template_noop,
 /area/template_noop)
 "P" = (
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating/damaged/airless,
 /area/ruin/unpowered)
 "Q" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict1.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict1.dmm
@@ -97,7 +97,7 @@
 "I" = (
 /obj/structure/alien/weeds,
 /obj/structure/table,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/unpowered)
 "S" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict3.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict3.dmm
@@ -48,7 +48,7 @@
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/unpowered)
 "H" = (
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/unpowered)
 "O" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict4.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict4.dmm
@@ -61,7 +61,7 @@
 /area/ruin/space/unpowered)
 "p" = (
 /obj/structure/table,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/mineral/titanium/blue/airless,
 /area/ruin/space/unpowered)
 "q" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict5.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict5.dmm
@@ -84,7 +84,7 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/space/unpowered)
 "lE" = (
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/unpowered)
 "mn" = (
@@ -245,7 +245,7 @@
 /area/ruin/space/unpowered)
 "LA" = (
 /obj/structure/table,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/unpowered)
 "LD" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/dj.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/dj.dmm
@@ -523,7 +523,7 @@
 "bt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/can,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -689,7 +689,7 @@
 	},
 /obj/structure/sink/directional/west,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},

--- a/_maps/map_files/RandomRuins/SpaceRuins/druglab.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/druglab.dmm
@@ -13,7 +13,7 @@
 /area/ruin/space/methlab)
 "d" = (
 /obj/structure/closet/crate,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating,
 /area/ruin/space/methlab)
 "e" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/emptyshell.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/emptyshell.dmm
@@ -41,7 +41,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
 "t" = (
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
 "T" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/freighter.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/freighter.dmm
@@ -153,7 +153,7 @@
 /area/ruin/space/powered)
 "nq" = (
 /obj/structure/closet/crate,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/mineral/plastitanium,
 /area/ruin/space/powered)
 "nD" = (
@@ -184,7 +184,7 @@
 /area/ruin/space/powered)
 "rV" = (
 /obj/effect/spawner/random/loot_crate,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/mineral/plastitanium,
 /area/ruin/space/powered)
 "st" = (
@@ -255,7 +255,7 @@
 /obj/structure/safe,
 /obj/item/id_decal/gold,
 /obj/item/stack/spacecash/c200,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "caution"

--- a/_maps/map_files/RandomRuins/SpaceRuins/intactemptyship.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/intactemptyship.dmm
@@ -138,7 +138,7 @@
 /area/ruin/space/powered)
 "U" = (
 /obj/structure/closet,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/mineral/titanium/purple,
 /area/ruin/space/powered)
 

--- a/_maps/map_files/RandomRuins/SpaceRuins/meatpackers.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/meatpackers.dmm
@@ -63,7 +63,7 @@
 "ap" = (
 /obj/item/restraints/handcuffs,
 /obj/structure/closet/crate,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating/airless,
 /area/ruin/unpowered/bmp_ship/delta)
 "aq" = (
@@ -194,7 +194,7 @@
 "aP" = (
 /obj/item/stack/spacecash/c50,
 /obj/item/stack/spacecash/c100,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/wood,
 /area/ruin/unpowered/bmp_ship/fore)
 "aQ" = (
@@ -213,7 +213,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/bmp_ship/fore)
 "aT" = (
@@ -714,7 +714,7 @@
 /obj/structure/closet/secure_closet/freezer/meat{
 	opened = 1
 	},
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -2198,7 +2198,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/bmp_ship/delta)
 "PE" = (
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/bmp_ship/aft)
 "PP" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/mechtransport.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/mechtransport.dmm
@@ -21,7 +21,7 @@
 /area/ruin/space/mech_transport)
 "aZ" = (
 /obj/effect/spawner/random/loot_crate,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/mech_transport)
 "bk" = (
@@ -158,7 +158,7 @@
 	},
 /obj/machinery/door/window,
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/mech_transport)
 "od" = (
@@ -196,7 +196,7 @@
 /area/ruin/space/mech_transport)
 "pJ" = (
 /obj/structure/closet/firecloset,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/mineral/plastitanium/red/airless,
 /area/ruin/space/mech_transport)
 "qs" = (
@@ -253,7 +253,7 @@
 /area/ruin/space/mech_transport)
 "sY" = (
 /obj/structure/closet,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating,
 /area/ruin/space/mech_transport)
 "ta" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/onehalf.dmm
@@ -1030,7 +1030,7 @@
 /area/ruin/space/onehalf/abandonedbridge)
 "dd" = (
 /obj/structure/closet/firecloset/full,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/onehalf/abandonedbridge)
 "de" = (
@@ -1125,7 +1125,7 @@
 /area/template_noop)
 "jI" = (
 /obj/structure/disposalpipe/trunk,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/onehalf/drone_bay)
 "jQ" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/rocky_motel.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/rocky_motel.dmm
@@ -459,9 +459,9 @@
 /obj/item/stack/sheet/mineral/gold/fifty,
 /obj/item/clothing/gloves/ring/plasma,
 /obj/item/banhammer,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
 /obj/item/reagent_containers/drinks/bottle/beer/sleepy_beer,
 /obj/structure/safe/floor,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/carpet/black,
 /area/ruin/space/rocky_motel)
 "Kn" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/sieged_lab.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/sieged_lab.dmm
@@ -156,7 +156,7 @@
 /area/ruin/space/sieged_lab)
 "kr" = (
 /obj/effect/spawner/random/storage,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /obj/effect/map_effect/marker_helper/mapmanip/submap/edge{
 	color = "#ff7f00"
 	},
@@ -856,8 +856,8 @@
 /area/ruin/space/sieged_lab)
 "PF" = (
 /obj/structure/safe/floor,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/rare/sieged_lab,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/rare/sieged_lab,
+/obj/effect/spawner/random/pool/spaceloot/sieged_lab,
+/obj/effect/spawner/random/pool/spaceloot/sieged_lab,
 /turf/simulated/floor/carpet/royalblue,
 /area/ruin/space/sieged_lab)
 "PI" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
@@ -127,7 +127,7 @@
 /area/ruin/space/powered/bar)
 "aF" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/wood,
 /area/ruin/space/powered/bar)
 "aG" = (
@@ -135,7 +135,7 @@
 /area/ruin/space/powered)
 "aH" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/wood,
 /area/ruin/space/powered/bar)
 "aI" = (
@@ -448,7 +448,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},

--- a/_maps/map_files/RandomRuins/SpaceRuins/submaps/rocky_motel_submap.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/submaps/rocky_motel_submap.dmm
@@ -174,7 +174,7 @@
 /obj/item/stack/sheet/mineral/gold/fifty,
 /obj/item/clothing/gloves/ring/plasma,
 /obj/item/banhammer,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating/burnt,
 /area/template_noop)
 "rK" = (
@@ -445,7 +445,7 @@
 /obj/item/stack/sheet/mineral/gold/fifty,
 /obj/item/clothing/gloves/ring/plasma,
 /obj/item/banhammer,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /obj/structure/safe/floor,
 /turf/simulated/floor/carpet/black,
 /area/template_noop)

--- a/_maps/map_files/RandomRuins/SpaceRuins/unathi_skiff.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/unathi_skiff.dmm
@@ -129,7 +129,7 @@
 /area/ruin/space/unathi_breacher/hold)
 "kb" = (
 /obj/structure/rack,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/pod/dark,
 /area/ruin/space/unathi_breacher/hold)
 "kf" = (
@@ -144,7 +144,7 @@
 "kt" = (
 /obj/structure/table,
 /obj/item/screwdriver,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel/airless,
 /area/ruin/space/unathi_breacher/engineering)
 "li" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
@@ -1270,7 +1270,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "darkred"
@@ -3225,7 +3225,7 @@
 /area/ruin/space/derelict/hallway/primary)
 "iI" = (
 /obj/structure/closet/firecloset,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "caution"
@@ -4844,7 +4844,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitered"
@@ -4889,7 +4889,7 @@
 /area/ruin/space/derelict/crew_quarters)
 "nh" = (
 /obj/structure/closet/athletic_mixed,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
 	},
@@ -5654,7 +5654,7 @@
 /area/ruin/space/derelict/hallway/primary)
 "pt" = (
 /obj/structure/closet/jcloset,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/derelict/crew_quarters)
@@ -6951,7 +6951,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/ruin/space/derelict/arrival)
 

--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp_tele.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp_tele.dmm
@@ -228,7 +228,7 @@
 /area/ruin/space/derelict/teleporter)
 "vr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkblue"

--- a/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
@@ -315,7 +315,7 @@
 /area/ruin/space/powered)
 "bk" = (
 /obj/structure/rack,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel{
 	icon_state = "chapel"
 	},
@@ -397,7 +397,7 @@
 /area/ruin/space/powered)
 "bz" = (
 /mob/living/simple_animal/hostile/mimic/crate,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating,
 /area/ruin/space/powered)
 "bA" = (
@@ -490,7 +490,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/powered)
 "EZ" = (
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating,
 /area/ruin/space/powered)
 "YM" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/wreckedcargoship.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/wreckedcargoship.dmm
@@ -271,7 +271,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/rack,
 /obj/item/stack/rods/fifty,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel{
 	icon_state = "titanium";
 	dir = 4
@@ -656,7 +656,7 @@
 	dir = 1
 	},
 /obj/effect/spawner/random/loot_crate,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/pod/light,
 /area/ruin/space/wreck_cargoship)
 "AN" = (
@@ -772,7 +772,7 @@
 "Fk" = (
 /obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding";
 	dir = 1
@@ -1074,7 +1074,7 @@
 	pixel_y = -32
 	},
 /obj/effect/spawner/random/loot_crate,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "blackcorner"
@@ -1183,7 +1183,7 @@
 "Vc" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "caution"
@@ -1298,7 +1298,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/effect/spawner/random/pool/spaceloot/mixed,
 /turf/simulated/floor/plating,
 /area/ruin/space/wreck_cargoship)
 "XX" = (

--- a/code/game/objects/effects/spawners/random/pool/space_loot.dm
+++ b/code/game/objects/effects/spawners/random/pool/space_loot.dm
@@ -255,7 +255,7 @@
 
 /obj/effect/spawner/random/pool/spaceloot/syndicate/mixed
 	loot = list(
-		/obj/effect/spawner/random/pool/spaceloot/syndicate/common = 30,
+		/obj/effect/spawner/random/pool/spaceloot/syndicate/common = 25,
 		/obj/effect/spawner/random/pool/spaceloot/syndicate/rare = 20,
 		/obj/effect/spawner/random/pool/spaceloot/syndicate/officer = 5,
 		/obj/effect/spawner/random/pool/spaceloot/syndicate/armory = 1,
@@ -402,4 +402,189 @@
 
 	loot = list(
 		/obj/item/gun/projectile/c_foam_launcher
+	)
+
+/obj/effect/spawner/random/pool/spaceloot/trader_departments
+	name = "trader department loot spawner"
+
+/obj/effect/spawner/random/pool/spaceloot/trader_departments/civilian
+	loot = /obj/effect/spawner/random/traders/civilian::loot
+
+/obj/effect/spawner/random/pool/spaceloot/trader_departments/science
+	// without /obj/item/autosurgeon/organ
+	loot = list(
+		/obj/item/paper/researchnotes = 125,
+
+		/obj/item/assembly/signaler/anomaly/random = 50,
+		/obj/item/autosurgeon/organ = 50,
+		/obj/item/slimepotion/sentience = 50,
+		/obj/item/slimepotion/transference = 50,
+
+		/obj/item/mecha_parts/mecha_equipment/weapon/energy/xray = 25,
+		/obj/item/mecha_parts/mecha_equipment/teleporter/precise = 25,
+		/obj/item/mod/construction/plating/research = 25,
+		/obj/item/storage/box/telescience = 25,
+		/obj/item/ai_upgrade/surveillance_upgrade = 25,
+	)
+
+/obj/effect/spawner/random/pool/spaceloot/trader_departments/engineering
+	loot = /obj/effect/spawner/random/traders/engineering::loot
+
+/obj/effect/spawner/random/pool/spaceloot/trader_departments/medical
+	loot = /obj/effect/spawner/random/traders/medical::loot
+
+/obj/effect/spawner/random/pool/spaceloot/trader_departments/security
+	loot = /obj/effect/spawner/random/traders/security::loot
+
+/obj/effect/spawner/random/pool/spaceloot/trader_departments/common
+	point_value = 20
+
+	loot = list(
+		/obj/effect/spawner/random/pool/spaceloot/trader_departments/civilian = 20,
+		/obj/effect/spawner/random/pool/spaceloot/trader_departments/science = 10,
+		/obj/effect/spawner/random/pool/spaceloot/trader_departments/engineering = 10,
+	)
+
+/obj/effect/spawner/random/pool/spaceloot/trader_departments/rare
+	point_value = 80
+	loot = list(
+		/obj/effect/spawner/random/pool/spaceloot/trader_departments/medical = 5,
+		/obj/effect/spawner/random/pool/spaceloot/trader_departments/security = 1,
+	)
+
+/obj/effect/spawner/random/pool/spaceloot/trader_organizations
+	name = "trader organization loot spawner"
+
+/obj/effect/spawner/random/pool/spaceloot/trader_organizations/federation_minor
+	loot = /obj/effect/spawner/random/traders/federation_minor::loot
+
+/obj/effect/spawner/random/pool/spaceloot/trader_organizations/ussp_minor
+	loot = /obj/effect/spawner/random/traders/ussp_minor::loot
+
+/obj/effect/spawner/random/pool/spaceloot/trader_organizations/steadfast_minor
+	loot = /obj/effect/spawner/random/traders/steadfast_minor::loot
+
+/obj/effect/spawner/random/pool/spaceloot/trader_organizations/merchantguild_major
+	loot = /obj/effect/spawner/random/traders/merchantguild_major::loot
+
+/obj/effect/spawner/random/pool/spaceloot/trader_organizations/cybersun_minor
+	loot = /obj/effect/spawner/random/traders/cybersun_minor::loot
+
+/obj/effect/spawner/random/pool/spaceloot/trader_organizations/glintscale_minor
+	loot = /obj/effect/spawner/random/traders/glintscale_minor::loot
+
+/obj/effect/spawner/random/pool/spaceloot/trader_organizations/steadfast_major
+	loot = /obj/effect/spawner/random/traders/steadfast_major::loot
+
+/obj/effect/spawner/random/pool/spaceloot/trader_organizations/syntheticunion_minor
+	// without /obj/item/autosurgeon/organ
+	loot = list(
+		/obj/item/clothing/glasses/meson/sunglasses = 5,
+		/obj/item/clothing/glasses/thermal/monocle = 5,
+		/obj/item/organ/internal/cyberimp/arm/toolset = 5,
+		/obj/item/organ/internal/cyberimp/arm/surgery = 5,
+		/obj/item/organ/internal/cyberimp/arm/janitorial = 5,
+		/obj/item/organ/internal/cyberimp/brain/anti_stam = 5,
+		/obj/item/organ/internal/cyberimp/brain/anti_sleep = 5,
+		/obj/item/organ/internal/cyberimp/brain/clown_voice = 4,
+		/obj/item/organ/internal/cyberimp/mouth/breathing_tube = 5,
+		/obj/item/organ/internal/cyberimp/chest/ipc_repair = 5,
+		/obj/item/organ/internal/cyberimp/chest/ipc_joints/magnetic_joints = 5,
+		/obj/item/organ/internal/cyberimp/chest/ipc_joints/sealed = 5,
+		/obj/item/flag/species/machine = 2
+	)
+
+/obj/effect/spawner/random/pool/spaceloot/trader_organizations/skipjack_minor
+	loot = /obj/effect/spawner/random/traders/skipjack_minor::loot
+
+/obj/effect/spawner/random/pool/spaceloot/trader_organizations/solarcentral_minor
+	loot = /obj/effect/spawner/random/traders/solarcentral_minor::loot
+
+/obj/effect/spawner/random/pool/spaceloot/trader_organizations/merchantguild_minor
+	loot = /obj/effect/spawner/random/traders/merchantguild_minor::loot
+
+/obj/effect/spawner/random/pool/spaceloot/trader_organizations/federation_major
+	loot = /obj/effect/spawner/random/traders/federation_major::loot
+
+/obj/effect/spawner/random/pool/spaceloot/trader_organizations/ussp_major
+	loot = /obj/effect/spawner/random/traders/ussp_major::loot
+
+/obj/effect/spawner/random/pool/spaceloot/trader_organizations/glintscale_major
+	loot = /obj/effect/spawner/random/traders/glintscale_major::loot
+
+/obj/effect/spawner/random/pool/spaceloot/trader_organizations/syntheticunion_major
+	loot = /obj/effect/spawner/random/traders/syntheticunion_major::loot
+
+/obj/effect/spawner/random/pool/spaceloot/trader_organizations/skipjack_major
+	loot = /obj/effect/spawner/random/traders/skipjack_major::loot
+
+/obj/effect/spawner/random/pool/spaceloot/trader_organizations/solarcentral_major
+	loot = /obj/effect/spawner/random/traders/solarcentral_major::loot
+
+/obj/effect/spawner/random/pool/spaceloot/trader_organizations/technocracy_minor
+	// without /obj/item/autosurgeon/organ
+	loot = list(
+		/obj/item/paper/researchnotes = 15,
+		/obj/item/storage/box/beakers/bluespace = 5,
+		/obj/item/storage/box/stockparts/deluxe = 5,
+		/obj/item/clothing/glasses/thermal/monocle = 5,
+		/obj/item/organ/internal/cyberimp/arm/toolset_abductor = 3,
+		/obj/item/organ/internal/cyberimp/arm/surgery = 4,
+		/obj/item/organ/internal/cyberimp/arm/advmop = 3,
+		/obj/item/organ/internal/cyberimp/brain/anti_stam = 5,
+		/obj/item/organ/internal/cyberimp/brain/anti_sleep = 5,
+		/obj/item/organ/internal/cyberimp/brain/anti_drop = 5,
+		/obj/item/flag/species/greys = 2
+	)
+
+/obj/effect/spawner/random/pool/spaceloot/trader_organizations/technocracy_major
+	loot = /obj/effect/spawner/random/traders/technocracy_major::loot
+
+/obj/effect/spawner/random/pool/spaceloot/trader_organizations/common
+	point_value = 30
+	loot = list(
+		/obj/effect/spawner/random/pool/spaceloot/trader_organizations/federation_minor,
+		/obj/effect/spawner/random/pool/spaceloot/trader_organizations/ussp_minor,
+		/obj/effect/spawner/random/pool/spaceloot/trader_organizations/steadfast_minor,
+		/obj/effect/spawner/random/pool/spaceloot/trader_organizations/merchantguild_major,
+	)
+
+/obj/effect/spawner/random/pool/spaceloot/trader_organizations/uncommon
+	point_value = 50
+	loot = list(
+		/obj/effect/spawner/random/pool/spaceloot/trader_organizations/cybersun_minor,
+		/obj/effect/spawner/random/pool/spaceloot/trader_organizations/glintscale_minor,
+		/obj/effect/spawner/random/pool/spaceloot/trader_organizations/steadfast_major,
+		/obj/effect/spawner/random/pool/spaceloot/trader_organizations/syntheticunion_minor,
+		/obj/effect/spawner/random/pool/spaceloot/trader_organizations/skipjack_minor,
+		/obj/effect/spawner/random/pool/spaceloot/trader_organizations/solarcentral_minor,
+		/obj/effect/spawner/random/pool/spaceloot/trader_organizations/merchantguild_minor,
+	)
+
+/obj/effect/spawner/random/pool/spaceloot/trader_organizations/rare
+	point_value = 150
+	loot = list(
+		/obj/effect/spawner/random/pool/spaceloot/trader_organizations/federation_major,
+		/obj/effect/spawner/random/pool/spaceloot/trader_organizations/ussp_major,
+		/obj/effect/spawner/random/pool/spaceloot/trader_organizations/glintscale_major,
+		/obj/effect/spawner/random/pool/spaceloot/trader_organizations/syntheticunion_major,
+		/obj/effect/spawner/random/pool/spaceloot/trader_organizations/skipjack_major,
+		/obj/effect/spawner/random/pool/spaceloot/trader_organizations/solarcentral_major,
+		/obj/effect/spawner/random/pool/spaceloot/trader_organizations/technocracy_minor,
+		/obj/effect/spawner/random/pool/spaceloot/trader_organizations/technocracy_major,
+	)
+
+/obj/effect/spawner/random/pool/spaceloot/trader_mixed
+	loot = list(
+		/obj/effect/spawner/random/pool/spaceloot/trader_departments/common = 10,
+		/obj/effect/spawner/random/pool/spaceloot/trader_organizations/common = 10,
+		/obj/effect/spawner/random/pool/spaceloot/trader_organizations/uncommon = 5,
+		/obj/effect/spawner/random/pool/spaceloot/trader_departments/rare = 2,
+		/obj/effect/spawner/random/pool/spaceloot/trader_organizations/rare = 2,
+	)
+
+/obj/effect/spawner/random/pool/spaceloot/mixed
+	loot = list(
+		/obj/effect/spawner/random/pool/spaceloot/trader_mixed,
+		/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed
 	)

--- a/code/modules/awaymissions/mission_code/ruins/casino.dm
+++ b/code/modules/awaymissions/mission_code/ruins/casino.dm
@@ -1,5 +1,10 @@
-/obj/effect/spawner/random/pool/spaceloot/syndicate/rare/casino
+/obj/effect/spawner/random/pool/spaceloot/casino
 	guaranteed = TRUE
+	loot = list(
+		/obj/effect/spawner/random/pool/spaceloot/syndicate/rare,
+		/obj/effect/spawner/random/pool/spaceloot/trader_departments/rare,
+		/obj/effect/spawner/random/pool/spaceloot/trader_organizations/rare,
+	)
 
 /datum/spawn_pool/casino_mobs
 	available_points = 6

--- a/code/modules/awaymissions/mission_code/ruins/sieged_lab.dm
+++ b/code/modules/awaymissions/mission_code/ruins/sieged_lab.dm
@@ -176,5 +176,10 @@ GLOBAL_LIST_INIT(ruin_sieged_lab_research_loot, list(
 /obj/effect/mine/sieged_lab/mineEffect(mob/living/victim)
 	explosion(loc, 1, 0, 0, 1) // devastate the tile you are on, but leave everything else untouched
 
-/obj/effect/spawner/random/pool/spaceloot/syndicate/rare/sieged_lab
+/obj/effect/spawner/random/pool/spaceloot/sieged_lab
 	guaranteed = TRUE
+	loot = list(
+		/obj/effect/spawner/random/pool/spaceloot/syndicate/rare,
+		/obj/effect/spawner/random/pool/spaceloot/trader_departments/rare,
+		/obj/effect/spawner/random/pool/spaceloot/trader_organizations/rare,
+	)


### PR DESCRIPTION
## What Does This PR Do
This PR expands the space loot spawn pool by including spawners used by the trader event. The spawner lists are identical to those used in the trader event, except for:
1. Technocracy small gear: implant autosurgeon removed
2. Synthetic Union small gear: implant autosurgeon removed
3. Science department gear: implant autosurgeon removed
4. Cybersun industries large gear: not included at all

Departmental trader items are split into:
- Common: civilian, science, engineering
- Rare: medial, security
Organizational trader items are split into:
- Common: Federation small, USSP small, Steadfast small, Merchant Guild large
- Uncommon: Cybersun small, Glintscale small, Steadfast large, Synthetic Union small, Skipjack small, Skrell Central Authority small, Merchant Guild small
- Rare: Federation large, USSP large, Glintscale large, Synthetic Union large, Skipjack large, Skrell Central Authority large, technocracy small, technocracy large

Sieged lab and casino guaranteed rare spawns now also include departmental and organizational rare spawns.
Syndicate-themed ruins will still only spawn Syndicate pool loot. We could play with this in other ways by e.g. making the USSP ruins include USSP trader loot, but this is a good starting spot for now.
## Why It's Good For The Game
Space loot currently suffers from being Syndicate-themed only, and combat-focused. By adding in trader items we can quickly expand the kind of loot available with effectively pre-approved list of stuff we're okay with the crew having in rare circumstances, lots of which are not as combat-oriented. This also helps to bring up the floor of very boring, useless items like Syndicate coins and gonzo fist lighters. Low level loot shouldn't be completely worthless, and there should be more variety to it.
## Testing
Ran several rounds with ruins, checked blackbox data to verify spawns.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

![2025_06_04__14_48_14__#balance_chat _ Paradise Station - Discord](https://github.com/user-attachments/assets/3134e642-4cd8-42f0-a9ed-dd2db244ef77)
![2025_06_04__14_48_25__#balance_chat _ Paradise Station - Discord](https://github.com/user-attachments/assets/cba3b81c-717a-4903-9c36-a4cca236ebb9)

## Changelog
:cl:
add: As a result of pirate raids on merchant vessels in the sector, spawn loot may now include items typically only found on trader shuttles.
/:cl: