### PR TITLE
Fix ghosts getting double messages when true observing

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -166,9 +166,6 @@
 				var/mob/camera/eye/ai/eye = this_mob
 				if((ai_eyes == AI_EYE_INCLUDE || eye.relay_speech) && eye.ai && (!client_check || eye.ai.client))
 					mobs |= eye.ai
-			for(var/mob/dead/observer/ghost in this_mob.observers)
-				if(!client_check || ghost.client)
-					mobs += ghost
 		if(!length(next_layer))
 			return
 


### PR DESCRIPTION
## What Does This PR Do
Removes a check which adds true observers to the mob list. Observers are already caught in a prior check (line 164) and checking a second time ends up returning a list with doubled observers.
## Why It's Good For The Game
Prevents getting doubled messages when visible_message, atom_say, or anything else that uses get_mobs_in_view.
## Images of changes

https://github.com/user-attachments/assets/3e1efb22-00c3-4ac2-b502-3f77ca1b73e0

## Testing
I tested speaking, emoting and attacking. All messages went through and reached the observer, whether the observer was orbiting or true observing. Also tested speaking and emotes from the same character the observer is true observing.

atom_say also goes through.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Ghosts won't get doubled messages when observing someone.
/:cl: