### PR TITLE
Adds Armor to Shaft Miner Harshsuit and Smith Jumpsuit Per Item Description (Returns)

### DIFF
--- a/code/modules/clothing/under/jobs/cargo.dm
+++ b/code/modules/clothing/under/jobs/cargo.dm
@@ -92,6 +92,7 @@
 /obj/item/clothing/under/rank/cargo/miner/lavaland
 	name = "shaft miner's harshsuit"
 	desc = "It's an brown uniform with some padded armour for operating in hazardous environments."
+	armor = list(MELEE = 5, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, RAD = 0, FIRE = 20, ACID = 20)
 	icon_state = "explorer"
 	item_state = "explorer"
 	item_color = "explorer"
@@ -135,6 +136,7 @@
 /obj/item/clothing/under/rank/cargo/smith
 	name = "smith's jumpsuit"
 	desc = "A brown jumpsuit with some extra metal pieces strapped to it. You're not sure why, but the added armor doesn't make you feel any safer..."
+	armor = list(MELEE = 5, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, RAD = 0, FIRE = 20, ACID = 20)
 	icon_state = "smith"
 	item_state = "smith"
 	item_color = "smith"


### PR DESCRIPTION
I somehow uploaded the entire local DME file and it made the checks mad so here's attempt 2. I have been drinking.
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Exactly what the title says. This PR adds the following armor value to the Shaft Miner Harshsuit, Harshskirt, Overalls, as well as all three variants of the Smith Jumpsuit:
`armor = list(MELEE = 5, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, RAD = 0, FIRE = 20, ACID = 20)`
This is the same armor value the Expedition Jumpsuit (and variants) have.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The Shaft Miner Harshsuit and Smith Jumpsuit both have descriptions claiming to have armor, but the armor values are not actually there. This brings them inline with the descriptions, as well as the space-based counterpart, the Explorer. I did not add the armor to the "old" versions because they are... old. NT didn't bother giving much in self-preservation to the first few mining teams.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
I stabbed some Skrell in the chest with every Smith/Miner/Explorer jumpsuit. I confirm that all but the "old" shaft miner jumpsuit have their armor values and function as intended.
<!-- How did you test the PR, if at all? -->

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<img width="599" height="409" alt="image" src="https://github.com/user-attachments/assets/b4c2333a-287f-46fa-bf2c-90491314a5ac" />

## Changelog

:cl:
tweak: Added the armor values to six Mining-themed jumpsuits, as per item description.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
