### PR TITLE
don't encode messages from captains Authority Voice

### DIFF
--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -470,7 +470,7 @@
 	return new /datum/spell_targeting/self
 
 /datum/spell/big_voice/cast(list/targets, mob/living/user)
-	var/say_message = tgui_input_text(user, "Message:", "Speak With Authority")
+	var/say_message = tgui_input_text(user, "Message:", "Speak With Authority", encode = FALSE)
 	if(isnull(say_message))
 		revert_cast()
 	else


### PR DESCRIPTION
## What Does This PR Do
Messages sent from captains authority voice will no longer get encoded, preventing butchering names and words like "J'eff". Fixes #29802
## Why It's Good For The Game
Clear speech good.
## Images of changes

<img width="183" height="183" alt="image" src="https://github.com/user-attachments/assets/6eaea023-dd09-4ddd-87ae-9d0d3ec72963" />

## Testing
Spoke. Image relevant.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Captains' authority voice will no longer butcher words.
/:cl: