### PR TITLE
Pregame info for ghosts

### DIFF
--- a/code/controllers/subsystem/SSstatpanel.dm
+++ b/code/controllers/subsystem/SSstatpanel.dm
@@ -6,7 +6,10 @@ SUBSYSTEM_DEF(statpanels)
 	flags = SS_NO_INIT
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
 	var/list/currentrun = list()
+	/// Stuff shown to everyone.
 	var/list/global_data
+	/// Stuff shown to all admins.
+	var/list/admin_data
 	var/list/mc_data
 
 	/// How many subsystem fires between most tab updates
@@ -35,10 +38,24 @@ SUBSYSTEM_DEF(statpanels)
 			list("Players in Lobby:", "[length(GLOB.new_player_mobs)]")
 		)
 
+		admin_data = list()
+		if(SSticker?.current_state == GAME_STATE_PREGAME)
+			global_data += list(list("Time To Start:", SSticker.ticker_going ? deciseconds_to_time_stamp(SSticker.pregame_timeleft) : "DELAYED"))
+
+			var/players_ready = 0
+			admin_data += list(list("Players Ready:", "?"))
+			var/players_ready_index = length(admin_data)
+			for(var/mob/new_player/player in GLOB.player_list)
+				admin_data += list(list("[player.key]", player.ready ? "(Ready)" : "(Not ready)"))
+				if(player.ready)
+					players_ready++
+
+			admin_data[players_ready_index][2] = "[players_ready]"
+
 		if(SSshuttle.emergency)
 			var/eta = SSshuttle.emergency.getModeStr()
 			if(eta)
-				global_data[++global_data.len] = list("[eta]", "[SSshuttle.emergency.getTimerStr()]")
+				global_data += list(list("[eta]", "[SSshuttle.emergency.getTimerStr()]"))
 		src.currentrun = GLOB.clients.Copy()
 		mc_data = null
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -996,6 +996,8 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 /mob/proc/get_status_tab_items()
 	SHOULD_CALL_PARENT(TRUE)
 	var/list/status_tab_data = list()
+	if(check_rights(R_ADMIN, 0, src))
+		status_tab_data = SSstatpanels.admin_data.Copy()
 	return status_tab_data
 
 // facing verbs

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -1,8 +1,6 @@
 /mob/new_player
 	var/ready = FALSE
 	var/spawning = FALSE	//Referenced when you want to delete the new_player later on in the code.
-	var/totalPlayers = 0		 //Player counts for the Lobby tab
-	var/totalPlayersReady = 0
 	universal_speak = TRUE
 
 	invisibility = 101
@@ -96,17 +94,6 @@
 			status_tab_data[++status_tab_data.len] = list("Game Mode:", "[GLOB.master_mode]")
 		else
 			status_tab_data[++status_tab_data.len] = list("Game Mode:", "Secret")
-
-		if(SSticker.current_state == GAME_STATE_PREGAME)
-			status_tab_data[++status_tab_data.len] = list("Time To Start:", SSticker.ticker_going ? deciseconds_to_time_stamp(SSticker.pregame_timeleft) : "DELAYED")
-			if(check_rights(R_ADMIN, 0, src))
-				status_tab_data[++status_tab_data.len] = list("Players Ready:", "[totalPlayersReady]")
-			totalPlayersReady = 0
-			for(var/mob/new_player/player in GLOB.player_list)
-				if(check_rights(R_ADMIN, 0, src))
-					status_tab_data[++status_tab_data.len] = list("[player.key]", player.ready ? "(Ready)" : "(Not ready)")
-				if(player.ready)
-					totalPlayersReady++
 
 /mob/new_player/Topic(href, href_list[])
 	if(!client)


### PR DESCRIPTION
## What Does This PR Do
Adds the pre-game status panel information to pre-game observers during pre-game.

## Why It's Good For The Game
It's pretty silly that ghosts can't see how long it is until the game starts.

## Testing
Looked at stat panel as admin new player before round start.
Looked at stat panel as de-adminned new player before round start.
Looked at stat panel as admin ghost before round start.
Looked at stat panel as de-adminned ghost before round start.
Looked at stat panel as admin new player after round start.
Looked at stat panel as de-adminned new player after round start.
Looked at stat panel as admin ghost after round start.
Looked at stat panel as de-adminned ghost after round start.

All as expected, no runtimes.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog
:cl:
add: Ghosts can now see pre-round data until the round starts, just like people in the lobby.
/:cl: