### PR TITLE
periodic/trivial news headline tweaks

### DIFF
--- a/code/datums/periodic_news.dm
+++ b/code/datums/periodic_news.dm
@@ -5,6 +5,7 @@
 
 	var/round_time // time of the round at which this should be announced, in seconds
 	var/message // body of the message
+	var/headline
 	var/author = "Nanotrasen Editor"
 	var/channel_name = "Nyx Daily"
 	var/can_be_redacted = FALSE
@@ -12,6 +13,7 @@
 
 /datum/news_announcement/revolution_inciting_event/paycuts_suspicion
 	round_time = 60*10
+	headline = "Paycuts Suspected at Nanotrasen"
 	message = {"Reports have leaked that Nanotrasen Inc. is planning to put pay cuts into
 				effect on many of its Research Stations in Tau Ceti. Apparently these research
 				stations haven't been able to yield the expected revenue, and thus adjustments
@@ -20,6 +22,7 @@
 
 /datum/news_announcement/revolution_inciting_event/paycuts_confirmation
 	round_time = 60*40
+	headline = "Paycuts Confirmed at Nanotrasen"
 	message = {"Earlier rumours about pay cuts on Research Stations in the Tau Ceti system have
 				been confirmed. Shockingly, however, the cuts will only affect lower tier
 				personnel. Heads of Staff will, according to our sources, not be affected."}
@@ -27,6 +30,7 @@
 
 /datum/news_announcement/revolution_inciting_event/human_experiments
 	round_time = 60*90
+	headline = "Human Experimentation Alleged at Nanotrasen"
 	message = {"Unbelievable reports about human experimentation have reached our ears. According
 				to a refugee from one of the Tau Ceti Research Stations, their station, in order
 				to increase revenue, has refactored several of their facilities to perform experiments
@@ -38,6 +42,7 @@
 
 /datum/news_announcement/bluespace_research
 	round_time = 60*20
+	headline = "Bluespace Research Advances"
 	message = {"The new field of research trying to explain several interesting spacetime oddities,
 				also known as \"Bluespace Research\", has reached new heights. Of the several
 				hundred space stations now orbiting in Tau Ceti, fifteen are now specially equipped
@@ -48,6 +53,7 @@
 /datum/news_announcement/random_junk/cheesy_honkers
 	author = "Assistant Editor Carl Ritz"
 	channel_name = "The Gibson Gazette"
+	headline = "Cheesy Honkers Alleged Health Risk"
 	message = {"Do cheesy honkers increase risk of having a miscarriage? Several health administrations
 				say so!"}
 	round_time = 60 * 15
@@ -55,6 +61,7 @@
 /datum/news_announcement/random_junk/net_block
 	author = "Assistant Editor Carl Ritz"
 	channel_name = "The Gibson Gazette"
+	headline = "WETSKRELL.NT Blocked"
 	message = {"Several corporations banding together to block access to 'wetskrell.nt', site administrators
 	claiming violation of net laws."}
 	round_time = 60 * 50
@@ -62,7 +69,7 @@
 /datum/news_announcement/random_junk/found_ssd
 	channel_name = "Nyx Daily"
 	author = "Doctor Eric Hanfield"
-
+	headline = "Employees found SSD"
 	message = {"Several people have been found unconscious at their terminals. It is thought that it was due
 				to a lack of sleep or of simply migraines from staring at the screen too long. Camera footage
 				reveals that many of them were playing games instead of working and their pay has been docked
@@ -72,7 +79,7 @@
 /datum/news_announcement/lotus_tree
 	channel_name = "Nyx Daily"
 	author = "Reporter Leland H. Howards"
-
+	headline = "Explosion on Civilian Transport"
 	message = {"The newly-christened civilian transport Lotus Tree suffered two very large explosions near the
 				bridge today, and there are unconfirmed reports that the death toll has passed 50. The cause of
 				the explosions remain unknown, but there is speculation that it might have something to do with
@@ -84,7 +91,7 @@
 /datum/news_announcement/food_riots/breaking_news
 	channel_name = "Nyx Daily"
 	author = "Reporter Ro'kii Ar-Raqis"
-
+	headline = "Food Riots in Tenebrae Lupus"
 	message = {"Breaking news: Food riots have broken out throughout the Refuge asteroid colony in the Tenebrae
 				Lupus system. This comes only hours after Nanotrasen officials announced they will no longer trade with the
 				colony, citing the increased presence of \"hostile factions\" on the colony has made trade too dangerous to
@@ -95,7 +102,7 @@
 /datum/news_announcement/food_riots/more
 	channel_name = "Nyx Daily"
 	author = "Reporter Ro'kii Ar-Raqis"
-
+	headline = "Food Riots Continue Amid NT Withdrawl"
 	message = {"More on the Refuge food riots: The Refuge Council has condemned Nanotrasen's withdrawal from
 	the colony, claiming \"there has been no increase in anti-Nanotrasen activity\", and \"\[the only] reason
 	Nanotrasen withdrew was because the \[Tenebrae Lupus] system's Plasma deposits have been completely mined out.
@@ -132,6 +139,7 @@ GLOBAL_LIST_EMPTY(announced_news_types)
 	newMsg.author = news.author ? news.author : sendto.author
 	newMsg.admin_locked = !news.can_be_redacted
 	newMsg.body = news.message
+	newMsg.title = "[news.channel_name]: [news.headline]"
 
 	sendto.add_message(newMsg)
 

--- a/code/modules/economy/economy_events/economy_events_mundane.dm
+++ b/code/modules/economy/economy_events/economy_events_mundane.dm
@@ -136,14 +136,13 @@
 
 /datum/event/trivial_news/announce()
 	//copy-pasted from the admin verbs to submit new newscaster messages
-	var/datum/feed_message/newMsg = new /datum/feed_message
+	var/datum/feed_message/newMsg = new
 	newMsg.author = "Editor Mike Hammers"
-	//newMsg.is_admin_message = 1
 	var/datum/trade_destination/affected_dest = pick(GLOB.weighted_mundaneevent_locations)
-	newMsg.body = pick(file2list("config/news/trivial.txt"))
-	newMsg.body = replacetext(newMsg.body,"{{AFFECTED}}",affected_dest.name)
+	var/headline = pick(file2list("config/news/trivial.txt"))
+	newMsg.title = replacetext(headline, "{{AFFECTED}}", affected_dest.name)
 
 	GLOB.news_network.get_channel_by_name("The Gibson Gazette")?.add_message(newMsg)
 	for(var/nc in GLOB.allNewscasters)
 		var/obj/machinery/newscaster/NC = nc
-		NC.alert_news("The Gibson Gazette")
+		NC.alert_news("The Gibson Gazette: [newMsg.title]")

--- a/config/news/trivial.txt
+++ b/config/news/trivial.txt
@@ -1,85 +1,85 @@
-Tree stuck in tajaran; firefighters baffled.
-Armadillos want aardvarks removed from dictionary claims 'here first'.
-Angel found dancing on pinhead ordered to stop; cited for public nuisance.
-Letters claim they are better than numbers; 'Always have been'.
-Pens proclaim pencils obsolete, 'lead is dead'.
-Rock and paper sues scissors for discrimination.
-Steak tell-all book reveals he never liked sitting by potato.
-Woodchuck stops counting how many times he’s chucked 'Never again'.
-{{AFFECTED}} clerk first person able to pronounce '@*$%!'.
-{{AFFECTED}} delis serving boiled paperback dictionaries, 'Adjectives chewy' customers declare.
-{{AFFECTED}} weather deemed 'boring'; meteors and rad storms to be imported.
-Most {{AFFECTED}} security officers prefer cream over sugar.
-Palindrome speakers conference in {{AFFECTED}}; 'Wow!' says Otto.
-Question mark worshipped as deity by ancient {{AFFECTED}} dwellers.
-Spilled milk causes whole {{AFFECTED}} populace to cry.
-World largest carp patty at display on {{AFFECTED}}.
-'Here kitty kitty' no longer preferred tajaran retrieval technique.
-Man travels 7000 light years to retrieve lost hankie, 'It was my favorite'.
-New bowling lane that shoots mini-meteors at bowlers very popular.
-Guy gets tattoo of Tau Ceti on chest 'Asteroid tickles most'.
-Guy gets tattoo of Tau Ceti on chest 'Starship tickles most'.
-Guy gets tattoo of Tau Ceti on chest 'Star tickles most'.
-Guy gets tattoo of Tau Ceti on chest 'CentComm tickles most'.
-Skrell marries computer; wedding attended by 100 modems.
-Chef reports successfully using harmonica as cheese grater.
-Nanotrasen invents handkerchief that says 'Bless you' after sneeze.
-Clone accused of posing for other clones’s school photo.
-Clone accused of stealing other clones’s employee of the month award.
-Woman robs station with hair dryer; crewmen love new style.
-This space for rent.
+Tree Stuck in Tajaran; Firefighters Baffled
+Armadillos Want Aardvarks Removed From Dictionary, Claims 'Here First'
+Angel Found Dancing on Pinhead Ordered to Stop; Cited for Public Nuisance
+Letters Claim They Are Better Than Numbers: 'Always Have Been'
+Pens Proclaim Pencils Obsolete: 'Lead is Dead'
+Rock and Paper Sue Scissors for Discrimination
+Steak Tell-All Book Reveals He Never Liked Sitting By Potato
+Woodchuck Stops Counting How Many Times He's Chucked: 'Never Again'
+{{AFFECTED}} Clerk First Person Able to Pronounce '@*$%!'
+{{AFFECTED}} Delis Serving Boiled Paperback Dictionaries, 'Adjectives Chewy' Customers Declare
+{{AFFECTED}} Weather Deemed 'Boring'; Meteors and Rad Storms to Be Imported
+Most {{AFFECTED}} Security Officers Prefer Cream Over Sugar
+Palindrome Speakers Conference in {{AFFECTED}}; 'Wow!' Says Otto
+Question Mark Worshipped As Deity By Ancient {{AFFECTED}} Dwellers
+Spilled Milk Causes Whole {{AFFECTED}} Populace to Cry
+World Largest Carp Patty At Display on {{AFFECTED}}
+'Here Kitty Kitty' No Longer Preferred Tajaran Retrieval Technique
+Man Travels 7000 Light Years to Retrieve Lost Hankie: 'It Was My Favorite'
+New Bowling Lane That Shoots Mini-Meteors At Bowlers Very Popular
+Guy Gets Tattoo of Tau Ceti on Chest: 'Asteroid Tickles Most'
+Guy Gets Tattoo of Tau Ceti on Chest: 'Starship Tickles Most'
+Guy Gets Tattoo of Tau Ceti on Chest: 'Star Tickles Most'
+Guy Gets Tattoo of Tau Ceti on Chest: 'Centcom Tickles Most'
+Skrell Marries Computer; Wedding Attended By 100 Modems
+Chef Reports Successfully Using Harmonica As Cheese Grater
+Nanotrasen Invents Handkerchief That Says 'Bless You' After Sneeze
+Clone Accused of Posing for Other Clones's School Photo
+Clone Accused of Stealing Other Clones's Employee of the Month Award
+Woman Robs Station With Hair Dryer; Crewmen Love New Style
+This Space for Rent
 {{AFFECTED}} Baker Wins Pickled Crumpet Toss Three Years Running
-Skrell Scientist Discovers Abacus Can Be Used To Dry Towels
-Survey: 'Cheese Louise' Voted Best Pizza Restaurant In Tau Ceti
-I Was Framed, jokes {{AFFECTED}} artist
-Mysterious Loud Rumbling Noises In {{AFFECTED}} Found To Be Mysterious Loud Rumblings
-Alien ambassador becomes lost on {{AFFECTED}}, refuses to ask for directions
-Swamp Gas Verified To Be Exhalations Of Stars--Movie Stars--Long Passed
-Tainted Broccoli Weapon Of Choice For Syndicate Assassins
-Chefs Find Broccoli Effective Tool For Cutting Cheese
-Broccoli Found To Cause Grumpiness In Monkeys
-Survey: 80% Of People on {{AFFECTED}} Love Clog-Dancing
-Giant Hairball Has Perfect Grammar But Rolls rr's Too Much, Linguists Say
-{{AFFECTED}} Phonebooks Print All Wrong Numbers; Results In 15 New Marriages
-Tajaran Burglar Spotted on {{AFFECTED}}, Mistaken For Dalmatian
+Skrell Scientist Discovers Abacus Can Be Used to Dry Towels
+Survey: 'Cheese Louise' Voted Best Pizza Restaurant in Tau Ceti
+I Was Framed, Jokes {{AFFECTED}} Artist
+Mysterious Loud Rumbling Noises in {{AFFECTED}} Found to Be Mysterious Loud Rumblings
+Alien Ambassador Becomes Lost on {{AFFECTED}}, Refuses to Ask for Directions
+Swamp Gas Verified to Be Exhalations of Stars--Movie Stars--Long Passed
+Tainted Broccoli Weapon of Choice for Syndicate Assassins
+Chefs Find Broccoli Effective Tool for Cutting Cheese
+Broccoli Found to Cause Grumpiness in Monkeys
+Survey: 80% of People on {{AFFECTED}} Love Clog-Dancing
+Giant Hairball Has Perfect Grammar But Rolls Rr's Too Much, Linguists Say
+{{AFFECTED}} Phonebooks Print All Wrong Numbers; Results in 15 New Marriages
+Tajaran Burglar Spotted on {{AFFECTED}}, Mistaken for Dalmatian
 Gibson Gazette Updates Frequently Absurd, Poll Indicates
-Esoteric Verbosity Culminates In Communicative Ennui, {{AFFECTED}} Academics Note
+Esoteric Verbosity Culminates in Communicative Ennui, {{AFFECTED}} Academics Note
 Taj Demand Longer Breaks, Cleaner Litter, Slower Mice
-Survey: 3 Out Of 5 Skrell Loathe Modern Art
+Survey: 3 Out of 5 Skrell Loathe Modern Art
 Skrell Scientist Discovers Gravity While Falling Down Stairs
 Boy Saves Tajaran From Tree on {{AFFECTED}}, Thousands Cheer
-Shipment Of Apples Overturns, {{AFFECTED}} Diner Offers Applesauce Special
+Shipment of Apples Overturns, {{AFFECTED}} Diner Offers Applesauce Special
 Spotted Owl Spotted on {{AFFECTED}}
 Humans Everywhere Agree: Purring Tajarans Are Happy Tajarans
-From The Desk Of Wise Guy Sammy: One Word In This Gazette Is Sdrawkcab
-From The Desk Of Wise Guy Sammy: It's Hard To Have Too Much Shelf Space
-From The Desk Of Wise Guy Sammy: Wine And Friendships Get Better With Age
-From The Desk Of Wise Guy Sammy: The Insides Of Golf Balls Are Mostly Rubber Bands
-From The Desk Of Wise Guy Sammy: You Don't Have To Fool All The People, Just The Right Ones
-From The Desk Of Wise Guy Sammy: If You Made The Mess, You Clean It Up
-From The Desk Of Wise Guy Sammy: It Is Easier To Get Forgiveness Than Permission
-From The Desk Of Wise Guy Sammy: Check Your Facts Before Making A Fool Of Yourself
-From The Desk Of Wise Guy Sammy: You Can't Outwait A Bureaucracy
-From The Desk Of Wise Guy Sammy: It's Better To Yield Right Of Way Than To Demand It
-From The Desk Of Wise Guy Sammy: A Person Who Likes Cats Can't Be All Bad
-From The Desk Of Wise Guy Sammy: Help Is The Sunny Side Of Control
-From The Desk Of Wise Guy Sammy: Two Points Determine A Straight Line
-From The Desk Of Wise Guy Sammy: Reading Improves The Mind And Lifts The Spirit
-From The Desk Of Wise Guy Sammy: Better To Aim High And Miss Then To Aim Low And Hit
-From The Desk Of Wise Guy Sammy: Meteors Often Strike The Same Place More Than Once
-Tommy B. Saif Sez: Look Both Ways Before Boarding The Shuttle
-Tommy B. Saif Sez: Hold On; Sudden Stops Sometimes Necessary
+From the Desk of Wise Guy Sammy: One Word in This Gazette is Sdrawkcab
+From the Desk of Wise Guy Sammy: It's Hard to Have Too Much Shelf Space
+From the Desk of Wise Guy Sammy: Wine and Friendships Get Better With Age
+From the Desk of Wise Guy Sammy: The Insides of Golf Balls Are Mostly Rubber Bands
+From the Desk of Wise Guy Sammy: You Don't Have to Fool All the People, Just the Right Ones
+From the Desk of Wise Guy Sammy: If You Made the Mess, You Clean It Up
+From the Desk of Wise Guy Sammy: It is Easier to Get Forgiveness Than Permission
+From the Desk of Wise Guy Sammy: Check Your Facts Before Making a Fool of Yourself
+From the Desk of Wise Guy Sammy: You Can't Outwait a Bureaucracy
+From the Desk of Wise Guy Sammy: It's Better to Yield Right of Way Than to Demand It
+From the Desk of Wise Guy Sammy: A Person Who Likes Cats Can't Be All Bad
+From the Desk of Wise Guy Sammy: Help is the Sunny Side of Control
+From the Desk of Wise Guy Sammy: Two Points Determine a Straight Line
+From the Desk of Wise Guy Sammy: Reading Improves the Mind and Lifts the Spirit
+From the Desk of Wise Guy Sammy: Better to Aim High and Miss Then to Aim Low and Hit
+From the Desk of Wise Guy Sammy: Meteors Often Strike the Same Place More Than Once
+Tommy B. Saif Sez: Look Both Ways Before Boarding the Shuttle
+Tommy B. Saif Sez: Hold on; Sudden Stops Sometimes Necessary
 Tommy B. Saif Sez: Keep Fingers Away From Moving Panels
 Tommy B. Saif Sez: No Left Turn, Except Shuttles
-Tommy B. Saif Sez: Return Seats And Trays To Their Proper Upright Position
-Tommy B. Saif Sez: Eating And Drinking In Docking Bays Is Prohibited
-Tommy B. Saif Sez: Accept No Substitutes, And Don't Be Fooled By Imitations
-Tommy B. Saif Sez: Do Not Remove This Tag Under Penalty Of Law
+Tommy B. Saif Sez: Return Seats and Trays to Their Proper Upright Position
+Tommy B. Saif Sez: Eating and Drinking in Docking Bays is Prohibited
+Tommy B. Saif Sez: Accept No Substitutes, and Don't Be Fooled By Imitations
+Tommy B. Saif Sez: Do Not Remove This Tag Under Penalty of Law
 Tommy B. Saif Sez: Always Mix Thoroughly When So Instructed
-Tommy B. Saif Sez: Try To Keep Six Month's Expenses In Reserve
+Tommy B. Saif Sez: Try to Keep Six Month's Expenses in Reserve
 Tommy B. Saif Sez: Change Not Given Without Purchase
 Tommy B. Saif Sez: If You Break It, You Buy It
-Tommy B. Saif Sez: Reservations Must Be Cancelled 48 Hours Prior To Event To Obtain Refund
+Tommy B. Saif Sez: Reservations Must Be Cancelled 48 Hours Prior to Event to Obtain Refund
 Doughnuts: Is There Anything They Can't Do?
-If Tin Whistles Are Made Of Tin, What Do They Make Foghorns Out Of?
-Broccoli discovered to be colonies of tiny aliens with murder on their minds.
+If Tin Whistles Are Made of Tin, What Do They Make Foghorns Out of?
+Broccoli Discovered to Be Colonies of Tiny Aliens With Murder on Their Minds


### PR DESCRIPTION
## What Does This PR Do
Separate from #29680 as there's a bit more editorializing here, this PR gives periodic news (which currently don't show up in game, to my knowledge) headlines and moves trivial news content into the headline for the purposes of displaying in the newscaster. It also attempts to clean up the style of the trivial news items; the lines in trivial.txt are pretty clearly meant to be headlines, so they should be formatted as such. Surprisingly even the longer headlines, with the name of the newspaper prepended, don't overrun the runechat message size.
## Why It's Good For The Game
People probably rarely actually see these headlines because they only show up as "The Gibson Gazette!" in newscaster announcements and runechat and don't catch people's attention. Hopefully having these more prominently displayed also incentivizes people to add their own or maybe improve what's here, as honestly a bunch of these are pretty lame.
## Testing
![2025_06_27__08_02_56__Paradise Station 13](https://github.com/user-attachments/assets/17017897-2478-414b-bb6e-f538ea94af77)
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: The trivial and mundane news events will now announce their headlines from newscasters.
/:cl:
