### PR TITLE
add VV button to event manager

### DIFF
--- a/code/controllers/subsystem/SSevents.dm
+++ b/code/controllers/subsystem/SSevents.dm
@@ -198,7 +198,7 @@ SUBSYSTEM_DEF(events)
 			var/no_end = E.noAutoEnd
 			html += "<tr>"
 			html += "<td>[GLOB.severity_to_string[EM.severity]]</td>"
-			html += "<td>[EM.name]</td>"
+			html += "<td>[EM.name] [ADMIN_VV(E, "VV")]</td>"
 			html += "<td>[no_end ? "N/A" : station_time_timestamp("hh:mm:ss", ends_at)]</td>"
 			html += "<td>[no_end ? "N/A" : ends_in]</td>"
 			html += "<td><A align='right' href='byond://?src=[UID()];stop=\ref[E]'>Stop</A></td>"


### PR DESCRIPTION
## What Does This PR Do
This PR adds a VV button to active events in the event manager.
## Why It's Good For The Game
Lets me look at the thing at the place where I'm looking at it
## Images of changes
![2025_06_24__14_53_55__](https://github.com/user-attachments/assets/b3030297-1f16-4cbc-a7b1-ec07c25337c5)
## Testing
Clicked button, ensured the relevant event's VV came up.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC