### PR TITLE
add R_VIEWLOGS to /proc/rights2text()

### DIFF
--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -153,6 +153,7 @@
 	if(rights & R_VIEWRUNTIMES)	. += "[seperator]+VIEWRUNTIMES"
 	if(rights & R_MAINTAINER)	. += "[seperator]+MAINTAINER"
 	if(rights & R_DEV_TEAM)		. += "[seperator]+DEV_TEAM"
+	if(rights & R_VIEWLOGS)		. += "[seperator]+VIEWLOGS"
 
 /proc/ui_style2icon(ui_style)
 	switch(ui_style)


### PR DESCRIPTION
## What Does This PR Do
This PR adds R_VIEWLOGS to /proc/rights2text() so that it can actually be seen in the permissions list when added.
## Why It's Good For The Game
A bunch of permissions-related code will act funny if this proc isn't complete.
## Testing
Used permissions panel, ensured all permissions showed up as expected.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC