### PR TITLE
fix dvorak remote ai upload not working

### DIFF
--- a/code/modules/awaymissions/mission_code/ruins/telecomns.dm
+++ b/code/modules/awaymissions/mission_code/ruins/telecomns.dm
@@ -419,7 +419,7 @@ GLOBAL_LIST_EMPTY(telecomms_trap_tank)
 	if(istype(O, /obj/item/card/emag))
 		to_chat(user, "<span class='warning'>You are more likely to damage this with an emag, than achieve something useful.</span>")
 		return
-	var/time_to_die = integrated_console.attackby__legacy__attackchain(O, user, params)
+	var/time_to_die = integrated_console.item_interaction(user, O, params2list(params))
 	if(time_to_die)
 		to_chat(user, "<span class='danger'>[src]'s relay begins to overheat...</span>")
 		playsound(loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)

--- a/tools/ci/check_legacy_attack_chain.py
+++ b/tools/ci/check_legacy_attack_chain.py
@@ -90,6 +90,8 @@ class AttackChainCallWalker:
 
     def visit_Var(self, node, source_info):
         self.local_vars[str(node.name)] = node.declared_type
+        if node.value:
+            self.visit_Expr(node.value, source_info)
 
     def visit_Expr(self, node, source_info):
         if node.kind == NodeKind.CALL:


### PR DESCRIPTION
## What Does This PR Do
This PR fixes #29743. It also makes the attack chain CI a tiny bit better at finding bad uses of legacy procs.
## Why It's Good For The Game
Bugfix.
## Testing
Spawned in as assistant, spawned an AI, aghosted into the AI, aghosted back to the assistant, spawned a remote AI upload and "oxygen is toxic to humans" module, used the upload in hand, selected the AI, and used the module on the AI upload. Ensured I got the "Upload complete" message.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: The remote AI upload loot from DVORAK should now work as expected.
/:cl: