### PR TITLE
Adjusts BSH extra loot drop locations

### DIFF
--- a/code/_globalvars/mapping_vars.dm
+++ b/code/_globalvars/mapping_vars.dm
@@ -40,6 +40,7 @@ GLOBAL_LIST_EMPTY(ninjastart)
 GLOBAL_LIST_EMPTY(carplist) //list of all carp-spawn landmarks
 GLOBAL_LIST_EMPTY(syndicateofficer)
 GLOBAL_LIST_EMPTY(roundstart_observer_start)
+GLOBAL_LIST_EMPTY(maints_loot_spawns)
 
 //List of preloaded templates
 GLOBAL_LIST_EMPTY(map_templates)

--- a/code/game/objects/effects/spawners/random/maint_loot_spawners.dm
+++ b/code/game/objects/effects/spawners/random/maint_loot_spawners.dm
@@ -9,6 +9,8 @@
 /obj/effect/spawner/random/maintenance/Initialize(mapload)
 	loot = GLOB.maintenance_loot_tables
 	spawn_loot_count = rand(2, 4)
+	if(is_station_level(z))
+		GLOB.maints_loot_spawns += loc
 
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_EMPTY_MAINT))
 		spawn_loot_chance -= TRAIT_CHANCE_DELTA

--- a/code/modules/station_goals/bluespace_tap.dm
+++ b/code/modules/station_goals/bluespace_tap.dm
@@ -457,7 +457,7 @@
 	radio.autosay("<b>Power spike detected during Bluespace Harvester Operation. Large bluespace payload inbound.</b>", name, "Engineering")
 	// Build location list cache once
 	var/list/possible_spawns = list()
-	var/list/random_spawns = GLOB.nukedisc_respawn
+	var/list/random_spawns = GLOB.maints_loot_spawns
 	// Build list of spawn positions
 	for(var/turf/current_target_turf in view(3, src))
 		possible_spawns.Add(current_target_turf)
@@ -485,7 +485,7 @@
 /obj/machinery/power/bluespace_tap/proc/find_spawn_location(random = FALSE)
 	var/list/possible_spawns = list()
 	if(random)
-		possible_spawns = GLOB.nukedisc_respawn
+		possible_spawns = GLOB.maints_loot_spawns
 	else
 		// Build list of spawn positions
 		for(var/turf/current_target_turf in view(3, src))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Makes extra loot that drops from BSH motherlodes and manual pulls spawn at actual maints loot sites instead of only areas where the nuke disk respawns.

## Why It's Good For The Game

The intended purpose was to allow crew to have better access to BSH loot with a touch of risk. This fulfils that intention, and prevents situations like BSH loot spawning in the toxins mix chamber.

## Testing

Spawned BSH. Triggered motherlode. Saw BSH loot in maints.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Tweaked BSH extra loot drop locations
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
