### PR TITLE
Add timeouts to several move_away calls

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -233,10 +233,7 @@
 			if(isobj(H.shoes) && !(H.shoes.flags & NODROP))
 				var/thingy = H.shoes
 				H.drop_item_to_ground(thingy)
-				GLOB.move_manager.move_away(thingy, chassis, 15, 2)
-				spawn(20)
-					if(thingy)
-						GLOB.move_manager.stop_looping(thingy)
+				GLOB.move_manager.move_away(thingy, chassis, 15, 2, timeout=20)
 	for(var/obj/mecha/combat/reticence/R in oview(6, chassis))
 		R.occupant_message("\The [R] has protected you from [chassis]'s HONK at the cost of some power.")
 		R.use_power(R.get_charge() / 4)

--- a/code/game/objects/items/weapons/grenades/clusterbuster.dm
+++ b/code/game/objects/items/weapons/grenades/clusterbuster.dm
@@ -47,7 +47,7 @@
 	icon_state = "clusterbang_segment_active"
 	payload = payload_type
 	active = TRUE
-	GLOB.move_manager.move_away(src, loc, rand(1,4))
+	GLOB.move_manager.move_away(src, loc, rand(1,4), timeout=20)
 	spawn(rand(15,60))
 		prime()
 
@@ -69,7 +69,7 @@
 		var/obj/item/grenade/P = new type(loc)
 		if(istype(P, /obj/item/grenade))
 			P.active = TRUE
-		GLOB.move_manager.move_away(P,loc,rand(1,4))
+		GLOB.move_manager.move_away(P,loc,rand(1,4), timeout=20)
 
 		spawn(rand(15,60))
 			if(!QDELETED(P))

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -340,10 +340,7 @@
 			if(isobj(H.shoes))
 				var/thingy = H.shoes
 				if(H.drop_item_to_ground(H.shoes))
-					GLOB.move_manager.move_away(thingy, H, 15, 2)
-					spawn(20)
-						if(thingy)
-							GLOB.move_manager.stop_looping(thingy)
+					GLOB.move_manager.move_away(thingy, H, 15, 2, timeout=20)
 
 /obj/item/organ/internal/honktumor/cursed
 	unremovable = TRUE


### PR DESCRIPTION
## What Does This PR Do
Adds a timeout to two move_away calls that were missing it, so they don't cause objects to be perpetually trying to move.
Another couple were migrated from spawning their own timeout to the official mechanism.
A quick search through the code shows that these were the only `/obj` move_manager clients lacking a timeout. There are some on `/mob`, but AFAICT, the mob AI expects that, and will stop/replace the move command as needed.

## Why It's Good For The Game
A clusterbuster of airhorns should not create a constantly-triggered mass of airhorns that bust their way out of a locker when you try to collect them.

## Testing
Knocked someone's shoes off with a honk mech.
Set off a clusterbuster of airhorns.
Gave a clown a honk tumor.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
fix: Airhorn clusterbusters are no longer incredibly cursed.
/:cl: