### PR TITLE
remove several cameras from maints

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -45630,10 +45630,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Security Pod";
-	dir = 5
-	},
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -34423,10 +34423,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera{
-	c_tag = "Research Escape Pod";
-	dir = 1
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "purplecorner"
@@ -46270,10 +46266,6 @@
 /area/station/command/office/blueshield)
 "iJv" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera{
-	c_tag = "Medbay Escape Pod";
-	dir = 1
-	},
 /obj/structure/chair/sofa/bench{
 	dir = 1;
 	cover_color = "#85130b"
@@ -82317,10 +82309,6 @@
 	},
 /area/station/security/lobby)
 "qGY" = (
-/obj/machinery/camera{
-	c_tag = "North Maint Escape Pod";
-	dir = 1
-	},
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -87564,10 +87552,6 @@
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/fsmaint)
 "rPj" = (
-/obj/machinery/camera{
-	c_tag = "Bridge Escape Pod";
-	dir = 1
-	},
 /obj/structure/chair/sofa/bench/right{
 	dir = 1;
 	cover_color = "#85130b"
@@ -92827,10 +92811,6 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/gambling_den)
 "sUD" = (
-/obj/machinery/camera{
-	c_tag = "Civilian Escape Pod";
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 0;
@@ -97486,10 +97466,6 @@
 /area/station/service/chapel)
 "tYJ" = (
 /obj/structure/table,
-/obj/machinery/camera{
-	c_tag = "Command Atmospherics Checkpoint";
-	dir = 6
-	},
 /obj/item/reagent_containers/syringe,
 /obj/item/storage/pill_bottle/random_drug_bottle,
 /turf/simulated/floor/plating,
@@ -102497,9 +102473,6 @@
 	},
 /area/station/hallway/primary/aft/west)
 "veg" = (
-/obj/machinery/camera{
-	c_tag = "Service Atmospherics Checkpoint"
-	},
 /obj/effect/landmark/spawner/nukedisc_respawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port2)
@@ -116727,10 +116700,6 @@
 /area/station/maintenance/disposal/external/southwest)
 "ylI" = (
 /obj/structure/table,
-/obj/machinery/camera{
-	c_tag = "Cargo Atmospherics Checkpoint";
-	dir = 8
-	},
 /obj/item/storage/toolbox/mechanical{
 	pixel_y = 5
 	},

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -59821,16 +59821,10 @@
 /area/space)
 "hEe" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/camera{
-	c_tag = "Research Break Room";
-	dir = 4;
-	network = list("Research","SS13")
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/port)
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/solar_maintenance/aft_port)
 "hEk" = (
 /obj/structure/closet/walllocker/emerglocker/directional/west,
 /obj/effect/turf_decal/delivery/hollow,
@@ -125215,7 +125209,7 @@ aaa
 aaa
 xDJ
 mbi
-jme
+hEe
 hJS
 xDJ
 aaa
@@ -132238,7 +132232,7 @@ drn
 ntF
 rvY
 nFq
-hEe
+mQi
 ptQ
 swS
 nhw


### PR DESCRIPTION
## What Does This PR Do
This PR removes several cameras which were in maintenance areas.
## Why It's Good For The Game
Our [mapping design guidelines](https://devdocs.paradisestation.org/mapping/design/) are clear that AI cameras are not permitted in maintenance. Most of these cameras are in areas that are unambiguously maintenance tunnels. There are a handful of gray areas but I've gone with precedent and my own intuition with them:

1. Atmos checkpoints: are within maintenance areas, and boxstation does not include cameras for them, so I have removed them from elsewhere.
2. Cameras outside solars: The design guidelines state that the sole exception in the prohibition of cameras in maints is just outside solar maintenance. This prohibition was intended to only be for boxstation, but other maps have had cameras added in similar locations. I'd rather not have this carveout at all but if we are going to have it I think it's a bad idea for it to only apply to one map, one which also happens to be our reference map, which one should reasonably be able to expect to mimic without running afoul of the guidelines. Will probably follow up with a change to the guidelines to remove the mention of Boxstation from this rule.
## Testing
Visual inspection.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
del: Several cameras in maintenance areas of various stations have been removed.
/:cl: