### PR TITLE
Fix HoloDeck items not spawning

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -849,7 +849,7 @@ Returns 1 if the chain up to the area contains the given typepath
 
 	if(perfectcopy)
 		if(O && original)
-			var/static/list/forbidden_vars = list("type", "loc", "locs", "vars", "parent", "parent_type", "verbs", "ckey", "key", "power_supply", "contents", "reagents", "stat", "x", "y", "z", "group", "comp_lookup", "datum_components")
+			var/static/list/forbidden_vars = list("type", "loc", "locs", "vars", "parent", "parent_type", "pixloc", "verbs", "ckey", "key", "power_supply", "contents", "reagents", "stat", "x", "y", "z", "group", "comp_lookup", "datum_components")
 
 			for(var/V in original.vars - forbidden_vars)
 				if(islist(original.vars[V]))


### PR DESCRIPTION
## What Does This PR Do
Blacklists the pixloc var from being duplicated in perfect copy `DuplicateObject` proc. Pixloc also changes the `loc` var which moves items back to Z1, causing them to get deleted. Fixes #29818
## Why It's Good For The Game
Holodeck works.
## Images of changes

<img width="759" height="928" alt="image" src="https://github.com/user-attachments/assets/f854876c-3756-4306-bd63-35cfa272f7aa" />

## Testing
image
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Holodeck items will spawn again now.
/:cl: