### PR TITLE
adds adminbus human subtype

### DIFF
--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -114,7 +114,7 @@
 	if(delta_now < 3 SECONDS)
 		return
 	// Stop counting, print, and reset
-	if(timer_id != TIMER_ID_NULL) 
+	if(timer_id != TIMER_ID_NULL)
 		deltimer(timer_id)
 		timer_id = TIMER_ID_NULL
 	print_summary()
@@ -140,6 +140,32 @@
 	log_debug("Fire rate = [hits_per_sec] hits/sec")
 	log_debug("Total damage = [total_damage], DPS = [damage_per_sec]")
 	log_debug("############### End hit report ################")
+
+// For adminbus fuckery
+/mob/living/carbon/human/admin
+	real_name = "unknown force"
+	status_flags = GODMODE
+	density = FALSE
+	incorporeal_move = TRUE
+	gender = PLURAL
+	underwear = "Mens Black Alt"
+
+/mob/living/carbon/human/admin/Initialize(mapload, datum/species/new_species)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_SILENT_FOOTSTEPS, ROUNDSTART_TRAIT)
+	invisibility = INVISIBILITY_OBSERVER
+	see_invisible = INVISIBILITY_OBSERVER
+	remove_from_all_data_huds()
+	rename_character(real_name, initial(real_name))
+	set_alpha_tracking(170, src)
+
+/mob/living/carbon/human/admin/update_sight()
+	. = ..()
+	see_invisible = INVISIBILITY_OBSERVER
+
+/mob/living/carbon/human/admin/CanPass(obj/item/projectile/P)
+	return TRUE
+
 /mob/living/carbon/human/skrell/Initialize(mapload)
 	. = ..(mapload, /datum/species/skrell)
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Adds a custom subtype of human for admin fuckery. This subtype effectively has noclip, godmode, and invisimin enabled by default. Additionally, it has an alpha of 170 to distinguish it from normal humans for observers. It has been named "unknown force" in the rare event that its name is shown when interacting with something.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Unfortunately, as good as the advanced admin interaction observer tool is, sometimes you need a human mob to interact with stuff. This bridges that gap.

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
<img width="265" height="337" alt="image" src="https://github.com/user-attachments/assets/598d2591-783c-4613-9fc5-ebc329303087" />

## Testing

<!-- How did you test the PR, if at all? -->
Fucked around a bit, thrown items pass through you, you cant get hit by gunshots.
Unfortunately you cant pull objects, but you can grab people.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
