### PR TITLE
Make all siphon vents siphon

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -46,6 +46,7 @@
 
 /obj/machinery/atmospherics/unary/vent_pump/siphon
 	releasing = FALSE
+	external_pressure_bound = 0
 
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on
 	on = TRUE


### PR DESCRIPTION
## What Does This PR Do
The `/obj/machinery/atmospherics/unary/vent_pump/siphon` and `/obj/machinery/atmospherics/unary/vent_pump/siphon/on` vent subtypes are used in mapping to create vents that siphon by default, like the one in the xenobiology slime kill chamber. Unfortunately, siphon vents respect the external pressure bound, so if there's normal air in the room, these vents will do nothing by default. Farragus alone had the necessary override to set this to 0.

Since the intent of the mapper is clearly to make a vent that siphons, this sets the default pressure bound to 0, so that they actually siphon. 

## Why It's Good For The Game
Mapping objects should work in the way that they appear to.

## Testing
Turned down the cooler in xenobiology on Cyberiad. Slime kill chamber worked as expected.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
fix: Mapped-in vents that appear to siphon will now actually siphon, instead of only taking air above normal pressure. This makes xenobiology kill chambers work more intuitively.
/:cl: