### PR TITLE
Removes swear from end of round report

### DIFF
--- a/code/game/jobs/job_objective.dm
+++ b/code/game/jobs/job_objective.dm
@@ -73,7 +73,7 @@
 			count++
 
 		if(tasks_completed >= 1)
-			text += "<br>&nbsp;<font color='green'><B>[employee.name] did their fucking job!</B></font>"
+			text += "<br>&nbsp;<font color='green'><b>[employee.name] did their job!</b></font>"
 			SSblackbox.record_feedback("tally", "employee_success", 1, "SUCCESS")
 		else
 			SSblackbox.record_feedback("tally", "employee_success", 1, "FAIL")


### PR DESCRIPTION
## What Does This PR Do
Removes the swearing from end of round report.
## Why It's Good For The Game
It just looks odd the way it is right now. It makes the report look silly by keeping it.
## Testing
I altered the string, testing is not needed.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog

:cl:
tweak: Tweaked the 'did their job' text for end of round reports.
/:cl:
