### PR TITLE
Tweak: Makes ore redemption machines take in sheets from the input side

### DIFF
--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -48,6 +48,7 @@
 	/// The currently inserted design disk.
 	var/obj/item/disk/design_disk/inserted_disk
 	var/datum/component/material_container/mat_container
+	var/invalid_material
 
 
 /obj/machinery/mineral/ore_redemption/Initialize(mapload)
@@ -149,8 +150,14 @@
 	for(var/obj/item/stack/stack in input)
 		if(QDELETED(stack))
 			return
-		mat_container.insert_stack(stack, stack.amount)
+		if(!mat_container.insert_stack(stack, stack.amount))
+			stack.forceMove(get_step(src, output_dir))
+			invalid_material = TRUE
 		CHECK_TICK
+	if(invalid_material)
+		playsound(src, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
+		atom_say("ERROR - Spitting out invalid materials.")
+		invalid_material = FALSE
 	// Process it
 	if(length(ore_buffer))
 		message_sent = FALSE

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -47,11 +47,12 @@
 	var/datum/research/files
 	/// The currently inserted design disk.
 	var/obj/item/disk/design_disk/inserted_disk
+	var/datum/component/material_container/mat_container
 
 
 /obj/machinery/mineral/ore_redemption/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/material_container, list(MAT_METAL, MAT_GLASS, MAT_SILVER, MAT_GOLD, MAT_DIAMOND, MAT_PLASMA, MAT_URANIUM, MAT_BANANIUM, MAT_TRANQUILLITE, MAT_TITANIUM, MAT_BLUESPACE, MAT_PLATINUM, MAT_IRIDIUM, MAT_PALLADIUM), INFINITY, FALSE, /obj/item/stack, null, CALLBACK(src, PROC_REF(on_material_insert)))
+	mat_container = AddComponent(/datum/component/material_container, list(MAT_METAL, MAT_GLASS, MAT_SILVER, MAT_GOLD, MAT_DIAMOND, MAT_PLASMA, MAT_URANIUM, MAT_BANANIUM, MAT_TRANQUILLITE, MAT_TITANIUM, MAT_BLUESPACE, MAT_PLATINUM, MAT_IRIDIUM, MAT_PALLADIUM), INFINITY, FALSE, /obj/item/stack, null, CALLBACK(src, PROC_REF(on_material_insert)))
 	ore_buffer = list()
 	files = new /datum/research/smelter(src)
 	// Stock parts
@@ -144,6 +145,11 @@
 			continue
 		ore_buffer |= O
 		O.forceMove(src)
+		CHECK_TICK
+	for(var/obj/item/stack/stack in input)
+		if(QDELETED(stack))
+			return
+		mat_container.insert_stack(stack, stack.amount)
 		CHECK_TICK
 	// Process it
 	if(length(ore_buffer))


### PR DESCRIPTION
## What Does This PR Do
Makes ore redemption machines take in sheets from the input side. Sheets go through the material containers' `insert_stack` proc, like it would if it was manually inserted by a player. There, sheets that aren't accepted by the ORM get filtered out, meanwhile accepted sheets are inserted into it.

Invalid sheets will get spit out the output side, with a buzz and a message notifying crew that the material is invalid. Also, prevents needless processing if someone dumps 100 invalid stacks in the input.
## Why It's Good For The Game
With the Smith being responsible to bring refined materials up to station, there's a lot of tedium in inserting all the sheets in the ORM. This will permit smiths to just dump a crate of mats in the input, much like miners do with ore.
## Images of changes

![image](https://github.com/user-attachments/assets/bfcd4fac-7deb-4b6a-95ce-b9a66364f867)


https://github.com/user-attachments/assets/932e1aa7-4aaa-4991-a421-2dcf1aca1b91

## Testing
Spawned one of every single sheet, in order to insert into the ORM. All the sheets not accepted by the ORM remained outside. Verified that I can insert each single visible sheet by hand as well.

Confirmed that the ORM spits out unaccepted sheets.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: Ore Redemption Machine can auto-insert sheets from its input.
tweak: Ore Redemption Machine will spit out invalid sheets on its output side with an auditory beep.
/:cl: