### PR TITLE
Fixes basicmobs not counting for DNA samples

### DIFF
--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -94,10 +94,10 @@ GLOBAL_LIST_INIT(non_simple_animals, typecacheof(list(/mob/living/carbon/human/m
 		to_chat(user, "<span class='notice'>Plant data added to local storage.</span>")
 
 	//animals
-	if(isanimal(target) || is_type_in_typecache(target, GLOB.non_simple_animals))
-		if(isanimal(target))
-			var/mob/living/simple_animal/A = target
-			if(!A.healable)//simple approximation of being animal not a robot or similar
+	if(isanimal_or_basicmob(target) || is_type_in_typecache(target, GLOB.non_simple_animals))
+		if(isanimal_or_basicmob(target))
+			var/mob/living/A = target
+			if(!A.healable) // simple approximation of being animal not a robot or similar
 				to_chat(user, "<span class='warning'>No compatible DNA detected</span>")
 				return
 		if(animals[target.type])


### PR DESCRIPTION
## What Does This PR Do
Lets "basic mobs" be DNA sampled, some examples are: All the nether world mobs, the cow and pig and deer. This list is soon to expand to most naturally spawning mobs, so best fix this now


## Why It's Good For The Game
bug fixes #29762

## Testing
DNA sampled some basic mobs, and simple mobs, both worked, both counted on the vault
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:

fix: Fixed basic mobs not counting as compatible mobs with the dna vault
/:cl:
