### PR TITLE
Make it easier to get blob player panels.

### DIFF
--- a/code/__HELPERS/mob_helpers.dm
+++ b/code/__HELPERS/mob_helpers.dm
@@ -558,6 +558,10 @@ GLOBAL_LIST_EMPTY(do_after_once_tracker)
 		return null
 	if(ismob(A))
 		return A
+	if(istype(A, /obj/structure/blob/core))
+		var/obj/structure/blob/core/blob = A
+		if(blob.overmind)
+			return blob.overmind
 
 	. = null
 	for(var/mob/M in A)


### PR DESCRIPTION
## What Does This PR Do
Adminghosts can now ctrl+click blob cores to open their player panel.

## Why It's Good For The Game
Admin tooling good.

## Testing
Made blob.
Ctrl+clicked as adminghost.
:+1: 

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
fix: Adminghosts can now ctrl+click blob cores to open their player panel.
/:cl: