### PR TITLE
Migrate crematorium and morgue tray to the new attack chain

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -37,6 +37,7 @@
 	anchored = TRUE
 	var/open_sound = 'sound/items/deconstruct.ogg'
 	var/status
+	new_attack_chain = TRUE
 
 /obj/structure/morgue/Initialize(mapload)
 	. = ..()
@@ -172,17 +173,12 @@
 		return ..()
 	attack_hand(user)
 
-/obj/structure/morgue/attackby__legacy__attackchain(P as obj, mob/user as mob, params)
-	if(is_pen(P))
-		var/t = rename_interactive(user, P)
-
-		if(isnull(t))
-			return
-
+/obj/structure/morgue/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	if(is_pen(used))
+		rename_interactive(user, used)
 		update_icon(UPDATE_OVERLAYS)
 		add_fingerprint(user)
-		return
-
+		return ITEM_INTERACT_COMPLETE
 	return ..()
 
 /obj/structure/morgue/wirecutter_act(mob/user)
@@ -340,6 +336,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	var/repairstate = CREMATOR_OPERATIONAL // Repairstate 0 is DESTROYED, 1 has the igniter applied but needs welding (IN_REPAIR), 2 is OPERATIONAL
 	var/locked = FALSE
 	var/open_sound = 'sound/items/deconstruct.ogg'
+	new_attack_chain = TRUE
 
 /obj/structure/crematorium/Initialize(mapload)
 	. = ..()
@@ -419,19 +416,20 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	GLOB.crematoriums += src
 	return TRUE
 
-/obj/structure/crematorium/attackby__legacy__attackchain(obj/item/P, mob/user, params)
-	if(is_pen(P))
-		rename_interactive(user, P)
+/obj/structure/crematorium/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	if(is_pen(used))
+		rename_interactive(user, used)
 		add_fingerprint(user)
-		return
-	if(istype(P, /obj/item/assembly/igniter))
+		return ITEM_INTERACT_COMPLETE
+	if(istype(used, /obj/item/assembly/igniter))
 		if(repairstate == CREMATOR_DESTROYED)
 			user.visible_message("<span class='notice'>[user] replaces [src]'s igniter.</span>", "<span class='notice'>You replace [src]'s damaged igniter. Now it just needs its paneling welded.</span>")
 			repairstate = CREMATOR_IN_REPAIR
 			desc = "A broken human incinerator. No longer works well on barbeque nights. It requires its paneling to be welded to function."
-			qdel(P)
+			qdel(used)
 		else
 			to_chat(user, "<span class='notice'>[src] does not need its igniter replaced.</span>")
+		return ITEM_INTERACT_COMPLETE
 	return ..()
 
 /obj/structure/crematorium/relaymove(mob/user as mob)


### PR DESCRIPTION
## What Does This PR Do
Migrates the crematorium and morgue tray to the new attack chain.
## Why It's Good For The Game
Progress to the new attack chain.
## Testing
Renamed and unnamed a morgue tray. Cut a tag off a morgue tray. Attacked and broke a morgue tray.
Renamed and unnamed a crematorium. Cremated a body. Attacked and broke a crematorium. Repaired a crematorium.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC