### PR TITLE
MODSuit clothing icon files can be overridden by its skin

### DIFF
--- a/code/__DEFINES/mod.dm
+++ b/code/__DEFINES/mod.dm
@@ -40,6 +40,14 @@
 // Flags for skin modifiers
 #define MAKE_SPACEPROOF (1<<0)
 
-//Defines used to override MOD clothing's icon and worn icon files in the skin.
+// Defines used to override MOD clothing's icon, worn icon and sprite sheets files in the skin.
 #define MOD_ICON_OVERRIDE "mod_icon_override"
 
+#define MOD_WORN_ICON_OVERRIDE "mod_worn_icon_override"
+
+#define MOD_SPRITE_SHEETS_OVERRIDE "mod_sprite_sheets_override"
+
+#define HELMET_SPRITE_SHEETS "helmet_sprite_sheets"
+#define CHESTPLATE_SPRITE_SHEETS "chestplate_sprite_sheets"
+#define GAUNTLETS_SPRITE_SHEETS "gauntlets_sprite_sheets"
+#define BOOTS_SPRITE_SHEETS "boots_sprite_sheets"

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -986,3 +986,10 @@
 /proc/lists_equal_unordered(list/list_one, list/list_two)
 	// This ensures that both lists contain the same elements by checking if the difference between them is empty in both directions.
 	return !length(list_one ^ list_two)
+
+/// Tries to return a value of input[key1][key2] if both keys exist, otherwise returns null
+/proc/get_nested_value(list/input, key1, key2)
+	var/list/check_exist = input[key1]
+	if(!islist(check_exist))
+		return
+	return check_exist[key2]

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -163,8 +163,6 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	var/list/sprite_sheets_inhand
 	/// Used to override hardcoded clothing dmis in human clothing proc.
 	var/icon_override
-	/// Used to override hardcoded clothing inventory object dmis in human clothing proc.
-	var/sprite_sheets_obj
 
 	//Tooltip vars
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -116,18 +116,6 @@
 
 	return TRUE
 
-/obj/item/clothing/proc/refit_for_species(target_species)
-	//Set icon
-	if(sprite_sheets && (target_species in sprite_sheets))
-		icon_override = sprite_sheets[target_species]
-	else
-		icon_override = initial(icon_override)
-
-	if(sprite_sheets_obj && (target_species in sprite_sheets_obj))
-		icon = sprite_sheets_obj[target_species]
-	else
-		icon = initial(icon)
-
 /**
   * Used for any clothing interactions when the user is on fire. (e.g. Cigarettes getting lit.)
   */

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -30,13 +30,6 @@
 		"Drask" = 'icons/mob/clothing/species/drask/helmet.dmi',
 		"Grey" = 'icons/mob/clothing/species/grey/helmet.dmi'
 		)
-	sprite_sheets_obj = list(
-		"Unathi" = 'icons/obj/clothing/species/unathi/hats.dmi',
-		"Tajaran" = 'icons/obj/clothing/species/tajaran/hats.dmi',
-		"Skrell" = 'icons/obj/clothing/species/skrell/hats.dmi',
-		"Vox" = 'icons/obj/clothing/species/vox/hats.dmi',
-		"Vulpkanin" = 'icons/obj/clothing/species/vulpkanin/hats.dmi'
-		)
 
 /obj/item/clothing/head/helmet/space/hardsuit/Initialize(mapload)
 	. = ..()
@@ -155,13 +148,6 @@
 		"Vox" = 'icons/mob/clothing/species/vox/suit.dmi',
 		"Vulpkanin" = 'icons/mob/clothing/species/vulpkanin/suit.dmi',
 		"Drask" = 'icons/mob/clothing/species/drask/suit.dmi'
-		)
-	sprite_sheets_obj = list(
-		"Unathi" = 'icons/obj/clothing/species/unathi/suits.dmi',
-		"Tajaran" = 'icons/obj/clothing/species/tajaran/suits.dmi',
-		"Skrell" = 'icons/obj/clothing/species/skrell/suits.dmi',
-		"Vox" = 'icons/obj/clothing/species/vox/suits.dmi',
-		"Vulpkanin" = 'icons/obj/clothing/species/vulpkanin/suits.dmi'
 		)
 
 	var/obj/item/clothing/head/helmet/space/hardsuit/helmet

--- a/code/modules/clothing/spacesuits/misc_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/misc_spacesuits.dm
@@ -183,9 +183,6 @@
 		"Unathi" = 'icons/mob/clothing/species/unathi/helmet.dmi',
 		"Vulpkanin" = 'icons/mob/clothing/species/vulpkanin/helmet.dmi',
 		)
-	sprite_sheets_obj = list(
-		"Vox" = 'icons/obj/clothing/species/vox/hats.dmi'
-		)
 
 /obj/item/clothing/suit/space/eva/paramedic
 	name = "paramedic EVA suit"
@@ -203,9 +200,6 @@
 		"Unathi" = 'icons/mob/clothing/species/unathi/suit.dmi',
 		"Vulpkanin" = 'icons/mob/clothing/species/vulpkanin/suit.dmi',
 		)
-	sprite_sheets_obj = list(
-		"Vox" = 'icons/obj/clothing/species/vox/suits.dmi'
-		)
 
 /obj/item/clothing/suit/space/eva
 	name = "EVA suit"
@@ -219,12 +213,6 @@
 		"Unathi" = 'icons/mob/clothing/species/unathi/suit.dmi',
 		"Vox" = 'icons/mob/clothing/species/vox/suit.dmi',
 		"Vulpkanin" = 'icons/mob/clothing/species/vulpkanin/suit.dmi',
-		)
-	sprite_sheets_obj = list(
-		"Tajaran" = 'icons/obj/clothing/species/tajaran/suits.dmi',
-		"Unathi" = 'icons/obj/clothing/species/unathi/suits.dmi',
-		"Vox" = 'icons/obj/clothing/species/vox/suits.dmi',
-		"Vulpkanin" = 'icons/obj/clothing/species/vulpkanin/suits.dmi'
 		)
 
 /obj/item/clothing/head/helmet/space/eva
@@ -243,10 +231,6 @@
 		"Vulpkanin" = 'icons/mob/clothing/species/vulpkanin/helmet.dmi',
 		"Grey" = 'icons/mob/clothing/species/grey/helmet.dmi'
 		)
-	sprite_sheets_obj = list(
-		"Vox" = 'icons/obj/clothing/species/vox/hats.dmi',
-		"Vulpkanin" = 'icons/obj/clothing/species/vulpkanin/hats.dmi'
-		)
 
 //Mime's Hardsuit
 /obj/item/clothing/head/helmet/space/eva/mime
@@ -255,9 +239,7 @@
 	desc = ". . ."
 	icon_state = "spacemimehelmet"
 	item_state = "spacemimehelmet"
-	sprite_sheets = list(
-		"Vox" = 'icons/mob/clothing/species/vox/helmet.dmi')
-	sprite_sheets_obj = null
+	sprite_sheets = list("Vox" = 'icons/mob/clothing/species/vox/helmet.dmi')
 
 /obj/item/clothing/suit/space/eva/mime
 	name = "mime EVA suit"
@@ -265,9 +247,7 @@
 	desc = ". . ."
 	icon_state = "spacemime_suit"
 	item_state = "spacemime_items"
-	sprite_sheets = list(
-		"Vox" = 'icons/mob/clothing/species/vox/suit.dmi')
-	sprite_sheets_obj = null
+	sprite_sheets = list("Vox" = 'icons/mob/clothing/species/vox/suit.dmi')
 
 /obj/item/clothing/head/helmet/space/eva/clown
 	name = "clown EVA helmet"
@@ -275,9 +255,7 @@
 	desc = "An EVA helmet specifically designed for the clown. SPESSHONK!"
 	icon_state = "clownhelmet"
 	item_state = "clownhelmet"
-	sprite_sheets = list(
-		"Vox" = 'icons/mob/clothing/species/vox/helmet.dmi')
-	sprite_sheets_obj = null
+	sprite_sheets = list("Vox" = 'icons/mob/clothing/species/vox/helmet.dmi')
 
 /obj/item/clothing/suit/space/eva/clown
 	name = "clown EVA suit"
@@ -285,6 +263,4 @@
 	desc = "An EVA suit specifically designed for the clown. SPESSHONK!"
 	icon_state = "spaceclown_suit"
 	item_state = "spaceclown_items"
-	sprite_sheets = list(
-		"Vox" = 'icons/mob/clothing/species/vox/suit.dmi')
-	sprite_sheets_obj = null
+	sprite_sheets = list("Vox" = 'icons/mob/clothing/species/vox/suit.dmi')


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Kinda finishes porting of https://github.com/tgstation/tgstation/pull/65733

It was ported only particularly by Qwerty and never actually worked
We also have sprite_sheets, so i added support for them as well

Removes outdated proc `refit_for_species` - it messed up with `icon_override` and we don't use it at all

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Only good for downstreams. Otherwise no affect (maybe a bit less performance i believe cos of added procs?)
We had to do some real shit to create modsuits on SS220, with these changes it will be much more easier

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Tested on downstream. It worked, no runtimes. Also tested on upstream (there), spawned some modsuits - nothing has changed, everything is working as always

Here is an example of how `skins` looks like on downstream with the changes. It might be shortened by using defines, tho

![image](https://github.com/user-attachments/assets/0b77e21f-ad39-4852-b0af-df2d0e80d2eb)

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
