### PR TITLE
Fix cyborg geiger counter not detecting radiation and migrate geiger counters to new attack chain

### DIFF
--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -206,7 +206,7 @@
 			to_chat(user, "<span class='warning'>Turn off [src] before you perform this action!</span>")
 			return FALSE
 		user.visible_message("<span class='notice'>[user] unscrews [src]'s maintenance panel and begins fiddling with its innards...</span>", "<span class='notice'>You begin resetting [src]...</span>")
-		if(!I.use_tool(src, user, 40, I.tool_volume))
+		if(!I.use_tool(src, user, 40, volume = I.tool_volume))
 			return FALSE
 		user.visible_message("<span class='notice'>[user] refastens [src]'s maintenance panel!</span>", "<span class='notice'>You reset [src] to its factory settings!</span>")
 		emagged = FALSE


### PR DESCRIPTION
## What Does This PR Do
Migrates geiger counters to the new attack chain, fixes cyborg geiger counter not detecting ambient radiation, fixes emagged geiger counters being impossible to fix.  Fixes #29752

The cyborg geiger counter was supposed to register the RAD_ACT signal and refer to a redirect proc which bypasses their radiation protection. Problem is that the signal was registered under the geiger counters `equip` proc which cyborgs do not call. I moved it to the `activate_self` proc, which registers when the scanner is activated and unregisters it when deactivated.
## Why It's Good For The Game
Functioning item.
## Testing
As a human, scanned radiation ranged and melee, detected ambient radiation, put it in my backpack, emagged a geiger counter and fixed it.
As a cyborg, scanned radiation ranged and melee and detected ambient radiation.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Engineering cyborg geiger counter can detect radiation.
fix: Emagged geiger counters are fixable.
/:cl: