### PR TITLE
[s] fix vertical offsets incorrectly stacking when switching between resting and standing positions

### DIFF
--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -18,7 +18,13 @@
 	if(resize != RESIZE_DEFAULT_SIZE)
 		changed++
 		ntransform.Scale(resize)
-		ntransform.Translate(0, (resize - 1) * 16) // Pixel Y shift: 1.25 = 4, 1.5 = 8, 2 -> 16, 3 -> 32, 4 -> 48, 5 -> 64
+		if(body_position == LYING_DOWN) // Manipulate the X axis when horizontal
+			if(lying_angle == 270) // Depending on our lying angle, we need to add or remove from the offset.
+				ntransform.Translate((resize - 1) * -16, 0)
+			else
+				ntransform.Translate((resize - 1) * 16, 0)
+		else
+			ntransform.Translate(0, (resize - 1) * 16) // Pixel Y shift: 1.25 = 4, 1.5 = 8, 2 -> 16, 3 -> 32, 4 -> 48, 5 -> 64
 		resize = RESIZE_DEFAULT_SIZE
 
 	if(changed)


### PR DESCRIPTION
## What Does This PR Do
Y offsets get swapped with X offsets when laying down. That results in offsets getting stacked together if you shift vertically while standing, then unshift when resting, eventually going visually off-screen.
## Why It's Good For The Game
Breaking the laws of physics isn't good. Makes fighting people impossible.
## Testing
I used the Dwarf gene in a variety of ways, when standing, resting, when changing between the two. My offset updated appropriately and I didn't float away into any direction.
Tested vendor squashing, it doesn't reach that code.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Fixed a bug where offsets would stack incorrectly when switching between resting and standing.
/:cl: