### PR TITLE
Fix a var that should be a list but isn't

### DIFF
--- a/code/game/machinery/vendors/wardrobe_vendors.dm
+++ b/code/game/machinery/vendors/wardrobe_vendors.dm
@@ -333,7 +333,7 @@
 	icon_panel = "drobe"
 	icon_addon = "genedrobe"
 	category = VENDOR_TYPE_CLOTHING
-	ads_list = "Perfect for the mad scientist in you!"
+	ads_list = list("Perfect for the mad scientist in you!")
 	vend_reply = "Thank you for using the GeneDrobe!"
 	products = list(/obj/item/clothing/under/rank/rnd/geneticist = 3,
 					/obj/item/clothing/shoes/laceup = 3,


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

`ads_list` is always supposed to be a list.

Note that the `ads_list` var itself is commented as unimplemented, but removing it is outside the scope of this PR. I'm just the type fixer. You want it removed? Remove it yourself.

Caught by WIP OpenDream typechecking.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

bro it's not a list
