### PR TITLE
Fixes Kinetic Assembler and Scientific Assembler's missing open closed states, makes RPED work on them

### DIFF
--- a/code/modules/smithing/machinery/kinetic_assembler.dm
+++ b/code/modules/smithing/machinery/kinetic_assembler.dm
@@ -63,6 +63,8 @@
 	. = ..()
 	if(panel_open)
 		icon_state = "assembler_wires"
+	else
+		icon_state = "assembler"
 
 /obj/machinery/smithing/kinetic_assembler/default_deconstruction_screwdriver(mob/user, icon_state_open, icon_state_closed, obj/item/I)
 	. = ..()
@@ -117,6 +119,9 @@
 			return
 
 /obj/machinery/smithing/kinetic_assembler/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	if(istype(used, /obj/item/storage/part_replacer))
+		return ..()
+
 	if(operating)
 		to_chat(user, "<span class='warning'>[src] is still operating!</span>")
 		return ITEM_INTERACT_COMPLETE
@@ -291,8 +296,10 @@
 	. = ..()
 	if(panel_open)
 		icon_state = "assembler_wires"
+	else
+		icon_state = "assembler"
 
-/obj/machinery/smithing/kinetic_assembler/default_deconstruction_screwdriver(mob/user, icon_state_open, icon_state_closed, obj/item/I)
+/obj/machinery/smithing/scientific_assembler/default_deconstruction_screwdriver(mob/user, icon_state_open, icon_state_closed, obj/item/I)
 	. = ..()
 	update_icon(UPDATE_ICON_STATE)
 
@@ -303,6 +310,9 @@
 		icon_state = "assembler_wires"
 
 /obj/machinery/smithing/scientific_assembler/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	if(istype(used, /obj/item/storage/part_replacer))
+		return ..()
+
 	if(operating)
 		to_chat(user, "<span class='warning'>[src] is still operating!</span>")
 		return ITEM_INTERACT_COMPLETE


### PR DESCRIPTION
## What Does This PR Do
Fixes a wrong path for the scientific assemblers screwdriver interaction, adds missing closed wire panel icon states for both machines, makes both machines upgradeable by a regular RPED. Fixes #29605
## Why It's Good For The Game
Bugs bad. Lack of upgrades bad.
## Testing
Unscrewed and screwed the 2 assemblers, upgraded both assemblers with a regular RPED.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Scientific and Kinetic assembler will appropriately update their icon state, whether their panel is open or closed.
fix: Scientific and Kinetic assembler are both upgradeable by a normal RPED.
/:cl: