### PR TITLE
Fix atom picker not properly releasing keys

### DIFF
--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -613,9 +613,9 @@ GLOBAL_PROTECT(VVmaint_only)
 			return null
 		sleep(1)
 
-	click_intercept = null
+	picker.quit()
 	return picker.picked
-	
+
 
 /client/proc/modify_variables(atom/O, param_var_name = null, autodetect_class = 0)
 	if(!check_rights(R_VAREDIT))


### PR DESCRIPTION
## What Does This PR Do
Rather than just nulling `click_intercept`, the atom picker will now quit itself (which qdels it). Fixes #29503
## Why It's Good For The Game
Functional mouseclicks for admins.
## Testing
Called procs using Visible Atom for their arguments. The procs worked, my clicks worked too.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Proc Call with Visible Atom will no longer screw with mouse clicks.
/:cl: