### PR TITLE
Volcanic Activity Fixes

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
@@ -848,7 +848,7 @@
 /obj/docking_port/mobile/mining,
 /obj/structure/fans/tiny,
 /obj/docking_port/stationary{
-	area_type = /area/lavaland/surface/outdoors;
+	area_type = /area/lavaland/surface/outdoors/outpost/no_boulder;
 	dir = 8;
 	dwidth = 3;
 	height = 5;

--- a/code/datums/weather/weather_types/lavaland_weather.dm
+++ b/code/datums/weather/weather_types/lavaland_weather.dm
@@ -171,8 +171,12 @@
 		var/hits = 0
 		var/target
 		for(var/turf/T in get_area_turfs(/area/lavaland/surface/outdoors))
-			if(istype(T, /turf/simulated/floor/)) // dont waste our time hitting walls
+			if(istype(get_area(T), /area/lavaland/surface/outdoors/outpost/no_boulder))
+				continue // No hitting the no boulder area
+			if(istype(T, /turf/simulated/floor)) // dont waste our time hitting walls
 				valid_targets += T
+		if(isnull(valid_targets)) // prevents a runtime when coding without lavaland enabled. Or theres somehow ZERO turfs.
+			return
 		while(hits <= 150 && length(valid_targets)) //sling a bunch of rocks around the map
 			target = pick(valid_targets)
 			new /obj/effect/temp_visual/rock_target(target)
@@ -186,6 +190,8 @@
 	sleep(ROCKFALL_DELAY)
 	for(var/mob/M in GLOB.player_list)
 		var/turf/M_turf = get_turf(M)
+		if(isnull(target))
+			return
 		if(M_turf.z == target.z)
 			M.playsound_local(target, 'sound/effects/explosionfar.ogg', 50, 1, get_rand_frequency(), distance_multiplier = 0)
 			shake_camera(M, 2, 4)
@@ -228,8 +234,8 @@
 	sleep(duration)
 	T = get_turf(src)
 	var/turf_area = get_area(T)
-	if(ispath(turf_area, /area/shuttle)) //prevent hitting the shuttle when it moves
-		log_debug("we hit a shuttle area. breaking rock")
+	if(istype(turf_area, /area/shuttle)) //prevent hitting the shuttle when it moves
+		log_debug("A rockfall has somehow struck at [x], [y].")
 		qdel(src)
 		return
 	playsound(T, 'sound/effects/break_stone.ogg', 80, TRUE)
@@ -246,7 +252,7 @@
 				L.gib()
 	if(!islava(T) && !istype(T, /turf/simulated/floor/chasm)) // Splash harmlessly into the lava pools
 		for(var/obj/structure/thing in T.contents) // dont cover the tendrils
-			if(thing.name == "necropolis tendril")
+			if(istype(thing, /obj/structure/spawner/lavaland))
 				return
 		T.ChangeTurf(/turf/simulated/mineral/random/high_chance/volcanic)
 

--- a/code/datums/weather/weather_types/lavaland_weather.dm
+++ b/code/datums/weather/weather_types/lavaland_weather.dm
@@ -234,7 +234,7 @@
 	sleep(duration)
 	T = get_turf(src)
 	var/turf_area = get_area(T)
-	if(istype(turf_area, /area/shuttle)) //prevent hitting the shuttle when it moves
+	if(istype(turf_area, /area/shuttle)) // prevent hitting the shuttle when it moves
 		log_debug("A rockfall has somehow struck at [x], [y].")
 		qdel(src)
 		return

--- a/code/game/area/areas/mining_areas.dm
+++ b/code/game/area/areas/mining_areas.dm
@@ -64,6 +64,10 @@
 	name = "Mining Station Catwalk"
 	icon_state = "mining"
 
+/area/lavaland/surface/outdoors/outpost/no_boulder
+	name = "Mining Station"
+	icon_state = "mining"
+
 /area/mine/outpost/comms
 	name = "Mining Station Communications"
 	icon_state = "tcomms"


### PR DESCRIPTION
## What Does This PR Do

Provides the following fixes for volcanic activity:

- Boulders no longer target the shuttle layer **at all** and if they do, the check that sees if it breaks it now actually works again.
- Boulders will no longer hide tendrils (as was intended originally) and will now break before changeturf is called
- If lavaland is not loaded from config (for quick testing) it will no longer run a runtime every weather act.

as a side effect, a new are type has been made that acts like outside but will not be targeted by the storm:
/area/lavaland/surface/outdoors/outpost/no_boulder
 

## Why It's Good For The Game

boulders should be very dangerous, but should break certain things like shuttles.

## Testing

threw boulders at shuttle, checked with debug mode if it skips no_boulder areas. Manually threw boulders at the shuttle. threw boulders at tendrils and at fauna

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed some unintended behavior with volcanic activity
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
