### PR TITLE
Fixes Kinetic Assembler Runtime

### DIFF
--- a/code/modules/smithing/machinery/kinetic_assembler.dm
+++ b/code/modules/smithing/machinery/kinetic_assembler.dm
@@ -88,6 +88,9 @@
 		return
 	switch(removed)
 		if("Primary")
+			if(!primary)
+				to_chat(user, "<span class='warning'>There is no primary component to remove.</span>")
+				return
 			to_chat(user, "<span class='notice'>You remove [primary] from the primary component slot of [src].</span>")
 			if(primary.burn_check(user))
 				primary.burn_user(user)
@@ -98,6 +101,9 @@
 			primary = null
 			return
 		if("Secondary")
+			if(!secondary)
+				to_chat(user, "<span class='warning'>There is no secondary component to remove.</span>")
+				return
 			to_chat(user, "<span class='notice'>You remove [secondary] from the secondary component slot of [src].</span>")
 			if(secondary.burn_check(user))
 				secondary.burn_user(user)
@@ -108,6 +114,9 @@
 			secondary = null
 			return
 		if("Trim")
+			if(!trim)
+				to_chat(user, "<span class='warning'>There is no trim component to remove.</span>")
+				return
 			to_chat(user, "<span class='notice'>You remove [trim] from the trim component slot of [src].</span>")
 			if(trim.burn_check(user))
 				trim.burn_user(user)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes a runtime in the kinetic assembler.

## Why It's Good For The Game

Runtimes bad.

## Testing

Tried to remove a component that didn't exist. Didn't runtime.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed a runtime with the kinetic assembler
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
