### PR TITLE
register non-mapload docking ports on init

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -165,6 +165,11 @@
 
 	var/lock_shuttle_doors = 0
 
+/obj/docking_port/stationary/Initialize(mapload)
+	. = ..()
+	if(!mapload)
+		register()
+
 // Preset for adding whiteship docks to ruins. Has widths preset which will auto-assign the shuttle
 /obj/docking_port/stationary/whiteship
 	dwidth = 6


### PR DESCRIPTION
## What Does This PR Do
This PR adds a stanza to stationary docking port Initializes, registering them with SSshuttle if they were not created on mapload.
## Why It's Good For The Game
SSshuttle handles registering docking ports created during mapload, but if a docking port is loaded in after the fact, the shuttle consoles expecting to link to it are locked out. This can be an issue if, say, you need to latespawn a ruin with a docking port that crew needs to get to.
## Testing
Spawned lavaland without ruins, uploaded and placed NT mining complex, ensured mining shuttle console at docks and on shuttle were unlocked and worked as expected.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC