### PR TITLE
Unpin most of our tools' python dependencies

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -8,4 +8,4 @@ PyYaml>=6.0.1 # maplint also
 beautifulsoup4>=4.12.2
 
 # various CI checks
-avulto>=0.1.13
+avulto==0.1.13

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,11 +1,11 @@
-pygit2==1.13.1
-bidict==0.22.1
-Pillow==10.3.0
-json5==0.9.14
+pygit2>=1.13.1
+bidict>=0.22.1
+Pillow>=10.3.0
+json5>=0.9.14
 
 # changelogs
-PyYaml==6.0.1 # maplint also
-beautifulsoup4==4.12.2
+PyYaml>=6.0.1 # maplint also
+beautifulsoup4>=4.12.2
 
 # various CI checks
-avulto==0.1.13
+avulto>=0.1.13


### PR DESCRIPTION
## What Does This PR Do
Unpins most of our tools' python dependencies

## Why It's Good For The Game
Some of the versions we were requiring are old enough that they are incompatible with newer systems. By allowing the tooling to use newer versions where available, we let them keep up to date without having to micromanage their versions over time. The downside is that there's a chance a newer version will break things, but as we've already seen that *old* versions break things, too, it seems reasonable to take the risk.

## Testing
Made a commit. Hooks ran. Stuff built. Commit completed.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
NPFC