### PR TITLE
Prevent language-switching in the middle of a word or number.

### DIFF
--- a/code/_globalvars/_regexes.dm
+++ b/code/_globalvars/_regexes.dm
@@ -2,4 +2,5 @@ GLOBAL_DATUM_INIT(filename_forbidden_chars, /regex, regex(@{""|[\\\n\t/?%*:|<>]|
 GLOBAL_DATUM_INIT(is_color, /regex, regex("^#\[0-9a-fA-F]{6}$"))
 GLOBAL_DATUM_INIT(regex_rgb_text, /regex, regex(@"^#?(([0-9a-fA-F]{8})|([0-9a-fA-F]{6})|([0-9a-fA-F]{3}))$"))
 GLOBAL_DATUM_INIT(is_http_protocol, /regex, regex("^https?://"))
+GLOBAL_DATUM_INIT(is_alphanumeric, /regex, regex(@"[0-9a-zA-Z]"))
 GLOBAL_PROTECT(filename_forbidden_chars)

--- a/code/modules/mob/mob_say_base.dm
+++ b/code/modules/mob/mob_say_base.dm
@@ -159,8 +159,17 @@
 
 /mob/proc/find_valid_prefixes(message)
 	var/list/prefixes = list() // [["Common", start, end], ["Gutter", start, end]]
+	var/lower_message = lowertext(message)
+	var/is_alphanumeric = FALSE
+	var/was_alphanumeric = FALSE
 	for(var/i in 1 to length(message))
-		var/selection = trim_right(lowertext(copytext(message, i, i + 3)))
+		was_alphanumeric = is_alphanumeric
+		is_alphanumeric = GLOB.is_alphanumeric.Find(lower_message[i])
+		if(was_alphanumeric)
+			// Language prefixes should not activate in the middle of a word or number.
+			continue
+
+		var/selection = trim_right(copytext(lower_message, i, i + 3))
 		var/datum/language/L = GLOB.language_keys[selection]
 		if(L != null && can_speak_language(L)) // What the fuck... remove the L != null check if you ever find out what the fuck is adding `null` to the languages list on absolutely random mobs... seriously what the hell...
 			prefixes[++prefixes.len] = list(L, i, i + length(selection))


### PR DESCRIPTION
## What Does This PR Do
Changes the language parsing to not allow language switches that start in the middle of a word or number.

## Why It's Good For The Game
Mostly so it won't eat anomaly codes when they happen to overlap with a language you know.

## Images of changes
![image](https://github.com/user-attachments/assets/41eef3f2-2d95-40a1-be59-2f1a500d2e38)

## Testing
See above.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
tweak: You can no longer switch languages in the middle of a word or number; the character before the language selector has to be a space or some sort of punctuation. Notably, this means you can now say an anomaly's code is 4.1 without having to worry about whether you know sol common (and other similar language issues).
/:cl: