### PR TITLE
Fixes conveyor belts blocking cargo crates from spawning

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -108,8 +108,8 @@
 		for(var/atom/A in T.contents)
 			if(!A.simulated)
 				continue
-			if(istype(A, /obj/machinery/light))
-				continue //hacky but whatever, shuttles need three spots each for this shit
+			if(istype(A, /obj/machinery/light) || istype(A, /obj/machinery/conveyor))
+				continue // Objects we're fine with spawning crates on.
 			contcount++
 
 		if(contcount)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds an exclusion for conveyor belts in the handling of spawning supply crates.

## Why It's Good For The Game
Fixes #29646

## Images of changes
![belts](https://github.com/user-attachments/assets/559625ed-3baf-436b-986f-03f0e7904084)

## Testing
Mapping in conveyors in the entirety of the supply shuttle, ordered crates.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
fix: Cargo crates can spawn on top of conveyor belts in the shuttle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
