### PR TITLE
Some Job Perk Tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -2200,6 +2200,8 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 					analysis += "<span class='info'>You conclude [src]'s [E.name] is broken.</span>"
 				else
 					analysis += "<span class='info'>You conclude [src]'s [E.name] has a [E.broken_description].</span>"
+		if(!analysis.len)
+			analysis += "<span class='info'>[src] appears to be in perfect health.</span>"
 		to_chat(user, chat_box_healthscan(analysis.Join("<br>")))
 
 /mob/living/carbon/human/pointed(atom/A as mob|obj|turf in view())
@@ -2210,8 +2212,15 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 
 	if(istype(A, /obj/effect/temp_visual/point) || istype(A, /atom/movable/emissive_blocker))
 		return FALSE
-	if(mind && HAS_TRAIT(mind, TRAIT_COFFEE_SNOB) && reagents.has_reagent("coffee"))
-		changeNext_move(CLICK_CD_POINT / 3)
+	if(mind && HAS_TRAIT(mind, TRAIT_COFFEE_SNOB))
+		var/found_coffee = FALSE
+		for(var/reagent in reagents.reagent_list)
+			if(istype(reagent, /datum/reagent/consumable/drink/coffee))
+				found_coffee = TRUE
+		if(found_coffee)
+			changeNext_move(CLICK_CD_POINT / 3)
+		else
+			changeNext_move(CLICK_CD_POINT)
 	else
 		changeNext_move(CLICK_CD_POINT)
 

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -2200,7 +2200,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 					analysis += "<span class='info'>You conclude [src]'s [E.name] is broken.</span>"
 				else
 					analysis += "<span class='info'>You conclude [src]'s [E.name] has a [E.broken_description].</span>"
-		if(!analysis.len)
+		if(!length(analysis))
 			analysis += "<span class='info'>[src] appears to be in perfect health.</span>"
 		to_chat(user, chat_box_healthscan(analysis.Join("<br>")))
 
@@ -2212,7 +2212,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 
 	if(istype(A, /obj/effect/temp_visual/point) || istype(A, /atom/movable/emissive_blocker))
 		return FALSE
-	if(mind && HAS_TRAIT(mind, TRAIT_COFFEE_SNOB))
+	if(mind && HAS_MIND_TRAIT(src, TRAIT_COFFEE_SNOB))
 		var/found_coffee = FALSE
 		for(var/reagent in reagents.reagent_list)
 			if(istype(reagent, /datum/reagent/consumable/drink/coffee))

--- a/code/modules/mob/living/silicon/robot/robot_mob.dm
+++ b/code/modules/mob/living/silicon/robot/robot_mob.dm
@@ -935,6 +935,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 			return ITEM_INTERACT_COMPLETE
 		playsound(src, 'sound/items/deconstruct.ogg', 50, TRUE)
 		being_charged = TRUE
+		to_chat(src, "<span class='notice'>[user] begins to manually charge your internal cell.</span>")
 		while(do_after(user, 0.5 SECONDS, target = src))
 			var/cell_difference = cell.maxcharge - cell.charge
 			if(donor.charge >= 500 && cell_difference >= 500)

--- a/code/modules/reagents/chemistry/reagents/drinks_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks_reagents.dm
@@ -372,6 +372,17 @@
 	drink_desc = "The perfect blend of coffee, milk, and chocolate."
 	taste_description = "chocolatey coffee"
 
+/datum/reagent/consumable/drink/coffee/cafe_latte/pumpkin_latte
+	name = "Pumpkin Latte"
+	id = "pumpkin_latte"
+	description = "A mix of pumpkin juice and coffee."
+	color = "#F4A460"
+	nutriment_factor = 3 * REAGENTS_METABOLISM
+	drink_icon = "pumpkin_latte"
+	drink_name = "Pumpkin Latte"
+	drink_desc = "A mix of coffee and pumpkin juice."
+	taste_description = "overpriced hipster spices"
+
 /datum/reagent/consumable/drink/tea
 	name = "Tea"
 	id = "tea"
@@ -488,17 +499,6 @@
 	drink_name = "Blue Cherry Shake"
 	drink_desc = "An exotic blue milkshake."
 	taste_description = "blues"
-
-/datum/reagent/consumable/drink/pumpkin_latte
-	name = "Pumpkin Latte"
-	id = "pumpkin_latte"
-	description = "A mix of pumpkin juice and coffee."
-	color = "#F4A460"
-	nutriment_factor = 3 * REAGENTS_METABOLISM
-	drink_icon = "pumpkin_latte"
-	drink_name = "Pumpkin Latte"
-	drink_desc = "A mix of coffee and pumpkin juice."
-	taste_description = "overpriced hipster spices"
 
 /datum/reagent/consumable/drink/gibbfloats
 	name = "Gibb Floats"


### PR DESCRIPTION


## What Does This PR Do

Gives medical examinations a message if theres no issues, Makes rapid pointing work with all coffees, and gives borgs a message when manually charged

## Why It's Good For The Game

giving some QOL to the QOL pr

## Testing

examined, drank some coffee, and charged some borgs

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Tweaked some job perks in a minor way
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
