### PR TITLE
Allow sentient bees to enter and leave apiaries + fix queen bee home not being set

### DIFF
--- a/code/modules/hydroponics/beekeeping/beebox.dm
+++ b/code/modules/hydroponics/beekeeping/beebox.dm
@@ -170,6 +170,7 @@
 		qb.queen.forceMove(src)
 		bees += qb.queen
 		queen_bee = qb.queen
+		queen_bee.beehome = src
 		qb.queen = null
 
 		if(queen_bee)
@@ -205,6 +206,17 @@
 /obj/structure/beebox/wrench_act(mob/user, obj/item/I)
 	. = TRUE
 	default_unfasten_wrench(user, I, time = 20)
+
+/obj/structure/beebox/attack_animal(mob/living/simple_animal/M)
+	if(!istype(M, /mob/living/simple_animal/hostile/poison/bees))
+		return ..()
+
+	M.forceMove(src)
+	bees += M
+
+/obj/structure/beebox/relaymove(mob/user)
+	user.forceMove(get_turf(src))
+	bees -= user
 
 /obj/structure/beebox/attack_hand(mob/user)
 	if(ishuman(user))


### PR DESCRIPTION
## What Does This PR Do
Allows sentient bees to enter hives by clicking on them (regardless of intent) and to leave them by moving. Also fixes Queen Bees not having their home set to the apiary. Fixes #29378

Shouldn't interfere with the AI pollination handling of bees, as that seems to be handled in their AI.
## Why It's Good For The Game
Sentience event can leave players stuck in an apiary. Homeless Queen Bee is sad.
## Images of changes

https://github.com/user-attachments/assets/4c0a6296-7865-47fb-a7ff-99b627b4c991

## Testing
Exited apiary, nuzzled a human, stung a human, entered the apiary.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Sentient bees can now enter and exit apiaries.
fix: Queen bee now gets its home set to the apiary it's placed in.
/:cl: