### PR TITLE
Order of required ruins

### DIFF
--- a/code/datums/mapping/templates/lavaland_map_templates.dm
+++ b/code/datums/mapping/templates/lavaland_map_templates.dm
@@ -63,6 +63,7 @@
 	suffix = "lavaland_surface_golem_ship.dmm"
 	allow_duplicates = FALSE
 	always_place = TRUE
+	always_place_priority = 1
 	megafauna_safe_range = TRUE
 
 /datum/map_template/ruin/lavaland/althland_facility
@@ -250,6 +251,7 @@
 	suffix = "lavaland_surface_nt.dmm"
 	allow_duplicates = FALSE
 	always_place = TRUE
+	always_place_priority = 100
 	never_spawn_on_the_same_level = list("lavaland_relay")
 
 /datum/map_template/ruin/lavaland/legiongate
@@ -259,6 +261,7 @@
 	suffix = "lavaland_surface_legiongate.dmm"
 	allow_duplicates = FALSE
 	always_place = TRUE
+	always_place_priority = 10
 
 /datum/map_template/ruin/lavaland/lavaland_relay
 	id = "lavaland_relay"
@@ -270,6 +273,7 @@
 	never_spawn_on_the_same_level = list("gulag")
 	allow_duplicates = FALSE // Less space on lavaland. Ideally we would figure out a way to ban this from spawning the same level as the mining base
 	always_place = TRUE // Since only one can spawn for now, might as well ensure it.
+	always_place_priority = 5
 
 // MARK: Bridges
 

--- a/code/datums/mapping/templates/space_map_templates.dm
+++ b/code/datums/mapping/templates/space_map_templates.dm
@@ -282,6 +282,7 @@
 	description = "A secret base researching illegal bioweapons, it is closely guarded by an elite team of syndicate agents."
 	suffix = "syndie_space_base.dmm"
 	always_place = TRUE
+	always_place_priority = 10
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/space/syndiecakesfactory

--- a/code/datums/ruins.dm
+++ b/code/datums/ruins.dm
@@ -9,12 +9,19 @@
 
 	/// Prevents megafauna spawning within a certain range of ruins.
 	var/megafauna_safe_range = FALSE
-	var/unpickable = FALSE 	 //If TRUE these won't be placed automatically (can still be forced or loaded with another ruin)
-	var/always_place = FALSE //Will skip the whole weighting process and just plop this down, ideally you want the ruins of this kind to have no cost.
-	var/placement_weight = 1 //How often should this ruin appear
+	/// If TRUE these won't be placed automatically (can still be forced or loaded with another ruin).
+	var/unpickable = FALSE
+	/// If TRUE, the placer will skip the whole weighting process and just plop this down.
+	/// Ideally you want the ruins of this kind to have no cost.
+	var/always_place = FALSE
+	/// Required ruins with higher priority will be placed first.
+	var/always_place_priority = 0
+	/// How often should non-required ruin appear.
+	var/placement_weight = 1
+	/// Whether or not this ruin can spawn multiple times.
 	var/allow_duplicates = TRUE
-	var/list/never_spawn_with = null //If this ruin is spawned these will not eg list(/datum/map_template/ruin/base_alternate)
-
+	/// If this ruin is spawned these will not eg list(/datum/map_template/ruin/base_alternate).
+	var/list/never_spawn_with = null
 	/// If a ruin ID is in this list, this ruin will not spawn on the same level as that ruin.
 	var/list/never_spawn_on_the_same_level = list()
 


### PR DESCRIPTION
## What Does This PR Do  

Adds an `always_place_priority` value to ruin definitions, allowing explicit control over the order in which critical ruins are placed on the map.  

## Why It's Good For The Game  

Currently, the placement order of critical ruins (e.g., Mining Outpost, Legion Gate, Lavaland NT Relay) depends on their definition order in code, which is unreliable. This can lead to the Mining Outpost being blocked by others (e.g., Legion Gate spawning in the center of Lavaland, or NT Relay occupying an entire level).

This PR ensures that high-priority ruins (like the Mining Outpost) are placed **first**, preventing softlocks.

## Testing
Tested on a downstream server - Mining Outpost now reliably spawns before blocking structures.

## Declaration  
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.  

## Changelog  
:cl: Maxiemar  
fix: Mining Outpost now spawns before potential blockers like Legion Gate or Lavaland NT Relay, preventing map-generation issues.  
/:cl:  