### PR TITLE
place required ruins in decreasing order of size

### DIFF
--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -60,3 +60,6 @@
 
 /proc/cmp_changeling_power_category_asc(datum/changeling_power_category/a, datum/changeling_power_category/b)
 	return initial(a.priority) - initial(b.priority)
+
+/proc/cmp_ruin_placement_cost(datum/map_template/ruin/A, datum/map_template/ruin/B)
+	return A.get_cost() - B.get_cost()

--- a/code/datums/mapping/ruin_placer.dm
+++ b/code/datums/mapping/ruin_placer.dm
@@ -149,6 +149,7 @@
 			continue
 		ruins_available[R] = R.placement_weight
 
+	forced_ruins = sortTim(forced_ruins, GLOBAL_PROC_REF(cmp_ruin_placement_cost))
 	while(length(forced_ruins))
 		var/datum/map_template/ruin/ruin = forced_ruins[length(forced_ruins)]
 		var/datum/ruin_placement/placement = new(ruin, base_padding_ = base_padding)


### PR DESCRIPTION
## What Does This PR Do
This PR modifies ruin placement to place required ruins in decreasing order by size.
## Why It's Good For The Game
Required ruins can still fail to place if no place can be found for them. Small ruins placed in the middle of large areas make it impossible for larger ruins to be placed, which is fine if we don't care if the large ruin is required, but if we're just iterating over required ruins, we should place them from largest to smallest to increase the guarantee that they all get placed as expected.
Lavaland currently has a lot of required ruins, and the largest one is the most important.
## Testing
Ensured ruins placed in expected order. Before:
![2025_06_09__17_34_24__code_datums_mapping_ruin_placer dm - Paradise (Workspace) - Visual Studio Code](https://github.com/user-attachments/assets/d8bdf01e-a6ca-4357-8951-0a7c2e8ef72a)
The list starts from the end and goes backwards, so the relay, a small ruin, would be placed, immediately followed by the legion gate, a large ruin. Given we randomize placement locations and give up after 100 tries, it's possible that the relay in the middle of one z-level and the legion gate in the middle of another z-level could successfully exhaust the 100 attempts to place the mining station.
After:
![2025_06_09__17_24_40__code_datums_mapping_ruin_placer dm - Paradise (Workspace) - Visual Studio Code](https://github.com/user-attachments/assets/71162783-022b-4298-acd9-93f5288a969b)
Mining station is the first from the end of the list, so gets placed first.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
fix: Improvements have been made to ensure mining station spawns properly.