### PR TITLE
ensure space transit z levels receive comms

### DIFF
--- a/_maps/__MAP_DEFINES.dm
+++ b/_maps/__MAP_DEFINES.dm
@@ -33,6 +33,8 @@
 	#define REACHABLE_SPACE_ONLY "Reachable Space Only"
 	/// A level used for spawning map areas in tests
 	#define GAME_TEST_LEVEL "Game Test Level"
+	/// Tcomms relays will always extend to this level.
+	#define TCOMM_RELAY_ALWAYS "Tcomm Relay Always"
 
 // Level names
 	#define MAIN_STATION "Main Station"

--- a/code/__DEFINES/dcs/global_signals.dm
+++ b/code/__DEFINES/dcs/global_signals.dm
@@ -4,7 +4,7 @@
  * All signals send the source datum of the signal as the first argument
  */
 
-///from base of datum/controller/subsystem/mapping/proc/add_new_zlevel(): (list/args)
+///from base of datum/controller/subsystem/mapping/proc/add_new_zlevel(): (name, linkage, list/traits, transition_tag, level_type, zlevel)
 #define COMSIG_GLOB_NEW_Z "!new_z"
 /// called after a successful var edit somewhere in the world: (list/args)
 #define COMSIG_GLOB_VAR_EDIT "!var_edit"

--- a/code/controllers/subsystem/non_firing/SSmapping.dm
+++ b/code/controllers/subsystem/non_firing/SSmapping.dm
@@ -111,8 +111,8 @@ SUBSYSTEM_DEF(mapping)
 
 	// Makes a blank space level for the sake of randomness
 	GLOB.space_manager.add_new_zlevel("Empty Area", linkage = CROSSLINKED, traits = empty_z_traits)
-	// Add a reserved z-level
-	add_reservation_zlevel()
+	// Add a reserved z-level for shuttle transit
+	add_reservation_zlevel(required_traits = list(TCOMM_RELAY_ALWAYS))
 
 	// Now we make a list of areas for teleport locs
 	// Located below is some of the worst code I've ever seen
@@ -406,7 +406,7 @@ SUBSYSTEM_DEF(mapping)
 	var/list/required_traits = reserve.required_traits | Z_FLAG_RESERVED
 	for(var/z in GLOB.space_manager.z_list)
 		var/datum/space_level/level = GLOB.space_manager.z_list[z]
-		if(!level.has_traits(required_traits))
+		if(!level.has_all_traits(required_traits))
 			continue
 		if(reserve.reserve(width, height, z))
 			return reserve

--- a/code/controllers/subsystem/non_firing/SSmapping.dm
+++ b/code/controllers/subsystem/non_firing/SSmapping.dm
@@ -408,7 +408,7 @@ SUBSYSTEM_DEF(mapping)
 		var/datum/space_level/level = GLOB.space_manager.z_list[z]
 		if(!level.has_traits(required_traits))
 			continue
-		if(reserve.reserve(width, height, level.zpos))
+		if(reserve.reserve(width, height, z))
 			return reserve
 	//If we didn't return at this point, theres a good chance we ran out of room on the exisiting reserved z levels, so lets try a new one
 	var/z_level_num = add_reservation_zlevel(required_traits)

--- a/code/game/machinery/tcomms/tcomms_core.dm
+++ b/code/game/machinery/tcomms/tcomms_core.dm
@@ -79,8 +79,6 @@
 		return FALSE
 	if(zlevel in reachable_zlevels)
 		return TRUE
-	if(check_level_trait(zlevel, TCOMM_RELAY_ALWAYS))
-		return TRUE
 	else
 		return FALSE
 

--- a/code/modules/space_management/space_level.dm
+++ b/code/modules/space_management/space_level.dm
@@ -189,9 +189,9 @@ GLOBAL_LIST_INIT(cable_typecache, typecacheof(/obj/structure/cable))
 	SSmachines.setup_template_powernets(cables)
 	cables.Cut()
 
-/datum/space_level/proc/has_traits(list/traits)
+/datum/space_level/proc/has_all_traits(list/traits)
 	// Cool, horrible set inclusion
-	return sortTim(flags & traits, GLOBAL_PROC_REF(cmp_text_asc)) == sortTim(traits, GLOBAL_PROC_REF(cmp_text_asc))
+	return length(flags & traits) == length(traits)
 
 /datum/space_level/lavaland/set_transition_borders()
 	// really no reason why these need to be so large,

--- a/code/modules/space_management/space_level.dm
+++ b/code/modules/space_management/space_level.dm
@@ -189,6 +189,10 @@ GLOBAL_LIST_INIT(cable_typecache, typecacheof(/obj/structure/cable))
 	SSmachines.setup_template_powernets(cables)
 	cables.Cut()
 
+/datum/space_level/proc/has_traits(list/traits)
+	// Cool, horrible set inclusion
+	return sortTim(flags & traits, GLOBAL_PROC_REF(cmp_text_asc)) == sortTim(traits, GLOBAL_PROC_REF(cmp_text_asc))
+
 /datum/space_level/lavaland/set_transition_borders()
 	// really no reason why these need to be so large,
 	// especially since ruin placement is already constrained

--- a/code/modules/space_management/turf_reservation.dm
+++ b/code/modules/space_management/turf_reservation.dm
@@ -37,6 +37,9 @@
 	/// The turf type the reservation is initially made with
 	var/turf_type = /turf/space
 
+	/// The z-level traits required by the turf reservation
+	var/list/required_traits = list()
+
 /datum/turf_reservation/New()
 	LAZYADD(SSmapping.turf_reservations, src)
 
@@ -153,3 +156,4 @@
 
 /datum/turf_reservation/transit
 	turf_type = /turf/space/transit
+	required_traits = list(TCOMM_RELAY_ALWAYS)

--- a/code/modules/space_management/turf_reservation.dm
+++ b/code/modules/space_management/turf_reservation.dm
@@ -37,7 +37,10 @@
 	/// The turf type the reservation is initially made with
 	var/turf_type = /turf/space
 
-	/// The z-level traits required by the turf reservation
+	/// The z-level traits required by the turf reservation. Modify only if
+	/// you are absolutely certain pre-existing reservation types do not support
+	/// your use-case, as an entirely new z-level will be reserved if this list
+	/// of traits is unique.
 	var/list/required_traits = list()
 
 /datum/turf_reservation/New()

--- a/code/modules/space_management/zlevel_manager.dm
+++ b/code/modules/space_management/zlevel_manager.dm
@@ -107,7 +107,6 @@ GLOBAL_DATUM_INIT(space_manager, /datum/zlev_manager, new())
 // Increments the max z-level by one
 // For convenience's sake returns the z-level added
 /datum/zlev_manager/proc/add_new_zlevel(name, linkage = SELFLOOPING, traits = list(BLOCK_TELEPORT), transition_tag, level_type = /datum/space_level)
-	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NEW_Z, args)
 	if(name in levels_by_name)
 		throw EXCEPTION("Name already in use: [name]")
 	world.maxz++
@@ -117,6 +116,7 @@ GLOBAL_DATUM_INIT(space_manager, /datum/zlev_manager, new())
 	var/datum/space_level/S = new level_type(our_z, name, transition_type = linkage, traits = traits, transition_tag_ = transition_tag)
 	levels_by_name[name] = S
 	z_list["[our_z]"] = S
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NEW_Z, name, linkage, traits, transition_tag, level_type, our_z)
 	return our_z
 
 /datum/zlev_manager/proc/cut_levels_downto(new_maxz)


### PR DESCRIPTION
## What Does This PR Do
This PR adds a z-level trait which is checked by tcomms relays. Z-levels with this trait will always receive radio messages, regardless of whether there's a relay on them. It refactors a bit of the surrounding code, adding the ability to specify required traits in a turf reservation and ensuring a z-level with those traits exists before creating a new one. It makes the signature for the new z-level signal more explicit, and has tcomms cores register to listen for when they get added, since that can happen whenever one is requested. Fixes #29653.
## Why It's Good For The Game
Allows transit z-levels to have tcomms as expected, but doesn't force all new space levels to have one, so admins can still have their events on levels that are out of radio range.
## Testing
Got on mining shuttle, sent a radio message when in transit. Logged in as a guest, ensured I could hear radio from transit sector when shuttle was in transit. May want to TM it just for sanity's sake.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Telecomms messages will properly be relayed to and from ships and shuttles in transit.
/:cl: