### PR TITLE
Statpanel properly renders modsuit control's icon

### DIFF
--- a/code/controllers/subsystem/SSstatpanel.dm
+++ b/code/controllers/subsystem/SSstatpanel.dm
@@ -269,7 +269,7 @@ SUBSYSTEM_DEF(statpanels)
 		if(ismob(thing) || length(thing.overlays) > 2)
 			generated_string = costly_icon2asset(thing, parent)
 		else
-			generated_string = icon2asset(thing, parent)
+			generated_string = icon2asset(thing, parent, thing.icon_state)
 
 		newly_seen[thing] = generated_string
 		if(TICK_CHECK)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Closes #26363

Fixes error modsuits on statpanel (sorry for cyrillic)

![short image](https://github.com/user-attachments/assets/fe867e3a-0c57-46b9-afe2-f4df52d18bfb)

`icon2asset` now receives icon state of a thing to render instead of always taking it as a `null`

this affects literally any atom btw, not only modsuits

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

proper icon render

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

no errors

![not so short image](https://github.com/user-attachments/assets/a43614d4-3048-450f-bca9-008ffad81591)

also everything is kinda the same with other items? so i don't think it'll break anything

![image](https://github.com/user-attachments/assets/5380a958-cdf0-44c4-a5dc-1c4bd3983f82)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

above

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Modsuits on statpanel won't be rendered as "ERROR" anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
