### PR TITLE
Give syndicate base airlocks names.

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
@@ -647,6 +647,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -807,6 +808,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -917,6 +919,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -1399,7 +1402,9 @@
 	},
 /area/ruin/unpowered/syndicate_space_base/service)
 "hV" = (
-/obj/machinery/door/airlock/hatch/syndicate,
+/obj/machinery/door/airlock/hatch/syndicate{
+	name = "Custodial Closet"
+	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1998,6 +2003,7 @@
 "lw" = (
 /obj/machinery/door/airlock/hatch/syndicate,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/atmos)
 "lD" = (
@@ -2218,6 +2224,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -2520,6 +2527,17 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/toxlaunch)
+"og" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	name = "Recycling"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ruin/unpowered/syndicate_space_base/arrivals)
 "ol" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2911,7 +2929,6 @@
 /turf/simulated/floor/redgrid,
 /area/ruin/unpowered/syndicate_space_base/telecomms)
 "qR" = (
-/obj/machinery/door/airlock/hatch/syndicate,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2921,6 +2938,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/airlock/hatch/syndicate{
+	name = "Library"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -4422,6 +4442,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -4725,9 +4746,21 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/main)
+"Bw" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	name = "Teleporter Room"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ruin/unpowered/syndicate_space_base/arrivals)
 "Bx" = (
 /obj/machinery/door/airlock/hatch/syndicate,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -4786,6 +4819,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -5195,7 +5229,9 @@
 	},
 /area/ruin/unpowered/syndicate_space_base/storage)
 "EH" = (
-/obj/machinery/door/airlock/hatch/syndicate,
+/obj/machinery/door/airlock/hatch/syndicate{
+	name = "Dressing Room"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -5406,6 +5442,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -5415,6 +5452,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -5541,6 +5579,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -5597,6 +5636,21 @@
 	icon_state = "white"
 	},
 /area/ruin/unpowered/syndicate_space_base/medbay)
+"Gu" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	name = "Library"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ruin/unpowered/syndicate_space_base/arrivals)
 "Gz" = (
 /obj/effect/spawner/window/plastitanium,
 /turf/simulated/floor/plating,
@@ -5705,6 +5759,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -6396,13 +6451,15 @@
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/ruin/unpowered/syndicate_space_base/cave)
 "Ln" = (
-/obj/machinery/door/airlock/hatch/syndicate,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/door/airlock/hatch/syndicate{
+	name = "Dressing Room"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -6523,6 +6580,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -7523,6 +7581,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -8127,6 +8186,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -8322,6 +8382,7 @@
 /obj/machinery/door/airlock/hatch/syndicate,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -8365,6 +8426,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -8464,6 +8526,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -8686,6 +8749,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -9648,7 +9712,7 @@ xn
 nf
 hi
 QN
-hV
+Bw
 zH
 zH
 Xo
@@ -9798,7 +9862,7 @@ xn
 xn
 xn
 IT
-Ln
+Gu
 xn
 xn
 xn
@@ -10097,7 +10161,7 @@ wJ
 xn
 vR
 Ic
-hV
+og
 xD
 yc
 Og

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -159,6 +159,12 @@
 /obj/effect/mapping_helpers/airlock/autoname/payload(obj/machinery/door/airlock)
 	airlock.name = get_area_name(airlock, TRUE)
 
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base
+	name = "syndie base airlock autoname helper"
+
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base/payload(obj/machinery/door/airlock)
+	airlock.name = replacetext(get_area_name(airlock, TRUE), "Syndicate Space Base ", "")
+
 // Will cfoam an airlock
 /obj/effect/mapping_helpers/airlock/c_foam
 	name = "airlock c_foam helper"


### PR DESCRIPTION
## What Does This PR Do
This PR:
- Creates a special airlock naming helper for the syndicate base which strips "Syndicate Space Base" from the area's name to create its name
- Applies that helper to most of the space base's airlocks
- Manually edits a few airlock names where there isn't a distinct area
There are a few hatches without names, namely the ones leading to the cave, because I couldn't think of a good name for them that would make sense from both the outside and the inside.
## Why It's Good For The Game
Navigating the base should not require having to open every single airlock to see where it leads; the fact that they're called "syndicate hatches" is silly and unhelpful enough.
## Testing
Visual inspection.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: The airlocks in the Syndicate Base now have appropriate names.
/:cl: