### PR TITLE
Make robots resizeable by editing the resize var in VV

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_mob.dm
+++ b/code/modules/mob/living/silicon/robot/robot_mob.dm
@@ -12,6 +12,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	bubble_icon = "robot"
 	universal_understand = TRUE
 	deathgasp_on_death = TRUE
+	appearance_flags = LONG_GLIDE | PIXEL_SCALE | KEEP_TOGETHER | TILE_BOUND
 	blocks_emissive = EMISSIVE_BLOCK_UNIQUE
 	hud_type = /datum/hud/robot
 
@@ -1826,6 +1827,22 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	if(ourapc.malfai && !(src in ourapc.malfai.connected_robots))
 		return FALSE
 	return TRUE
+
+/mob/living/silicon/robot/update_transform()
+	var/matrix/ntransform = matrix(transform)
+	var/final_pixel_y = pixel_y
+	var/final_dir = dir
+	var/changed = 0
+
+	if(resize != RESIZE_DEFAULT_SIZE)
+		changed++
+		ntransform.Scale(resize)
+		ntransform.Translate(0, (resize - 1) * 16) // Pixel Y shift: 1.25 = 4, 1.5 = 8, 2 -> 16, 3 -> 32, 4 -> 48, 5 -> 64
+		resize = RESIZE_DEFAULT_SIZE
+
+	if(changed)
+		floating = FALSE
+		animate(src, transform = ntransform, time = (lying_prev == 0 || lying_angle == 0) ? 2 : 0, pixel_y = final_pixel_y, dir = final_dir, easing = (EASE_IN|EASE_OUT))
 
 /mob/living/silicon/robot/plushify(plushie_override, curse_time)
 	if(curse_time == -1)


### PR DESCRIPTION
## What Does This PR Do
Makes robots resizeable with the resize var in VV. Ripped the code from the human update_transform. Also, included extra flags to robots, particularly PIXEL_SCALE, KEEP_TOGETHER (so they scale good) and TILE_BOUND. TILE_BOUND probably doesn't change much, but byond apparently spends a fair bit of resources to render things without TILE_BOUND.
## Why It's Good For The Game
admin shenanigan tools
## Images of changes

![image](https://github.com/user-attachments/assets/0aeebbfc-73fd-4b00-b5d1-370a9bdceb31)

## Testing
Made a borg small, made a borg large
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC