### PR TITLE
Remove dead people appearing asleep "Weekend at Bernie's" behavior

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -238,20 +238,15 @@
 
 
 	var/appears_dead = FALSE
-	var/just_sleeping = FALSE //We don't appear as dead upon casual examination, just sleeping
 
 	if(stat == DEAD || HAS_TRAIT(src, TRAIT_FAKEDEATH))
 		var/obj/item/clothing/glasses/E = get_item_by_slot(ITEM_SLOT_EYES)
-		var/are_we_in_weekend_at_bernies = E?.tint && istype(buckled, /obj/structure/chair) //Are we in a chair with our eyes obscured?
 
-		if(isliving(user) && are_we_in_weekend_at_bernies)
-			just_sleeping = TRUE
-		else
-			appears_dead = TRUE
+		appears_dead = TRUE
 
 		if(suiciding)
 			msg += "<span class='warning'>[p_they(TRUE)] appear[p_s()] to have committed suicide... there is no hope of recovery.</span>\n"
-		if(!just_sleeping)
+		else
 			msg += "<span class='deadsay'>[p_they(TRUE)] [p_are()] limp and unresponsive"
 			if(get_int_organ(/obj/item/organ/internal/brain) && !client) // body has no online player inside - let's look for ghost
 				if(!check_ghost_client()) // our ghost is offline or no ghost attached to body
@@ -314,7 +309,7 @@
 	msg += "</span>"
 
 	if(!appears_dead)
-		if(stat == UNCONSCIOUS || just_sleeping)
+		if(stat == UNCONSCIOUS)
 			msg += "[p_they(TRUE)] [p_are()]n't responding to anything around [p_them()] and seems to be asleep.\n"
 		else if(getBrainLoss() >= 60)
 			msg += "[p_they(TRUE)] [p_are()] staring forward with a blank expression.\n"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Removes "Weekend at Bernie's"ing people. Meaning people in chairs wearing sunglasses appeared to be sleeping and not dead. Now if you are dead in a chair, you appear dead, no matter what.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

If no one is in on the joke, it isn't funny.

See this comment on [the original PR](https://github.com/ParadiseSS13/Paradise/pull/18649).

> The author of this feature on /tg/station was concerned that if it happened with any chair, it'd risk losing its novelty and end up being something that happened unintentionally more often than not.

I have only seen this feature cause confusion for new and experienced players alike. I have not seen it used for its intended purpose. Death can already be confusing with people ghosting, going catatonic, declaring DNR, suiciding, SSD bubbles appearing on corpses. This does not need to complicate things further. I don't see any value in retaining this feature in any way, shape, or form.

## Testing

<!-- How did you test the PR, if at all? -->

Killed myself in a chair wearing sunglasses, examined myself, appeared dead. Joined with a second client and examined the body, still looks dead to me coach.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: dead people in chairs wearing sunglasses look dead when examined
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
