### PR TITLE
Gives MMI/Robobrain/Posibrain EMP Immunity Inside Silicon Mobs

### DIFF
--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -220,14 +220,17 @@
 /obj/item/mmi/emp_act(severity)
 	if(!brainmob)
 		return
-	else
-		switch(severity)
-			if(1)
-				brainmob.emp_damage += rand(20,30)
-			if(2)
-				brainmob.emp_damage += rand(10,20)
-			if(3)
-				brainmob.emp_damage += rand(0,10)
+
+	if(issilicon(loc)) // Silicons aren't affected by brain damage and there is no way to fix silicon brain damage either.
+		return
+
+	switch(severity)
+		if(1)
+			brainmob.emp_damage += rand(20,30)
+		if(2)
+			brainmob.emp_damage += rand(10,20)
+		if(3)
+			brainmob.emp_damage += rand(0,10)
 	..()
 
 /obj/item/mmi/Destroy()

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -226,11 +226,11 @@
 
 	switch(severity)
 		if(1)
-			brainmob.emp_damage += rand(20,30)
+			brainmob.emp_damage += rand(20, 30)
 		if(2)
-			brainmob.emp_damage += rand(10,20)
+			brainmob.emp_damage += rand(10, 20)
 		if(3)
-			brainmob.emp_damage += rand(0,10)
+			brainmob.emp_damage += rand(0, 10)
 	..()
 
 /obj/item/mmi/Destroy()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
When inserted into a silicon mob, MMIs, robobrains, and positronic brains will early-return their `emp_act()` and take no brain damage as a result.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Silicon mobs themselves are completely unaffected by brain damage, and there is also no way to repair brain damage in a silicon mob without completely deconstructing them.

There is no way to tell how much brain damage has accumulated, and the effects of accumulated damage only manifest upon deconstruction. This is very silly.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Mag dumped a cyborg with an ion rifle.
Deconstructed it.
Checked for brain damage, there was none.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<img width="1670" height="124" alt="image" src="https://github.com/user-attachments/assets/e62ed0b8-498a-4f02-ae46-6493617ea89f" />

  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: MMIs, robobrains, and positronic brains do not take damage whilst inside a silicon mob.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
