### PR TITLE
Add R_VIEWLOGS permission.

### DIFF
--- a/code/__DEFINES/admin_defines.dm
+++ b/code/__DEFINES/admin_defines.dm
@@ -40,9 +40,10 @@
 #define R_VIEWRUNTIMES	(1<<16)
 #define R_MAINTAINER	(1<<17)
 #define R_DEV_TEAM		(1<<18)
+#define R_VIEWLOGS		(1<<19)
 // Update the following two defines if you add more
 
-#define R_MAXPERMISSION (1<<18) // This holds the maximum value for a permission. It is used in iteration, so keep it updated.
+#define R_MAXPERMISSION (1<<19) // This holds the maximum value for a permission. It is used in iteration, so keep it updated.
 
 #define R_HOST			(~0) // Sum of all permissions to allow easy setting.
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -274,6 +274,10 @@ GLOBAL_LIST_INIT(view_runtimes_verbs, list(
 	/client/proc/visualize_interesting_turfs,
 	/client/proc/profile_code
 ))
+GLOBAL_LIST_INIT(view_logs_verbs, list(
+	/client/proc/getserverlogs,
+	/client/proc/get_server_logs_by_round_id,
+))
 
 /client/proc/add_admin_verbs()
 	if(holder)
@@ -323,6 +327,8 @@ GLOBAL_LIST_INIT(view_runtimes_verbs, list(
 				control_freak = 0
 		if(holder.rights & R_DEV_TEAM)
 			add_verb(src, GLOB.admin_verbs_dev)
+		if(holder.rights & R_VIEWLOGS)
+			add_verb(src, GLOB.view_logs_verbs)
 		if(is_connecting_from_localhost())
 			add_verb(src, /client/proc/export_current_character)
 

--- a/code/modules/admin/verbs/getlogs.dm
+++ b/code/modules/admin/verbs/getlogs.dm
@@ -4,7 +4,7 @@
 	set desc = "View/retrieve logfiles."
 	set category = "Admin"
 
-	if(!check_rights(R_ADMIN))
+	if(!check_rights(R_ADMIN|R_VIEWLOGS))
 		return
 
 	access_file_by_browsing_path(usr, "data/logs/")
@@ -15,7 +15,7 @@
 	set desc = "View/retrieve logfiles for a given round."
 	set category = "Admin"
 
-	if(!check_rights(R_ADMIN))
+	if(!check_rights(R_ADMIN|R_VIEWLOGS))
 		return
 
 	var/round_id = input(usr, "Enter a round ID.", "Enter Round ID", "[GLOB.round_id]") as null|text


### PR DESCRIPTION
## What Does This PR Do
This PR adds a distinct permission bitfield for viewing log files, which can be used in place of R_ADMIN when viewing server logs. They still show up in the Admin tab but that's fine because everyone gets one of those anyways.
## Why It's Good For The Game
Fine-grained/flexible permissions are good, and this allows us to give permissions for the dev team to view logs when necessary.
## Testing
Looked at.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

Staff approved.
## Changelog
NPFC