### PR TITLE
Tweak: Makes embalming headless corpses with a dropper no longer possible. Adds 2 fail messages for embalming a headless corpse with a dropper.

### DIFF
--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -35,6 +35,12 @@
 			var/mob/living/carbon/human/H = target
 			var/obj/item/safe_thing = null
 
+			if(!H.get_organ(BODY_ZONE_HEAD))
+				user.visible_message("<span class='warning'>With a blank stare, [user] drips something where [H]'s eyes should be, but the body has no head to be found. Perhaps [user] is as dead inside as their patient.</span>", \
+				"<span class='warning'>You mindlessly drip something into [H]'s eyes, not realizing that [H.p_their()] head is missing. It's hard to tell which of you is more dead inside.</span>")
+				reagents.remove_any(amount_per_transfer_from_this)
+				return
+
 			if(H.glasses)
 				safe_thing = H.glasses
 			if(H.wear_mask)
@@ -43,11 +49,6 @@
 			if(H.head)
 				if(H.head.flags_cover & MASKCOVERSEYES)
 					safe_thing = H.head
-			else
-				user.visible_message("<span class='warning'>With a blank stare, [user] drips something where [H]'s eyes should be, but the body has no head to be found. Perhaps [user] is as dead inside as their patient.</span>", \
-				"<span class='warning'>You mindlessly drip something into [H]'s eyes, not realizing that [H.p_their()] head is missing. It's hard to tell which of you is more dead inside.</span>")
-				reagents.remove_any(amount_per_transfer_from_this)
-				return
 
 			if(safe_thing)
 				visible_message("<span class='danger'>[user] tries to drip something into [H]'s eyes, but fails!</span>")

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -43,6 +43,11 @@
 			if(H.head)
 				if(H.head.flags_cover & MASKCOVERSEYES)
 					safe_thing = H.head
+			else
+				user.visible_message("<span class='warning'>With a blank stare, [user] drips something where [H]'s eyes should be, but the body has no head to be found. Perhaps [user] is as dead inside as their patient.</span>", \
+				"<span class='warning'>You mindlessly drip something into [H]'s eyes, not realizing that [H.p_their()] head is missing. It's hard to tell which of you is more dead inside.</span>")
+				reagents.remove_any(amount_per_transfer_from_this)
+				return
 
 			if(safe_thing)
 				visible_message("<span class='danger'>[user] tries to drip something into [H]'s eyes, but fails!</span>")

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -36,7 +36,7 @@
 			var/obj/item/safe_thing = null
 
 			if(!H.get_organ(BODY_ZONE_HEAD))
-				user.visible_message("<span class='warning'>With a blank stare, [user] drips something where [H]'s eyes should be, but the body has no head to be found. Perhaps [user] is as dead inside as their patient.</span>", \
+				user.visible_message("<span class='warning'>With a blank stare, [user] drips something where [H]'s eyes should be, but the body has no head to be found. Perhaps [user] is as dead inside as [user.p_their()] patient.</span>", \
 				"<span class='warning'>You mindlessly drip something into [H]'s eyes, not realizing that [H.p_their()] head is missing. It's hard to tell which of you is more dead inside.</span>")
 				reagents.remove_any(amount_per_transfer_from_this)
 				return


### PR DESCRIPTION
## What Does This PR Do
Adds 2 humorous messages when embalming a headless corpse. The embalming will fail, since there's no head. Fixes #29758
## Why It's Good For The Game
Dripping into non-existent eyes is immersion breaking and this is humorous.

## Images
Message shown to user
<img width="670" height="51" alt="image" src="https://github.com/user-attachments/assets/3e03517d-d1d0-41e1-ab62-51007d6d3cf7" />

Bystander message
<img width="709" height="62" alt="image" src="https://github.com/user-attachments/assets/7f757403-0558-46f3-b2b1-5a2951b75f5a" />

## Testing
Images + Retested after fixing the head check.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: You can no longer embalm headless corpses with a dropper. Should be injected with formaldehyde.
add: Added fail messages for embalming headless corpses.
/:cl: