### PR TITLE
sortmobs() fixes

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -386,8 +386,11 @@
 	for(var/mob/living/simple_animal/slime/M in sortmob)
 		moblist.Add(M)
 	for(var/mob/living/simple_animal/M in sortmob)
-		moblist.Add(M)
+		if(!istype(M, /mob/living/simple_animal/slime))
+			moblist.Add(M)
 	for(var/mob/living/basic/M in sortmob)
+		moblist.Add(M)
+	for(var/mob/camera/blob/M in sortmob)
 		moblist.Add(M)
 	return moblist
 


### PR DESCRIPTION
## What Does This PR Do
`sortmobs()` is used in a few places where we want mobs of the same type to appear together, notably the orbit menu and the (global) player panel.

This fixes two issues with `sortmobs()`:
1. Slimes were listed twice.
2. Blob overminds were not listed at all.

## Why It's Good For The Game
Makes it much more feasible for admins to deal with blobs, improves orbit menu, and removes some duplicate entries.

## Testing
Became a slime. Looked at player panel and orbit menu.
Became a blob. Looked at player panel and orbit menu.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
fix: Blob overminds now appear in orbit menu and admins' player listing
fix: Slimes no longer appear twice in orbit menu and admins' player listing
/:cl: