### PR TITLE
[s] Fixes AI able to jump to saved locations while in a mech

### DIFF
--- a/code/datums/keybindings/ai_keybinds.dm
+++ b/code/datums/keybindings/ai_keybinds.dm
@@ -50,6 +50,10 @@
 	. = ..()
 	var/mob/living/silicon/ai/AI = C.mob
 
+	if(ismecha(AI.loc))
+		to_chat(AI, "<span class='warning'>You can't change camera locations while in a mech!</span>")
+		return
+
 	if(AI.stored_locations[location_number] == "unset")
 		to_chat(AI, "<span class='warning'>You haven't set location [location_number] yet!</span>")
 		return


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes the AI being able to jump to saved locations as their eye while in a mech

## Why It's Good For The Game

Bug bad

## Testing

Tried to jump to location in mech. Was denied.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixes a bug in AI camera controls
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
