### PR TITLE
Alien hand 'spells' are no longer magical

### DIFF
--- a/code/datums/spells/alien_spells/basetype_alien_touch.dm
+++ b/code/datums/spells/alien_spells/basetype_alien_touch.dm
@@ -42,6 +42,9 @@
 	/// Beepsky shouldn't be arresting you over this
 	needs_permit = FALSE
 
+/obj/item/melee/touch_attack/alien/customised_abstract_text()
+	return
+
 /obj/item/melee/touch_attack/alien/proc/plasma_check(plasma, mob/living/carbon/user)
 	var/plasma_current = user.get_plasma()
 	if(plasma_current < plasma)

--- a/code/datums/spells/alien_spells/corrosive_acid_spit.dm
+++ b/code/datums/spells/alien_spells/corrosive_acid_spit.dm
@@ -33,6 +33,9 @@
 		to_chat(C, "<span class='noticealien'>You cannot dissolve this object.</span>")
 	handle_delete(user)
 
+/obj/item/melee/touch_attack/alien/corrosive_acid/customised_abstract_text(mob/living/carbon/owner)
+	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is dripping with vile corrosive goo!</span>"
+
 /datum/spell/touch/alien_spell/burning_touch
 	name = "Blazing touch"
 	desc = "Boil acid within your hand to burn through anything you touch with it, dealing a lot of damage to aliens and destroying resin structures instantly."
@@ -74,3 +77,7 @@
 			C.add_plasma(-100)
 			qdel(target)
 	handle_delete(user)
+
+/obj/item/melee/touch_attack/alien/burning_touch/customised_abstract_text(mob/living/carbon/owner)
+	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] has a shimmering mirage around it!</span>"
+


### PR DESCRIPTION
## What Does This PR Do
Makes the xenomorph related in hand spells not appear to be magical
So if a human/xeno is holding the corrosive acid that queens and drones can use, it'll appear on inspect as "[pronoun]'s [left/right] hand is dripping with vile corrosive goo!"
And if a human uses the hijacked organ, on inspect it'll appear as "[pronoun]'s [left/right] hand has a shimmering mirage around it!" (this one could be subject to change with how powerful the spell is, and how unassuming the warning text is)

## Why It's Good For The Game
Fixes #29736
Xenomorphs dont.. well, those things dont usually use magic.. so it shouldn't appear as if xenomorphs are "holding" magic related stuff
Same with the hijacked version, its not /meant/ to be magic, so it shouldn't appear as such

## Testing
inspected the corrosive acid in hand spell inspect, and the burning touch in hand spell
<!-- How did you test the PR, if at all? -->

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
tweak: Xenomorph related in hand spells no longer appear as "magic fire"
/:cl: