### PR TITLE
Adds storage dumping

### DIFF
--- a/code/game/objects/items/weapons/storage/storage_base.dm
+++ b/code/game/objects/items/weapons/storage/storage_base.dm
@@ -128,12 +128,14 @@
 		open(M)
 		return
 
-	if(ismodcontrol(over_object))
+	if(isstorage(over_object))
+		var/obj/item/storage = over_object
+		if(!storage.in_storage)
+			dump_storage(M, over_object)
+			return
+	else if(ismodcontrol(over_object))
 		var/obj/item/mod/control/mod = over_object
 		dump_storage(M, mod.bag)
-		return
-	if(isstorage(over_object))
-		dump_storage(M, over_object)
 		return
 
 	if((istype(over_object, /obj/structure/table) || isfloorturf(over_object)) && length(contents) \

--- a/code/game/objects/items/weapons/storage/storage_base.dm
+++ b/code/game/objects/items/weapons/storage/storage_base.dm
@@ -103,6 +103,17 @@
 /obj/item/storage/proc/removal_allowed_check(mob/user)
 	return TRUE
 
+/obj/item/storage/proc/dump_storage(mob/user, obj/item/storage/target)
+	if(!length(contents) || user.restrained() || (HAS_TRAIT(user, TRAIT_HANDS_BLOCKED)) || !user.can_reach(target) || src == target)
+		return
+	for(var/obj/item/thing in contents)
+		if(!target.can_be_inserted(thing))
+			continue
+		if(!do_after(user, 0.3 SECONDS, target = user))
+			break
+		playsound(loc, "rustle", 50, TRUE, -5)
+		target.handle_item_insertion(thing, user)
+
 /obj/item/storage/MouseDrop(obj/over_object, src_location, over_location, src_control, over_control, params)
 	if(!ismob(usr)) //so monkeys can take off their backpacks -- Urist
 		return
@@ -115,6 +126,14 @@
 		if(M.s_active)
 			M.s_active.close(M)
 		open(M)
+		return
+
+	if(ismodcontrol(over_object))
+		var/obj/item/mod/control/mod = over_object
+		dump_storage(M, mod.bag)
+		return
+	if(isstorage(over_object))
+		dump_storage(M, over_object)
 		return
 
 	if((istype(over_object, /obj/structure/table) || isfloorturf(over_object)) && length(contents) \

--- a/code/modules/mob/living/carbon/human/human_inventory.dm
+++ b/code/modules/mob/living/carbon/human/human_inventory.dm
@@ -342,6 +342,7 @@
 					I.forceMove(C.bag)
 			else
 				I.forceMove(back)
+			I.in_storage = TRUE
 		if(ITEM_SLOT_ACCESSORY)
 			var/obj/item/clothing/under/uniform = src.w_uniform
 			uniform.attackby__legacy__attackchain(I, src)

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -277,6 +277,14 @@
 		if(ismecha(M.loc))
 			return
 
+		if(ismodcontrol(over_object))
+			var/obj/item/mod/control/target = over_object
+			bag?.dump_storage(M, target.bag)
+			return
+		if(isstorage(over_object))
+			bag?.dump_storage(M, over_object)
+			return
+
 		if(!M.restrained() && !M.stat)
 			playsound(loc, "rustle", 50, TRUE, -5)
 


### PR DESCRIPTION
## What Does This PR Do
Adds storage dumping inbetween storage items like bags, belts, boxes. There's a 0.3 second do after for each item, which gets canceled if the player moves.
## Why It's Good For The Game
QoL. It makes transferring items between storages easier, especially if they're not on you (eg transferring items between bags on the ground).
## Images of changes

https://github.com/user-attachments/assets/bc4a6526-240f-4708-a36b-1f6245708756

## Testing
Dumped a toolbox in my belt, my belt in a toolbox, dumped a bag into another bag on the floor, tried dumping a modsuit without a bag and into a modsuit without a bag.

Shuffled boxes inside my inventory without dumping contents into each other.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
add: Storage dumping between storage items.
fix: roundstart in backpack items will now be marked as in_storage
/:cl:
