### PR TITLE
create flag to skip species transform reequip

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -14,6 +14,7 @@
 #define NODECONSTRUCT			(1<<9)
 #define EARBANGPROTECT			(1<<10)
 #define HEADBANGPROTECT			(1<<11)
+#define SKIP_TRANSFORM_REEQUIP	(1<<12)		// This flag makes items be skipped when a user transforms species.
 
 #define BLOCK_GAS_SMOKE_EFFECT	(1<<12)	// blocks the effect that chemical clouds would have on a mob --glasses, mask and helmets ONLY!
 #define THICKMATERIAL 			(1<<12)	//prevents syringes, parapens and hypos if the external suit or helmet (if targeting head) has this flag. Example: space suits, biosuit, bombsuits, thick suits that cover your body. (NOTE: flag shared with BLOCK_GAS_SMOKE_EFFECT)

--- a/code/datums/components/two_handed.dm
+++ b/code/datums/components/two_handed.dm
@@ -410,7 +410,7 @@
 	name = "offhand"
 	icon_state = "offhand"
 	w_class = WEIGHT_CLASS_HUGE
-	flags = ABSTRACT | NODROP
+	flags = ABSTRACT | NODROP | SKIP_TRANSFORM_REEQUIP
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	var/wielded = FALSE // Off Hand tracking of wielded status
 

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1185,6 +1185,8 @@
 	for(var/thing in thing_to_check)
 		var/obj/item/I = get_item_by_slot(thing)
 		if(I)
+			if(I.flags & SKIP_TRANSFORM_REEQUIP)
+				continue
 			kept_items[I] = thing
 			item_flags[I] = I.flags
 			I.flags = 0 // Temporary set the flags to 0


### PR DESCRIPTION
## What Does This PR Do
Species changes create a list of items which then get re-equipped. That includes the offhand item from the two-handed component. That results in two-handed items like fireaxes to brick themselves if a user changes species.

This PR adds a flag `SKIP_TRANSFORM_REEQUIP`, which is then added on the offhand item from the two-handed component. Species changes will check for that flag and skip any items that have it.
## Why It's Good For The Game
Bricking your hands is not good.
## Images of changes

https://github.com/user-attachments/assets/e57bc3d8-c909-4755-92f8-853f9015dc8f

## Testing
Transformed with a wielded fireaxe, the offhand object was not reequipped.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: You will no longer brick your offhand when transforming as a cling with a wielded item.
/:cl: