### PR TITLE
Shotgun change

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -638,7 +638,7 @@
 	)
 	emag_override_modules = list(/obj/item/reagent_containers/drinks/bottle/beer/sleepy_beer)
 	emag_modules = list(/obj/item/restraints/handcuffs/cable/zipties/cyborg, /obj/item/instrument/guitar/cyborg)
-	malf_modules = list(/obj/item/gun/projectile/shotgun/automatic/combat/cyborg)
+	malf_modules = list(/obj/item/gun/energy/gun/shotgun/cyborg)
 	special_rechargables = list(
 		/obj/item/reagent_containers/condiment/enzyme,
 		/obj/item/reagent_containers/drinks/bottle/beer/sleepy_beer,

--- a/code/modules/projectiles/ammunition/energy_lens.dm
+++ b/code/modules/projectiles/ammunition/energy_lens.dm
@@ -48,6 +48,9 @@
 	select_name = "kill"
 	delay = 1 SECONDS
 
+/obj/item/ammo_casing/energy/laser/eshotgun/cyborg
+	e_cost = 500
+
 /obj/item/ammo_casing/energy/laser/heavy
 	projectile_type = /obj/item/projectile/beam/laser/heavylaser
 	select_name = "anti-vehicle"

--- a/code/modules/projectiles/guns/energy/energy.dm
+++ b/code/modules/projectiles/guns/energy/energy.dm
@@ -265,6 +265,19 @@
 	. += "This scatter-beam technology allows for more energy output per trigger pull, however the increased heat on the focusing lens has resulted in a decreased fire rate compared to the standard fare. \
 	It is a Nanotrasen officer's best friend, allowing them to stop crime one trigger pull at a time."
 
+/obj/item/gun/energy/gun/shotgun/cyborg
+	name = "Energy Scatterbeam"
+	desc = "An energy emitter that fires spread-fire laser shells."
+	icon_state = "eshotgun"
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/eshotgun/cyborg)
+
+/obj/item/gun/energy/gun/shotgun/newshot()
+	..()
+	robocharge()
+
+/obj/item/gun/energy/emitter/gun/shotgun/emp_act()
+	return
+
 // MARK: FAKE ENERGY GUN
 /obj/item/gun/energy/gun/fake
 	name = "replica EG-7 energy gun"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Takes the malf cyborg combat shotgun and turns it into an eshotgun. This eshotgun does not have a disable mode, and has the energy cost tied directly to the battery. This does the following:
1 - Service borg uptime during malf is abysmal, and the DPS it does is staggering currently during that short uptime. This reduces DPS while also increasing uptime
2 - Bugs: The current borg shotgun reloads either not at all or abysmally slowly. This remedies that by tying ammo to battery.

## Why It's Good For The Game

Service malf module could use a tune up and it's more thematic than a standard shotgun

## Testing

Became a malf service borg. Had eshotgun. Fired it about 20 times before battery died.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
![image](https://github.com/user-attachments/assets/87f57660-e213-4ce9-bcee-a4d32ca79771)


## Changelog

:cl:
tweak: Changed malf service borg combat shottie to an eshotgun
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
