### PR TITLE
Moved Farragus Holodeck firelock to the correct position

### DIFF
--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -36752,6 +36752,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/station/public/fitness)
 "gDx" = (
@@ -91346,11 +91347,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/theatre)
-"sEG" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/public/fitness)
 "sES" = (
 /obj/machinery/door/airlock/public/glass{
 	autoclose = 0;
@@ -144091,7 +144087,7 @@ lTY
 pwt
 pwt
 pwt
-sEG
+pwt
 gDu
 kWu
 ddq


### PR DESCRIPTION
## What Does This PR Do

Moved a firelock on Farragus Holodeck one tile down so it is over a door instead of a window.

## Why It's Good For The Game

Inconsistent firelock positioning probably a mapping error, and mapping errors are bad.

## Testing

Booted up testserver, checked location of firelock

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Moved a firelock on Farragus holodeck to the correct position
/:cl: