### PR TITLE
Fix camera static offsets over transformed turf

### DIFF
--- a/code/modules/mob/camera/chunk.dm
+++ b/code/modules/mob/camera/chunk.dm
@@ -8,6 +8,7 @@
 	var/list/inactive_cameras = list()
 	var/list/turfs = list()
 	var/list/seenby = list()
+	var/image/camera_static
 	var/changed = FALSE
 	var/updating = FALSE
 	var/x = 0
@@ -107,7 +108,7 @@
 		var/turf/T = get_turf(c)
 		if(get_dist(point, T) > CAMERA_VIEW_DISTANCE + (CAMERA_CHUNK_SIZE / 2))
 			// Still needed for Ais who get created on Z level 1 on the spot of the new player
-			continue 
+			continue
 
 		for(var/turf/t in c.can_see())
 			if(turfs[t])
@@ -127,7 +128,9 @@
 
 	for(var/turf/t as anything in vis_removed)
 		if(!t.obscured)
-			t.obscured = image('icons/effects/cameravis.dmi', t, null, BYOND_LIGHTING_LAYER + 0.1)
+			camera_static = image('icons/effects/cameravis.dmi', t, null, BYOND_LIGHTING_LAYER + 0.1)
+			camera_static.appearance_flags = RESET_TRANSFORM
+			t.obscured = camera_static
 			t.obscured.plane = BYOND_LIGHTING_PLANE + 1
 		obscured += t.obscured
 		images_to_add += t.obscured
@@ -166,6 +169,8 @@
 
 	for(var/turf/t as anything in obscured_turfs)
 		if(!t.obscured)
-			t.obscured = image('icons/effects/cameravis.dmi', t, "black", BYOND_LIGHTING_LAYER + 0.1)
+			camera_static = image('icons/effects/cameravis.dmi', t, "black", BYOND_LIGHTING_LAYER + 0.1)
+			camera_static.appearance_flags = RESET_TRANSFORM
+			t.obscured = camera_static
 			t.obscured.plane = BYOND_LIGHTING_PLANE + 1
 		obscured += t.obscured


### PR DESCRIPTION
## What Does This PR Do
Fixes camera static offsets by applying `RESET_TRANSFORM` on the image. Fixes #19693
## Why It's Good For The Game
It looks janky without it.
## Images of changes
Cyberiad departures with cameras cut. Grass area is properly covered.

![image](https://github.com/user-attachments/assets/0f23cd6f-b821-44ff-857f-0a3a70657447)

## Testing
Loaded in as engineer, cut cameras in areas with grass, rejoined as AI and I observed the turfs. Grassy area in departures was properly covered, grassy area in the weed den in maints is properly covered.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Camera static won't be offset when displayed over grass.
/:cl: