### PR TITLE
Fix legions on lavaland not moving

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/hivelord.dm
@@ -192,9 +192,6 @@
 	var/dwarf_mob = FALSE
 	var/mob/living/carbon/human/stored_mob
 
-/mob/living/simple_animal/hostile/asteroid/hivelord/legion/Process_Spacemove(movement_dir, continuous_move)
-	return FALSE
-
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion/dwarf
 	name = "dwarf legion"
 	desc = "You can still see what was once a dwarf under the shifting mass of corruption."


### PR DESCRIPTION
## What Does This PR Do
`handle_automated_movement` relies on `Process_Spacemove` to check whether or not a mob is allowed to move. That's where gravity checks happen, lattice checks. With legions returning FALSE on it, they never go through these checks and will always fail movement. Fixes #29617
## Why It's Good For The Game
Functional AI good.
## Testing
Loaded lavaland, observed legions moving around.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
Fix: Legions are capable of moving again.
/:cl: