### PR TITLE
move airlock chamber setup out of lateinit

### DIFF
--- a/code/game/machinery/airlock_control/airlock_controllers.dm
+++ b/code/game/machinery/airlock_control/airlock_controllers.dm
@@ -9,13 +9,13 @@
 
 	// Setup vars
 
-	/// Airlock ID for all exterior doors to link to on LateInitialize()
+	/// Airlock ID for all exterior doors to link to.
 	var/ext_door_link_id
-	/// Airlock ID for all interior doors to link to on LateInitialize()
+	/// Airlock ID for all interior doors to link to.
 	var/int_door_link_id
-	/// Button ID for all exterior buttons to link to on LateInitialize()
+	/// Button ID for all exterior buttons to link to.
 	var/ext_button_link_id
-	/// Vutton ID for all exterior buttons to link to on LateInitialize()
+	/// Vutton ID for all exterior buttons to link to.
 	var/int_button_link_id
 
 	// Actual holding vars
@@ -29,7 +29,7 @@
 	/// Target state (MONE, INOPEN, OUTOPEN)
 	var/target_state = TARGET_NONE
 
-	/// Vent ID for all vents to link to on LateInitialize()
+	/// Vent ID for all vents to link to.
 	var/vent_link_id
 	/// All vents to control. Soft-refs only.
 	var/list/vents = list()
@@ -37,14 +37,7 @@
 	// Program vars
 	var/target_pressure
 
-
-/obj/machinery/airlock_controller/Initialize(mapload)
-	..()
-	// We do all the work in there
-	return INITIALIZE_HINT_LATELOAD
-
-// Do setup of stuff here
-/obj/machinery/airlock_controller/LateInitialize()
+/obj/machinery/airlock_controller/proc/link_all_items()
 	for(var/obj/machinery/door/airlock/A in GLOB.airlocks)
 		if(A.id_tag == int_door_link_id)
 			interior_doors |= A.UID()
@@ -377,8 +370,9 @@ send an additional command to open the door again.
 			cycleDoors(TARGET_OUTOPEN)
 
 /* =============================== AIR CYCLER - Ensures internal pressure matches (just about) the void or the normal atmosphere */
-/obj/machinery/airlock_controller/air_cycler/LateInitialize()
-	..()
+/obj/machinery/airlock_controller/air_cycler/link_all_items()
+	. = ..()
+
 	for(var/obj/machinery/atmospherics/unary/vent_pump/V as anything in GLOB.all_vent_pumps)
 		if(V.autolink_id == vent_link_id)
 			vents += V.UID()

--- a/code/game/objects/effects/spawners/airlock_spawner.dm
+++ b/code/game/objects/effects/spawners/airlock_spawner.dm
@@ -49,7 +49,9 @@ This spawner places pipe leading up to the interior door, you will need to finis
 	handle_door_creation(turf_interior, TRUE, one_door_interior)
 	handle_door_creation(turf_exterior, FALSE, one_door_exterior)
 	handle_pipes_creation(turf_interior)
-	handle_control_placement()
+
+	var/obj/machinery/airlock_controller/controller = make_controller()
+	controller.link_all_items()
 
 	for(var/obj/effect/mapping_helpers/airlock/access/access_helper in loc)
 		qdel(access_helper)
@@ -117,7 +119,7 @@ This spawner places pipe leading up to the interior door, you will need to finis
 	set_access_helper(the_button)
 	return the_button
 
-/obj/effect/spawner/airlock/proc/handle_control_placement() //Stick the controller on the wall, this will ONLY be unsuitable if airlocks are on both the south and west turfs
+/obj/effect/spawner/airlock/proc/make_controller() //Stick the controller on the wall, this will ONLY be unsuitable if airlocks are on both the south and west turfs
 	var/turf/T = get_turf(src)
 	var/obj/machinery/airlock_controller/air_cycler/AC = new(T)
 	set_access_helper(AC)
@@ -137,6 +139,8 @@ This spawner places pipe leading up to the interior door, you will need to finis
 		AC.forceMove(T)
 		AC.pixel_x += 25
 		AC.pixel_y += 9
+
+	return AC
 
 /obj/effect/spawner/airlock/proc/handle_pipes_creation(turf/T) //This places all required piping down, then properly initializes it. T is the turf that the interior airlock occupies
 	var/turf/below_T = get_step(T, opposite_interior_direction)

--- a/code/modules/mapping/dynamic_airlock_linker.dm
+++ b/code/modules/mapping/dynamic_airlock_linker.dm
@@ -100,12 +100,10 @@ RESTRICT_TYPE(/datum/dynamic_airlock_linker)
 		controller.req_access = req_access
 		controller.req_one_access = req_one_access
 
-		// despite airlock controllers looking this up in GLOB.airlocks in
-		// LateInitialize, we need to hold their hand here because *we're*
-		// (typically) in Initialize, so not all relevant airlocks may have been
-		// added to GLOB.airlocks yet.
 		controller.interior_doors = interior_airlocks.Copy()
 		controller.exterior_doors = exterior_airlocks.Copy()
+
+		controller.link_all_items()
 
 	QDEL_LIST_CONTENTS(interior_helpers)
 	QDEL_LIST_CONTENTS(exterior_helpers)

--- a/code/modules/mapping/dynamic_airlocks.dm
+++ b/code/modules/mapping/dynamic_airlocks.dm
@@ -23,8 +23,11 @@
 
 /obj/effect/map_effect/dynamic_airlock/Initialize(mapload)
 	..()
+	return INITIALIZE_HINT_LATELOAD
 
-	. = INITIALIZE_HINT_QDEL
+/obj/effect/map_effect/dynamic_airlock/LateInitialize()
+	. = ..()
+
 	// One helper out of all the connected ones will actually set everything up
 	// and qdel all the connected ones so the linker doesn't attempt to do its
 	// thing more than once per zone
@@ -33,6 +36,8 @@
 
 	var/datum/dynamic_airlock_linker/linker = new()
 	linker.build(src)
+
+	qdel(src)
 
 /obj/effect/map_effect/dynamic_airlock/proc/collect_sibling_item(atom/A)
 	if(is_type_in_list(A, valid_siblings))


### PR DESCRIPTION
## What Does This PR Do
This PR moves airlock controller machine linking to a proc independent of its init order, setting it up either when the pre-mapped airlock helper is in its Initialize, or a dynamic airlock helper is in its setup.
## Why It's Good For The Game
The dynamic airlock controller worked by deleting some map effects before they were initialized, in order to prevent the same airlock chamber from being set up twice, but this actually causes tests to fail (which we haven't seen on CI for other reasons which I'm fixing). Not only does this fix the test failures, but it also provides a hook to later enable players to create airlock chambers in-game.
## Testing
Tested both dynamic airlocks and airlock mapping helpers on Cere.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC