### PR TITLE
Make lesser form update flavor text appropriately

### DIFF
--- a/code/modules/antagonists/changeling/powers/humanform.dm
+++ b/code/modules/antagonists/changeling/powers/humanform.dm
@@ -22,7 +22,7 @@
 	user.dna = chosen_dna.Clone()
 	user.real_name = chosen_dna.real_name
 	domutcheck(user, MUTCHK_FORCED)
-	user.flavor_text = ""
+	user.flavor_text = chosen_dna.flavor_text
 	user.dna.UpdateSE()
 	user.dna.UpdateUI()
 	user.sync_organ_dna(1)

--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -25,6 +25,7 @@
 
 	H.visible_message("<span class='warning'>[H] transforms!</span>")
 	to_chat(H, "<span class='warning'>Our genes cry out!</span>")
+	H.flavor_text = ""
 	H.monkeyize()
 
 	H.adjustBruteLoss(brute_damage)


### PR DESCRIPTION
## What Does This PR Do
Transforming into a monkey with Lesser Form will null your flavor text. Transforming back into a human will update your flavor text according to the DNA. Fixes #25477
## Why It's Good For The Game
Prevents monkey clings from getting meta'd with flavor text.
## Images of changes

![image](https://github.com/user-attachments/assets/318dc28d-8cc0-496d-a9bf-93e60b4112ba)

## Testing
Transformed a flavorful moth into a monkey, flavor text cleared itself. Transformed back into a moth, flavor text updated back to the moths.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Changeling lesser form will update flavor text.
/:cl: