### PR TITLE
Mech Scattershot now requires Illegals 3

### DIFF
--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1052,7 +1052,7 @@
 	desc = "Allows for the construction of LBX AC 10."
 	id = "mech_scattershot"
 	build_type = MECHFAB
-	req_tech = list("combat" = 4)
+	req_tech = list("combat" = 4, "syndicate" = 3)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot
 	materials = list(MAT_METAL=10000)
 	construction_time = 10 SECONDS


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Increases the Scattershot mech weapon to require illegals 3 to craft.

## Why It's Good For The Game

Nanotrasen is known for being more keen on energy weapons. The scattershot is definitively not that, being a large-bore mech shotgun that fires 4 lethal 25-brute bullets. This reigns them in a bit, as they are the current best mech weapon for general usage.

## Testing

Compiled

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <img width="1266" height="50" alt="image" src="https://github.com/user-attachments/assets/ffd3a2b7-3584-47cb-88c7-569628567059" />
<img width="1164" height="63" alt="image" src="https://github.com/user-attachments/assets/3304b15a-c687-470d-b331-22a9f6ada831" />
<img width="907" height="281" alt="image" src="https://github.com/user-attachments/assets/a50cd56b-e08f-4faa-97e2-d8db6f046543" />


## Changelog

:cl:
tweak: Scattershot now requires illegals level 3 to craft
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
