### PR TITLE
Fixes fireballs not exploding when hitting turf, and fixes homing fireball/toolbox not being blocked by the nazar

### DIFF
--- a/code/modules/projectiles/projectile/homing_projectiles.dm
+++ b/code/modules/projectiles/projectile/homing_projectiles.dm
@@ -30,6 +30,8 @@
 	nodamage = 1
 	armour_penetration_percentage = 100
 	flag = MAGIC
+	antimagic_flags = MAGIC_RESISTANCE
+	antimagic_charge_cost = 1
 
 /obj/item/projectile/homing/magic/toolbox
 	name = "magic toolbox"
@@ -68,6 +70,9 @@
 
 /obj/item/projectile/homing/magic/homing_fireball/on_hit(mob/living/target)
 	. = ..()
+	if(ismob(target))
+		if(!.)
+			return .
 	explosion(get_turf(target), explosion_devastate, explosion_heavy, explosion_light, explosion_flash, 0, flame_range = explosion_fire, cause = "Homing Fireball")
 	if(istype(target)) //multiple flavors of pain
 		target.adjustFireLoss(10) // does 20 brute, and 10 burn + explosion. Pretty brutal.

--- a/code/modules/projectiles/projectile/magic_projectiles.dm
+++ b/code/modules/projectiles/projectile/magic_projectiles.dm
@@ -46,21 +46,6 @@
 	impact_light_range = 2.5
 	impact_light_color_override = LIGHT_COLOR_PURPLE
 
-/obj/item/projectile/magic/fireball
-	name = "bolt of fireball"
-	icon_state = "fireball"
-	damage = 10
-	damage_type = BRUTE
-	nodamage = 0
-	immolate = 6
-
-	//explosion values
-	var/exp_devastate = -1
-	var/exp_heavy = 0
-	var/exp_light = 2
-	var/exp_flash = 3
-	var/exp_fire = 2
-
 /obj/item/projectile/magic/death/on_hit(mob/living/carbon/target)
 	. = ..()
 	if(!.)
@@ -78,6 +63,21 @@
 		target.death(FALSE)
 
 		target.visible_message("<span class='danger'>[target] topples backwards as the death bolt impacts [target.p_them()]!</span>")
+
+/obj/item/projectile/magic/fireball
+	name = "bolt of fireball"
+	icon_state = "fireball"
+	damage = 10
+	damage_type = BRUTE
+	nodamage = 0
+	immolate = 6
+
+	//explosion values
+	var/exp_devastate = -1
+	var/exp_heavy = 0
+	var/exp_light = 2
+	var/exp_flash = 3
+	var/exp_fire = 2
 
 /obj/item/projectile/magic/fireball/Range()
 	var/turf/T1 = get_step(src,turn(dir, -45))
@@ -99,8 +99,9 @@
 
 /obj/item/projectile/magic/fireball/on_hit(target)
 	. = ..()
-	if(!.)
-		return .
+	if(!isturf(target))
+		if(!.)
+			return .
 	var/turf/T = get_turf(target)
 	explosion(T, exp_devastate, exp_heavy, exp_light, exp_flash, 0, flame_range = exp_fire, cause = name)
 	if(ismob(target)) //multiple flavors of pain

--- a/code/modules/projectiles/projectile/magic_projectiles.dm
+++ b/code/modules/projectiles/projectile/magic_projectiles.dm
@@ -6,27 +6,25 @@
 	nodamage = 1
 	armour_penetration_percentage = 100
 	flag = MAGIC
-	/// determines what type of antimagic can block the spell projectile
-	var/antimagic_flags = MAGIC_RESISTANCE
-	/// determines the drain cost on the antimagic item
-	var/antimagic_charge_cost = 1
+	antimagic_flags = MAGIC_RESISTANCE
+	antimagic_charge_cost = 1
 
-/obj/item/projectile/magic/prehit(atom/target)
-	if(isliving(target))
-		var/mob/living/victim = target
-		if(victim.can_block_magic(antimagic_flags, antimagic_charge_cost))
-			visible_message("<span class='warning'>[src] fizzles on contact with [victim]!</span>")
-			damage = 0
-			nodamage = 1
-			return FALSE
-	return ..()
+// /obj/item/projectile/magic/prehit(atom/target)
+	// if(isliving(target))
+	// 	var/mob/living/victim = target
+	// 	if(victim.can_block_magic(antimagic_flags, antimagic_charge_cost))
+	// 		visible_message("<span class='warning'>[src] fizzles on contact with [victim]!</span>")
+	// 		damage = 0
+	// 		nodamage = 1
+	// 		return FALSE
+// 	// return ..()
 
-/obj/item/projectile/magic/on_hit(atom/target, blocked, hit_zone)
-	if(isliving(target))
-		var/mob/living/victim = target
-		if(victim.can_block_magic(antimagic_flags, antimagic_charge_cost)) // Yes we have to check this twice welcome to bullet hell code
-			return FALSE
-	return ..()
+// /obj/item/projectile/magic/on_hit(atom/target, blocked, hit_zone)
+// 	if(isliving(target))
+// 		var/mob/living/victim = target
+// 		if(victim.can_block_magic(antimagic_flags, antimagic_charge_cost)) // Yes we have to check this twice welcome to bullet hell code
+// 			return FALSE
+// 	return ..()
 
 
 /obj/item/projectile/magic/death
@@ -99,11 +97,10 @@
 
 /obj/item/projectile/magic/fireball/on_hit(target)
 	. = ..()
-	if(!isturf(target))
+	if(ismob(target))
 		if(!.)
 			return .
-	var/turf/T = get_turf(target)
-	explosion(T, exp_devastate, exp_heavy, exp_light, exp_flash, 0, flame_range = exp_fire, cause = name)
+	explosion(get_turf(target), exp_devastate, exp_heavy, exp_light, exp_flash, 0, flame_range = exp_fire, cause = name)
 	if(ismob(target)) //multiple flavors of pain
 		var/mob/living/M = target
 		M.take_overall_damage(0,10) //between this 10 burn, the 10 brute, the explosion brute, and the onfire burn, your at about 65 damage if you stop drop and roll immediately

--- a/code/modules/projectiles/projectile/magic_projectiles.dm
+++ b/code/modules/projectiles/projectile/magic_projectiles.dm
@@ -9,24 +9,6 @@
 	antimagic_flags = MAGIC_RESISTANCE
 	antimagic_charge_cost = 1
 
-// /obj/item/projectile/magic/prehit(atom/target)
-	// if(isliving(target))
-	// 	var/mob/living/victim = target
-	// 	if(victim.can_block_magic(antimagic_flags, antimagic_charge_cost))
-	// 		visible_message("<span class='warning'>[src] fizzles on contact with [victim]!</span>")
-	// 		damage = 0
-	// 		nodamage = 1
-	// 		return FALSE
-// 	// return ..()
-
-// /obj/item/projectile/magic/on_hit(atom/target, blocked, hit_zone)
-// 	if(isliving(target))
-// 		var/mob/living/victim = target
-// 		if(victim.can_block_magic(antimagic_flags, antimagic_charge_cost)) // Yes we have to check this twice welcome to bullet hell code
-// 			return FALSE
-// 	return ..()
-
-
 /obj/item/projectile/magic/death
 	name = "bolt of death"
 	icon_state = null
@@ -103,7 +85,7 @@
 	explosion(get_turf(target), exp_devastate, exp_heavy, exp_light, exp_flash, 0, flame_range = exp_fire, cause = name)
 	if(ismob(target)) //multiple flavors of pain
 		var/mob/living/M = target
-		M.take_overall_damage(0,10) //between this 10 burn, the 10 brute, the explosion brute, and the onfire burn, your at about 65 damage if you stop drop and roll immediately
+		M.adjustFireLoss(10) //between this 10 burn, the 10 brute, the explosion brute, and the onfire burn, your at about 65 damage if you stop drop and roll immediately
 
 
 /obj/item/projectile/magic/fireball/infernal

--- a/code/modules/projectiles/projectile_base.dm
+++ b/code/modules/projectiles/projectile_base.dm
@@ -135,6 +135,11 @@
 	/// Can our ricochet autoaim hit our firer?
 	var/ricochet_shoots_firer = TRUE
 
+	/// determines what type of antimagic can block the spell projectile
+	var/antimagic_flags
+	/// determines the drain cost on the antimagic item
+	var/antimagic_charge_cost
+
 /obj/item/projectile/New()
 	return ..()
 
@@ -160,12 +165,23 @@
 	qdel(src)
 
 /obj/item/projectile/proc/prehit(atom/target)
+	if(isliving(target))
+		var/mob/living/victim = target
+		if(victim.can_block_magic(antimagic_flags, antimagic_charge_cost))
+			visible_message("<span class='warning'>[src] fizzles on contact with [victim]!</span>")
+			damage = 0
+			nodamage = 1
+			return FALSE
 	return TRUE
 
 /obj/item/projectile/proc/on_hit(atom/target, blocked = 0, hit_zone)
 	var/turf/target_loca = get_turf(target)
 	var/hitx
 	var/hity
+	if(isliving(target))
+		var/mob/living/victim = target
+		if(victim.can_block_magic(antimagic_flags, antimagic_charge_cost)) // Yes we have to check this twice welcome to bullet hell code
+			return FALSE
 	if(target == original)
 		hitx = target.pixel_x + p_x - 16
 		hity = target.pixel_y + p_y - 16


### PR DESCRIPTION
## What Does This PR Do
Fixes the nazar not blocking the homing fireball/tool box spell, by doing this i had to rescope the checks to the base projectile path.
Fixes the fireball spell/wand not doing anything when they hit walls
also cleans up some code in the fireball on hit proc
fixes #28070
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
turf/objects shouldn't be blocking magic, while the nazar should be blocking the homing magic


## Testing
tested a handful of guns and wands on walls and nazar holders, all seems to work. Though theres *alot* of projectiles that i cant all realistically test. however rescoping the antimagic check should:tm: only effect magic projectiles since its checking for a flag as well.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
fix: Fixed the nazar not blocking homing fireball/toolbox spells
fix: Fixed fireballs not properly exploding when hitting turf/objects 
/:cl:
