### PR TITLE
add 60-pop floor to emerald

### DIFF
--- a/code/datums/mapping/station_maps.dm
+++ b/code/datums/mapping/station_maps.dm
@@ -31,7 +31,8 @@
 	fluff_name = "NSS Diagoras"
 	technical_name = "EmeraldStation"
 	map_path = "_maps/map_files/stations/emeraldstation.dmm"
-	webmap_url = "https://affectedarc07.co.uk/emerald.html"
+	webmap_url = "https://webmap.affectedarc07.co.uk/maps/paradise/emeraldstation/"
+	min_players_random = 60
 	welcome_sound = 'sound/AI/welcome_diagoras.ogg'
 
 /datum/map/test_tiny


### PR DESCRIPTION
## What Does This PR Do
This PR sets the minimum server pop required for emeraldstation to roll on random days to 60, same as cere. I don't know for sure if this is the right number, on-station pop typically doubles over the course of a round due to latejoins, but we can tweak it later if necessary.

It also fixes the webmap URL since it was still pointed to the version that was present during the TM, last year.
## Why It's Good For The Game
Larger maps rolling for lower server populations frustrate players, and emerald is even larger than cere, so it should have a similar population requirement.
## Testing
Visual inspection.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: Diagoras has had its minimum server population set to 60 players.
/:cl: