### PR TITLE
Prevent ghosts orbiting items when double examining

### DIFF
--- a/code/_onclick/observer_onclick.dm
+++ b/code/_onclick/observer_onclick.dm
@@ -8,6 +8,9 @@
 	if(modifiers["middle"]) // Let ghosts point without teleporting
 		return
 
+	if(modifiers["shift"]) // Let ghosts examine without teleporting
+		return
+
 	if(can_reenter_corpse && mind && mind.current)
 		if(A == mind.current || (mind.current in A)) // double click your corpse or whatever holds it
 			reenter_corpse()						// (cloning scanner, body bag, closet, mech, etc)


### PR DESCRIPTION
## What Does This PR Do
Overrides the Shift Dblclick for ghosts, letting them double examine items without yeeting themselves onto the item. Fixes #28734
## Why It's Good For The Game
Jankiness not good.
## Testing
Observed a mob, opened his backpack, double examined his tarot cards. Closed his backpack, double examined his backpack, backpack didn't open.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Ghost double examine will no longer orbit the item.
/:cl: