### PR TITLE
Reverts Handheld Pulse Weapons to non-hitscan

### DIFF
--- a/code/modules/projectiles/ammunition/energy_lens.dm
+++ b/code/modules/projectiles/ammunition/energy_lens.dm
@@ -65,14 +65,14 @@
 	e_cost = (100 / 3) * 2 // 15 * 12.5 damage = 187.5 damage. Almost as much as a base laser gun, but takes longer to get all the shots out.
 
 /obj/item/ammo_casing/energy/laser/pulse
-	projectile_type = /obj/item/projectile/beam/pulse/hitscan
+	projectile_type = /obj/item/projectile/beam/pulse
 	muzzle_flash_color = LIGHT_COLOR_DARKBLUE
 	e_cost = 200
 	select_name = "DESTROY"
 	fire_sound = 'sound/weapons/pulse.ogg'
 
 /obj/item/ammo_casing/energy/laser/scatter/pulse
-	projectile_type = /obj/item/projectile/beam/pulse/hitscan
+	projectile_type = /obj/item/projectile/beam/pulse
 	e_cost = 200
 	select_name = "ANNIHILATE"
 	fire_sound = 'sound/weapons/pulse.ogg'

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -132,7 +132,7 @@
 	/// If this shot can immediately destroy rwalls or not
 	var/weakened_against_rwalls = FALSE
 
-/obj/item/projectile/beam/pulse/hitscan
+/obj/item/projectile/beam/pulse/hitscan // This is still used in Pulse Turrets and Mecha Pulse
 	impact_effect_type = null
 	light_color = null
 	hitscan = TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Makes handheld pulse weapons (pulse rifle/carbine, M1911-P, pulse annihilator, etc) fire the good ol' pulse lasers. Does not change the Pulse Turrets (centcomm) or the Marauder's Heavy Pulse, both of which are still hitscan.

## Why It's Good For The Game

1. It's honestly more intuitive to use non-hitscan weapons, after experimenting with them a while. 
2. Hitscan is best reserved for non-handheld weapons like turrets or mechas.
3. Personal bias, the image of a hallway being filled with flying pulse lasers when the DS boards is just a lot cooler than the current beams which flash for a second then disappear.

## Testing

It built.
The server launched off the code.
I joined. Spawned in an M1911-P, a Pulse Carbine, a Pulse Destroyer, a Pulse Annihilator. Fired all of them. All fired non-hitscan Pulse beams.
Spawned in a Seraph. Realised it doesn't have a Heavy Pulse. Spawned in a Marauder. Fired the Heavy Pulse. Worked properly as a hitscan beam.
Spawned in a Centcomm turret. Made it hate all organic life. It fired a hitscan beam. Shot the turret. Take that, machines.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<img width="939" height="52" alt="image" src="https://github.com/user-attachments/assets/92da982a-682b-458d-9a0f-848f550caedc" />
<img width="751" height="97" alt="image" src="https://github.com/user-attachments/assets/fa54f1f4-3148-447c-9dd2-fd6101ed24cf" />
I will not be answering questions about my discord nickname in the staffcord.

## Changelog

:cl:
tweak: Handheld pulse weapons now fire non-hitscan pulse beams again. Turrets and Mechas unaffected.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
