### PR TITLE
remove redundant loop in ruin placement

### DIFF
--- a/code/datums/mapping/ruin_placer.dm
+++ b/code/datums/mapping/ruin_placer.dm
@@ -64,13 +64,12 @@
 				bottom_left.y_pos -= padding
 				top_right.x_pos += padding
 				top_right.y_pos += padding
-				var/list/affected_turfs = block(bottom_left.x_pos, bottom_left.y_pos, z_level, top_right.x_pos, top_right.y_pos, z_level)
 
 				// One sanity check just in case
 				if(!ruin.fits_in_map_bounds(central_turf, centered = TRUE))
 					valid = FALSE
 
-				for(var/turf/check in affected_turfs)
+				for(var/turf/check in block(bottom_left.x_pos, bottom_left.y_pos, z_level, top_right.x_pos, top_right.y_pos, z_level))
 					var/area/new_area = get_area(check)
 					if(!(istype(new_area, area_whitelist)) || check.flags & NO_RUINS)
 						valid = FALSE
@@ -78,14 +77,6 @@
 
 				if(!valid)
 					continue
-
-				for(var/turf/T in affected_turfs)
-					for(var/obj/structure/spawner/nest in T)
-						qdel(nest)
-					for(var/mob/living/simple_animal/monster in T)
-						qdel(monster)
-					for(var/obj/structure/flora/ash/plant in T)
-						qdel(plant)
 
 				var/loaded = ruin.load(central_turf, centered = TRUE)
 				if(!loaded)


### PR DESCRIPTION
## What Does This PR Do
This PR removes a redundant loop in ruin placement where large blocks of turfs are iterated over for no gain. This extra step of deleting spawners, mobs, and flora was pretty clearly a holdover from some aspect of Lavaland code; however, those things only spawn in cave procgen, which happens _after_ ruin placement. We're also no longer storing the block of turfs created when checking the placement area, which might trigger BYOND to optimize something behind the scenes?
## Why It's Good For The Game
Improving roundstart performance is good.
## Testing
Ran server a few times, sanity checked ruins.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC