### PR TITLE
Tweak modsuit's pinned modules and stabilize jetpack by default

### DIFF
--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -53,6 +53,9 @@
 		/obj/item/mod/module/flashlight,
 		/obj/item/mod/module/jetpack
 	)
+	default_pins = list(
+		/obj/item/mod/module/jetpack,
+	)
 
 /obj/item/mod/control/pre_equipped/engineering
 	theme = /datum/mod_theme/engineering
@@ -187,6 +190,10 @@
 		/obj/item/mod/module/dispenser/mirage,
 		/obj/item/mod/module/jetpack,
 	)
+	default_pins = list(
+		/obj/item/mod/module/jetpack,
+		/obj/item/mod/module/dispenser/mirage,
+	)
 
 /obj/item/mod/control/pre_equipped/safeguard
 	theme = /datum/mod_theme/safeguard
@@ -200,6 +207,7 @@
 	)
 	default_pins = list(
 		/obj/item/mod/module/jetpack/advanced,
+		/obj/item/mod/module/dispenser/mirage,
 	)
 
 /obj/item/mod/control/pre_equipped/safeguard/gamma
@@ -211,9 +219,6 @@
 		/obj/item/mod/module/jetpack/advanced,
 		/obj/item/mod/module/holster,
 		/obj/item/mod/module/energy_shield/gamma,
-	)
-	default_pins = list(
-		/obj/item/mod/module/jetpack/advanced,
 	)
 
 /obj/item/mod/control/pre_equipped/praetorian
@@ -238,7 +243,6 @@
 	default_pins = list(
 		/obj/item/mod/module/jetpack/advanced,
 	)
-	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF // Theft targets should be hard to destroy
 
 /obj/item/mod/control/pre_equipped/magnate/Initialize(mapload)
 	. = ..()
@@ -249,6 +253,9 @@
 	applied_modules = list(
 		/obj/item/mod/module/storage,
 		/obj/item/mod/module/waddle,
+		/obj/item/mod/module/bikehorn,
+	)
+	default_pins = list(
 		/obj/item/mod/module/bikehorn,
 	)
 
@@ -339,7 +346,6 @@
 /obj/item/mod/control/pre_equipped/prototype
 	starting_frequency = MODLINK_FREQ_THETA
 	theme = /datum/mod_theme/prototype
-	req_access = list()
 	applied_modules = list(
 		/obj/item/mod/module/storage,
 		/obj/item/mod/module/welding,
@@ -366,6 +372,10 @@
 		/obj/item/mod/module/magboot/advanced,
 		/obj/item/mod/module/jetpack/advanced,
 		/obj/item/mod/module/ert_camera,
+	)
+	default_pins = list(
+		/obj/item/mod/module/jetpack/advanced,
+		/obj/item/mod/module/magboot/advanced,
 	)
 	/// The insignia type, insignias show what sort of member of the ERT you're dealing with.
 	var/insignia_type = /obj/item/mod/module/insignia
@@ -515,6 +525,7 @@
 	)
 	default_pins = list(
 		/obj/item/mod/module/bikehorn,
+		/obj/item/mod/module/jetpack/advanced,
 	)
 	activation_step_time = 0.1 SECONDS // coders are cooler than admins
 

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -128,7 +128,7 @@
 	overlay_state_inactive = "module_jetpack"
 	overlay_state_active = "module_jetpack_on"
 	/// Do we stop the wearer from gliding in space.
-	var/stabilize = FALSE
+	var/stabilize = TRUE
 	var/thrust_callback
 
 /obj/item/mod/module/jetpack/Initialize(mapload)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Adds some nice modules to default pins

Stabilizes jetpack module by default - it's better on than off and you don't anymore have to do like 6 clicks every single time to enable stab

Removes resistance flags from magnate mod, flags are added on Initialize() by magnate's theme, no need to duplicate it
Removes empty req_access from prototype mod (did nothing)

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Jetpacks should be pinned by default, they drain battery by a lot and you want to switch their states in 1 click or even bind it to some key

All modsuits now have their jetpacks pinned - was weird that it vary from mod to mod

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiles. Selected debug mod, it had pinned jetpack module and i wasn't drifting in space

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Some modsuits now have more pinned modules by default.
tweak: Jetpack modsuit module is now stabilized by default.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
