### PR TITLE
Various vending machine fixes

### DIFF
--- a/code/game/machinery/vendors/custom_vendors.dm
+++ b/code/game/machinery/vendors/custom_vendors.dm
@@ -28,7 +28,7 @@
 	return linked_pos?.linked_account || ..()
 
 /obj/machinery/economy/vending/custom/item_interaction(mob/living/user, obj/item/used, list/modifiers)
-	if(user.a_intent == INTENT_HARM)
+	if(user.a_intent == INTENT_HARM || (used.flags & ABSTRACT))
 		return ..()
 
 	if((isnull(linked_pos) || locked(user) != VENDOR_LOCKED) && istype(used, /obj/item/eftpos))
@@ -50,6 +50,10 @@
 
 /// Tries to add something to the vendor. can_wait returns INSERT_NEEDS_INPUT if it would wait for user input, quiet suppresses success messages, and bag is used when the item is being transferred from a storage item.
 /obj/machinery/economy/vending/custom/proc/try_add_stock(mob/living/user, obj/item/used, can_wait = TRUE, quiet = FALSE, obj/item/storage/bag = null)
+	if(istype(used, /obj/item/holder))
+		to_chat(user, "<span class='warning'>[used] wriggles out of your hands!</span>")
+		user.drop_item_to_ground(used)
+		return INSERT_FAIL
 	if(isnull(bag) && !user.canUnEquip(used, FALSE))
 		to_chat(user, "<span class='warning'>\The [used] is stuck to your hand!</span>")
 		return INSERT_FAIL
@@ -76,7 +80,7 @@
 					user.unequip(used)
 				else
 					bag.remove_from_storage(used)
-				used.moveToNullspace()
+				used.forceMove(src)
 				if(!quiet)
 					user.visible_message("<span class='notice'>[user] puts [used] into [src].</span>", "<span class='notice>'You put [used] into [src].</span>")
 				return INSERT_DONE
@@ -114,7 +118,7 @@
 		user.unequip(used)
 	else
 		bag.remove_from_storage(used)
-	used.moveToNullspace()
+	used.forceMove(src)
 	if(!quiet)
 		user.visible_message("<span class='notice'>[user] puts [used] into [src].</span>", "<span class='notice'>You put [used] into [src].</span>")
 	return INSERT_DONE

--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -1034,6 +1034,10 @@
 		var/damage = squish_damage
 		var/picked_angle = pick(90, 270)
 		var/should_crit = !from_combat && crit
+		var/turf/turf = get_turf(victim)
+		for(var/obj/thing in turf)
+			if(thing.flags & ON_BORDER) // Crush directional windows, flipped tables and windoors.
+				thing.deconstruct(FALSE, TRUE)
 		if(!crit && !from_combat)
 			// only deal this extra bit of damage if they wouldn't otherwise be taking the double damage from critting
 			damage *= self_knockover_factor
@@ -1043,6 +1047,8 @@
 			tilted = TRUE
 			anchored = FALSE
 			layer = ABOVE_MOB_LAYER
+			return TRUE
+		return FALSE
 
 	var/should_throw_at_target = TRUE
 


### PR DESCRIPTION
## What Does This PR Do
custom vendor now ignores abstract items (like slappers)
## Why It's Good For The Game
Prevents buggy, unpredictable behaviours.
## Testing
Tipped vendors on myself, tried selling various things, tried selling a slapper and a grab.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Custom vendors will no longer accept abstract items for sale.
/:cl: