### PR TITLE
remove spurious emergency shuttle port in meta space

### DIFF
--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -117136,7 +117136,7 @@ aaa
 aaa
 aaa
 aaa
-cZp
+aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION
## What Does This PR Do
This PR removes an extraneous emergency shuttle port with the id "emergency_home" from south of meta departures.
## Why It's Good For The Game
When the Lance beacon is placed, it removes the one that is typically mapped into departures in order to drop it where the beacon is. If there's two beacons with this ID on the map, this will only delete the first, leaving the lance to attempt to dock far south of actual departures, because its "emergency_home" beacon is second in the list of beacons with that ID.
## Testing
Ordered lance, placed it, called shuttle, VV'd SSshuttle to make it go faster. Ensured that lance docked at station.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: The Lance should now properly dock at Cerebron.
/:cl: