### PR TITLE
fix holodeck runtiming on load

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -960,6 +960,7 @@ Returns 1 if the chain up to the area contains the given typepath
 							"luminosity",
 							"parent_type",
 							"parent",
+							"pixloc",
 							"signal_procs",
 							"type",
 							"vars",


### PR DESCRIPTION
## What Does This PR Do
This PR removes "pixloc" from the list of vars dynamically copied to objects when loading holodeck presets.
## Why It's Good For The Game
First bugfix as a result of running 516 on the server?
## Images of changes
### Before
<img width="703" height="73" alt="2025_07_10__21_01_02__Paradise Station 13" src="https://github.com/user-attachments/assets/face7223-d0cb-4a20-a871-f2c3f07f1b89" />
<img width="1515" height="1033" alt="2025_07_10__21_03_38__Paradise Station 13" src="https://github.com/user-attachments/assets/66f8c38f-5647-48ca-b68c-c89f4f20c4af" />

### After
<img width="1361" height="1063" alt="2025_07_10__21_06_51__Paradise Station 13" src="https://github.com/user-attachments/assets/0e2b7de8-fa19-4776-8a04-c49323f7ffe9" />

## Testing
See above
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: The holodeck should load scenes properly again.
/:cl: