### PR TITLE
Xenomorphs can have all organs dissected now

### DIFF
--- a/code/modules/research/xenobiology/xenobiology_dissections.dm
+++ b/code/modules/research/xenobiology/xenobiology_dissections.dm
@@ -84,7 +84,11 @@
 				new_organ.unknown_quality = pick_quality(tool, surgery.get_surgery_step())
 				user.put_in_inactive_hand(new_organ)
 				SSblackbox.record_feedback("nested tally", "xeno_organ_type", 1, list("[new_organ.true_organ_type]", new_organ.unknown_quality))
-			target.contains_xeno_organ = FALSE
+			if(!isalien(target))
+				target.contains_xeno_organ = FALSE
+			else if(!length(target.surgery_container.xeno_specialized_organs))
+				target.contains_xeno_organ = FALSE
+
 	return SURGERY_STEP_CONTINUE
 
 /datum/surgery_step/generic/dissect/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

fixes an oversight in which xenomorphs were set as having no xenobio organs too early

## Why It's Good For The Game

you should be able to get all the organs from a xeno, as intended

## Testing

removed a lot of xeno organs

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Xenomorphs can now have all organs removed from them now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
