### PR TITLE
Update cling shield description so it doesn't claim it can auto-parry

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -216,7 +216,7 @@
 	/// Used for deleting gun after hitting something
 	var/hit_something = FALSE
 	/// True if we're shooting our shot -- used to track shooting to prevent deleting mid shot
-	var/shooting_right_now = FALSE 
+	var/shooting_right_now = FALSE
 
 /obj/item/gun/magic/tentacle/process_fire(atom/target, mob/living/user, message, params, zone_override, bonus_spread)
 	shooting_right_now = TRUE
@@ -411,7 +411,7 @@
 /datum/action/changeling/weapon/shield
 	name = "Organic Shield"
 	desc = "We reform one of our arms into a hard shield. Costs 20 chemicals."
-	helptext = "Organic tissue cannot resist damage forever, with the shield breaking after it is hit 6 times. Automatically parries. Cannot be used while in lesser form."
+	helptext = "Organic tissue cannot resist damage forever, with the shield breaking after it is hit 6 times. Can be used to parry attacks and projectiles. Cannot be used while in lesser form."
 	button_overlay_icon_state = "organic_shield"
 	chemical_cost = 20
 	dna_cost = 2


### PR DESCRIPTION
## What Does This PR Do
Automatic parrying was removed from the cling shield, this PR updates its description so it doesnt lie to players.
## Why It's Good For The Game
Lying is bad.
## Images of changes
![image](https://github.com/user-attachments/assets/b77e7214-ec9d-4da5-90e3-b05375f55689)
## Testing
Viewed ingame
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Cling shield description no longer says it can auto parry.
/:cl: