### PR TITLE
Prevent AI queen bees from leaving the apiary

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -323,6 +323,11 @@
 	QDEL_NULL(queen)
 	return ..()
 
+/mob/living/simple_animal/hostile/poison/bees/queen/consider_wakeup()
+	if(beehome && loc == beehome) // The queen is home and doesn't have to do anything.
+		return
+	return ..()
+
 /mob/living/simple_animal/hostile/poison/bees/consider_wakeup()
 	if(beehome && loc == beehome) // If bees are chilling in their nest, they're not actively looking for targets
 		idle = min(100, ++idle)


### PR DESCRIPTION
## What Does This PR Do
Prevents AI queen bees from leaving the apiary. From what I can tell, queen bees weren't intended to be able to leave their apiary and lack the code that lets them go back into one. Queen bees will not leave the apiary and their AI will remain idle, unless they've somehow been forced out of the apiary, either it being destroyed or admin shenanigans. Fixes #29608
## Why It's Good For The Game
Keeping the queen in the apiary lets you split her with royal jelly and change her reagent.
## Testing
Watched bees for 30 minutes. Split a queen with royal jelly.
Sentient queen bees can leave the apiary and if they return into it, they're able to be taken out like normal.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Queen bees won't leave their apiaries on their own anymore.
/:cl: