### PR TITLE
Migrates the Mindflayer's Silicon Administrative Override to the new Attack Chain

### DIFF
--- a/code/modules/antagonists/mind_flayer/powers/flayer_stealth_powers.dm
+++ b/code/modules/antagonists/mind_flayer/powers/flayer_stealth_powers.dm
@@ -187,27 +187,35 @@
 	color = COLOR_BLACK
 	flags = ABSTRACT | DROPDEL
 	w_class = WEIGHT_CLASS_HUGE
+	new_attack_chain = TRUE
 	var/conversion_time = 7 SECONDS
 
-/obj/item/melee/swarm_hand/afterattack__legacy__attackchain(atom/target, mob/living/user, proximity_flag, click_parameters)
-	. = ..()
-	if(!isrobot(target))
-		return
-	var/mob/living/silicon/robot/borg = target
-	target.visible_message(
-		"<span class='danger'>[user] puts [user.p_their()] hands on [target] and begins transferring energy!</span>",
+/obj/item/melee/swarm_hand/pre_attack(atom/A, mob/living/user, params)
+	if(..())
+		return FINISH_ATTACK
+
+	if(!isrobot(A))
+		to_chat(user, "<span class='warning'>[src] will have no effect against this target!</span>")
+		return FINISH_ATTACK
+
+	var/mob/living/silicon/robot/borg = A
+	borg.visible_message(
+		"<span class='danger'>[user] puts [user.p_their()] hands on [borg] and begins transferring energy!</span>",
 		"<span class='userdanger'>[user] puts [user.p_their()] hands on you and begins transferring energy!</span>")
 	if(borg.emagged || !borg.is_emaggable)
 		to_chat(user, "<span class='notice'>Your override attempt fails before it can even begin.</span>")
 		qdel(src)
-		return
+		return FINISH_ATTACK
+
 	if(!do_mob(user, borg, conversion_time, hidden = TRUE))
 		to_chat(user, "<span class='notice'>Your concentration breaks.</span>")
 		qdel(src)
-		return
+		return FINISH_ATTACK
+
 	to_chat(user, "<span class='notice'>The mass of swarms vanish into the cyborg's internals. Success.</span>")
 	INVOKE_ASYNC(src, PROC_REF(emag_borg), borg, user)
 	qdel(src)
+	return FINISH_ATTACK
 
 /obj/item/melee/swarm_hand/proc/emag_borg(mob/living/silicon/robot/borg, mob/living/user)
 	if(QDELETED(borg) || QDELETED(user))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Title.
Fixes #28671.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Attack migration good.
Bug bad.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned a borg.
Spawned an IPC, turned them into a mindflayer and gave them the silicon override spell.
Used it on the borg successfully.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixes the mindflayer Silicon Administrative Override ability not working.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
