### PR TITLE
fix a typo in can_pass_info decl

### DIFF
--- a/code/__HELPERS/paths/path.dm
+++ b/code/__HELPERS/paths/path.dm
@@ -281,7 +281,7 @@
 	/// Are we being thrown?
 	var/thrown = FALSE
 	/// Are we anchored
-	var/anchored = FLASH_LIGHT_POWER
+	var/anchored = FALSE
 
 	/// Are we a ghost? (they have effectively unique pathfinding)
 	var/is_observer = FALSE


### PR DESCRIPTION
## What Does This PR Do
This PR fixes a typo in /datum/can_pass_info's type declaration. This shouldn't have had any effect on pathing since the field's value gets clobbered in the constructor, but better safe than sorry.
## Why It's Good For The Game
Correct code good.
## Testing
Visual inspection.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC