### PR TITLE
Add implant modification to VV menu for admins

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -88,6 +88,7 @@
 	.["Jump to Object"] = "byond://?_src_=vars;jump_to=[UID()]"
 	.["Delete"] = "byond://?_src_=vars;delete=[UID()]"
 	.["Modify Traits"] = "byond://?_src_=vars;traitmod=[UID()]"
+	.["Modify Implants"] = "byond://?_src_=vars;implants=[UID()]"
 	.["Add Component/Element"] = "byond://?_src_=vars;addcomponent=[UID()]"
 	.["Remove Component/Element"] = "byond://?_src_=vars;removecomponent=[UID()]"
 	.["Mass Remove Component/Element"] = "byond://?_src_=vars;massremovecomponent=[UID()]"
@@ -1273,6 +1274,14 @@
 		if(!istype(A))
 			return
 		holder.modify_traits(A)
+
+	else if(href_list["implants"])
+		if(!check_rights(NONE))
+			return
+		var/mob/living/carbon/implantee = locateUID(href_list["implants"])
+		if(!istype(implantee))
+			return
+		holder.modify_implants(implantee)
 
 	if(href_list["addcomponent"])
 		if(!check_rights(NONE))

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1177,6 +1177,43 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	usr << browse(dat.Join("<br>"), "window=goals;size=400x400")
 
+/datum/admins/proc/modify_implants(mob/living/carbon/M)
+	if(!M)
+		return
+
+	var/add_or_remove = tgui_input_list(usr, "Add or Remove Implant?", "Modify Implants", list("Add","Remove"))
+	if(!add_or_remove)
+		return
+
+	var/static/list/implants
+	if(!length(implants))
+		implants = subtypesof(/obj/item/bio_chip)
+
+	switch(add_or_remove)
+		if("Add")
+			var/obj/item/bio_chip/chip_to_add = tgui_input_list(usr, "Select implant to add.", "Implants", implants)
+			if(!chip_to_add)
+				return
+			chip_to_add = new chip_to_add
+			if(!chip_to_add.implant(M))
+				to_chat(usr, "<span class='warning'>Failed to bio-chip [M].</span>")
+				if(chip_to_add)
+					qdel(chip_to_add)
+				return
+		if("Remove")
+			var/list/chips = list()
+			for(var/obj/item/bio_chip/chip in M.contents)
+				if(!istype(chip))
+					continue
+				chips += chip
+			if(!length(chips))
+				to_chat(usr, "<span class='notice'>[M] has no bio-chips.</span>")
+				return
+			var/obj/item/bio_chip/chip_to_remove = tgui_input_list(usr, "Select implant to remove.", "Implants", chips)
+			if(!chip_to_remove)
+				return
+			qdel(chip_to_remove)
+
 /// Allow admin to add or remove traits of datum
 /datum/admins/proc/modify_traits(datum/D)
 	if(!D)


### PR DESCRIPTION
## What Does This PR Do
Admins have yearned for this! Adds the ability to remove or add implants through the VV menu. Can only manipulate carbon mobs. If it fails to implant a biochip, it will get qdelled if it still exists. When removing, it'll also qdel itself.
## Why It's Good For The Game
Easier manipulation of bio-chips for admins.
## Images of changes

https://github.com/user-attachments/assets/61b7a124-8728-41e8-bab5-8926d09406f6

## Testing
Added adrenaline to a mob, activated it. Removed adrenaline from a mob. Removed mindshield from a mob.
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC