### PR TITLE
Moves the compressor grind  special species actions to the species datum

### DIFF
--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -114,7 +114,7 @@
 	if(delta_now < 3 SECONDS)
 		return
 	// Stop counting, print, and reset
-	if(timer_id != TIMER_ID_NULL) 
+	if(timer_id != TIMER_ID_NULL)
 		deltimer(timer_id)
 		timer_id = TIMER_ID_NULL
 	print_summary()
@@ -155,10 +155,6 @@
 /mob/living/carbon/human/vox/Initialize(mapload)
 	. = ..(mapload, /datum/species/vox)
 
-/mob/living/carbon/human/vox/compressor_grind(turf/location)
-	new /obj/item/food/fried_vox(loc)
-	return ..()
-
 /mob/living/carbon/human/skeleton/Initialize(mapload)
 	. = ..(mapload, /datum/species/skeleton)
 
@@ -186,10 +182,6 @@
 /mob/living/carbon/human/diona/Initialize(mapload)
 	. = ..(mapload, /datum/species/diona)
 
-/mob/living/carbon/human/diona/compressor_grind()
-	new /obj/item/food/salad(loc)
-	return ..()
-
 /mob/living/carbon/human/pod_diona/Initialize(mapload)
 	. = ..(mapload, /datum/species/diona/pod)
 
@@ -198,10 +190,6 @@
 
 /mob/living/carbon/human/machine/created
 	name = "Integrated Robotic Chassis"
-
-/mob/living/carbon/human/machine/compressor_grind()
-	new /obj/item/stack/sheet/mineral/titanium(loc)
-	return ..()
 
 /mob/living/carbon/human/machine/created/Initialize(mapload)
 	. = ..()
@@ -224,10 +212,6 @@
 
 /mob/living/carbon/human/drask/Initialize(mapload)
 	. = ..(mapload, /datum/species/drask)
-
-/mob/living/carbon/human/drask/compressor_grind(turf/location)
-	new /obj/item/soap(loc)
-	return ..()
 
 /mob/living/carbon/human/monkey/Initialize(mapload)
 	. = ..(mapload, /datum/species/monkey)
@@ -2280,3 +2264,8 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 		changeNext_move(CLICK_CD_POINT)
 
 	DEFAULT_QUEUE_OR_CALL_VERB(VERB_CALLBACK(src, PROC_REF(run_pointed), A))
+
+/// Default behavior when getting ground up in a compressor
+/mob/living/carbon/human/compressor_grind()
+	dna.species.do_compressor_grind(src)
+	. = ..()

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -1224,3 +1224,7 @@ It'll return null if the organ doesn't correspond, so include null checks when u
 /// Is this species able to be legion infested?
 /datum/species/proc/can_be_legion_infested()
 	return TRUE
+
+/// Prototype for additional behaviour when a specific species is ground by a compressor.
+/datum/species/proc/do_compressor_grind(mob/living/carbon/human)
+	return

--- a/code/modules/mob/living/carbon/human/species/diona_species.dm
+++ b/code/modules/mob/living/carbon/human/species/diona_species.dm
@@ -137,3 +137,6 @@
 	species_traits = list(NO_HAIR, NOT_SELECTABLE)
 	pod = TRUE
 	inherent_factions = list("plants", "vines")
+
+/datum/species/diona/do_compressor_grind(mob/living/carbon/human/H)
+	new /obj/item/food/salad(H.loc)

--- a/code/modules/mob/living/carbon/human/species/drask.dm
+++ b/code/modules/mob/living/carbon/human/species/drask.dm
@@ -68,3 +68,5 @@
 		)
 	autohiss_exempt = list("Orluum")
 
+/datum/species/drask/do_compressor_grind(mob/living/carbon/human/H)
+	new /obj/item/soap(H.loc)

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -220,3 +220,6 @@
 								)
 		var/error_message = pick(error_messages)
 		to_chat(H, "<span class='boldwarning'>[error_message]</span>")
+
+/datum/species/machine/do_compressor_grind(mob/living/carbon/human/H)
+	new /obj/item/stack/sheet/mineral/titanium(H.loc)

--- a/code/modules/mob/living/carbon/human/species/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/vox.dm
@@ -139,3 +139,6 @@
 		return FALSE //Handling reagent removal on our own.
 
 	return ..()
+
+/datum/species/vox/do_compressor_grind(mob/living/carbon/human/H)
+	new /obj/item/food/fried_vox(H.loc)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #29778
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Corrects an oversight
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
- Spawned humans, changed their species and lobbed them at a spinning turbine
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Moves the species behaviour of compressor grinding to the species datum(oversight fix)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
