### PR TITLE
vv refactor day 1 patch

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -215,12 +215,12 @@
 	var/list/dropdownoptions = list()
 	if(islist)
 		dropdownoptions = list(
-			"---",
-			"Add Item" = "byond://?_src_=vars;listadd=[refid]",
-			"Remove Nulls" = "byond://?_src_=vars;listnulls=[refid]",
-			"Remove Dupes" = "byond://?_src_=vars;listdupes=[refid]",
-			"Set len" = "byond://?_src_=vars;listlen=[refid]",
-			"Shuffle" = "byond://?_src_=vars;listshuffle=[refid]"
+			"<option>---</option>",
+			"<option value='byond://?_src_=vars;listadd=[refid]'>Add Item</option>",
+			"<option value='byond://?_src_=vars;listnulls=[refid]'>Remove Nulls</option>",
+			"<option value='byond://?_src_=vars;listdupes=[refid]'>Remove Dupes</option>",
+			"<option value='byond://?_src_=vars;listlen=[refid]'>Set len</option>",
+			"<option value='byond://?_src_=vars;listshuffle=[refid]'>Shuffle</option>"
 		)
 	else
 		dropdownoptions = D.vv_get_dropdown()

--- a/code/game/atom_vv.dm
+++ b/code/game/atom_vv.dm
@@ -18,9 +18,12 @@
 	VV_DROPDOWN_OPTION(VV_HK_EXPLODE, "Trigger explosion")
 	VV_DROPDOWN_OPTION(VV_HK_EMP, "Trigger EM pulse")
 
+/atom/proc/vv_modify_name_link()
+	return "byond://?_src_=vars;datumedit=[UID()];varnameedit=name"
+
 /atom/vv_get_header()
 	. = ..()
-	. += "<a href='byond://?_src_=vars;datumedit=[UID()];varnameedit=name'><b>[src]</b></a>"
+	. += "<a href='[vv_modify_name_link()]'><b>[src]</b></a>"
 	if(dir)
 		. += "<br><font size='1'><a href='byond://?_src_=vars;rotatedatum=TRUE;[VV_HK_TARGET]=[UID()];rotatedir=left'><<</a> <a href='byond://?_src_=vars;datumedit=[UID()];varnameedit=dir'>[dir2text(dir)]</a> <a href='byond://?_src_=vars;rotatedatum=TRUE;[VV_HK_TARGET]=[UID()];rotatedir=right'>>></a></font>"
 

--- a/code/modules/mob/mob_vv.dm
+++ b/code/modules/mob/mob_vv.dm
@@ -1,6 +1,9 @@
+/mob/vv_modify_name_link()
+	return "byond://?_src_=vars;rename=TRUE;[VV_HK_TARGET]=[UID()]"
+
 /mob/vv_get_header()
 	. = ..()
-	. += "<br><font size='1'><a href='byond://?_src_=vars;datumedit=[UID()];varnameedit=ckey'>[ckey ? ckey : "No ckey"]</a> / <a href='byond://?_src_=vars;rename=TRUE;[VV_HK_TARGET]=[UID()]'>[real_name ? real_name : "No real name"]</a></font>"
+	. += "<br><font size='1'><a href='byond://?_src_=vars;datumedit=[UID()];varnameedit=ckey'>[ckey ? ckey : "No ckey"]</a> / <a href='byond://?_src_=vars;datumedit=[UID()];varnameedit=real_name'>[real_name ? real_name : "No real name"]</a></font>"
 
 /mob/vv_get_dropdown()
 	. = ..()


### PR DESCRIPTION
## What Does This PR Do
This PR puts the "admin renaming" (that properly modifies name, real_name, ID, datacore, etc) link for mobs back as the large version of their name in the VV's header. I modified these in #29673 because the header is inherited and the link is different for mobs versus other objects, and the naive real_name var editing link didn't seem useful when the admin renaming link existed. This is all back to what it should be now.

It also fixes drop down options for lists not being present.
## Why It's Good For The Game
Makes sure links work as expected for admins.
## Images of changes
![2025_07_10__00_34_41__Paradise Station 13](https://github.com/user-attachments/assets/5dc30cb1-9388-42be-b3a3-f09aa3d0f77c)
![2025_07_10__00_34_55__Paradise Station 13](https://github.com/user-attachments/assets/b1f86b7b-aee4-4a75-9939-103f24553d5c)
![2025_07_10__02_22_44__Paradise Station 13](https://github.com/user-attachments/assets/aa21e5d4-ff0d-4559-9c76-e32d124c19e7)

## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC