### PR TITLE
Don't transfer mind when reincarnating.

### DIFF
--- a/code/modules/mob/dead/observer/observer_base.dm
+++ b/code/modules/mob/dead/observer/observer_base.dm
@@ -811,11 +811,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	var/mob/living/carbon/human/new_char = new(get_turf(src))
 	client.prefs.active_character.copy_to(new_char)
-	if(mind)
-		mind.active = TRUE
-		mind.transfer_to(new_char)
-	else
-		new_char.key = key
+	mind = null
+	new_char.key = key
 
 	return new_char
 


### PR DESCRIPTION
## What Does This PR Do
Removes the mind transfer step from re-incarnating a ghost into a mob.

## Why It's Good For The Game
Admins frequently use the re-incarnate link in Player Panel, often their own, to create new human mobs with a given outfit. This has always behaved rather oddly when combined with creating antags.

The reason for the odd behavior is the rather questionable decision to transfer any mind the ghost has into the new mob. This creates unexpected results if, for instance, you:

1. Re-incarnate yourself.
2. Make yourself an antag.
3. Aghost.
4. Re-incarnate again.

Because the existing mind gets transferred, it's forcibly pulled out of the first mob and stuffed into the second.

## Testing
Repeatedly re-incarnated myself, sometimes adding antag datums, sometimes as an ancient vampire (because it comes with spells). Moved around between the mobs. Everything behaved consistently.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
fix: Reincarnating a ghost as an admin will no longer have unexpected effects if the ghost has a pre-existing mind.
/:cl: