### PR TITLE
Optimise ip2group tables to use ints instead of varchars

### DIFF
--- a/SQL/paradise_schema.sql
+++ b/SQL/paradise_schema.sql
@@ -542,11 +542,11 @@ CREATE TABLE `changelog` (
 --
 DROP TABLE IF EXISTS `ip2group`;
 CREATE TABLE `ip2group` (
-  `ip` varchar (18) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `date` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL,
-  `groupstr` varchar (32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  PRIMARY KEY (`ip`),
-  KEY `groupstr` (`groupstr`)
+	`ip` INT(10) UNSIGNED NOT NULL,
+	`date` TIMESTAMP NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+	`groupstr` INT(10) UNSIGNED NOT NULL,
+	PRIMARY KEY (`ip`) USING BTREE,
+	INDEX `groupstr` (`groupstr`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 --

--- a/SQL/updates/67-68.sql
+++ b/SQL/updates/67-68.sql
@@ -14,7 +14,7 @@ CREATE TABLE `ip2group_copy` (
 DELETE FROM ip2group WHERE groupstr = ''; # This is junk
 
 INSERT INTO ip2group_copy (ip, date, groupstr)
-SELECT INET_ATON(`ip`), `date`, CAST(`groupstr` AS INT) FROM ip2group;
+SELECT INET_ATON(`ip`), `date`, CAST(`groupstr` AS UNSIGNED) FROM ip2group;
 
 # Drop old table
 DROP TABLE `ip2group`;

--- a/SQL/updates/67-68.sql
+++ b/SQL/updates/67-68.sql
@@ -1,0 +1,23 @@
+# Updating DB from 67-68 -AffectedArc07
+# Changes the data types in ip2group from varchar to int
+
+# Create temporary table
+CREATE TABLE `ip2group_copy` (
+	`ip` INT UNSIGNED NOT NULL,
+	`date` TIMESTAMP NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+	`groupstr` INT UNSIGNED NOT NULL,
+	PRIMARY KEY (`ip`) USING BTREE,
+	INDEX `groupstr` (`groupstr`) USING BTREE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+# Migrate data
+DELETE FROM ip2group WHERE groupstr = ''; # This is junk
+
+INSERT INTO ip2group_copy (ip, date, groupstr)
+SELECT INET_ATON(`ip`), `date`, CAST(`groupstr` AS INT) FROM ip2group;
+
+# Drop old table
+DROP TABLE `ip2group`;
+
+# Rename new table
+RENAME TABLE `ip2group_copy` TO `ip2group`;

--- a/code/__DEFINES/misc_defines.dm
+++ b/code/__DEFINES/misc_defines.dm
@@ -438,7 +438,7 @@
 #define INVESTIGATE_DEATHS "deaths"
 
 // The SQL version required by this version of the code
-#define SQL_VERSION 67
+#define SQL_VERSION 68
 
 // Vending machine stuff
 #define CAT_NORMAL (1<<0)

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -173,7 +173,7 @@ ipc_screens = [
 # Enable/disable the database on a whole
 sql_enabled = false
 # SQL version. If this is a mismatch, round start will be delayed
-sql_version = 67
+sql_version = 68
 # SQL server address. Can be an IP or DNS name
 sql_address = "127.0.0.1"
 # SQL server port


### PR DESCRIPTION
## What Does This PR Do
Optimise ip2group tables to use ints instead of varchars

## Why It's Good For The Game
Storing IPs and other info as strings is cringe, this makes joins and other updates so much faster. Theres no good reason to store them as strings when we can do the same with unsigned ints.

I'll need to update backend tooling after this is merged but that can wait.

## Testing
Tried converting a copy of the prod dataset, all worked fine.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
NPFC