### PR TITLE
Allows people to toggle the cryocell auto-eject timer on and off

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -235,6 +235,7 @@
 #define STATUS_EFFECT_REMOVE_CUFFS /datum/status_effect/action_status_effect/remove_handcuffs
 #define STATUS_EFFECT_REMOVE_MUZZLE /datum/status_effect/action_status_effect/remove_muzzle
 #define STATUS_EFFECT_UNBUCKLE /datum/status_effect/action_status_effect/unbuckle
+#define STATUS_EFFECT_EXIT_CRYOCELL /datum/status_effect/action_status_effect/exit_cryocell
 
 //////////////////////////
 // Mind batter variants //

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -820,6 +820,11 @@ so as to remain in compliance with the most up-to-date laws."
 	name = "Legcuffed"
 	desc = "You're legcuffed, which slows you down considerably. Click the alert to free yourself."
 
+/atom/movable/screen/alert/restrained/cryocell
+	name = "Cryogenics"
+	desc = "You're inside a freezing cold medical cell. Click the alert to free yourself."
+	icon_state = "asleep"
+
 /atom/movable/screen/alert/restrained/Click()
 	if(!isliving(usr) || !..())
 		return

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -406,3 +406,6 @@
 
 /datum/status_effect/action_status_effect/unbuckle
 	id = "unbuckle"
+
+/datum/status_effect/action_status_effect/exit_cryocell
+	id = "exit_cryocell"

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -1011,6 +1011,19 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 	update_inv_handcuffed()
 	update_hands_hud()
 
+// Called to escape a cryocell
+/mob/living/carbon/proc/cryo_resist(obj/machinery/atmospherics/unary/cryo_cell/cell)
+	var/effective_breakout_time = 1 MINUTES
+	if(stat != UNCONSCIOUS)
+		effective_breakout_time = 5 SECONDS
+
+	if(has_status_effect(STATUS_EFFECT_EXIT_CRYOCELL))
+		to_chat(src, "<span class='notice'>You are already trying to exit [cell].</span>")
+		return
+
+	apply_status_effect(STATUS_EFFECT_EXIT_CRYOCELL)
+	cell.attempt_escape(src, effective_breakout_time)
+
 /mob/living/carbon/get_standard_pixel_y_offset()
 	if(IS_HORIZONTAL(src))
 		if(buckled)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -730,6 +730,10 @@
 
 ///proc extender of [/mob/living/verb/resist] meant to make the process queable if the server is overloaded when the verb is called
 /mob/living/proc/run_resist()
+	if(istype(loc, /obj/machinery/atmospherics/unary/cryo_cell))
+		var/obj/C = loc
+		C.container_resist(src)
+		return
 	if(!can_resist())
 		return
 	changeNext_move(CLICK_CD_RESIST)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Allows one to use a multitool on a cryocell with an open panel to disable the 1-minute auto-eject timer.

## Why It's Good For The Game

Brought forth from decoration woes, this allows players to utilize cryocells as a method of decor by having the occupants not auto-eject after a certain time frame. Currently, regardless of power status or anything else, anyone put into a cryo cell is ejected after one minute. This allows people to turn off that functionality.

People can still manually exit cryocells, and all cryocells currently start with the auto-eject timer on. If someone were to be crammed into a cryocell with it off, eventually the cryocell will run out of cryoxodone and the person inside will regain consciousness, allowing them to exit the cell freely.

This does not effect the other automatic eject functions - just the catch-all 1 minute timer.

## Testing

Turned off cryocell auto eject. Skrell did not get ejected automatically after a minute. Hopped in, was able to free self after cryox ran out.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Cryocells can now have their auto-eject timer turned off with a multitool
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
