### PR TITLE
Fix flavortext not clearing itself if you transform into a flavorless person

### DIFF
--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1075,8 +1075,7 @@
 	if(include_species_change) //We have to call this after new_dna.Clone() so that species actions don't get overwritten
 		dna.species.on_species_gain(src)
 	real_name = new_dna.real_name
-	if(dna.flavor_text)
-		flavor_text = dna.flavor_text
+	flavor_text = dna.flavor_text
 	domutcheck(src, MUTCHK_FORCED) //Ensures species that get powers by the species proc handle_dna keep them
 	dna.UpdateSE()
 	dna.UpdateUI()


### PR DESCRIPTION
## What Does This PR Do
Removes a check for new present flavor text. Flavor text will now always be updated when transforming, whether it's empty or full. Fixes #28135
## Why It's Good For The Game
Prevents clings from being meta'd through flavor text.
## Images of changes
pre-transform
![image](https://github.com/user-attachments/assets/48dd0049-bb80-45e8-9bf4-574f0c4bb30a)
post-transform
![image](https://github.com/user-attachments/assets/396145e8-bda2-43b4-b090-c22a29816921)
## Testing
Transformed from a flavorful moth into a flavorless human. My flavortext was empty. Transformed back into a flavorful moth, flavor text returned.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Flavor text will now clear itself properly when DNA is changed.
/:cl: