### PR TITLE
Allow ahudded or no respawnability ghosts to spawn in ghost b ar

### DIFF
--- a/code/modules/awaymissions/mob_spawn.dm
+++ b/code/modules/awaymissions/mob_spawn.dm
@@ -52,6 +52,10 @@
 	var/death_cooldown = 0
 	/// If antagbanned people are prevented from using it, only false for the ghost bar spawner.
 	var/restrict_antagban = TRUE
+	/// If people without respawnability are prevented from using it.
+	var/restrict_respawnability = TRUE
+	/// If late-observers with ahud are prevented from using it.
+	var/restrict_ahud = TRUE
 
 /obj/effect/mob_spawn/attack_ghost(mob/user)
 	if(!valid_to_spawn(user))
@@ -107,12 +111,12 @@
 	if((jobban_isbanned(user, ban_type) || (restrict_antagban && jobban_isbanned(user, ROLE_SYNDICATE))))
 		to_chat(user, "<span class='warning'>You are jobanned!</span>")
 		return FALSE
-	if(!HAS_TRAIT(user, TRAIT_RESPAWNABLE))
+	if(!HAS_TRAIT(user, TRAIT_RESPAWNABLE) && restrict_respawnability)
 		to_chat(user, "<span class='warning'>You currently do not have respawnability!</span>")
 		return FALSE
 	if(isobserver(user))
 		var/mob/dead/observer/O = user
-		if(!O.check_ahud_rejoin_eligibility())
+		if(!O.check_ahud_rejoin_eligibility() && restrict_ahud)
 			to_chat(user, "<span class='warning'>Upon using the antagHUD you forfeited the ability to join the round.</span>")
 			return FALSE
 	if(time_check(user))

--- a/code/modules/ruins/ghost_bar.dm
+++ b/code/modules/ruins/ghost_bar.dm
@@ -12,6 +12,8 @@ GLOBAL_LIST_EMPTY(occupants_by_key)
 	assignedrole = "Ghost Bar Occupant"
 	death_cooldown = 1 MINUTES
 	restrict_antagban = FALSE
+	restrict_respawnability = FALSE
+	restrict_ahud = FALSE
 
 /obj/effect/mob_spawn/human/alive/ghost_bar/create(ckey, flavour = TRUE, name, mob/user = usr) // So divorced from the normal proc it's just being overriden
 	var/datum/character_save/save_to_load
@@ -79,7 +81,10 @@ GLOBAL_LIST_EMPTY(occupants_by_key)
 	H.mind.special_role = assignedrole
 	H.mind.offstation_role = TRUE
 	ADD_TRAIT(H, TRAIT_PACIFISM, GHOST_ROLE)
-	ADD_TRAIT(H, TRAIT_RESPAWNABLE, GHOST_ROLE)
+	if(isobserver(user))
+		var/mob/dead/observer/ghost = user
+		if(ghost.can_reenter_corpse)
+			ADD_TRAIT(H, TRAIT_RESPAWNABLE, GHOST_ROLE)
 
 	H.key = ckey
 	H.dna.species.after_equip_job(/datum/job/assistant, H)


### PR DESCRIPTION
## What Does This PR Do
Allows ahudded or no respawnability ghosts to respawn in ghost bar. Adds 2 vars to spawners that can bypass spawn restrictions for respawnability and ahud respectively. They are currently set to `FALSE` only on Ghost Bar. Adds a check which prevents ghosts from receiving `TRAIT_RESPAWNABLE` in ghost bar if they dont have respawnability when spawning. Fixes #23939
## Why It's Good For The Game
A spawner that's OOC and focused around ghosts only, it should freely permit ghosts.
## Testing
As a non-admin, spawned in  ghost bar with respawnability and without ahud. Spawned in ghost bar without respawnability. Spawned in ghost bar without respawnability and with ahud. Upon returning to being an observer, I seemed to retain my previous statuses. Antag hud is held in a list by CKEY and respawnability appears to stick through ghost bar.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: Ahudded users can respawn in ghost bar.
tweak: No respawnability users can respawn in ghost bar.
tweak: Users without respawnability will not gain respawnability as ghost bar occupants.
/:cl: