### PR TITLE
Adds new trader shuttles for each trader type

### DIFF
--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -394,10 +394,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ninja/outpost)
-"bA" = (
-/obj/effect/landmark/spawner/tradergearminor,
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/trade/sol)
 "bB" = (
 /obj/effect/landmark/abductor/scientist,
 /turf/simulated/floor/plating/abductor,
@@ -4030,13 +4026,6 @@
 /obj/item/reagent_containers/glass/bottle/adminordrazine,
 /turf/simulated/floor/plasteel/freezer,
 /area/admin)
-"of" = (
-/turf/simulated/wall/mineral/titanium,
-/area/shuttle/trade/sol)
-"og" = (
-/obj/effect/spawner/window/shuttle,
-/turf/simulated/floor/plating,
-/area/shuttle/trade/sol)
 "oh" = (
 /obj/structure/flora/grass/jungle,
 /turf/simulated/floor/grass/jungle,
@@ -4139,13 +4128,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plasteel/freezer,
 /area/admin)
-"oF" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "burst_l"
-	},
-/turf/simulated/floor/plating/airless,
-/area/shuttle/trade/sol)
 "oG" = (
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "nukeop_ready";
@@ -4161,11 +4143,6 @@
 /obj/item/storage/fancy/crayons,
 /turf/simulated/floor/plasteel/freezer,
 /area/syndicate_mothership)
-"oI" = (
-/obj/effect/spawner/random/traders/civilian,
-/obj/structure/closet,
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/trade/sol)
 "oJ" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/condiment/saltshaker{
@@ -4188,11 +4165,6 @@
 	icon_state = "cafeteria"
 	},
 /area/tdome/tdomeobserve)
-"oL" = (
-/obj/effect/spawner/random/traders/minerals,
-/obj/structure/closet,
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/trade/sol)
 "oM" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/beer{
@@ -4237,14 +4209,6 @@
 	icon_state = "bar"
 	},
 /area/syndicate_mothership)
-"oS" = (
-/obj/machinery/light/spot{
-	dir = 1
-	},
-/obj/effect/spawner/random/traders/donksoft,
-/obj/structure/closet,
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/trade/sol)
 "oT" = (
 /obj/item/bikehorn/airhorn,
 /obj/structure/flora/grass/jungle,
@@ -4279,12 +4243,6 @@
 	},
 /turf/simulated/floor/backrooms_carpet,
 /area/backrooms)
-"pa" = (
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/trade/sol)
-"pc" = (
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/trade/sol)
 "pe" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -4298,14 +4256,6 @@
 /obj/structure/lightable/bonfire,
 /turf/simulated/floor/plating/asteroid/snow,
 /area/syndicate_mothership)
-"pg" = (
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/obj/machinery/door/airlock/titanium/glass{
-	name = "trader shuttle airlock";
-	security_level = 6
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/trade/sol)
 "ph" = (
 /turf/simulated/wall/r_wall,
 /area/start)
@@ -4316,12 +4266,6 @@
 	},
 /turf/simulated/floor/plasteel/freezer,
 /area/syndicate_mothership)
-"pj" = (
-/obj/machinery/light/spot{
-	dir = 1
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/trade/sol)
 "pk" = (
 /obj/item/storage/box/donkpockets,
 /obj/structure/table/glass/reinforced/plastitanium,
@@ -4449,30 +4393,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass,
 /area/centcom/evac)
-"pO" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8
-	},
-/turf/simulated/floor/plating/airless,
-/area/shuttle/trade/sol)
-"pP" = (
-/obj/machinery/door_control/no_emag{
-	id = "soltrader_north";
-	name = "Trade Deposits Door";
-	normaldoorcontrol = 1;
-	pixel_x = 24;
-	pixel_y = -8;
-	req_access = list(160)
-	},
-/obj/machinery/door_control/no_emag{
-	id = "trader_privacy";
-	name = "Privacy Shutters Control";
-	pixel_x = 24;
-	pixel_y = 8;
-	req_access = list(160)
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/trade/sol)
 "pR" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -4595,9 +4515,6 @@
 /obj/item/storage/fancy/matches,
 /turf/simulated/floor/carpet/black,
 /area/ghost_bar)
-"qn" = (
-/turf/simulated/wall/mineral/titanium/nodiagonal,
-/area/shuttle/trade/sol)
 "qo" = (
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/assault_pod)
@@ -4607,22 +4524,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/centcom/control)
-"qq" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "soltradeship_north";
-	name = "Security Doors";
-	opacity = 0
-	},
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/obj/machinery/door/airlock/titanium/glass{
-	id_tag = "soltrader_north";
-	name = "trader shuttle airlock";
-	security_level = 6
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/trade/sol)
 "qr" = (
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/centcom/evac)
@@ -5108,11 +5009,6 @@
 /obj/machinery/computer/shuttle/syndicate/drop_pod,
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/assault_pod)
-"rK" = (
-/obj/effect/spawner/random/traders/science,
-/obj/structure/closet,
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/trade/sol)
 "rL" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -5183,11 +5079,6 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/transport)
-"rY" = (
-/obj/effect/spawner/random/traders/medical,
-/obj/structure/closet,
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/trade/sol)
 "rZ" = (
 /obj/item/radio/intercom/syndicate{
 	pixel_x = -28
@@ -5205,12 +5096,6 @@
 "sd" = (
 /turf/simulated/floor/backrooms_carpet,
 /area/backrooms)
-"se" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/trade/sol)
 "sf" = (
 /turf/simulated/floor/light,
 /area/centcom/specops)
@@ -5221,18 +5106,6 @@
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/assault_pod)
-"sh" = (
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "open";
-	id_tag = "trader_privacy";
-	name = "Privacy Shutters";
-	opacity = 0
-	},
-/obj/effect/spawner/window/shuttle,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/trade/sol)
 "sj" = (
 /turf/simulated/floor/plasteel/dark,
 /area/tdome/tdomeadmin)
@@ -5258,13 +5131,6 @@
 /obj/structure/railing,
 /turf/simulated/floor/plasteel,
 /area/centcom/evac)
-"sq" = (
-/obj/machinery/economy/atm/directional/north,
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/trade/sol)
 "sr" = (
 /obj/machinery/door/poddoor/impassable{
 	name = "Heavy Supply";
@@ -5656,12 +5522,6 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation/centcom)
-"tM" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/trade/sol)
 "tN" = (
 /obj/machinery/door/window/classic/normal{
 	dir = 1
@@ -5705,21 +5565,16 @@
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership)
 "tY" = (
-/obj/docking_port/mobile/trade_sol,
-/obj/machinery/door/airlock/titanium/glass{
-	id_tag = "s_docking_airlock"
-	},
 /obj/docking_port/stationary{
 	dir = 8;
-	dwidth = 4;
-	height = 11;
+	dwidth = 11;
+	height = 30;
 	id = "trader_base";
 	name = "docking bay at Trading Satellite";
-	width = 9
+	width = 22
 	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/trade/sol)
+/turf/space,
+/area/space/centcomm)
 "tZ" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "trader_base";
@@ -5906,13 +5761,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/admin)
-"uB" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "burst_r"
-	},
-/turf/simulated/floor/plating/airless,
-/area/shuttle/trade/sol)
 "uC" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -5960,11 +5808,6 @@
 	icon_state = "green"
 	},
 /area/centcom/evac)
-"uP" = (
-/obj/effect/spawner/random/traders/security,
-/obj/structure/closet,
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/trade/sol)
 "uR" = (
 /obj/machinery/door/airlock/titanium,
 /obj/structure/fans/tiny,
@@ -6006,21 +5849,6 @@
 /obj/structure/statue/uranium/nuke,
 /turf/simulated/floor/plating/asteroid/snow,
 /area/syndicate_mothership)
-"vb" = (
-/obj/effect/spawner/random/traders/engineering,
-/obj/structure/closet,
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/trade/sol)
-"vc" = (
-/obj/machinery/flasher{
-	id = "soltraderflash";
-	pixel_y = -28
-	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/trade/sol)
 "vd" = (
 /turf/simulated/floor/carpet/green,
 /area/ghost_bar)
@@ -6071,41 +5899,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/admin)
-"vo" = (
-/obj/machinery/door_control/no_emag{
-	id = "soltrader_south";
-	name = "Trade Deposits Door";
-	normaldoorcontrol = 1;
-	pixel_x = 24;
-	pixel_y = 8;
-	req_access = list(160)
-	},
-/obj/machinery/flasher_button{
-	id = "soltraderflash";
-	pixel_x = 24;
-	pixel_y = -8
-	},
-/obj/machinery/computer/shuttle/trade/sol{
-	dir = 8
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/trade/sol)
-"vp" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "soltradeship_south";
-	name = "Security Doors";
-	opacity = 0
-	},
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/obj/machinery/door/airlock/titanium/glass{
-	id_tag = "soltrader_south";
-	name = "trader shuttle airlock";
-	security_level = 6
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/trade/sol)
 "vq" = (
 /obj/structure/chair/sofa/corp,
 /turf/simulated/floor/transparent/glass,
@@ -6294,25 +6087,6 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/carpet,
 /area/admin)
-"vY" = (
-/obj/effect/spawner/random/traders/large_item,
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/trade/sol)
-"vZ" = (
-/obj/effect/spawner/random/traders/vehicle,
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/trade/sol)
-"wa" = (
-/obj/machinery/light/spot,
-/obj/effect/spawner/random/traders/service,
-/obj/structure/closet,
-/obj/item/stack/tile/disco_light/thirty,
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/trade/sol)
-"wb" = (
-/obj/machinery/light/spot,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/trade/sol)
 "wc" = (
 /obj/structure/urinal{
 	pixel_y = 28
@@ -12818,10 +12592,6 @@
 	icon_state = "bot"
 	},
 /area/shuttle/escape)
-"SU" = (
-/obj/effect/landmark/spawner/tradergearmajor,
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/trade/sol)
 "SV" = (
 /turf/simulated/wall/indestructible/fakeglass,
 /area/tdome/tdomeadmin)
@@ -48177,17 +47947,17 @@ aN
 aN
 aN
 aN
-vG
-vG
-vG
-vG
-vG
-vG
-vG
-vG
-vG
-vG
-vG
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
 aN
 aN
 aN
@@ -48434,17 +48204,17 @@ aN
 aN
 aN
 aN
-vG
-of
-oF
-pO
-oF
-pO
-uB
-pO
-uB
-of
-vG
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
 aN
 aN
 aN
@@ -48691,17 +48461,17 @@ aN
 aN
 aN
 aN
-vG
-of
-of
-of
-of
-of
-of
-of
-of
-of
-vG
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
 aN
 aN
 aN
@@ -48948,17 +48718,17 @@ aN
 aN
 aN
 aN
-vG
-of
-oI
-pc
-bA
-pc
-SU
-pc
-vY
-of
-vG
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
 aN
 aN
 aN
@@ -49205,17 +48975,17 @@ aN
 aN
 aN
 aN
-vG
-og
-oL
-pc
-rY
-pc
-vb
-pc
-vZ
-og
-vG
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
 aN
 aN
 aN
@@ -49462,17 +49232,17 @@ aN
 aN
 aN
 aN
-vG
-of
-oS
-pc
-rK
-pc
-uP
-pc
-wa
-of
-vG
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
 aN
 aN
 aN
@@ -49719,17 +49489,17 @@ aN
 aN
 aN
 aN
-vG
-of
-pa
-pa
-pa
-pa
-pa
-se
-pa
-of
-vG
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
 aN
 aN
 aN
@@ -49976,17 +49746,17 @@ aN
 aN
 aN
 aN
-vG
-of
-pc
-pP
-se
-se
-se
-vo
-pc
-of
-vG
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
 aN
 aN
 aN
@@ -50233,17 +50003,17 @@ aN
 aN
 aN
 aN
-vG
-of
-pg
-qn
-sh
-sh
-sh
-qn
-pg
-of
-vG
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
 aN
 aN
 aN
@@ -50490,17 +50260,17 @@ aN
 aN
 aN
 aN
-vG
-of
-pc
-of
-sq
-tM
-vc
-of
-pc
-of
-vG
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
 aN
 aN
 aN
@@ -50747,17 +50517,17 @@ aN
 aN
 aN
 aN
-vG
-og
-pj
-qq
-pc
-pc
-pc
-vp
-wb
-og
-vG
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
 aN
 aN
 aN
@@ -51004,17 +50774,17 @@ aN
 aN
 aN
 aN
-vG
-of
-of
-of
-og
+aN
+aN
+aN
+aN
+aN
 tY
-og
-of
-of
-of
-vG
+aN
+aN
+aN
+aN
+aN
 aN
 aN
 aN
@@ -51261,13 +51031,13 @@ aN
 aN
 aN
 aN
-vG
-vG
-vG
+aN
+aN
+aN
 vG
 vG
 tZ
-vG
+tZ
 vG
 vG
 vG
@@ -51524,7 +51294,7 @@ aN
 vG
 sv
 tF
-tA
+tF
 vG
 wc
 wB

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -5713,7 +5713,7 @@
 	dir = 8;
 	dwidth = 4;
 	height = 11;
-	id = "trade_sol_base";
+	id = "trader_base";
 	name = "docking bay at Trading Satellite";
 	width = 9
 	},
@@ -5722,7 +5722,7 @@
 /area/shuttle/trade/sol)
 "tZ" = (
 /obj/machinery/door/airlock/external{
-	id_tag = "trade_sol_base";
+	id_tag = "trader_base";
 	name = "Docking Port"
 	},
 /obj/structure/fans/tiny,

--- a/_maps/map_files/shuttles/trader/trader_base_glint.dmm
+++ b/_maps/map_files/shuttles/trader/trader_base_glint.dmm
@@ -1,0 +1,718 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ar" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"bb" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"cH" = (
+/obj/structure/shelf,
+/obj/effect/turf_decal/siding/end{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"dd" = (
+/obj/machinery/door/airlock/survival_pod/glass{
+	id_tag = "trader_port"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"dL" = (
+/obj/machinery/flasher{
+	id = "trader_flash";
+	pixel_x = -28
+	},
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"el" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/civilian,
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/obj/machinery/flasher_button{
+	id = "trader_flash";
+	pixel_y = 23;
+	req_access = list(160)
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_privacy";
+	name = "Privacy Shutters Control";
+	pixel_y = 24;
+	req_access = list(160);
+	pixel_x = 10
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_port";
+	name = "Trade Deposits Door";
+	normaldoorcontrol = 1;
+	pixel_x = -10;
+	req_access = list(160);
+	pixel_y = 24
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"fB" = (
+/obj/effect/spawner/random/traders/vehicle,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"hi" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"hv" = (
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"hx" = (
+/obj/machinery/economy/atm/directional/north,
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"iz" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"iO" = (
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"kX" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/wrapping_paper,
+/obj/item/stack/package_wrap{
+	pixel_y = 8
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"li" = (
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"mK" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/turf_decal/stripes/line,
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"nJ" = (
+/obj/effect/turf_decal/siding{
+	dir = 10
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"oh" = (
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"pH" = (
+/obj/machinery/door/airlock/survival_pod/glass{
+	id_tag = "trader_starboard"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"pN" = (
+/obj/structure/bed,
+/obj/item/bedsheet/green,
+/obj/structure/sign/poster/official/unathismash/directional/north,
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"sm" = (
+/obj/structure/bed,
+/obj/item/bedsheet/green,
+/obj/structure/sign/poster/official/unathicrush/directional/north,
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"sw" = (
+/obj/effect/spawner/random/traders/large_item,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"sZ" = (
+/obj/effect/turf_decal/siding{
+	dir = 9
+	},
+/obj/effect/landmark/spawner/tradergearminor,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"tt" = (
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"uV" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1
+	},
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"vi" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/animalhide/lizard,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"wB" = (
+/obj/structure/shelf,
+/obj/effect/turf_decal/siding/end{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"wV" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"xa" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/minerals,
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"xJ" = (
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/obj/structure/closet,
+/obj/item/stack/tile/disco_light/thirty,
+/obj/effect/spawner/random/traders/service,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"yo" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"yR" = (
+/obj/structure/extinguisher_cabinet{
+	name = "east bump";
+	pixel_x = 30
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"Ao" = (
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/engineering,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"Bd" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/survival_pod/glass{
+	id_tag = "s_docking_airlock"
+	},
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"BY" = (
+/turf/template_noop,
+/area/template_noop)
+"Cs" = (
+/obj/effect/turf_decal/siding{
+	dir = 6
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"CF" = (
+/obj/effect/spawner/window/shuttle/survival_pod,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"CM" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/science,
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/obj/machinery/flasher_button{
+	id = "trader_flash";
+	pixel_y = 23;
+	req_access = list(160)
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_privacy";
+	name = "Privacy Shutters Control";
+	pixel_y = 24;
+	req_access = list(160);
+	pixel_x = -10
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_starboard";
+	name = "Trade Deposits Door";
+	normaldoorcontrol = 1;
+	pixel_x = 10;
+	req_access = list(160);
+	pixel_y = 24
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"Ep" = (
+/obj/item/hand_labeler,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/structure/table/reinforced,
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"Et" = (
+/obj/structure/closet,
+/obj/effect/turf_decal/siding{
+	dir = 10
+	},
+/obj/effect/spawner/random/traders/security,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"Fh" = (
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"FX" = (
+/turf/simulated/wall/mineral/titanium/survival/pod,
+/area/shuttle/trade/sol)
+"Gr" = (
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"Hm" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/medical,
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"IX" = (
+/obj/structure/extinguisher_cabinet{
+	name = "west bump";
+	pixel_x = -30
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"JQ" = (
+/obj/machinery/computer/shuttle/trade/sol,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"KM" = (
+/obj/machinery/door/airlock/survival_pod,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"Lv" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/donksoft,
+/obj/effect/turf_decal/siding{
+	dir = 6
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"Lw" = (
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"LO" = (
+/obj/structure/table/reinforced,
+/obj/item/toy/plushie/lizardplushie,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"MM" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"Pu" = (
+/obj/machinery/door/airlock/survival_pod/glass,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"Qi" = (
+/obj/effect/spawner/window/shuttle/survival_pod,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "trader_privacy";
+	name = "Privacy Shutters"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"SP" = (
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"TR" = (
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/obj/item/flag/species/unathi,
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"VH" = (
+/obj/machinery/flasher{
+	id = "trader_flash";
+	pixel_x = 28
+	},
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"VZ" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"YZ" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"Ze" = (
+/turf/simulated/wall/mineral/titanium/survival/nodiagonal,
+/area/shuttle/trade/sol)
+"Zm" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/survival_pod/glass{
+	id_tag = "s_docking_airlock"
+	},
+/obj/docking_port/mobile/trader{
+	height = 17;
+	width = 14;
+	dwidth = 7;
+	preferred_direction = 1;
+	dir = 2
+	},
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"ZH" = (
+/obj/effect/turf_decal/siding{
+	dir = 5
+	},
+/obj/effect/landmark/spawner/tradergearmajor,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"ZP" = (
+/obj/item/flag/species/unathi,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+
+(1,1,1) = {"
+BY
+BY
+BY
+BY
+FX
+CF
+CF
+Ze
+Ze
+Ze
+Ze
+CF
+CF
+FX
+BY
+BY
+BY
+"}
+(2,1,1) = {"
+BY
+BY
+BY
+FX
+Ze
+YZ
+MM
+CF
+ZP
+fB
+Ze
+pN
+iO
+FX
+FX
+Ze
+Ze
+"}
+(3,1,1) = {"
+BY
+BY
+FX
+Ze
+iO
+Lw
+uV
+Pu
+li
+li
+Ze
+vi
+iO
+Ze
+li
+hi
+yo
+"}
+(4,1,1) = {"
+BY
+FX
+Ze
+Ze
+dd
+Ze
+Ze
+Ze
+CF
+li
+Ze
+Ze
+KM
+Ze
+li
+hi
+yo
+"}
+(5,1,1) = {"
+BY
+FX
+TR
+dL
+iO
+Ze
+el
+xa
+Lv
+li
+IX
+Pu
+li
+Gr
+li
+hi
+yo
+"}
+(6,1,1) = {"
+FX
+Ze
+hx
+iO
+bb
+Qi
+VZ
+li
+li
+li
+sZ
+Ze
+SP
+nJ
+li
+FX
+Ze
+"}
+(7,1,1) = {"
+Zm
+mK
+iO
+iO
+bb
+Qi
+kX
+li
+cH
+li
+Ao
+Ze
+Ep
+wV
+li
+FX
+BY
+"}
+(8,1,1) = {"
+Bd
+mK
+iO
+iO
+bb
+Qi
+kX
+li
+wB
+li
+xJ
+Ze
+JQ
+wV
+li
+FX
+BY
+"}
+(9,1,1) = {"
+FX
+Ze
+hx
+iO
+bb
+Qi
+VZ
+li
+li
+li
+ZH
+Ze
+Fh
+Cs
+li
+FX
+Ze
+"}
+(10,1,1) = {"
+BY
+FX
+TR
+VH
+iO
+Ze
+CM
+Hm
+Et
+li
+yR
+Pu
+li
+hv
+li
+hi
+yo
+"}
+(11,1,1) = {"
+BY
+FX
+Ze
+Ze
+pH
+Ze
+Ze
+Ze
+CF
+li
+Ze
+Ze
+KM
+Ze
+li
+hi
+yo
+"}
+(12,1,1) = {"
+BY
+BY
+FX
+Ze
+iO
+tt
+oh
+Pu
+li
+li
+Ze
+LO
+iO
+Ze
+li
+hi
+yo
+"}
+(13,1,1) = {"
+BY
+BY
+BY
+FX
+Ze
+ar
+iz
+CF
+ZP
+sw
+Ze
+sm
+iO
+Ze
+FX
+Ze
+Ze
+"}
+(14,1,1) = {"
+BY
+BY
+BY
+BY
+FX
+CF
+CF
+Ze
+Ze
+Ze
+Ze
+CF
+CF
+FX
+BY
+BY
+BY
+"}

--- a/_maps/map_files/shuttles/trader/trader_base_guild.dmm
+++ b/_maps/map_files/shuttles/trader/trader_base_guild.dmm
@@ -1,0 +1,1102 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ab" = (
+/obj/structure/chair/comfy/brown,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"at" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/royalblack,
+/area/shuttle/trade/sol)
+"ay" = (
+/obj/item/kirbyplants/large,
+/obj/effect/turf_decal/woodsiding{
+	dir = 6
+	},
+/turf/simulated/floor/carpet/purple,
+/area/shuttle/trade/sol)
+"aZ" = (
+/obj/structure/table/wood/fancy/orange,
+/obj/item/ashtray/bronze{
+	pixel_y = 3
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_robustgold{
+	pixel_x = 6;
+	pixel_y = -8
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"bl" = (
+/turf/simulated/wall/mineral/titanium,
+/area/shuttle/trade/sol)
+"dh" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 5
+	},
+/turf/simulated/floor/carpet/green,
+/area/shuttle/trade/sol)
+"dC" = (
+/obj/machinery/light/spot,
+/obj/structure/table/wood/fancy/orange,
+/obj/item/storage/photo_album{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/camera{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"ea" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 6
+	},
+/turf/simulated/floor/carpet/royalblack,
+/area/shuttle/trade/sol)
+"es" = (
+/obj/structure/table/wood/fancy/orange,
+/obj/item/clothing/mask/cigarette/cigar/cohiba,
+/obj/item/clothing/mask/cigarette/cigar/cohiba{
+	pixel_x = 1;
+	pixel_y = 6
+	},
+/obj/item/storage/fancy/matches{
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"eD" = (
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/obj/effect/turf_decal/woodsiding{
+	dir = 8
+	},
+/obj/structure/table/wood/fancy/purple,
+/obj/item/paper_bin{
+	pixel_y = 5
+	},
+/obj/item/pen/multi/fountain{
+	pixel_y = 4
+	},
+/turf/simulated/floor/carpet/purple,
+/area/shuttle/trade/sol)
+"eN" = (
+/obj/machinery/door_control/no_emag{
+	id = "trader_privacy";
+	name = "Privacy Shutters Control";
+	pixel_y = -24;
+	req_access = list(160);
+	pixel_x = -10
+	},
+/obj/machinery/flasher_button{
+	id = "trader_flash";
+	pixel_y = -23;
+	req_access = list(160)
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_starboard";
+	name = "Trade Deposits Door";
+	normaldoorcontrol = 1;
+	pixel_x = 10;
+	req_access = list(160);
+	pixel_y = -24
+	},
+/obj/item/flag/species/nian,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"eP" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/purple,
+/area/shuttle/trade/sol)
+"eS" = (
+/obj/item/kirbyplants/large,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"fN" = (
+/obj/machinery/flasher{
+	id = "trader_flash";
+	pixel_y = -28
+	},
+/obj/structure/chair/sofa/left{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"gA" = (
+/obj/item/kirbyplants/large,
+/obj/effect/turf_decal/woodsiding{
+	dir = 9
+	},
+/turf/simulated/floor/carpet/purple,
+/area/shuttle/trade/sol)
+"hd" = (
+/obj/structure/table/wood/fancy/orange,
+/obj/item/reagent_containers/glass/bottle/oculine{
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/woodsiding{
+	dir = 6
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/carpet/royalblue,
+/area/shuttle/trade/sol)
+"hs" = (
+/obj/effect/turf_decal/woodsiding,
+/turf/simulated/floor/carpet/royalblue,
+/area/shuttle/trade/sol)
+"hy" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 9
+	},
+/obj/item/kirbyplants/large,
+/turf/simulated/floor/carpet/royalblack,
+/area/shuttle/trade/sol)
+"hO" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/green,
+/area/shuttle/trade/sol)
+"hV" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 10
+	},
+/turf/simulated/floor/carpet/green,
+/area/shuttle/trade/sol)
+"iD" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 6
+	},
+/turf/simulated/floor/carpet/purple,
+/area/shuttle/trade/sol)
+"jC" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 5
+	},
+/turf/simulated/floor/carpet/royalblue,
+/area/shuttle/trade/sol)
+"jO" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/royalblue,
+/area/shuttle/trade/sol)
+"kv" = (
+/obj/structure/chair/comfy/brown,
+/turf/simulated/floor/carpet/purple,
+/area/shuttle/trade/sol)
+"kA" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 1
+	},
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/royalblue,
+/area/shuttle/trade/sol)
+"kN" = (
+/obj/machinery/door_control/no_emag{
+	id = "trader_privacy";
+	name = "Privacy Shutters Control";
+	pixel_y = -24;
+	req_access = list(160);
+	pixel_x = 10
+	},
+/obj/machinery/flasher_button{
+	id = "trader_flash";
+	pixel_y = -23;
+	req_access = list(160)
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_port";
+	name = "Trade Deposits Door";
+	normaldoorcontrol = 1;
+	pixel_x = -10;
+	req_access = list(160);
+	pixel_y = -24
+	},
+/obj/item/flag/species/nian,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"kO" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 6
+	},
+/turf/simulated/floor/carpet/royalblue,
+/area/shuttle/trade/sol)
+"lx" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"ly" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 9
+	},
+/turf/simulated/floor/carpet/purple,
+/area/shuttle/trade/sol)
+"lz" = (
+/obj/effect/turf_decal/woodsiding,
+/turf/simulated/floor/carpet/green,
+/area/shuttle/trade/sol)
+"mk" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 10
+	},
+/turf/simulated/floor/carpet/royalblack,
+/area/shuttle/trade/sol)
+"mJ" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/minerals,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"mP" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/royalblue,
+/area/shuttle/trade/sol)
+"mT" = (
+/obj/machinery/door/airlock/titanium/glass,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"nR" = (
+/obj/effect/spawner/window/shuttle,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"oC" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"pm" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 10
+	},
+/turf/simulated/floor/carpet/royalblue,
+/area/shuttle/trade/sol)
+"pF" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/purple,
+/area/shuttle/trade/sol)
+"pK" = (
+/obj/structure/extinguisher_cabinet{
+	name = "north bump";
+	pixel_y = 30
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"qd" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/engineering,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"qR" = (
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/obj/effect/turf_decal/woodsiding{
+	dir = 4
+	},
+/obj/structure/table/wood/fancy/purple,
+/obj/item/paper_bin{
+	pixel_y = 5
+	},
+/obj/item/pen/multi/fountain{
+	pixel_y = 4
+	},
+/turf/simulated/floor/carpet/purple,
+/area/shuttle/trade/sol)
+"rc" = (
+/obj/machinery/economy/atm/directional/west,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"ro" = (
+/obj/item/kirbyplants/large,
+/obj/effect/turf_decal/woodsiding{
+	dir = 10
+	},
+/turf/simulated/floor/carpet/purple,
+/area/shuttle/trade/sol)
+"rr" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 9
+	},
+/turf/simulated/floor/carpet/royalblue,
+/area/shuttle/trade/sol)
+"rt" = (
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"sd" = (
+/obj/structure/table/wood/fancy/orange,
+/obj/item/reagent_containers/glass/bottle/oculine{
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/woodsiding{
+	dir = 10
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/carpet/royalblue,
+/area/shuttle/trade/sol)
+"sp" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 5
+	},
+/turf/simulated/floor/carpet/purple,
+/area/shuttle/trade/sol)
+"sq" = (
+/obj/structure/chair/sofa/left{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"sI" = (
+/turf/template_noop,
+/area/template_noop)
+"va" = (
+/obj/effect/spawner/window/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "trader_privacy";
+	name = "Privacy Shutters"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"wg" = (
+/obj/structure/closet,
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/obj/item/stack/tile/disco_light/thirty,
+/obj/effect/spawner/random/traders/service,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"xi" = (
+/obj/item/flag/species/nian,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"xv" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "trader_port";
+	security_level = 6
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"xH" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/purple,
+/area/shuttle/trade/sol)
+"xS" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/royalblack,
+/area/shuttle/trade/sol)
+"yd" = (
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/purple,
+/area/shuttle/trade/sol)
+"yX" = (
+/obj/effect/landmark/spawner/tradergearmajor,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"zE" = (
+/obj/structure/chair/sofa/right{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"zF" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock"
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"AX" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/royalblack,
+/area/shuttle/trade/sol)
+"Be" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/royalblue,
+/area/shuttle/trade/sol)
+"BJ" = (
+/obj/item/kirbyplants/large,
+/obj/effect/turf_decal/woodsiding{
+	dir = 5
+	},
+/turf/simulated/floor/carpet/royalblack,
+/area/shuttle/trade/sol)
+"Cq" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"CA" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "trader_starboard";
+	security_level = 6
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"Dk" = (
+/obj/structure/table/wood/fancy/orange,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/effect/turf_decal/woodsiding{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/royalblack,
+/area/shuttle/trade/sol)
+"Dy" = (
+/obj/effect/spawner/random/traders/vehicle,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"DN" = (
+/obj/structure/table/wood/fancy/orange,
+/obj/item/reagent_containers/drinks/bottle/vermouth{
+	pixel_x = -7;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/drinks/bottle/gin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"DR" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 6
+	},
+/turf/simulated/floor/carpet/green,
+/area/shuttle/trade/sol)
+"EI" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/donksoft,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"FR" = (
+/obj/machinery/computer/shuttle/trade/sol,
+/obj/effect/turf_decal/woodsiding{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/royalblack,
+/area/shuttle/trade/sol)
+"Gi" = (
+/obj/effect/spawner/random/traders/large_item,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"GG" = (
+/obj/machinery/light/spot,
+/obj/structure/table/wood/fancy/orange,
+/obj/item/book/manual/barman_recipes{
+	pixel_y = 4
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"Hh" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 1
+	},
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/royalblue,
+/area/shuttle/trade/sol)
+"Hi" = (
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"HC" = (
+/obj/structure/shelf/clockwork,
+/turf/simulated/floor/carpet/royalblue,
+/area/shuttle/trade/sol)
+"HV" = (
+/obj/machinery/flasher{
+	id = "trader_flash";
+	pixel_y = -28
+	},
+/obj/structure/chair/sofa/right{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"Is" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/civilian,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"IH" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/medical,
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"JH" = (
+/obj/effect/landmark/spawner/tradergearminor,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"Ks" = (
+/obj/item/flag/species/nian,
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"Kz" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock"
+	},
+/obj/docking_port/mobile/trader{
+	height = 20;
+	width = 16;
+	dwidth = 8;
+	preferred_direction = 1;
+	dir = 1;
+	port_direction = 8
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"ME" = (
+/turf/simulated/floor/carpet/royalblue,
+/area/shuttle/trade/sol)
+"Oi" = (
+/obj/machinery/door/airlock/titanium,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"Pl" = (
+/turf/simulated/wall/mineral/titanium/nodiagonal,
+/area/shuttle/trade/sol)
+"Pm" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"PM" = (
+/obj/machinery/economy/atm/directional/east,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"SR" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/security,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"Tf" = (
+/obj/structure/table/wood/fancy/orange,
+/obj/effect/spawner/random/food_or_drink/dinner,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"Tk" = (
+/obj/effect/spawner/window/shuttle,
+/obj/structure/curtain/black,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"TC" = (
+/obj/effect/turf_decal/woodsiding,
+/turf/simulated/floor/carpet/royalblack,
+/area/shuttle/trade/sol)
+"TE" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/obj/effect/turf_decal/woodsiding{
+	dir = 10
+	},
+/obj/structure/sign/poster/official/cohiba_robusto_ad/directional/south,
+/turf/simulated/floor/carpet/royalblue,
+/area/shuttle/trade/sol)
+"UC" = (
+/obj/effect/turf_decal/woodsiding,
+/turf/simulated/floor/carpet/purple,
+/area/shuttle/trade/sol)
+"UE" = (
+/obj/structure/table/wood/fancy/purple,
+/turf/simulated/floor/carpet/purple,
+/area/shuttle/trade/sol)
+"UI" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "trader_privacy";
+	name = "Privacy Shutters"
+	},
+/obj/effect/spawner/window/shuttle,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"VE" = (
+/obj/structure/table/wood/fancy/orange,
+/obj/item/reagent_containers/drinks/shaker{
+	pixel_x = -8;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/drinks/drinkingglass{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"Wt" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 10
+	},
+/turf/simulated/floor/carpet/purple,
+/area/shuttle/trade/sol)
+"Wx" = (
+/obj/structure/table/wood/fancy/orange,
+/obj/effect/turf_decal/woodsiding{
+	dir = 5
+	},
+/obj/item/toy/plushie/nianplushie/royal,
+/turf/simulated/floor/carpet/royalblue,
+/area/shuttle/trade/sol)
+"WP" = (
+/obj/structure/table/wood/fancy/orange,
+/obj/effect/turf_decal/woodsiding{
+	dir = 9
+	},
+/obj/item/toy/plushie/nianplushie/monarch,
+/turf/simulated/floor/carpet/royalblue,
+/area/shuttle/trade/sol)
+"Xd" = (
+/obj/item/bedsheet/brown,
+/obj/structure/bed,
+/obj/effect/turf_decal/woodsiding{
+	dir = 6
+	},
+/obj/structure/sign/poster/official/high_class_martini/directional/south,
+/turf/simulated/floor/carpet/royalblue,
+/area/shuttle/trade/sol)
+"Xm" = (
+/obj/structure/table/wood/fancy/orange,
+/obj/item/stack/wrapping_paper,
+/obj/item/stack/package_wrap{
+	pixel_y = 8
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"XD" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/science,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"Yd" = (
+/obj/structure/coatrack,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"YD" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 9
+	},
+/turf/simulated/floor/carpet/green,
+/area/shuttle/trade/sol)
+"Zo" = (
+/obj/item/kirbyplants/large,
+/obj/effect/turf_decal/woodsiding{
+	dir = 5
+	},
+/turf/simulated/floor/carpet/purple,
+/area/shuttle/trade/sol)
+
+(1,1,1) = {"
+sI
+sI
+sI
+sI
+sI
+sI
+sI
+sI
+sI
+sI
+sI
+bl
+Pl
+nR
+nR
+nR
+Pl
+Pl
+Pl
+sI
+"}
+(2,1,1) = {"
+bl
+Tk
+Tk
+Pl
+nR
+nR
+nR
+Pl
+Pl
+Pl
+Pl
+Pl
+gA
+pF
+pF
+pF
+ro
+Pm
+lx
+sI
+"}
+(3,1,1) = {"
+Tk
+WP
+sd
+Pl
+Yd
+DN
+VE
+Pl
+Dy
+Cq
+JH
+nR
+eP
+kv
+UE
+yd
+UC
+Pm
+lx
+sI
+"}
+(4,1,1) = {"
+Tk
+Hh
+hs
+Oi
+Hi
+ab
+Tf
+Pl
+pK
+Hi
+Hi
+mT
+sp
+xH
+qR
+xH
+iD
+Pm
+lx
+sI
+"}
+(5,1,1) = {"
+Tk
+jC
+Xd
+Pl
+Hi
+Hi
+GG
+Pl
+nR
+mT
+nR
+Pl
+mT
+Pl
+Pl
+Pl
+xv
+Pl
+Pl
+bl
+"}
+(6,1,1) = {"
+bl
+Tk
+Tk
+Pl
+Hi
+Hi
+xi
+Pl
+SR
+Hi
+qd
+wg
+Hi
+kN
+Pl
+Ks
+Hi
+rc
+fN
+Pl
+"}
+(7,1,1) = {"
+sI
+sI
+sI
+nR
+hy
+AX
+mk
+mT
+Hi
+rr
+Be
+Be
+pm
+ab
+UI
+rt
+YD
+hV
+zE
+Pl
+"}
+(8,1,1) = {"
+sI
+sI
+sI
+nR
+Dk
+at
+TC
+Pl
+Is
+jO
+ME
+HC
+hs
+Xm
+va
+eS
+hO
+lz
+Hi
+zF
+"}
+(9,1,1) = {"
+sI
+sI
+sI
+nR
+FR
+at
+TC
+Pl
+mJ
+jO
+ME
+HC
+hs
+Xm
+va
+eS
+hO
+lz
+Hi
+Kz
+"}
+(10,1,1) = {"
+sI
+sI
+sI
+nR
+BJ
+xS
+ea
+mT
+Hi
+jC
+mP
+mP
+kO
+ab
+UI
+rt
+dh
+DR
+sq
+Pl
+"}
+(11,1,1) = {"
+bl
+Tk
+Tk
+Pl
+Hi
+Hi
+xi
+Pl
+EI
+Hi
+XD
+IH
+Hi
+eN
+Pl
+Ks
+Hi
+PM
+HV
+Pl
+"}
+(12,1,1) = {"
+Tk
+rr
+TE
+Pl
+Hi
+Hi
+dC
+Pl
+nR
+mT
+nR
+Pl
+mT
+Pl
+Pl
+Pl
+CA
+Pl
+Pl
+bl
+"}
+(13,1,1) = {"
+Tk
+kA
+hs
+Oi
+Hi
+ab
+Tf
+Pl
+pK
+Hi
+Hi
+mT
+ly
+pF
+eD
+pF
+Wt
+Pm
+lx
+sI
+"}
+(14,1,1) = {"
+Tk
+Wx
+hd
+Pl
+Yd
+aZ
+es
+Pl
+Gi
+oC
+yX
+nR
+eP
+kv
+UE
+yd
+UC
+Pm
+lx
+sI
+"}
+(15,1,1) = {"
+bl
+Tk
+Tk
+Pl
+nR
+nR
+nR
+Pl
+Pl
+Pl
+Pl
+Pl
+Zo
+xH
+xH
+xH
+ay
+Pm
+lx
+sI
+"}
+(16,1,1) = {"
+sI
+sI
+sI
+sI
+sI
+sI
+sI
+sI
+sI
+sI
+sI
+bl
+Pl
+nR
+nR
+nR
+Pl
+Pl
+Pl
+sI
+"}

--- a/_maps/map_files/shuttles/trader/trader_base_skip.dmm
+++ b/_maps/map_files/shuttles/trader/trader_base_skip.dmm
@@ -1,0 +1,742 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"am" = (
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/engineering,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"aD" = (
+/obj/structure/bed,
+/obj/item/bedsheet/green,
+/obj/structure/sign/poster/official/choir/directional/north,
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"aE" = (
+/turf/simulated/wall/mineral/titanium,
+/area/shuttle/trade/sol)
+"aS" = (
+/obj/effect/spawner/random/traders/vehicle,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"bg" = (
+/obj/effect/turf_decal/siding{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"bX" = (
+/turf/simulated/wall/mineral/iron,
+/area/shuttle/trade/sol)
+"cg" = (
+/obj/machinery/flasher{
+	id = "trader_flash";
+	pixel_x = -28
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"cl" = (
+/obj/effect/mapping_helpers/turfs/damage,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"ek" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/survival_pod/glass{
+	id_tag = "s_docking_airlock"
+	},
+/obj/docking_port/mobile/trader{
+	height = 17;
+	width = 14;
+	dwidth = 7;
+	preferred_direction = 1;
+	dir = 2
+	},
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"gg" = (
+/obj/effect/mapping_helpers/turfs/damage,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"gJ" = (
+/obj/machinery/door/airlock/survival_pod/glass{
+	id_tag = "trader_starboard"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"hE" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"ih" = (
+/obj/item/hand_labeler,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/structure/table/reinforced,
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"kS" = (
+/obj/structure/extinguisher_cabinet{
+	name = "east bump";
+	pixel_x = 30
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"mT" = (
+/obj/machinery/door/airlock/titanium/glass,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"nh" = (
+/obj/effect/spawner/random/traders/large_item,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"nr" = (
+/obj/machinery/flasher{
+	id = "trader_flash";
+	pixel_x = 28
+	},
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"nC" = (
+/obj/effect/mapping_helpers/turfs/damage,
+/obj/structure/sign/poster/official/choir/directional/north,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"oc" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"oi" = (
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"oL" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "trader_privacy";
+	name = "Privacy Shutters"
+	},
+/obj/effect/spawner/window/plastitanium,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"pG" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/minerals,
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"qk" = (
+/obj/machinery/door/airlock/titanium/glass,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"rj" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/civilian,
+/obj/machinery/flasher_button{
+	id = "trader_flash";
+	pixel_y = 23;
+	req_access = list(160)
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_privacy";
+	name = "Privacy Shutters Control";
+	pixel_y = 24;
+	req_access = list(160);
+	pixel_x = 10
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_port";
+	name = "Trade Deposits Door";
+	normaldoorcontrol = 1;
+	pixel_x = -10;
+	req_access = list(160);
+	pixel_y = 24
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"rQ" = (
+/obj/structure/shelf,
+/obj/effect/turf_decal/siding/end{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"uE" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/donksoft,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"vV" = (
+/obj/effect/turf_decal/siding{
+	dir = 5
+	},
+/obj/effect/landmark/spawner/tradergearmajor,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"ws" = (
+/obj/structure/shelf,
+/obj/effect/turf_decal/siding/end{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"xb" = (
+/obj/machinery/door/airlock/survival_pod/glass,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"yv" = (
+/obj/machinery/door/airlock/survival_pod/glass,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"yH" = (
+/obj/effect/turf_decal/siding{
+	dir = 10
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"yM" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/turf_decal/stripes/line,
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"yV" = (
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"ze" = (
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "trader_port";
+	security_level = 6
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"zQ" = (
+/turf/template_noop,
+/area/template_noop)
+"Ai" = (
+/obj/item/flag/species/vox,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"AP" = (
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"AY" = (
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"Bd" = (
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"Cg" = (
+/turf/simulated/wall/mineral/titanium/nodiagonal,
+/area/shuttle/trade/sol)
+"CH" = (
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"Dr" = (
+/obj/effect/spawner/window/shuttle/survival_pod,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"DD" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"DU" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"Ea" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/wrapping_paper,
+/obj/item/stack/package_wrap{
+	pixel_y = 8
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"Fh" = (
+/obj/item/flag/species/vox,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"FB" = (
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"Ht" = (
+/turf/simulated/wall/mineral/titanium/survival/pod,
+/area/shuttle/trade/sol)
+"Jo" = (
+/obj/machinery/economy/atm/directional/north,
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"Kj" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/science,
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/obj/machinery/flasher_button{
+	id = "trader_flash";
+	pixel_y = 23;
+	req_access = list(160)
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_privacy";
+	name = "Privacy Shutters Control";
+	pixel_y = 24;
+	req_access = list(160);
+	pixel_x = -10
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_starboard";
+	name = "Trade Deposits Door";
+	normaldoorcontrol = 1;
+	pixel_x = 10;
+	req_access = list(160);
+	pixel_y = 24
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"KJ" = (
+/obj/structure/bed,
+/obj/item/toy/plushie/voxplushie,
+/obj/item/clothing/glasses/sunglasses_fake{
+	pixel_x = -1;
+	pixel_y = 9
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"KP" = (
+/obj/structure/closet,
+/obj/effect/turf_decal/siding{
+	dir = 10
+	},
+/obj/effect/spawner/random/traders/security,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"Le" = (
+/turf/simulated/wall/mineral/titanium/survival/nodiagonal,
+/area/shuttle/trade/sol)
+"Lk" = (
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"LB" = (
+/obj/effect/turf_decal/siding{
+	dir = 9
+	},
+/obj/effect/landmark/spawner/tradergearminor,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"Nt" = (
+/obj/structure/extinguisher_cabinet{
+	name = "west bump";
+	pixel_x = -30
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"NW" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/medical,
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"Ob" = (
+/obj/effect/mapping_helpers/turfs/damage,
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"Pp" = (
+/obj/item/flag/species/vox,
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"PY" = (
+/obj/effect/mapping_helpers/turfs/damage,
+/obj/effect/decal/cleanable/glass,
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"Qx" = (
+/obj/machinery/computer/shuttle/trade/sol,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"QI" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"Rl" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"RI" = (
+/obj/effect/mapping_helpers/turfs/damage,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"Sg" = (
+/obj/item/flag/species/vox,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"SE" = (
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/obj/structure/closet,
+/obj/item/stack/tile/disco_light/thirty,
+/obj/effect/spawner/random/traders/service,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"Ub" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/mapping_helpers/turfs/damage,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"VF" = (
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"VX" = (
+/obj/machinery/door/airlock/survival_pod,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"WG" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/survival_pod/glass{
+	id_tag = "s_docking_airlock"
+	},
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
+"YG" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"ZI" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+
+(1,1,1) = {"
+zQ
+zQ
+zQ
+zQ
+aE
+Cg
+Cg
+Cg
+Cg
+Cg
+aE
+zQ
+PY
+Ht
+zQ
+zQ
+zQ
+"}
+(2,1,1) = {"
+zQ
+zQ
+zQ
+aE
+aE
+VF
+bX
+Sg
+FB
+aS
+bX
+bX
+bX
+Ht
+Ht
+Le
+Le
+"}
+(3,1,1) = {"
+zQ
+zQ
+aE
+aE
+VF
+cl
+qk
+FB
+FB
+FB
+bX
+KJ
+Ob
+gg
+FB
+YG
+ZI
+"}
+(4,1,1) = {"
+zQ
+aE
+Cg
+Cg
+ze
+bX
+bX
+bX
+FB
+FB
+bX
+bX
+nC
+FB
+yV
+YG
+ZI
+"}
+(5,1,1) = {"
+zQ
+Ht
+Ai
+cg
+FB
+bX
+rj
+pG
+uE
+gg
+Nt
+mT
+RI
+gg
+yV
+YG
+ZI
+"}
+(6,1,1) = {"
+Ht
+Le
+Jo
+gg
+oc
+oL
+Rl
+gg
+gg
+FB
+LB
+Le
+Lk
+yH
+yV
+Ht
+Le
+"}
+(7,1,1) = {"
+ek
+yM
+AY
+gg
+Ob
+oL
+Ea
+yV
+ws
+yV
+am
+Le
+ih
+hE
+yV
+Ht
+zQ
+"}
+(8,1,1) = {"
+WG
+yM
+AY
+gg
+AY
+oL
+Ea
+yV
+rQ
+yV
+SE
+Le
+Qx
+hE
+yV
+Ht
+zQ
+"}
+(9,1,1) = {"
+Ht
+Le
+Jo
+Ob
+oc
+oL
+Rl
+yV
+yV
+yV
+vV
+Le
+oi
+bg
+yV
+Ht
+Le
+"}
+(10,1,1) = {"
+zQ
+Ht
+Pp
+nr
+AY
+Le
+Kj
+NW
+KP
+yV
+kS
+xb
+yV
+AP
+yV
+YG
+ZI
+"}
+(11,1,1) = {"
+zQ
+Ht
+Ht
+Ht
+gJ
+Le
+Le
+Le
+Ub
+yV
+Le
+Le
+VX
+Le
+yV
+YG
+ZI
+"}
+(12,1,1) = {"
+zQ
+zQ
+Ht
+Ht
+AY
+Bd
+CH
+yv
+yV
+yV
+Le
+DU
+AY
+Le
+yV
+YG
+ZI
+"}
+(13,1,1) = {"
+zQ
+zQ
+zQ
+Ht
+Le
+DD
+QI
+Dr
+Fh
+nh
+Le
+aD
+AY
+Le
+Ht
+Le
+Le
+"}
+(14,1,1) = {"
+zQ
+zQ
+zQ
+zQ
+Le
+Dr
+Dr
+Le
+Le
+Le
+Le
+Dr
+Dr
+Ht
+zQ
+zQ
+zQ
+"}

--- a/_maps/map_files/shuttles/trader/trader_base_skrell.dmm
+++ b/_maps/map_files/shuttles/trader/trader_base_skrell.dmm
@@ -1,0 +1,857 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"cc" = (
+/obj/machinery/door_control/no_emag{
+	id = "trader_privacy";
+	name = "Privacy Shutters Control";
+	pixel_y = -24;
+	req_access = list(160);
+	pixel_x = -10
+	},
+/obj/machinery/flasher_button{
+	id = "trader_flash";
+	pixel_y = -23;
+	req_access = list(160)
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_starboard";
+	name = "Trade Deposits Door";
+	normaldoorcontrol = 1;
+	pixel_x = 10;
+	req_access = list(160);
+	pixel_y = -24
+	},
+/obj/item/flag/species/skrell,
+/obj/structure/extinguisher_cabinet{
+	name = "east bump";
+	pixel_x = 30
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"cW" = (
+/obj/structure/table/glass/reinforced/titanium,
+/obj/effect/turf_decal/woodsiding{
+	dir = 9
+	},
+/obj/item/toy/plushie/skrellplushie,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"fP" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass/jungle/no_creep,
+/area/shuttle/trade/sol)
+"fR" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/obj/machinery/door/airlock/titanium/glass,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"fZ" = (
+/obj/structure/flora/junglebush/large,
+/turf/simulated/floor/grass/jungle/no_creep,
+/area/shuttle/trade/sol)
+"hf" = (
+/obj/structure/bed,
+/obj/item/bedsheet/blue,
+/obj/effect/turf_decal/woodsiding{
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"hu" = (
+/obj/structure/flora/ausbushes/leafybush,
+/turf/simulated/floor/grass/jungle/no_creep,
+/area/shuttle/trade/sol)
+"hI" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass/jungle/no_creep,
+/area/shuttle/trade/sol)
+"jh" = (
+/obj/structure/shelf,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"jU" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"ki" = (
+/obj/effect/spawner/random/traders/large_item,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"lb" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/medical,
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"lf" = (
+/obj/structure/chair/sofa/right{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"li" = (
+/turf/simulated/wall/mineral/titanium/nodiagonal,
+/area/shuttle/trade/sol)
+"nQ" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/simulated/floor/grass/jungle/no_creep,
+/area/shuttle/trade/sol)
+"qJ" = (
+/obj/effect/landmark/spawner/tradergearminor,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"rw" = (
+/obj/item/stack/wrapping_paper,
+/obj/item/stack/package_wrap{
+	pixel_y = 8
+	},
+/obj/structure/table/glass/reinforced/titanium,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"rF" = (
+/obj/effect/spawner/window/shuttle,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"se" = (
+/obj/item/flag/species/skrell,
+/obj/machinery/light/spot,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"sV" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"tQ" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"vQ" = (
+/obj/machinery/light/spot,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"vR" = (
+/obj/machinery/door_control/no_emag{
+	id = "trader_privacy";
+	name = "Privacy Shutters Control";
+	pixel_y = -24;
+	req_access = list(160);
+	pixel_x = 10
+	},
+/obj/machinery/flasher_button{
+	id = "trader_flash";
+	pixel_y = -23;
+	req_access = list(160)
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_port";
+	name = "Trade Deposits Door";
+	normaldoorcontrol = 1;
+	pixel_x = -10;
+	req_access = list(160);
+	pixel_y = -24
+	},
+/obj/item/flag/species/skrell,
+/obj/structure/extinguisher_cabinet{
+	name = "west bump";
+	pixel_x = -30
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"wf" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/science,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"wg" = (
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "trader_starboard";
+	security_level = 6
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"xx" = (
+/turf/simulated/wall/mineral/titanium,
+/area/shuttle/trade/sol)
+"xA" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass/jungle/no_creep,
+/area/shuttle/trade/sol)
+"yA" = (
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"zY" = (
+/obj/structure/chair/sofa/right{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"AU" = (
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"Bu" = (
+/obj/effect/spawner/window/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "trader_privacy";
+	name = "Privacy Shutters"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"Dg" = (
+/obj/structure/flora/rock/jungle,
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/grass/jungle/no_creep,
+/area/shuttle/trade/sol)
+"Dr" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/minerals,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"DG" = (
+/obj/machinery/flasher{
+	id = "trader_flash";
+	pixel_x = 28
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"FI" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/civilian,
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"FL" = (
+/obj/effect/spawner/random/traders/vehicle,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"FM" = (
+/obj/structure/chair/sofa/left{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"Gn" = (
+/obj/structure/table/glass/reinforced/titanium,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"GY" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass/jungle/no_creep,
+/area/shuttle/trade/sol)
+"Hh" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/donksoft,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"Ix" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "trader_privacy";
+	name = "Privacy Shutters"
+	},
+/obj/effect/spawner/window/shuttle,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"JD" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/grass/jungle/no_creep,
+/area/shuttle/trade/sol)
+"JM" = (
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"Kd" = (
+/obj/structure/flora/junglebush,
+/turf/simulated/floor/grass/jungle/no_creep,
+/area/shuttle/trade/sol)
+"Km" = (
+/obj/machinery/economy/atm/directional/west,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"KT" = (
+/obj/machinery/flasher{
+	id = "trader_flash";
+	pixel_x = -28
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"KW" = (
+/obj/machinery/door/airlock/titanium/glass,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"Ln" = (
+/turf/template_noop,
+/area/template_noop)
+"LD" = (
+/obj/structure/bed,
+/obj/effect/turf_decal/woodsiding{
+	dir = 5
+	},
+/obj/item/bedsheet/blue,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"MM" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/grass/jungle/no_creep,
+/area/shuttle/trade/sol)
+"NU" = (
+/obj/structure/flora/ausbushes/genericbush,
+/turf/simulated/floor/grass/jungle/no_creep,
+/area/shuttle/trade/sol)
+"Os" = (
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"Ot" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"Pa" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock"
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"QN" = (
+/obj/machinery/computer/shuttle/trade/sol,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"Rz" = (
+/obj/effect/landmark/spawner/tradergearmajor,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"Tf" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 10
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"Tm" = (
+/turf/simulated/floor/grass/jungle/no_creep,
+/area/shuttle/trade/sol)
+"Tx" = (
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "trader_port";
+	security_level = 6
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"TA" = (
+/obj/structure/table/glass/reinforced/titanium,
+/obj/effect/turf_decal/woodsiding{
+	dir = 5
+	},
+/obj/item/toy/plushie/siamese_cat,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"Ue" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"Un" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock"
+	},
+/obj/docking_port/mobile/trader{
+	height = 21;
+	width = 18;
+	dwidth = 9;
+	preferred_direction = 1;
+	dir = 1;
+	port_direction = 8
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"US" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 6
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"Vm" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/security,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"VR" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/engineering,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"Wa" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"XG" = (
+/obj/machinery/economy/atm/directional/east,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"YQ" = (
+/obj/structure/closet,
+/obj/item/stack/tile/disco_light/thirty,
+/obj/effect/spawner/random/traders/service,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"Zd" = (
+/obj/structure/sink/puddle,
+/turf/simulated/floor/grass/jungle/no_creep,
+/area/shuttle/trade/sol)
+
+(1,1,1) = {"
+Ln
+Ln
+Ln
+Ln
+rF
+rF
+rF
+rF
+li
+li
+xx
+Ln
+Ln
+Ln
+Ln
+Ln
+Ln
+Ln
+Ln
+Ln
+Ln
+"}
+(2,1,1) = {"
+Ln
+Ln
+rF
+rF
+rF
+nQ
+Tm
+Kd
+Tm
+GY
+li
+rF
+rF
+rF
+li
+sV
+Ot
+Ln
+Ln
+Ln
+Ln
+"}
+(3,1,1) = {"
+Ln
+rF
+rF
+NU
+Tm
+Tm
+Tm
+Tm
+Tm
+Tm
+fR
+Os
+FM
+lf
+rF
+Os
+sV
+Ot
+Ln
+Ln
+Ln
+"}
+(4,1,1) = {"
+rF
+rF
+fP
+Tm
+Tm
+Tm
+fZ
+JD
+Dg
+Tm
+rF
+Os
+Os
+Os
+KW
+Os
+Os
+sV
+Ot
+Ln
+Ln
+"}
+(5,1,1) = {"
+rF
+cW
+Tf
+Tm
+hI
+rF
+rF
+rF
+li
+li
+li
+ki
+Os
+Os
+rF
+AU
+Os
+Os
+tQ
+Ot
+Ln
+"}
+(6,1,1) = {"
+rF
+LD
+US
+hu
+rF
+rF
+Ln
+Ln
+li
+Hh
+wf
+Os
+Os
+vQ
+li
+li
+li
+Tx
+li
+li
+xx
+"}
+(7,1,1) = {"
+rF
+rF
+rF
+rF
+rF
+Ln
+Ln
+xx
+li
+Dr
+Os
+Os
+Os
+Os
+vR
+li
+Km
+Os
+KT
+se
+li
+"}
+(8,1,1) = {"
+Ln
+Ln
+Ln
+Ln
+Ln
+Ln
+Ln
+rF
+FI
+Os
+Os
+Os
+qJ
+Os
+jU
+Ix
+Wa
+Os
+Os
+Wa
+li
+"}
+(9,1,1) = {"
+Ln
+Ln
+Ln
+Ln
+Ln
+Ln
+Ln
+rF
+Gn
+Wa
+Os
+Os
+jh
+Os
+rw
+Bu
+Os
+Os
+Os
+Os
+Pa
+"}
+(10,1,1) = {"
+Ln
+Ln
+Ln
+Ln
+Ln
+Ln
+Ln
+rF
+QN
+Wa
+Os
+Os
+jh
+Os
+rw
+Bu
+Os
+Os
+Os
+Os
+Un
+"}
+(11,1,1) = {"
+Ln
+Ln
+Ln
+Ln
+Ln
+Ln
+Ln
+rF
+lb
+Os
+Os
+Os
+Rz
+Os
+jU
+Ix
+Wa
+Os
+Os
+Wa
+li
+"}
+(12,1,1) = {"
+rF
+rF
+rF
+rF
+rF
+Ln
+Ln
+xx
+li
+Vm
+Os
+Os
+Os
+Os
+cc
+li
+XG
+Os
+DG
+se
+li
+"}
+(13,1,1) = {"
+rF
+hf
+Tf
+nQ
+rF
+rF
+Ln
+Ln
+li
+VR
+YQ
+Os
+Os
+vQ
+li
+li
+li
+wg
+li
+li
+xx
+"}
+(14,1,1) = {"
+rF
+TA
+US
+Tm
+Kd
+rF
+rF
+rF
+li
+li
+li
+FL
+Os
+Os
+rF
+yA
+Os
+Os
+tQ
+Ot
+Ln
+"}
+(15,1,1) = {"
+rF
+rF
+GY
+Tm
+Tm
+Tm
+Tm
+Tm
+MM
+hI
+rF
+Os
+Os
+Os
+KW
+Os
+Os
+Ue
+Ot
+Ln
+Ln
+"}
+(16,1,1) = {"
+Ln
+rF
+rF
+Tm
+Tm
+Tm
+Zd
+Tm
+Tm
+Tm
+fR
+Os
+zY
+JM
+rF
+Os
+Ue
+Ot
+Ln
+Ln
+Ln
+"}
+(17,1,1) = {"
+Ln
+Ln
+rF
+rF
+rF
+nQ
+xA
+JD
+Kd
+Tm
+li
+rF
+rF
+rF
+li
+Ue
+Ot
+Ln
+Ln
+Ln
+Ln
+"}
+(18,1,1) = {"
+Ln
+Ln
+Ln
+Ln
+rF
+rF
+rF
+rF
+li
+li
+xx
+Ln
+Ln
+Ln
+Ln
+Ln
+Ln
+Ln
+Ln
+Ln
+Ln
+"}

--- a/_maps/map_files/shuttles/trader/trader_base_sol.dmm
+++ b/_maps/map_files/shuttles/trader/trader_base_sol.dmm
@@ -1,0 +1,801 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aM" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/donksoft,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"cM" = (
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkbluecorners"
+	},
+/area/shuttle/trade/sol)
+"df" = (
+/obj/structure/table/reinforced,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"dN" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/minerals,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"eI" = (
+/obj/machinery/economy/atm/directional/east,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"fc" = (
+/obj/structure/closet,
+/obj/item/stack/tile/disco_light/thirty,
+/obj/effect/spawner/random/traders/service,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"fe" = (
+/obj/item/flag/solgov,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"fL" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/medical,
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"fW" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"fZ" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"gq" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"gA" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"hi" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"hM" = (
+/turf/simulated/wall/mineral/titanium,
+/area/shuttle/trade/sol)
+"kr" = (
+/obj/effect/spawner/window/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "trader_privacy";
+	name = "Privacy Shutters"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"lh" = (
+/obj/item/flag/solgov,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/flasher{
+	id = "trader_flash";
+	pixel_x = 28
+	},
+/obj/machinery/light/spot,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"lO" = (
+/obj/machinery/door_control/no_emag{
+	id = "trader_privacy";
+	name = "Privacy Shutters Control";
+	pixel_y = -24;
+	req_access = list(160);
+	pixel_x = -10
+	},
+/obj/machinery/flasher_button{
+	id = "trader_flash";
+	pixel_y = -23;
+	req_access = list(160)
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_starboard";
+	name = "Trade Deposits Door";
+	normaldoorcontrol = 1;
+	pixel_x = 10;
+	req_access = list(160);
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"pd" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/security,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"uk" = (
+/obj/machinery/economy/atm/directional/west,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"uF" = (
+/obj/effect/spawner/window/shuttle,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"xK" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"zp" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/engineering,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"zV" = (
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "trader_port";
+	security_level = 6
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/shuttle/trade/sol)
+"CH" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/shuttle/trade/sol)
+"Fb" = (
+/turf/simulated/wall/mineral/titanium/nodiagonal,
+/area/shuttle/trade/sol)
+"Fe" = (
+/obj/structure/bed,
+/obj/item/bedsheet/blue,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkbluefull"
+	},
+/area/shuttle/trade/sol)
+"FV" = (
+/obj/item/stack/wrapping_paper,
+/obj/item/stack/package_wrap{
+	pixel_y = 8
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"FZ" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"Gk" = (
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock"
+	},
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/shuttle/trade/sol)
+"Hb" = (
+/obj/structure/shelf/command,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/shuttle/trade/sol)
+"ID" = (
+/obj/structure/sign/poster/official/kpop/directional/north,
+/obj/structure/table/reinforced,
+/obj/item/lighter/zippo{
+	pixel_x = 9;
+	pixel_y = 6
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_carp{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkbluefull"
+	},
+/area/shuttle/trade/sol)
+"IG" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"IX" = (
+/obj/item/flag/solgov,
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/flasher{
+	id = "trader_flash";
+	pixel_x = -28
+	},
+/obj/machinery/light/spot,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"Jc" = (
+/obj/machinery/door_control/no_emag{
+	id = "trader_privacy";
+	name = "Privacy Shutters Control";
+	pixel_y = -24;
+	req_access = list(160);
+	pixel_x = 10
+	},
+/obj/machinery/flasher_button{
+	id = "trader_flash";
+	pixel_y = -23;
+	req_access = list(160)
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_port";
+	name = "Trade Deposits Door";
+	normaldoorcontrol = 1;
+	pixel_x = -10;
+	req_access = list(160);
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"Lg" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/shuttle/engine/heater,
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"LH" = (
+/obj/effect/spawner/random/traders/vehicle,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"Mn" = (
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkbluefull"
+	},
+/area/shuttle/trade/sol)
+"No" = (
+/obj/machinery/door/airlock/titanium/glass,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/shuttle/trade/sol)
+"NG" = (
+/obj/structure/extinguisher_cabinet{
+	name = "south bump";
+	pixel_y = -30
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"Of" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/shuttle/trade/sol)
+"OE" = (
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"OT" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/science,
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"Pa" = (
+/obj/effect/landmark/spawner/tradergearminor,
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"Pw" = (
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock"
+	},
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/obj/docking_port/mobile/trader{
+	height = 15;
+	width = 14;
+	dwidth = 7;
+	preferred_direction = 1;
+	dir = 1;
+	port_direction = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/shuttle/trade/sol)
+"PU" = (
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "trader_starboard";
+	security_level = 6
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/shuttle/trade/sol)
+"Qw" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkbluefull"
+	},
+/area/shuttle/trade/sol)
+"QN" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/civilian,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"Rp" = (
+/obj/machinery/computer/shuttle/trade/sol,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"RX" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"SA" = (
+/obj/effect/spawner/random/traders/large_item,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"VT" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"Wy" = (
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkbluecorners"
+	},
+/area/shuttle/trade/sol)
+"WB" = (
+/obj/machinery/door/airlock/titanium,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/shuttle/trade/sol)
+"Xi" = (
+/turf/template_noop,
+/area/template_noop)
+"XX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/shuttle/trade/sol)
+"Yn" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkbluefull"
+	},
+/area/shuttle/trade/sol)
+"Yy" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "trader_privacy";
+	name = "Privacy Shutters"
+	},
+/obj/effect/spawner/window/shuttle,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"Zi" = (
+/obj/structure/sign/poster/official/core/directional/north,
+/obj/structure/table/reinforced,
+/obj/item/toy/plushie/slimeplushie,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkbluefull"
+	},
+/area/shuttle/trade/sol)
+"Zx" = (
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+"Zy" = (
+/obj/effect/landmark/spawner/tradergearmajor,
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkblue"
+	},
+/area/shuttle/trade/sol)
+
+(1,1,1) = {"
+Xi
+Xi
+Xi
+Xi
+Xi
+Xi
+hM
+Fb
+Fb
+Fb
+Fb
+hi
+fZ
+Xi
+Xi
+"}
+(2,1,1) = {"
+Xi
+Xi
+Xi
+Xi
+hM
+Fb
+Fb
+QN
+Pa
+LH
+Fb
+fW
+fZ
+Xi
+Xi
+"}
+(3,1,1) = {"
+Xi
+Xi
+hM
+Fb
+Fb
+Fb
+dN
+Wy
+CH
+CH
+No
+XX
+fW
+fZ
+Xi
+"}
+(4,1,1) = {"
+Xi
+Xi
+Fb
+Zi
+Yn
+Fb
+aM
+CH
+CH
+NG
+Fb
+VT
+CH
+Lg
+fZ
+"}
+(5,1,1) = {"
+Xi
+hM
+Fb
+Fe
+Mn
+Fb
+OT
+CH
+CH
+Jc
+Fb
+Fb
+zV
+Fb
+Fb
+"}
+(6,1,1) = {"
+uF
+uF
+Fb
+Fb
+WB
+Fb
+fe
+CH
+CH
+xK
+Yy
+uk
+CH
+IX
+Fb
+"}
+(7,1,1) = {"
+uF
+df
+FZ
+OE
+CH
+No
+CH
+CH
+Hb
+FV
+kr
+gA
+CH
+Of
+Gk
+"}
+(8,1,1) = {"
+uF
+Rp
+gq
+Zx
+CH
+No
+CH
+CH
+Hb
+FV
+kr
+gA
+CH
+Of
+Pw
+"}
+(9,1,1) = {"
+uF
+uF
+Fb
+Fb
+WB
+Fb
+fe
+CH
+CH
+xK
+Yy
+eI
+CH
+lh
+Fb
+"}
+(10,1,1) = {"
+Xi
+hM
+Fb
+Fe
+Mn
+Fb
+fL
+CH
+CH
+lO
+Fb
+Fb
+PU
+Fb
+Fb
+"}
+(11,1,1) = {"
+Xi
+Xi
+Fb
+ID
+Qw
+Fb
+pd
+CH
+CH
+NG
+Fb
+RX
+CH
+Lg
+fZ
+"}
+(12,1,1) = {"
+Xi
+Xi
+hM
+Fb
+Fb
+Fb
+zp
+cM
+CH
+CH
+No
+XX
+IG
+fZ
+Xi
+"}
+(13,1,1) = {"
+Xi
+Xi
+Xi
+Xi
+hM
+Fb
+Fb
+fc
+Zy
+SA
+Fb
+IG
+fZ
+Xi
+Xi
+"}
+(14,1,1) = {"
+Xi
+Xi
+Xi
+Xi
+Xi
+Xi
+hM
+Fb
+Fb
+Fb
+hM
+hi
+fZ
+Xi
+Xi
+"}

--- a/_maps/map_files/shuttles/trader/trader_base_stead.dmm
+++ b/_maps/map_files/shuttles/trader/trader_base_stead.dmm
@@ -1,0 +1,752 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"bP" = (
+/obj/structure/extinguisher_cabinet{
+	name = "east bump";
+	pixel_x = 30
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"bT" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/titanium{
+	color = "#63D335"
+	},
+/area/shuttle/trade/sol)
+"bW" = (
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"dy" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"eM" = (
+/obj/effect/spawner/random/traders/vehicle,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"fA" = (
+/obj/machinery/computer/shuttle/trade/sol,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"fI" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/engineering,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"gs" = (
+/turf/simulated/wall/mineral/titanium/nodiagonal,
+/area/shuttle/trade/sol)
+"hE" = (
+/obj/item/flag/species/vulp,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"il" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock"
+	},
+/obj/docking_port/mobile/trader{
+	height = 17;
+	width = 16;
+	dwidth = 8;
+	preferred_direction = 1;
+	dir = 1;
+	port_direction = 8
+	},
+/turf/simulated/floor/mineral/titanium{
+	color = "#63D335"
+	},
+/area/shuttle/trade/sol)
+"iC" = (
+/obj/machinery/door/airlock/titanium/glass,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"iV" = (
+/turf/template_noop,
+/area/template_noop)
+"jg" = (
+/obj/item/toy/plushie/red_fox,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"ju" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"kM" = (
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"lw" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"mF" = (
+/obj/effect/spawner/random/traders/large_item,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"nx" = (
+/obj/machinery/door_control/no_emag{
+	id = "trader_privacy";
+	name = "Privacy Shutters Control";
+	pixel_y = -24;
+	req_access = list(160);
+	pixel_x = -10
+	},
+/obj/machinery/flasher_button{
+	id = "trader_flash";
+	pixel_y = -23;
+	req_access = list(160)
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_starboard";
+	name = "Trade Deposits Door";
+	normaldoorcontrol = 1;
+	pixel_x = 10;
+	req_access = list(160);
+	pixel_y = -24
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"nH" = (
+/obj/effect/spawner/window/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "trader_privacy";
+	name = "Privacy Shutters"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"ou" = (
+/obj/structure/shelf,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"pp" = (
+/obj/machinery/economy/atm/directional/east,
+/turf/simulated/floor/mineral/titanium{
+	color = "#63D335"
+	},
+/area/shuttle/trade/sol)
+"rb" = (
+/turf/simulated/floor/mineral/titanium/yellow,
+/area/shuttle/trade/sol)
+"rB" = (
+/obj/machinery/flasher{
+	id = "trader_flash";
+	pixel_x = -28
+	},
+/obj/item/flag/species/vulp,
+/turf/simulated/floor/mineral/titanium{
+	color = "#63D335"
+	},
+/area/shuttle/trade/sol)
+"ut" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"wS" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/minerals,
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"xk" = (
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium/yellow,
+/area/shuttle/trade/sol)
+"xt" = (
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "trader_starboard";
+	security_level = 6
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/titanium/yellow,
+/area/shuttle/trade/sol)
+"yu" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"zT" = (
+/obj/structure/bed,
+/obj/item/bedsheet/orange,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/root/directional/north,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"Aj" = (
+/turf/simulated/wall/mineral/titanium,
+/area/shuttle/trade/sol)
+"BS" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/security,
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"Ch" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/science,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"Dq" = (
+/obj/effect/spawner/window/shuttle,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"Dx" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock"
+	},
+/turf/simulated/floor/mineral/titanium{
+	color = "#63D335"
+	},
+/area/shuttle/trade/sol)
+"Fx" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"GF" = (
+/obj/structure/closet,
+/obj/item/stack/tile/disco_light/thirty,
+/obj/effect/spawner/random/traders/service,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"GO" = (
+/obj/machinery/door/airlock/titanium,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"Hp" = (
+/obj/machinery/door_control/no_emag{
+	id = "trader_privacy";
+	name = "Privacy Shutters Control";
+	pixel_y = -24;
+	req_access = list(160);
+	pixel_x = 10
+	},
+/obj/machinery/flasher_button{
+	id = "trader_flash";
+	pixel_y = -23;
+	req_access = list(160)
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_port";
+	name = "Trade Deposits Door";
+	normaldoorcontrol = 1;
+	pixel_x = -10;
+	req_access = list(160);
+	pixel_y = -24
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"Ht" = (
+/obj/machinery/door/airlock/titanium/glass,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/titanium/yellow,
+/area/shuttle/trade/sol)
+"HT" = (
+/obj/structure/table/wood,
+/obj/item/stack/wrapping_paper,
+/obj/item/stack/package_wrap{
+	pixel_y = 8
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"IP" = (
+/obj/structure/chair/wood/wings{
+	dir = 4
+	},
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/titanium{
+	color = "#63D335"
+	},
+/area/shuttle/trade/sol)
+"Ji" = (
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"Jn" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"JD" = (
+/obj/effect/landmark/spawner/tradergearmajor,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"KM" = (
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "trader_port";
+	security_level = 6
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/titanium/yellow,
+/area/shuttle/trade/sol)
+"Lg" = (
+/obj/effect/landmark/spawner/tradergearminor,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"LU" = (
+/obj/item/bedsheet/orange,
+/obj/structure/bed,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/darkpurpl/directional/north,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"MG" = (
+/obj/item/toy/plushie/orange_fox,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"MK" = (
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"Na" = (
+/turf/simulated/floor/mineral/titanium{
+	color = "#63D335"
+	},
+/area/shuttle/trade/sol)
+"Nd" = (
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/titanium/yellow,
+/area/shuttle/trade/sol)
+"Nt" = (
+/obj/structure/table/reinforced,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"QR" = (
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium{
+	color = "#63D335"
+	},
+/area/shuttle/trade/sol)
+"Ro" = (
+/obj/structure/extinguisher_cabinet{
+	name = "west bump";
+	pixel_x = -30
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"Rt" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"RI" = (
+/obj/machinery/light/spot,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"Sf" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "trader_privacy";
+	name = "Privacy Shutters"
+	},
+/obj/effect/spawner/window/shuttle,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"Sq" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/medical,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"TW" = (
+/obj/machinery/economy/atm/directional/west,
+/turf/simulated/floor/mineral/titanium{
+	color = "#63D335"
+	},
+/area/shuttle/trade/sol)
+"UG" = (
+/obj/machinery/flasher{
+	id = "trader_flash";
+	pixel_x = 28
+	},
+/obj/item/flag/species/vulp,
+/turf/simulated/floor/mineral/titanium{
+	color = "#63D335"
+	},
+/area/shuttle/trade/sol)
+"Yq" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/civilian,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"YC" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/donksoft,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+
+(1,1,1) = {"
+iV
+iV
+iV
+iV
+iV
+iV
+iV
+iV
+iV
+iV
+iV
+iV
+Aj
+gs
+Aj
+iV
+iV
+"}
+(2,1,1) = {"
+iV
+iV
+iV
+iV
+iV
+iV
+iV
+iV
+iV
+iV
+iV
+Aj
+gs
+Jn
+lw
+iV
+iV
+"}
+(3,1,1) = {"
+iV
+Aj
+Dq
+Dq
+Aj
+iV
+iV
+iV
+Aj
+gs
+gs
+gs
+Nd
+rb
+ut
+lw
+iV
+"}
+(4,1,1) = {"
+iV
+gs
+MG
+Rt
+gs
+gs
+gs
+gs
+gs
+MK
+Ro
+Ht
+rb
+rb
+ut
+lw
+iV
+"}
+(5,1,1) = {"
+iV
+gs
+zT
+MK
+gs
+Yq
+wS
+YC
+Ch
+MK
+RI
+gs
+gs
+KM
+gs
+gs
+Aj
+"}
+(6,1,1) = {"
+Aj
+gs
+gs
+GO
+gs
+hE
+MK
+MK
+MK
+MK
+Hp
+gs
+rB
+Na
+IP
+gs
+gs
+"}
+(7,1,1) = {"
+Dq
+kM
+Ji
+kM
+iC
+MK
+MK
+MK
+MK
+MK
+yu
+Sf
+bT
+Na
+Na
+TW
+gs
+"}
+(8,1,1) = {"
+Dq
+Nt
+Fx
+kM
+gs
+eM
+MK
+Lg
+ou
+MK
+HT
+nH
+Na
+Na
+Na
+Na
+Dx
+"}
+(9,1,1) = {"
+Dq
+fA
+Fx
+kM
+gs
+mF
+MK
+JD
+ou
+MK
+HT
+nH
+Na
+Na
+Na
+Na
+il
+"}
+(10,1,1) = {"
+Dq
+kM
+bW
+kM
+iC
+MK
+MK
+MK
+MK
+MK
+yu
+Sf
+bT
+Na
+Na
+pp
+gs
+"}
+(11,1,1) = {"
+Aj
+gs
+gs
+GO
+gs
+hE
+MK
+MK
+MK
+MK
+nx
+gs
+UG
+Na
+QR
+gs
+gs
+"}
+(12,1,1) = {"
+iV
+gs
+LU
+MK
+gs
+Sq
+BS
+fI
+GF
+MK
+RI
+gs
+gs
+xt
+gs
+gs
+Aj
+"}
+(13,1,1) = {"
+iV
+gs
+jg
+dy
+gs
+gs
+gs
+gs
+gs
+MK
+bP
+Ht
+rb
+rb
+ut
+lw
+iV
+"}
+(14,1,1) = {"
+iV
+Aj
+Dq
+Dq
+Aj
+iV
+iV
+iV
+Aj
+gs
+gs
+gs
+xk
+rb
+ut
+lw
+iV
+"}
+(15,1,1) = {"
+iV
+iV
+iV
+iV
+iV
+iV
+iV
+iV
+iV
+iV
+iV
+Aj
+gs
+ju
+lw
+iV
+iV
+"}
+(16,1,1) = {"
+iV
+iV
+iV
+iV
+iV
+iV
+iV
+iV
+iV
+iV
+iV
+iV
+Aj
+gs
+Aj
+iV
+iV
+"}

--- a/_maps/map_files/shuttles/trader/trader_base_syndicate.dmm
+++ b/_maps/map_files/shuttles/trader/trader_base_syndicate.dmm
@@ -1,0 +1,866 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"av" = (
+/obj/structure/table/glass/reinforced/plastitanium,
+/obj/item/toy/figure/crew/syndie,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"bZ" = (
+/turf/template_noop,
+/area/template_noop)
+"du" = (
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/science,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"dM" = (
+/obj/effect/spawner/window/plastitanium,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"eK" = (
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"fN" = (
+/obj/structure/chair/sofa/corp/left,
+/obj/machinery/flasher{
+	id = "trader_flash";
+	pixel_x = 28
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"gl" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"gD" = (
+/obj/structure/bed,
+/obj/item/bedsheet/syndie,
+/obj/structure/sign/poster/contraband/random/directional/north,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"gI" = (
+/obj/machinery/flasher_button{
+	id = "trader_flash";
+	pixel_y = 23;
+	req_access = list(160)
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_privacy";
+	name = "Privacy Shutters Control";
+	pixel_y = 24;
+	req_access = list(160);
+	pixel_x = 10
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_port";
+	name = "Trade Deposits Door";
+	normaldoorcontrol = 1;
+	pixel_x = -10;
+	req_access = list(160);
+	pixel_y = 24
+	},
+/obj/structure/table/glass/reinforced/plastitanium,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/effect/turf_decal/siding,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"hn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"hF" = (
+/obj/effect/spawner/random/traders/large_item,
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"ip" = (
+/obj/structure/extinguisher_cabinet{
+	name = "north bump";
+	pixel_y = 30
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"iA" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"jd" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/obj/structure/sign/poster/contraband/random/directional/north,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"jy" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"kc" = (
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"km" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"kx" = (
+/obj/structure/table/glass/reinforced/plastitanium,
+/obj/item/paper_bin,
+/obj/item/pen/multi/syndicate,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"kE" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"kM" = (
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"lk" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 4
+	},
+/obj/structure/sign/poster/contraband/random/directional/north,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"nc" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/plastitanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"nY" = (
+/obj/machinery/light/spot,
+/obj/machinery/economy/atm/directional/east,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"oZ" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/hatch{
+	id_tag = "s_docking_airlock"
+	},
+/obj/docking_port/mobile/trader{
+	height = 21;
+	width = 14;
+	dwidth = 7;
+	preferred_direction = 1;
+	dir = 2
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"ps" = (
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/medical,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"qK" = (
+/obj/effect/spawner/window/plastitanium,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "trader_privacy";
+	name = "Privacy Shutters"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"sz" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
+	},
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"sA" = (
+/obj/structure/chair/comfy/corp,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"sH" = (
+/obj/machinery/light/spot,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"tl" = (
+/obj/structure/closet,
+/obj/item/stack/tile/disco_light/thirty,
+/obj/effect/spawner/random/traders/service,
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"tH" = (
+/obj/structure/table/glass/reinforced/plastitanium,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"tX" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"uK" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/hatch{
+	id_tag = "s_docking_airlock"
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"vM" = (
+/obj/machinery/computer/shuttle/trade/sol,
+/obj/effect/turf_decal/woodsiding{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"wq" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/right,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"wA" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 5
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"xz" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"xE" = (
+/obj/structure/shelf,
+/obj/effect/turf_decal/siding{
+	dir = 6
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"xR" = (
+/obj/structure/table/glass/reinforced/plastitanium,
+/obj/item/ashtray/glass{
+	pixel_x = 8;
+	pixel_y = 1
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_syndicate{
+	pixel_x = -9;
+	pixel_y = 7
+	},
+/obj/item/lighter/zippo/contractor{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/woodsiding{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"ye" = (
+/obj/machinery/door/airlock/hatch,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"yH" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"za" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"zm" = (
+/obj/structure/chair/sofa/corp/right,
+/obj/machinery/flasher{
+	id = "trader_flash";
+	pixel_x = -28
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"zB" = (
+/obj/structure/table/glass/reinforced/plastitanium,
+/obj/item/stack/wrapping_paper,
+/obj/item/stack/package_wrap{
+	pixel_y = 8
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"zY" = (
+/obj/effect/turf_decal/siding{
+	dir = 5
+	},
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/minerals,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"CP" = (
+/obj/effect/landmark/spawner/tradergearmajor,
+/obj/effect/turf_decal/siding{
+	dir = 5
+	},
+/obj/machinery/light/spot,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"CU" = (
+/obj/machinery/light/spot,
+/obj/machinery/economy/atm/directional/west,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"DB" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"Fd" = (
+/obj/machinery/door/airlock/hatch,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"Gr" = (
+/obj/machinery/door/airlock/hatch{
+	security_level = 6;
+	id_tag = "trader_starboard"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"Hn" = (
+/obj/effect/turf_decal/siding{
+	dir = 9
+	},
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/engineering,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"HA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/chair/comfy/corp{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"Ia" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/chair/sofa/corp/left,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"ID" = (
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/donksoft,
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"Jn" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"JI" = (
+/turf/simulated/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/trade/sol)
+"KA" = (
+/obj/machinery/flasher_button{
+	id = "trader_flash";
+	pixel_y = 23;
+	req_access = list(160)
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_privacy";
+	name = "Privacy Shutters Control";
+	pixel_y = 24;
+	req_access = list(160);
+	pixel_x = -10
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_starboard";
+	name = "Trade Deposits Door";
+	normaldoorcontrol = 1;
+	pixel_x = 10;
+	req_access = list(160);
+	pixel_y = 24
+	},
+/obj/structure/table/glass/reinforced/plastitanium,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/effect/turf_decal/siding,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"Lf" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 9
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"LQ" = (
+/turf/simulated/wall/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"Mn" = (
+/obj/structure/chair/comfy/corp{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"Op" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"PN" = (
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/security,
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"Qk" = (
+/obj/structure/table/glass/reinforced/plastitanium,
+/obj/item/wirecutters,
+/obj/item/hemostat,
+/obj/item/scalpel,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"RQ" = (
+/obj/structure/shelf,
+/obj/effect/turf_decal/siding{
+	dir = 10
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"SY" = (
+/obj/effect/spawner/random/traders/vehicle,
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"TK" = (
+/obj/item/flag/syndi,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"TU" = (
+/obj/machinery/door/airlock/hatch{
+	security_level = 6;
+	id_tag = "trader_port"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"VQ" = (
+/obj/structure/table/glass/reinforced/plastitanium,
+/obj/item/toy/nuke,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"WV" = (
+/obj/effect/landmark/spawner/tradergearminor,
+/obj/effect/turf_decal/siding{
+	dir = 9
+	},
+/obj/machinery/light/spot,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"Xj" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/civilian,
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"YD" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"Zu" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+
+(1,1,1) = {"
+bZ
+bZ
+LQ
+LQ
+LQ
+LQ
+LQ
+LQ
+bZ
+bZ
+bZ
+bZ
+bZ
+LQ
+JI
+JI
+JI
+JI
+JI
+JI
+bZ
+"}
+(2,1,1) = {"
+bZ
+LQ
+LQ
+Op
+kM
+dM
+kc
+LQ
+LQ
+bZ
+bZ
+bZ
+LQ
+JI
+VQ
+JI
+kx
+tH
+nc
+Jn
+bZ
+"}
+(3,1,1) = {"
+LQ
+LQ
+eK
+iA
+kM
+ye
+kc
+SY
+LQ
+bZ
+bZ
+bZ
+LQ
+gD
+xz
+JI
+hn
+HA
+nc
+Jn
+bZ
+"}
+(4,1,1) = {"
+JI
+JI
+TU
+JI
+JI
+JI
+ip
+CP
+JI
+LQ
+bZ
+LQ
+LQ
+TK
+eK
+JI
+kc
+sH
+JI
+JI
+JI
+"}
+(5,1,1) = {"
+JI
+zm
+kc
+CU
+JI
+gI
+kc
+kc
+Xj
+JI
+JI
+JI
+JI
+JI
+Fd
+LQ
+kc
+Lf
+YD
+nc
+Jn
+"}
+(6,1,1) = {"
+JI
+Ia
+kc
+sA
+qK
+Mn
+kc
+kc
+zY
+ID
+du
+JI
+lk
+sz
+kc
+kc
+kc
+tX
+eK
+nc
+Jn
+"}
+(7,1,1) = {"
+oZ
+jy
+kc
+kc
+qK
+zB
+RQ
+kc
+kc
+kc
+Zu
+ye
+kc
+kc
+kc
+kc
+kc
+xR
+kE
+JI
+JI
+"}
+(8,1,1) = {"
+uK
+jy
+kc
+kc
+qK
+zB
+xE
+kc
+kc
+kc
+Zu
+ye
+kc
+kc
+kc
+kc
+kc
+vM
+kE
+JI
+JI
+"}
+(9,1,1) = {"
+JI
+wq
+kc
+sA
+qK
+Mn
+kc
+kc
+Hn
+PN
+ps
+JI
+jd
+gl
+kc
+kc
+kc
+tX
+eK
+nc
+Jn
+"}
+(10,1,1) = {"
+JI
+fN
+kc
+nY
+JI
+KA
+kc
+kc
+tl
+JI
+JI
+JI
+JI
+JI
+Fd
+LQ
+kc
+wA
+yH
+nc
+Jn
+"}
+(11,1,1) = {"
+JI
+JI
+Gr
+JI
+JI
+JI
+ip
+WV
+JI
+LQ
+bZ
+LQ
+JI
+TK
+eK
+JI
+kc
+sH
+JI
+JI
+JI
+"}
+(12,1,1) = {"
+LQ
+LQ
+eK
+DB
+kM
+ye
+kc
+hF
+LQ
+bZ
+bZ
+bZ
+JI
+gD
+xz
+JI
+km
+km
+nc
+Jn
+bZ
+"}
+(13,1,1) = {"
+bZ
+LQ
+LQ
+Op
+kM
+dM
+kc
+LQ
+LQ
+bZ
+bZ
+bZ
+LQ
+JI
+av
+JI
+za
+Qk
+nc
+Jn
+bZ
+"}
+(14,1,1) = {"
+bZ
+bZ
+LQ
+LQ
+LQ
+LQ
+LQ
+LQ
+bZ
+bZ
+bZ
+bZ
+bZ
+LQ
+JI
+JI
+JI
+JI
+JI
+JI
+bZ
+"}

--- a/_maps/map_files/shuttles/trader/trader_base_synth.dmm
+++ b/_maps/map_files/shuttles/trader/trader_base_synth.dmm
@@ -1,0 +1,531 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/simulated/wall/mineral/titanium,
+/area/shuttle/trade/sol)
+"b" = (
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"c" = (
+/obj/machinery/economy/atm/directional/west,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/nanotrasen_logo/directional/north,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"d" = (
+/obj/effect/turf_decal/box,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"e" = (
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"f" = (
+/obj/structure/extinguisher_cabinet{
+	name = "west bump";
+	pixel_x = -30
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"g" = (
+/obj/effect/spawner/random/traders/large_item,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"h" = (
+/obj/machinery/economy/atm/directional/east,
+/obj/structure/sign/vacuum/external{
+	icon_state = "doors";
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"i" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/donksoft,
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"j" = (
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "trader_port";
+	security_level = 6
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"k" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/flasher{
+	id = "trader_flash";
+	pixel_x = -28
+	},
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"l" = (
+/obj/structure/extinguisher_cabinet{
+	name = "east bump";
+	pixel_x = 30
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"m" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/medical,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"n" = (
+/obj/effect/landmark/spawner/tradergearminor,
+/obj/machinery/light/spot,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"o" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"p" = (
+/obj/structure/shelf,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"q" = (
+/obj/structure/closet,
+/obj/item/stack/tile/disco_light/thirty,
+/obj/effect/spawner/random/traders/service,
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"r" = (
+/turf/simulated/wall/mineral/titanium/nodiagonal,
+/area/shuttle/trade/sol)
+"s" = (
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "trader_starboard";
+	security_level = 6
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"t" = (
+/obj/item/toy/plushie/ipcplushie,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"u" = (
+/obj/machinery/door/airlock/titanium/glass,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"v" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/science,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"w" = (
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/red/corner,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"x" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/wrapping_paper,
+/obj/item/stack/package_wrap{
+	pixel_y = 8
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"y" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "trader_privacy";
+	name = "Privacy Shutters"
+	},
+/obj/effect/spawner/window/shuttle,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"z" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/minerals,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"A" = (
+/obj/effect/landmark/spawner/tradergearmajor,
+/obj/machinery/light/spot,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"C" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/security,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"D" = (
+/obj/machinery/recharge_station/upgraded,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"E" = (
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"F" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/flasher{
+	id = "trader_flash";
+	pixel_x = 28
+	},
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"G" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/caution/stand_clear/red{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"H" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"J" = (
+/obj/effect/spawner/random/traders/vehicle,
+/obj/structure/sign/poster/official/metal/directional/east,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"K" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"L" = (
+/obj/machinery/flasher_button{
+	id = "trader_flash";
+	pixel_y = 23;
+	req_access = list(160)
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_privacy";
+	name = "Privacy Shutters Control";
+	pixel_y = 24;
+	req_access = list(160);
+	pixel_x = -10
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_starboard";
+	name = "Trade Deposits Door";
+	normaldoorcontrol = 1;
+	pixel_x = 10;
+	req_access = list(160);
+	pixel_y = 24
+	},
+/obj/machinery/computer/shuttle/trade/sol{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"M" = (
+/obj/machinery/flasher_button{
+	id = "trader_flash";
+	pixel_y = 23;
+	req_access = list(160)
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_privacy";
+	name = "Privacy Shutters Control";
+	pixel_y = 24;
+	req_access = list(160);
+	pixel_x = 10
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_port";
+	name = "Trade Deposits Door";
+	normaldoorcontrol = 1;
+	pixel_x = -10;
+	req_access = list(160);
+	pixel_y = 24
+	},
+/obj/structure/table/reinforced,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"N" = (
+/obj/effect/spawner/window/shuttle,
+/obj/structure/sign/securearea,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"O" = (
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock"
+	},
+/obj/structure/fans/tiny,
+/obj/docking_port/mobile/trader{
+	height = 12;
+	width = 12;
+	dwidth = 6;
+	preferred_direction = 1;
+	dir = 2
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"P" = (
+/obj/item/flag/species/machine,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"R" = (
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"S" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"T" = (
+/turf/template_noop,
+/area/template_noop)
+"U" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/civilian,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"W" = (
+/obj/effect/spawner/window/shuttle,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"X" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"Y" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
+"Z" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/engineering,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+
+(1,1,1) = {"
+a
+W
+W
+W
+a
+a
+W
+a
+a
+a
+a
+T
+"}
+(2,1,1) = {"
+W
+P
+R
+G
+u
+f
+E
+i
+z
+U
+r
+a
+"}
+(3,1,1) = {"
+W
+d
+o
+b
+N
+R
+E
+R
+R
+R
+K
+H
+"}
+(4,1,1) = {"
+a
+r
+j
+r
+r
+M
+E
+v
+m
+n
+r
+r
+"}
+(5,1,1) = {"
+a
+c
+R
+k
+y
+X
+E
+R
+R
+P
+K
+H
+"}
+(6,1,1) = {"
+O
+Y
+R
+S
+y
+x
+E
+p
+R
+D
+K
+H
+"}
+(7,1,1) = {"
+e
+Y
+R
+S
+y
+x
+E
+p
+t
+D
+K
+H
+"}
+(8,1,1) = {"
+a
+h
+R
+F
+y
+X
+E
+R
+R
+P
+K
+H
+"}
+(9,1,1) = {"
+a
+r
+s
+r
+r
+L
+E
+C
+Z
+A
+r
+r
+"}
+(10,1,1) = {"
+W
+d
+o
+w
+N
+R
+E
+R
+R
+R
+K
+H
+"}
+(11,1,1) = {"
+W
+P
+R
+G
+u
+l
+E
+q
+J
+g
+r
+a
+"}
+(12,1,1) = {"
+a
+W
+W
+W
+a
+a
+W
+a
+a
+a
+a
+T
+"}

--- a/_maps/map_files/shuttles/trader/trader_base_techno.dmm
+++ b/_maps/map_files/shuttles/trader/trader_base_techno.dmm
@@ -1,0 +1,603 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/landmark/spawner/tradergearmajor,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"b" = (
+/obj/effect/spawner/random/traders/large_item,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"c" = (
+/obj/structure/bed/abductor,
+/obj/item/toy/plushie/abductor/agent,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"d" = (
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/obj/structure/closet/abductor,
+/obj/effect/spawner/random/traders/minerals,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"e" = (
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/obj/item/flag/species/greys,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"i" = (
+/obj/effect/spawner/window/reinforced/plasma/grilled,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "trader_privacy";
+	name = "Privacy Shutters"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"j" = (
+/obj/machinery/flasher_button{
+	id = "trader_flash";
+	pixel_y = 23;
+	req_access = list(160)
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_privacy";
+	name = "Privacy Shutters Control";
+	pixel_y = 24;
+	req_access = list(160);
+	pixel_x = -10
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_starboard";
+	name = "Trade Deposits Door";
+	normaldoorcontrol = 1;
+	pixel_x = 10;
+	req_access = list(160);
+	pixel_y = 24
+	},
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"k" = (
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/obj/structure/closet/abductor,
+/obj/effect/spawner/random/traders/engineering,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"m" = (
+/obj/machinery/door/airlock/abductor{
+	security_level = 6;
+	id_tag = "trader_port"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"n" = (
+/obj/structure/closet/abductor,
+/obj/effect/spawner/random/traders/science,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"o" = (
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/graydays/directional/north,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"p" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/flasher{
+	id = "trader_flash";
+	pixel_x = -28
+	},
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"q" = (
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"r" = (
+/obj/structure/bed/abductor,
+/obj/item/toy/plushie/greyplushie,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"s" = (
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"t" = (
+/obj/effect/landmark/spawner/tradergearminor,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"u" = (
+/obj/machinery/light/spot,
+/obj/item/flag/species/greys,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"v" = (
+/obj/machinery/door/airlock/abductor,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"w" = (
+/obj/effect/spawner/random/traders/vehicle,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"x" = (
+/obj/machinery/door/airlock/abductor,
+/obj/structure/fans/tiny,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"y" = (
+/obj/machinery/door/airlock/abductor{
+	security_level = 6;
+	id_tag = "trader_starboard"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"z" = (
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"A" = (
+/obj/machinery/flasher_button{
+	id = "trader_flash";
+	pixel_y = 23;
+	req_access = list(160)
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_privacy";
+	name = "Privacy Shutters Control";
+	pixel_y = 24;
+	req_access = list(160);
+	pixel_x = 10
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_port";
+	name = "Trade Deposits Door";
+	normaldoorcontrol = 1;
+	pixel_x = -10;
+	req_access = list(160);
+	pixel_y = 24
+	},
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"B" = (
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/obj/item/flag/species/greys,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"C" = (
+/turf/simulated/wall/mineral/abductor,
+/area/shuttle/trade/sol)
+"D" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/flasher{
+	id = "trader_flash";
+	pixel_x = 28
+	},
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"F" = (
+/obj/machinery/door/airlock/abductor,
+/obj/structure/fans/tiny,
+/obj/docking_port/mobile/trader{
+	height = 16;
+	width = 16;
+	dwidth = 8;
+	preferred_direction = 1;
+	dir = 2
+	},
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"G" = (
+/obj/machinery/computer/shuttle/trade/sol,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"H" = (
+/obj/structure/table/abductor,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"I" = (
+/obj/structure/closet/abductor,
+/obj/effect/spawner/random/traders/security,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"J" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"K" = (
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"L" = (
+/obj/machinery/economy/atm/directional/west,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"M" = (
+/turf/template_noop,
+/area/template_noop)
+"N" = (
+/obj/machinery/economy/atm/directional/east,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"O" = (
+/obj/effect/spawner/window/reinforced/plasma/grilled,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"P" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"Q" = (
+/obj/structure/table/abductor,
+/obj/item/stack/wrapping_paper,
+/obj/item/stack/package_wrap{
+	pixel_y = 8
+	},
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"R" = (
+/obj/structure/closet/abductor,
+/obj/effect/spawner/random/traders/medical,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"S" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"T" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"V" = (
+/obj/structure/closet/abductor,
+/obj/item/stack/tile/disco_light/thirty,
+/obj/effect/spawner/random/traders/service,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"W" = (
+/obj/structure/closet/abductor,
+/obj/effect/spawner/random/traders/civilian,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"X" = (
+/obj/structure/closet/abductor,
+/obj/effect/spawner/random/traders/donksoft,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"Y" = (
+/obj/structure/shelf/science,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+
+(1,1,1) = {"
+M
+M
+M
+M
+M
+C
+C
+C
+C
+C
+C
+M
+M
+M
+M
+M
+"}
+(2,1,1) = {"
+M
+M
+M
+C
+C
+C
+C
+X
+d
+W
+C
+C
+C
+M
+M
+M
+"}
+(3,1,1) = {"
+M
+M
+C
+C
+q
+q
+O
+q
+q
+q
+n
+C
+C
+C
+M
+M
+"}
+(4,1,1) = {"
+M
+C
+C
+q
+K
+q
+v
+q
+q
+q
+a
+C
+c
+C
+C
+M
+"}
+(5,1,1) = {"
+M
+C
+C
+m
+C
+C
+C
+s
+q
+q
+w
+C
+K
+q
+C
+M
+"}
+(6,1,1) = {"
+C
+C
+p
+q
+L
+e
+C
+A
+q
+q
+u
+C
+C
+v
+C
+C
+"}
+(7,1,1) = {"
+C
+J
+q
+q
+q
+S
+i
+P
+q
+q
+q
+v
+z
+q
+q
+C
+"}
+(8,1,1) = {"
+F
+q
+q
+q
+q
+q
+i
+Q
+q
+q
+Y
+C
+H
+P
+q
+C
+"}
+(9,1,1) = {"
+x
+q
+q
+q
+q
+q
+i
+Q
+q
+q
+Y
+C
+G
+P
+q
+C
+"}
+(10,1,1) = {"
+C
+T
+q
+q
+q
+S
+i
+P
+q
+q
+q
+v
+K
+q
+q
+C
+"}
+(11,1,1) = {"
+C
+C
+D
+q
+N
+B
+C
+j
+q
+q
+u
+C
+C
+v
+C
+C
+"}
+(12,1,1) = {"
+M
+C
+C
+y
+C
+C
+C
+s
+q
+q
+b
+C
+o
+q
+C
+M
+"}
+(13,1,1) = {"
+M
+C
+C
+q
+z
+q
+v
+q
+q
+q
+t
+C
+r
+C
+C
+M
+"}
+(14,1,1) = {"
+M
+M
+C
+C
+q
+q
+O
+q
+q
+q
+R
+C
+C
+C
+M
+M
+"}
+(15,1,1) = {"
+M
+M
+M
+C
+C
+C
+C
+V
+k
+I
+C
+C
+C
+M
+M
+M
+"}
+(16,1,1) = {"
+M
+M
+M
+M
+M
+C
+C
+C
+C
+C
+C
+M
+M
+M
+M
+M
+"}

--- a/_maps/map_files/shuttles/trader/trader_base_ussp.dmm
+++ b/_maps/map_files/shuttles/trader/trader_base_ussp.dmm
@@ -1,0 +1,892 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ah" = (
+/turf/simulated/floor/plasteel,
+/area/shuttle/trade/sol)
+"bw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/communist_state/directional/north,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"bE" = (
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"ew" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/civilian,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"fg" = (
+/obj/machinery/flasher_button{
+	id = "trader_flash";
+	pixel_y = 23;
+	req_access = list(160)
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_privacy";
+	name = "Privacy Shutters Control";
+	pixel_y = 24;
+	req_access = list(160);
+	pixel_x = -10
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_starboard";
+	name = "Trade Deposits Door";
+	normaldoorcontrol = 1;
+	pixel_x = 10;
+	req_access = list(160);
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"fv" = (
+/obj/structure/chair/sofa/bench/right,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"fz" = (
+/obj/machinery/economy/atm/directional/west,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"fO" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/security,
+/obj/machinery/light/spot,
+/turf/simulated/floor/plasteel{
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"gv" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	name = "north bump";
+	pixel_y = 30
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"gK" = (
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"hc" = (
+/turf/simulated/wall/mineral/titanium,
+/area/shuttle/trade/sol)
+"iv" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock"
+	},
+/turf/simulated/floor/plasteel,
+/area/shuttle/trade/sol)
+"jb" = (
+/obj/machinery/flasher_button{
+	id = "trader_flash";
+	pixel_y = 23;
+	req_access = list(160)
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_privacy";
+	name = "Privacy Shutters Control";
+	pixel_y = 24;
+	req_access = list(160);
+	pixel_x = 10
+	},
+/obj/machinery/door_control/no_emag{
+	id = "trader_port";
+	name = "Trade Deposits Door";
+	normaldoorcontrol = 1;
+	pixel_x = -10;
+	req_access = list(160);
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"jo" = (
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"kd" = (
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"kV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/ashtray/plastic,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"lv" = (
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"ml" = (
+/obj/structure/chair/sofa/bench/left,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"nI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"oM" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"qS" = (
+/obj/structure/closet,
+/obj/item/stack/tile/disco_light/thirty,
+/obj/effect/spawner/random/traders/service,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"rw" = (
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"sM" = (
+/obj/item/cigbutt,
+/obj/item/cigbutt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"uk" = (
+/obj/effect/spawner/random/traders/vehicle,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"uo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"ut" = (
+/obj/structure/bed,
+/obj/item/bedsheet/red,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"uB" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"uM" = (
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"uY" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"vu" = (
+/obj/effect/landmark/spawner/tradergearminor,
+/turf/simulated/floor/plasteel{
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"vz" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/wrapping_paper,
+/obj/item/stack/package_wrap{
+	pixel_y = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"vU" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/science,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"wu" = (
+/obj/structure/chair/sofa/bench/right,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"wQ" = (
+/obj/structure/bed,
+/obj/item/bedsheet/red,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"xe" = (
+/obj/machinery/door/airlock/titanium,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"xC" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
+/area/shuttle/trade/sol)
+"ya" = (
+/obj/effect/spawner/random/traders/large_item,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"yx" = (
+/obj/effect/turf_decal/arrows/red,
+/turf/simulated/floor/plasteel,
+/area/shuttle/trade/sol)
+"zJ" = (
+/obj/structure/sign/poster/contraband/cc64k_ad/directional/north,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"Ao" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"Bt" = (
+/obj/machinery/economy/atm/directional/east,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"By" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "trader_privacy";
+	name = "Privacy Shutters"
+	},
+/obj/effect/spawner/window/shuttle,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"BC" = (
+/obj/structure/shelf,
+/turf/simulated/floor/plasteel,
+/area/shuttle/trade/sol)
+"BX" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"Cr" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/engineering,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"Dj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/shuttle/trade/sol)
+"DE" = (
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "redcorner"
+	},
+/area/shuttle/trade/sol)
+"DW" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/cigarettes/cigpack_carp,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/lighter/random{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"Ek" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/medical,
+/obj/machinery/light/spot,
+/turf/simulated/floor/plasteel{
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"EK" = (
+/turf/template_noop,
+/area/template_noop)
+"Fw" = (
+/obj/effect/mapping_helpers/turfs/damage,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"Go" = (
+/obj/effect/spawner/window/shuttle,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"HZ" = (
+/obj/structure/table/reinforced,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"JY" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/minerals,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"KF" = (
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+"Ma" = (
+/obj/effect/landmark/spawner/tradergearmajor,
+/turf/simulated/floor/plasteel{
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"Mv" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"Nl" = (
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "trader_starboard";
+	security_level = 6
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/plasteel,
+/area/shuttle/trade/sol)
+"NU" = (
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"Oj" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	name = "north bump";
+	pixel_y = 30
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"ON" = (
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "trader_port";
+	security_level = 6
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/plasteel,
+/area/shuttle/trade/sol)
+"Pq" = (
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"PC" = (
+/obj/structure/chair,
+/turf/simulated/floor/plasteel{
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"PX" = (
+/obj/item/flag/ussp,
+/obj/machinery/flasher{
+	id = "trader_flash";
+	pixel_x = 28
+	},
+/obj/effect/turf_decal/box/red,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"Qs" = (
+/obj/item/flag/ussp,
+/obj/machinery/flasher{
+	id = "trader_flash";
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/box/red,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"QV" = (
+/obj/item/flag/ussp,
+/obj/effect/turf_decal/box/red,
+/turf/simulated/floor/plasteel{
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"RE" = (
+/obj/machinery/door/airlock/titanium/glass,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/plasteel,
+/area/shuttle/trade/sol)
+"RG" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock"
+	},
+/obj/docking_port/mobile/trader{
+	height = 18;
+	width = 16;
+	dwidth = 7;
+	preferred_direction = 1;
+	dir = 2
+	},
+/turf/simulated/floor/plasteel,
+/area/shuttle/trade/sol)
+"RR" = (
+/obj/effect/turf_decal/arrows/red{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/shuttle/trade/sol)
+"SC" = (
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "redcorner"
+	},
+/area/shuttle/trade/sol)
+"Tv" = (
+/turf/simulated/wall/mineral/titanium/nodiagonal,
+/area/shuttle/trade/sol)
+"Ty" = (
+/obj/machinery/computer/shuttle/trade/sol,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"UT" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/donksoft,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"Wq" = (
+/turf/open/floor/plating,
+/area/shuttle/trade/sol)
+"Xl" = (
+/obj/structure/chair/sofa/bench/left,
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/shuttle/trade/sol)
+"YV" = (
+/obj/machinery/door/airlock/titanium/glass,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
+
+(1,1,1) = {"
+EK
+EK
+EK
+EK
+EK
+hc
+Tv
+Go
+Tv
+hc
+EK
+EK
+EK
+EK
+EK
+EK
+EK
+EK
+"}
+(2,1,1) = {"
+EK
+EK
+hc
+Tv
+Tv
+Tv
+vU
+UT
+JY
+Tv
+hc
+EK
+EK
+EK
+EK
+EK
+EK
+EK
+"}
+(3,1,1) = {"
+EK
+EK
+Go
+KF
+Ao
+YV
+Dj
+ah
+ah
+ew
+Tv
+Tv
+Tv
+Tv
+Tv
+Tv
+hc
+EK
+"}
+(4,1,1) = {"
+hc
+Tv
+Tv
+ON
+Tv
+Tv
+gv
+uM
+ah
+QV
+Tv
+bw
+rw
+lv
+rw
+HZ
+Tv
+hc
+"}
+(5,1,1) = {"
+Go
+wu
+fz
+ah
+Qs
+Tv
+jb
+kd
+bE
+ah
+RE
+ah
+ah
+uM
+SC
+nI
+Mv
+oM
+"}
+(6,1,1) = {"
+Tv
+Xl
+ah
+ah
+uB
+By
+BX
+ah
+xC
+Ek
+Tv
+Tv
+xe
+Tv
+gK
+Wq
+Mv
+oM
+"}
+(7,1,1) = {"
+RG
+yx
+ah
+ah
+PC
+By
+vz
+BC
+xC
+vu
+Tv
+ut
+Fw
+Tv
+kV
+uY
+Mv
+oM
+"}
+(8,1,1) = {"
+iv
+RR
+ah
+ah
+PC
+By
+vz
+BC
+xC
+Ma
+Tv
+wQ
+Pq
+Tv
+Ty
+uY
+Mv
+oM
+"}
+(9,1,1) = {"
+Tv
+fv
+ah
+ah
+uB
+By
+BX
+ah
+xC
+fO
+Tv
+Tv
+xe
+Tv
+gK
+uB
+Mv
+oM
+"}
+(10,1,1) = {"
+Go
+ml
+Bt
+ah
+PX
+Tv
+fg
+jo
+NU
+ah
+RE
+ah
+ah
+rw
+DE
+sM
+Mv
+oM
+"}
+(11,1,1) = {"
+hc
+Tv
+Tv
+Nl
+Tv
+Tv
+Oj
+rw
+ah
+QV
+Tv
+zJ
+uM
+uo
+uM
+DW
+Tv
+hc
+"}
+(12,1,1) = {"
+EK
+EK
+Go
+Ao
+KF
+YV
+Dj
+ah
+ah
+ya
+Tv
+Tv
+Tv
+Tv
+Tv
+Tv
+hc
+EK
+"}
+(13,1,1) = {"
+EK
+EK
+hc
+Tv
+Tv
+Tv
+Cr
+qS
+uk
+Tv
+hc
+EK
+EK
+EK
+EK
+EK
+EK
+EK
+"}
+(14,1,1) = {"
+EK
+EK
+EK
+EK
+EK
+hc
+Tv
+Go
+Tv
+hc
+EK
+EK
+EK
+EK
+EK
+EK
+EK
+EK
+"}

--- a/code/controllers/subsystem/SSshuttles.dm
+++ b/code/controllers/subsystem/SSshuttles.dm
@@ -486,9 +486,7 @@ SUBSYSTEM_DEF(shuttle)
 		CRASH("A trader shuttle was already being loaded at centcomm when another shuttle attempted to load.")
 	trader_shuttle_loading = TRUE
 	// get the existing shuttle information, if any
-	var/timer = 0
-	var/mode = SHUTTLE_IDLE
-	var/obj/docking_port/mobile/trade_sol/dock = getDock("trader_base")
+	var/obj/docking_port/mobile/trader/dock = getDock("trader_base")
 
 	if(!dock)
 		var/m = "No dock found for preview shuttle, aborting."
@@ -516,7 +514,7 @@ SUBSYSTEM_DEF(shuttle)
 	// blanking the modification tab
 
 	trader_shuttle_loading = FALSE
-	return loaded_shuttle
+	return trade_shuttle
 
 /datum/controller/subsystem/shuttle/proc/request_transit_dock(obj/docking_port/mobile/M)
 	if(!istype(M))

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -34,7 +34,6 @@
 	name = "Base Shuttle Template (Admin)"
 
 
-
 // Shuttles start here:
 
 /datum/map_template/shuttle/emergency/bar
@@ -199,3 +198,57 @@
 	suffix = "skipjack"
 	name = "Vox Skipjack"
 	description = "Vox skipjack ship."
+
+// Trader Shuttles:
+/datum/map_template/shuttle/trader
+	port_id = "trader_base"
+
+/datum/map_template/shuttle/trader/sol
+	suffix = "sol"
+	name = "Solgov Trade Freighter"
+	description = "Trading vessel for solgov traders."
+
+/datum/map_template/shuttle/trader/ussp
+	suffix = "ussp"
+	name = "USSP Trade Barge"
+	description = "Trading vessel for USSP traders."
+
+/datum/map_template/shuttle/trader/cybersun
+	suffix = "syndicate"
+	name = "Cybersun Trade Skiff"
+	description = "Trading vessel for cybersun traders."
+
+/datum/map_template/shuttle/trader/glint_scale
+	suffix = "glint"
+	name = "Glint Scale Trade Hound"
+	description = "Trading vessel for glint scale traders."
+
+/datum/map_template/shuttle/trader/steadfast
+	suffix = "stead"
+	name = "Steadfast Co. Trade Freighter"
+	description = "Trading vessel for steadfast company traders."
+
+/datum/map_template/shuttle/trader/synthetic
+	suffix = "synth"
+	name = "Synthetic Union Trade Vessel"
+	description = "Trading vessel for synthetic union traders."
+
+/datum/map_template/shuttle/trader/skipjack
+	suffix = "skip"
+	name = "Vox Trade Skipjack"
+	description = "Trading vessel for skipjack traders."
+
+/datum/map_template/shuttle/trader/skrell
+	suffix = "skrell"
+	name = "Skrellian Trade Skiff"
+	description = "Trading vessel for skrellian central authority traders."
+
+/datum/map_template/shuttle/trader/technocracy
+	suffix = "techno"
+	name = "Technocracy Trade Pod"
+	description = "Trading vessel for technocracy traders."
+
+/datum/map_template/shuttle/trader/guild
+	suffix = "guild"
+	name = "Merchant Guild Trade Freighter"
+	description = "Trading vessel for merchant guild traders."

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -202,6 +202,7 @@
 // Trader Shuttles:
 /datum/map_template/shuttle/trader
 	port_id = "trader_base"
+	prefix = "_maps/map_files/shuttles/trader/"
 
 /datum/map_template/shuttle/trader/sol
 	suffix = "sol"

--- a/code/modules/events/traders.dm
+++ b/code/modules/events/traders.dm
@@ -88,7 +88,9 @@ GLOBAL_LIST_INIT(unused_trade_stations, list("sol"))
 			greet_trader(M, T)
 			success_spawn = TRUE
 	if(success_spawn)
-		SSshuttle.set_trader_shuttle(T.ship_template)
+		var/template = new T.ship_template()
+		var/obj/docking_port/mobile/trade_shuttle = SSshuttle.load_template(template)
+		SSshuttle.set_trader_shuttle(trade_shuttle)
 		GLOB.minor_announcement.Announce("A trading shuttle from [T.trader_location] has been granted docking permission at [station_name()] arrivals port 4.", "Trader Shuttle Docking Request Accepted", 'sound/AI/tradergranted.ogg')
 		// Get the list of spawn locations for company specific items, spawn gear
 		for(var/obj/effect/landmark/spawner/tradergearminor/A in GLOB.landmarks_list)
@@ -137,7 +139,7 @@ GLOBAL_LIST_INIT(unused_trade_stations, list("sol"))
 	/// What big ticket faction gear do they start with
 	var/trader_major_special
 	/// The type of shuttle the traders get
-	var/datum/map_template/shuttle/trade/ship_template
+	var/datum/map_template/shuttle/ship_template
 
 /datum/traders/sol
 	trader_type = "Trans-Solar Federation"
@@ -177,7 +179,7 @@ GLOBAL_LIST_INIT(unused_trade_stations, list("sol"))
 	trader_outfit = /datum/outfit/admin/trader/unathi
 	trader_minor_special = /obj/effect/spawner/random/traders/glintscale_minor
 	trader_major_special = /obj/effect/spawner/random/traders/glintscale_major
-	ship_template = /datum/map_template/shuttle/trader/glint
+	ship_template = /datum/map_template/shuttle/trader/glint_scale
 
 /datum/traders/vulp
 	trader_type = "Steadfast Trading Co."

--- a/code/modules/events/traders.dm
+++ b/code/modules/events/traders.dm
@@ -85,24 +85,23 @@ GLOBAL_LIST_INIT(unused_trade_stations, list("sol"))
 			for(var/datum/objective/O in trader_objectives)
 				M.mind.objective_holder.add_objective(O) // traders dont have a team, so we manually have to add this objective to all of their minds, without setting an owner
 			M.mind.offstation_role = TRUE
-
-			//Get the list of spawn locations for company specific items, spawn gear
-			for(var/obj/effect/landmark/spawner/tradergearminor/A in GLOB.landmarks_list)
-				var/obj/structure/closet/locker = new /obj/structure/closet(get_turf(A))
-				locker.open()
-				new T.trader_minor_special(locker)
-				locker.close()
-
-			for(var/obj/effect/landmark/spawner/tradergearmajor/B in GLOB.landmarks_list)
-				var/obj/structure/closet/locker = new /obj/structure/closet(get_turf(B))
-				locker.open()
-				new T.trader_major_special(locker)
-				locker.close()
-
 			greet_trader(M, T)
 			success_spawn = TRUE
 	if(success_spawn)
+		SSshuttle.set_trader_shuttle(T.ship_template)
 		GLOB.minor_announcement.Announce("A trading shuttle from [T.trader_location] has been granted docking permission at [station_name()] arrivals port 4.", "Trader Shuttle Docking Request Accepted", 'sound/AI/tradergranted.ogg')
+		// Get the list of spawn locations for company specific items, spawn gear
+		for(var/obj/effect/landmark/spawner/tradergearminor/A in GLOB.landmarks_list)
+			var/obj/structure/closet/locker = new /obj/structure/closet(get_turf(A))
+			locker.open()
+			new T.trader_minor_special(locker)
+			locker.close()
+
+		for(var/obj/effect/landmark/spawner/tradergearmajor/B in GLOB.landmarks_list)
+			var/obj/structure/closet/locker = new /obj/structure/closet(get_turf(B))
+			locker.open()
+			new T.trader_major_special(locker)
+			locker.close()
 	else
 		GLOB.unused_trade_stations += station // Return the station to the list of usable stations.
 
@@ -137,6 +136,8 @@ GLOBAL_LIST_INIT(unused_trade_stations, list("sol"))
 	var/trader_minor_special
 	/// What big ticket faction gear do they start with
 	var/trader_major_special
+	/// The type of shuttle the traders get
+	var/datum/map_template/shuttle/trade/ship_template
 
 /datum/traders/sol
 	trader_type = "Trans-Solar Federation"
@@ -146,6 +147,7 @@ GLOBAL_LIST_INIT(unused_trade_stations, list("sol"))
 	trader_outfit = /datum/outfit/admin/trader/sol
 	trader_minor_special = /obj/effect/spawner/random/traders/federation_minor
 	trader_major_special = /obj/effect/spawner/random/traders/federation_major
+	ship_template = /datum/map_template/shuttle/trader/sol
 
 /datum/traders/cyber
 	trader_type = "Cybersun Industries"
@@ -155,6 +157,7 @@ GLOBAL_LIST_INIT(unused_trade_stations, list("sol"))
 	trader_outfit = /datum/outfit/admin/trader/cyber
 	trader_minor_special = /obj/effect/spawner/random/traders/cybersun_minor
 	trader_major_special = /obj/effect/spawner/random/traders/cybersun_major
+	ship_template = /datum/map_template/shuttle/trader/cybersun
 
 /datum/traders/commie
 	trader_type = "USSP"
@@ -164,6 +167,7 @@ GLOBAL_LIST_INIT(unused_trade_stations, list("sol"))
 	trader_outfit = /datum/outfit/admin/trader/commie
 	trader_minor_special = /obj/effect/spawner/random/traders/ussp_minor
 	trader_major_special = /obj/effect/spawner/random/traders/ussp_major
+	ship_template = /datum/map_template/shuttle/trader/ussp
 
 /datum/traders/unathi
 	trader_type = "Glint Scales"
@@ -173,6 +177,7 @@ GLOBAL_LIST_INIT(unused_trade_stations, list("sol"))
 	trader_outfit = /datum/outfit/admin/trader/unathi
 	trader_minor_special = /obj/effect/spawner/random/traders/glintscale_minor
 	trader_major_special = /obj/effect/spawner/random/traders/glintscale_major
+	ship_template = /datum/map_template/shuttle/trader/glint
 
 /datum/traders/vulp
 	trader_type = "Steadfast Trading Co."
@@ -182,6 +187,7 @@ GLOBAL_LIST_INIT(unused_trade_stations, list("sol"))
 	trader_outfit = /datum/outfit/admin/trader/vulp
 	trader_minor_special = /obj/effect/spawner/random/traders/steadfast_minor
 	trader_major_special = /obj/effect/spawner/random/traders/steadfast_major
+	ship_template = /datum/map_template/shuttle/trader/steadfast
 
 /datum/traders/ipc
 	trader_type = "Synthetic Union"
@@ -191,6 +197,7 @@ GLOBAL_LIST_INIT(unused_trade_stations, list("sol"))
 	trader_outfit = /datum/outfit/admin/trader/ipc
 	trader_minor_special = /obj/effect/spawner/random/traders/syntheticunion_minor
 	trader_major_special = /obj/effect/spawner/random/traders/syntheticunion_major
+	ship_template = /datum/map_template/shuttle/trader/synthetic
 
 /datum/traders/vox
 	trader_type = "Skipjack"
@@ -200,6 +207,7 @@ GLOBAL_LIST_INIT(unused_trade_stations, list("sol"))
 	trader_outfit = /datum/outfit/admin/trader/vox
 	trader_minor_special = /obj/effect/spawner/random/traders/skipjack_minor
 	trader_major_special = /obj/effect/spawner/random/traders/skipjack_major
+	ship_template = /datum/map_template/shuttle/trader/skipjack
 
 /datum/traders/skrell
 	trader_type = "Skrellian Central Authority"
@@ -209,6 +217,7 @@ GLOBAL_LIST_INIT(unused_trade_stations, list("sol"))
 	trader_outfit = /datum/outfit/admin/trader/skrell
 	trader_minor_special = /obj/effect/spawner/random/traders/solarcentral_minor
 	trader_major_special = /obj/effect/spawner/random/traders/solarcentral_major
+	ship_template = /datum/map_template/shuttle/trader/skrell
 
 /datum/traders/grey
 	trader_type = "Technocracy"
@@ -218,6 +227,7 @@ GLOBAL_LIST_INIT(unused_trade_stations, list("sol"))
 	trader_outfit = /datum/outfit/admin/trader/grey
 	trader_minor_special = /obj/effect/spawner/random/traders/technocracy_minor
 	trader_major_special = /obj/effect/spawner/random/traders/technocracy_major
+	ship_template = /datum/map_template/shuttle/trader/technocracy
 
 /datum/traders/nian
 	trader_type = "Merchant Guild"
@@ -227,3 +237,4 @@ GLOBAL_LIST_INIT(unused_trade_stations, list("sol"))
 	trader_outfit = /datum/outfit/admin/trader/nian
 	trader_minor_special = /obj/effect/spawner/random/traders/merchantguild_minor
 	trader_major_special = /obj/effect/spawner/random/traders/merchantguild_major
+	ship_template = /datum/map_template/shuttle/trader/guild

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -899,14 +899,15 @@
 	width = 5
 	preferred_direction = EAST
 
-/obj/docking_port/mobile/trade_sol
+/obj/docking_port/mobile/trader
 	dir = 8
-	dwidth = 4
-	height = 11
-	id = "trade_sol"
+	dwidth = 11
+	height = 30
+	id = "trader"
 	name = "sol trade shuttle"
-	width = 9
+	width = 22
 	preferred_direction = EAST
+	timid = TRUE
 
 /obj/docking_port/mobile/nuke_ops
 	dheight = 9
@@ -1120,7 +1121,7 @@
 /obj/machinery/computer/shuttle/trade/sol
 	req_access = list(ACCESS_TRADE_SOL)
 	possible_destinations = "trader_base;trade_dock"
-	shuttleId = "trade_sol"
+	shuttleId = "trader"
 
 //#undef DOCKING_PORT_HIGHLIGHT
 

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -1119,7 +1119,7 @@
 
 /obj/machinery/computer/shuttle/trade/sol
 	req_access = list(ACCESS_TRADE_SOL)
-	possible_destinations = "trade_sol_base;trade_dock"
+	possible_destinations = "trader_base;trade_dock"
 	shuttleId = "trade_sol"
 
 //#undef DOCKING_PORT_HIGHLIGHT


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

This PR gives a unique shuttle to each type of trader. This diversifies the traders and makes them feel more unique.

Thank you CRUNCH for mapping out the shuttles.

TODO:

- [x] Shuttle types
- [ ] Station map adjustments for new shuttles

## Why It's Good For The Game

Different factions have different styles - this can be reflected in their ships.

## Images of changes

![image](https://github.com/user-attachments/assets/bd7f47ef-4e1a-4ab7-802f-10697d08b7b8)

## Testing

Spawned as many types of trader. Got in new ship. Flew ship to station.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
![image](https://github.com/user-attachments/assets/6e840bb4-62e4-4ad2-b21e-e5ce48dccb23)

  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Added faction specific trade shuttles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
