### PR TITLE
Fix VV delete.

### DIFF
--- a/code/datums/vv_core_topics.dm
+++ b/code/datums/vv_core_topics.dm
@@ -41,8 +41,8 @@
 		if(!check_rights(R_DEBUG, 0))
 			return
 
-		admin_delete(src)
-		href_list["datumrefresh"] = UID()
+		admin_delete(target)
+		return
 	if(href_list[VV_HK_MARK_OBJECT])
 		if(!check_rights(0))	return
 
@@ -50,7 +50,7 @@
 			to_chat(usr, "<span class='notice'>This can only be done to instances of type /datum.</span>")
 			return
 
-		src.holder.marked_datum = target
+		holder.marked_datum = target
 		href_list["datumrefresh"] = target.UID()
 	if(href_list[VV_HK_PROC_CALL])
 		if(!check_rights(R_PROCCALL))
@@ -75,7 +75,7 @@
 		if(!usr || result == "---Components---" || result == "---Elements---")
 			return
 
-		if(QDELETED(src))
+		if(QDELETED(target))
 			to_chat(usr, "<span class='notice'>That thing doesn't exist anymore!</span>", confidential = TRUE)
 			return
 
@@ -110,7 +110,7 @@
 			return
 		if(!usr || path == "---Components---" || path == "---Elements---")
 			return
-		if(QDELETED(src))
+		if(QDELETED(target))
 			to_chat(usr, "<span class='notice'>That thing doesn't exist anymore!</span>")
 			return
 		var/list/targets_to_remove_from = list(target)


### PR DESCRIPTION
## What Does This PR Do
Makes the VV delete dropdown item work properly again.
Also updates a couple other places where the VV menu was referencing the wrong object when error-checking.

## Why It's Good For The Game
Not having this working is very painful

## Testing
Deleted a chair in the wizard den.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
fix: VV delete works again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
