### PR TITLE
fix pool spawners deleting themselves way before they should

### DIFF
--- a/code/game/objects/effects/spawners/random/pool/pool_spawner.dm
+++ b/code/game/objects/effects/spawners/random/pool/pool_spawner.dm
@@ -41,7 +41,7 @@
 	else
 		pool.known_spawners |= src
 
-	return INITIALIZE_HINT_QDEL
+	return INITIALIZE_HINT_NORMAL
 
 /obj/effect/spawner/random/pool/generate_loot_list()
 	var/datum/spawn_pool/pool = GLOB.spawn_pool_manager.get(spawn_pool)


### PR DESCRIPTION
## What Does This PR Do
This PR fixes pool spawners deleting themselves and spawning their items in nullspace. idk why I even wrote this, I know full well they handle spawning in late mapping so they can't be qdel'd this early.
## Why It's Good For The Game
Bugfix.
## Testing
![2025_07_09__19_59_35__Paradise Station 13](https://github.com/user-attachments/assets/64ef1f39-e226-4e62-a1e1-5b96110bf973)
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Items in pool spawners, such as space loot and Lavaland mobs, should now spawn properly.
/:cl: