### PR TITLE
Tweak: Makes storage examine broadcast work, storage examines will only broadcast the top level storage, excludes bluespace pocket from being broadcast.

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -680,13 +680,14 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	if(isitem(examined))
 		var/obj/item/I = examined
 		if(I.in_storage)
+			while(isstorage(I.loc)) // grab the top level storage item
+				I = I.loc
 			if(get(I, /mob/living) == src)
-				I = get(I, /obj/item/storage)
 				if(istype(I, /obj/item/storage/hidden_implant)) // Don't annnounce items in a bluespace pocket.
 					return
-				loc_str = "inside [p_their()] [I.loc.name]..."
+				loc_str = "inside [p_their()] [I.name]..."
 			else
-				loc_str = "inside [I.loc]..."
+				loc_str = "inside [I]..."
 
 			examining_stored_item = TRUE
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -681,6 +681,9 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 		var/obj/item/I = examined
 		if(I.in_storage)
 			if(get(I, /mob/living) == src)
+				I = get(I, /obj/item/storage)
+				if(istype(I, /obj/item/storage/hidden_implant)) // Don't annnounce items in a bluespace pocket.
+					return
 				loc_str = "inside [p_their()] [I.loc.name]..."
 			else
 				loc_str = "inside [I.loc]..."
@@ -697,7 +700,7 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 			examining_worn_item = TRUE
 
 	var/can_see_str = "<span class='subtle'>\The [src] looks at [examined].</span>"
-	if(examining_worn_item)
+	if(examining_worn_item || examining_stored_item)
 		can_see_str = "<span class='subtle'>\The [src] looks [loc_str]</span>"
 
 	var/cannot_see_str = "<span class='subtle'>\The [src] looks [loc_str]</span>"


### PR DESCRIPTION
## What Does This PR Do
I missed adding `examining_stored_item` to the if check, which resulted in you directly examining items inside storage.
Storage examines will now only broadcast the top level storage item.
Added an istype check for the storage implant blue space pocket, so it doesnt broadcast that youre looking int your brain.
## Why It's Good For The Game
Functioning broadcasts is good, leaking that youre looking into your Hacker Bundle is not. Broadcasting that youre looking into your brain is also bad.
## Images of changes
![image](https://github.com/user-attachments/assets/c1570b1d-c6c8-4f60-ad07-6aa7c1f14502)
## Testing
Examined an item several levels deep (contractor box in contractor box) and it said I'm looking in the backpack.
Examined an item in a labcoat, says I looked into the labcoat.
Examined an item in my bluespace pocket, doesnt say anything.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Storage broadcasts now work
tweak: Storage broadcasts only broadcast the top level storage item
tweak: Bluespace pocket is no longer broadcast
/:cl: