### PR TITLE
Add logging for the splash screen selected.

### DIFF
--- a/code/controllers/subsystem/non_firing/SStitlescreen.dm
+++ b/code/controllers/subsystem/non_firing/SStitlescreen.dm
@@ -27,6 +27,7 @@ SUBSYSTEM_DEF(title)
 				break
 
 		var/file_path = "config/title_screens/images/[pick(title_screens)]"
+		log_debug("Loading title screen from '[file_path]'.")
 
 		var/icon/icon = new(fcopy_rsc(file_path))
 


### PR DESCRIPTION
## What Does This PR Do
Adds debug logging for the title screen file chosen.

## Why It's Good For The Game
Reasonable thing to log, and may help us track down #29769.

## Testing
Booted server. Opened game.log. Saw log entry.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
NPFC