### PR TITLE
Fixes observer admin/mentor buttons from not showing open tickets on login

### DIFF
--- a/code/modules/mob/dead/observer/observer_admin_actions.dm
+++ b/code/modules/mob/dead/observer/observer_admin_actions.dm
@@ -42,6 +42,7 @@
 
 /datum/action/innate/admin/ticket/proc/register_ticket_signals()
 	RegisterSignal(SStickets, COMSIGN_TICKET_COUNT_UPDATE, PROC_REF(update_tickets))
+	SStickets.open_ticket_count_updated() // update the starting count
 
 /datum/action/innate/admin/ticket/proc/update_tickets(ticketsystem, _ticket_amt)
 	ticket_amt = _ticket_amt
@@ -69,6 +70,7 @@
 
 /datum/action/innate/admin/ticket/mentor/register_ticket_signals()
 	RegisterSignal(SSmentor_tickets, COMSIGN_TICKET_COUNT_UPDATE, PROC_REF(update_tickets))
+	SSmentor_tickets.open_ticket_count_updated() // update the starting count
 
 /datum/action/innate/admin/ticket/mentor/admin_click(mob/user)
 	SSmentor_tickets.showUI(user)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Fixes observer admin/mentor buttons from not showing open tickets on login. Normally, it should show how many open tickets there are, but it doesn't update until a ticket is created/closed.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bug bad

## Testing

<!-- How did you test the PR, if at all? -->
I didn't. I just know this is the fix for it.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
