### PR TITLE
Tweak autodoc for some update_appearence related procs

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -499,12 +499,14 @@
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE_MORE, user, .)
 
 /**
- * Updates the appearence of the icon
+ * Updates the appearence of the atom, including text.
  *
  * Mostly delegates to update_name, update_desc, and update_icon
  *
  * Arguments:
  * - updates: A set of bitflags dictating what should be updated. Defaults to [ALL]
+ * 
+ * Supported bitflags: UPDATE_NAME, UPDATE_DESC, UPDATE_ICON
  */
 /atom/proc/update_appearance(updates=ALL)
 	SHOULD_NOT_SLEEP(TRUE)
@@ -531,7 +533,16 @@
 	PROTECTED_PROC(TRUE)
 	return SEND_SIGNAL(src, COMSIG_ATOM_UPDATE_DESC, updates)
 
-/// Updates the icon of the atom
+/**
+ * Updates the icon and overlays of the atom
+ *
+ * Mostly delegates to update_icon_state and update_overlays
+ *
+ * Arguments:
+ * - updates: A set of bitflags dictating what should be updated. Defaults to [ALL]
+ * 
+ * Supported bitflags: UPDATE_ICON_STATE, UPDATE_OVERLAYS
+ */
 /atom/proc/update_icon(updates=ALL)
 	SIGNAL_HANDLER
 	SHOULD_CALL_PARENT(TRUE)
@@ -558,12 +569,22 @@
 
 	SEND_SIGNAL(src, COMSIG_ATOM_UPDATED_ICON, updates)
 
-/// Updates the icon state of the atom
+/**
+ * Updates the icon state of the atom
+ *
+ * Excluding the base proc, or child overrides that do not intend to change the icon_state, this proc needs a minimum of two possible icon_states, otherwise it effectively becomes permanent and a redundant proc.
+ */
 /atom/proc/update_icon_state()
 	PROTECTED_PROC(TRUE)
 	return
 
-/// Updates the overlays of the atom. It has to return a list of overlays if it can't call the parent to create one. The list can contain anything that would be valid for the add_overlay proc: Images, mutable appearances, icon states...
+/**
+ * Updates the managed overlays of the atom
+ *
+ * Old overlays from this proc are removed when called, and does not affect overlays from outside it. e.g. add_overlay() called independently in a different proc.
+ *
+ * It has to return a list of overlays if it can't call the parent to create one. The list can contain anything that would be valid for the add_overlay proc: Images, mutable appearances, icon state names...
+ */
 /atom/proc/update_overlays()
 	PROTECTED_PROC(TRUE)
 	. = list()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes some of the autodoc for update_appearence and its related procs to be more descriptive, noting the available bitflags, or certain quirks/behaviors related to them.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

![Auto](https://github.com/user-attachments/assets/5905c55a-35fe-400c-aca3-1f17cb712e2a)

## Testing
Parsed the codebase, also compiled just in case.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
