### PR TITLE
link varedited airlock controllers in latemapping

### DIFF
--- a/code/controllers/subsystem/non_firing/SSlate_mapping.dm
+++ b/code/controllers/subsystem/non_firing/SSlate_mapping.dm
@@ -18,6 +18,13 @@ SUBSYSTEM_DEF(late_mapping)
 		if(console.find_destinations_in_late_mapping)
 			console.connect()
 
+	// Use whether we have any interior door UIDs as a proxy
+	// to determine if we haven't been linked yet
+	var/list/controllers = SSmachines.get_by_type(/obj/machinery/airlock_controller)
+	for(var/obj/machinery/airlock_controller/controller as anything in controllers)
+		if(!length(controller.interior_doors))
+			controller.link_all_items()
+
 	if(length(maze_generators))
 		var/watch = start_watch()
 		log_startup_progress("Generating mazes...")


### PR DESCRIPTION
## What Does This PR Do
This PR ensures that old-school hardcoded controllers, such as the ones used in xenobio, are properly linked. I'm dumb and forgot about this in #29672. It's still good that this linkage isn't happening in LateInitialize (as the work for constructable chambers relies on that), but it has to happen _somewhere_. Despite hating them, varedited airlocks still need to be possible, because they permit for configurations that can't be done otherwise, such as the controller proper being outside of the airlock chamber, which isn't supported by dynamic airlock linkers.
## Why It's Good For The Game
Bugfix.
## Testing
Spawned in Boxstation xeno, operated all linked machines of airlock chamber.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Airlock chambers such as xenobio's should work properly.
/:cl: