### PR TITLE
Fixes cyborgs being unable to make their cables pink or orange, as well as updates the choice list to tgui

### DIFF
--- a/code/modules/power/cables/cable_coil.dm
+++ b/code/modules/power/cables/cable_coil.dm
@@ -331,8 +331,10 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe/cable_restrain
 		color = COLOR_RED
 	else if(colorC == "rainbow")
 		color = color_rainbow()
-	else if(colorC == "orange") //byond only knows 16 colors by name, and orange isn't one of them
+	else if(colorC == "orange") // byond only knows 16 colors by name, and orange isn't one of them
 		color = COLOR_ORANGE
+	else if(colorC == "pink")
+		color = COLOR_PINK // nor is pink.. thanks byond
 	else
 		color = colorC
 
@@ -395,8 +397,8 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe/cable_restrain
 	return // icon_state should always be a full cable
 
 /obj/item/stack/cable_coil/cyborg/attack_self__legacy__attackchain(mob/user)
-	var/cablecolor = input(user,"Pick a cable color.","Cable Color") in list("red","yellow","green","blue","pink","orange","cyan","white")
-	color = cablecolor
+	var/cablecolor = tgui_input_list(usr, "Pick a cable color.", "Cable Color", list("red","yellow","green","blue","pink","orange","cyan","white"))
+	cable_color(cablecolor)
 	update_icon()
 
 #undef HEALPERCABLE


### PR DESCRIPTION
## What Does This PR Do
Makes the colour picking list a tgui list, like we've been moving towards
Fixes #29739 cyborgs being unable to make their cables pink or orange
This also might let cables spawn as pink

## Why It's Good For The Game
Bug fixes, TGUI is prettier than webui

## Images of changes
<img width="200" height="200" alt="dreamseeker_aeTi0AHXM9" src="https://github.com/user-attachments/assets/82d23f61-29b2-47c5-b7f4-e69d74a55cd1" />


## Testing
See above, swapped to each cable colour, placed each

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
tweak: The cyborg colour change list now uses a TGUI list
fix: Fixed cyborgs being unable to choose pink or orange as a cable color. (this fix also may mean pink cables spawn on roundstart)
