### PR TITLE
Gives all Heads of Staff energy pistols, equips with cybernetics

### DIFF
--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -173,7 +173,7 @@
 		/datum/job/smith = /obj/item/organ/internal/cyberimp/arm/toolset,
 		/datum/job/chaplain = /obj/item/organ/internal/cyberimp/brain/anti_drop,
 		/datum/job/chemist = /obj/item/organ/internal/liver/cybernetic,
-		/datum/job/chief_engineer = /obj/item/organ/internal/cyberimp/brain/wire_interface,
+		/datum/job/chief_engineer = /obj/item/organ/internal/cyberimp/cybernetic/shield,
 		/datum/job/cmo = /obj/item/organ/internal/cyberimp/chest/reviver,
 		/datum/job/clown = /obj/item/organ/internal/cyberimp/brain/anti_stam, //HONK!
 		/datum/job/chef = /obj/item/organ/internal/cyberimp/chest/nutriment/plus,
@@ -190,7 +190,7 @@
 		/datum/job/paramedic = /obj/item/organ/internal/cyberimp/mouth/breathing_tube,
 		/datum/job/psychiatrist = /obj/item/organ/internal/heart/cybernetic/upgraded, //heart of gold. Or at least part gold
 		/datum/job/qm = /obj/item/organ/internal/cyberimp/arm/telebaton,
-		/datum/job/rd = /obj/item/organ/internal/cyberimp/eyes/hud/diagnostic,
+		/datum/job/rd = /obj/item/organ/internal/cyberimp/arm/flash,
 		/datum/job/roboticist = /obj/item/organ/internal/cyberimp/eyes/hud/diagnostic,
 		/datum/job/scientist = /obj/item/organ/internal/ears/cybernetic,
 		/datum/job/xenobiologist = /obj/item/organ/internal/cyberimp/arm/surgery,

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -173,7 +173,7 @@
 		/datum/job/smith = /obj/item/organ/internal/cyberimp/arm/toolset,
 		/datum/job/chaplain = /obj/item/organ/internal/cyberimp/brain/anti_drop,
 		/datum/job/chemist = /obj/item/organ/internal/liver/cybernetic,
-		/datum/job/chief_engineer = /obj/item/organ/internal/cyberimp/cybernetic/shield,
+		/datum/job/chief_engineer = /obj/item/organ/internal/eyes/cybernetic/shield,
 		/datum/job/cmo = /obj/item/organ/internal/cyberimp/chest/reviver,
 		/datum/job/clown = /obj/item/organ/internal/cyberimp/brain/anti_stam, //HONK!
 		/datum/job/chef = /obj/item/organ/internal/cyberimp/chest/nutriment/plus,

--- a/code/game/jobs/job/engineering_jobs.dm
+++ b/code/game/jobs/job/engineering_jobs.dm
@@ -58,6 +58,7 @@
 	satchel = /obj/item/storage/backpack/satchel_eng
 	dufflebag = /obj/item/storage/backpack/duffel/engineering
 	box = /obj/item/storage/box/engineer
+	cybernetic_implants = list(/obj/item/organ/internal/cyberimp/brain/wire_interface)
 
 /datum/outfit/job/chief_engineer/on_mind_initialize(mob/living/carbon/human/H)
 	. = ..()

--- a/code/game/jobs/job/medical_jobs.dm
+++ b/code/game/jobs/job/medical_jobs.dm
@@ -55,7 +55,7 @@
 	backpack = /obj/item/storage/backpack/medic
 	satchel = /obj/item/storage/backpack/satchel_med
 	dufflebag = /obj/item/storage/backpack/duffel/medical
-
+	cybernetic_implants = list(/obj/item/organ/internal/cyberimp/eyes/hud/medical)
 
 /datum/outfit/job/cmo/on_mind_initialize(mob/living/carbon/human/H)
 	. = ..()

--- a/code/game/jobs/job/science_jobs.dm
+++ b/code/game/jobs/job/science_jobs.dm
@@ -64,6 +64,7 @@
 	backpack = /obj/item/storage/backpack/science
 	satchel = /obj/item/storage/backpack/satchel_tox
 	dufflebag = /obj/item/storage/backpack/duffel/science
+	cybernetic_implants = list(/obj/item/organ/internal/cyberimp/eyes/hud/diagnostic)
 
 /datum/outfit/job/rd/on_mind_initialize(mob/living/carbon/human/H)
 	. = ..()

--- a/code/game/jobs/job/security_jobs.dm
+++ b/code/game/jobs/job/security_jobs.dm
@@ -69,6 +69,7 @@
 	backpack = /obj/item/storage/backpack/security
 	satchel = /obj/item/storage/backpack/satchel_sec
 	dufflebag = /obj/item/storage/backpack/duffel/security
+	cybernetic_implants = list(/obj/item/organ/internal/cyberimp/eyes/hud/security)
 
 /datum/outfit/job/hos/on_mind_initialize(mob/living/carbon/human/H)
 	. = ..()

--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -44,6 +44,7 @@
 	backpack = /obj/item/storage/backpack/captain
 	satchel = /obj/item/storage/backpack/satchel_cap
 	dufflebag = /obj/item/storage/backpack/duffel/captain
+	cybernetic_implants = list(/obj/item/organ/internal/cyberimp/eyes/hud/skill)
 
 /datum/outfit/job/captain/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
@@ -127,6 +128,7 @@
 	)
 
 	bio_chips = list()
+	cybernetic_implants = list(/obj/item/organ/internal/cyberimp/eyes/hud/skill)
 
 /datum/job/nanotrasenrep
 	title = "Nanotrasen Representative"

--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo_lockers.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo_lockers.dm
@@ -67,6 +67,7 @@
 	new /obj/item/cartridge/qm(src)
 	new /obj/item/storage/bag/mail(src)
 	new /obj/item/melee/knuckleduster/nanotrasen(src)
+	new /obj/item/gun/energy/gun/mini(src)
 
 /// used in mining outpost
 /obj/structure/closet/secure_closet/quartermaster/lavaland

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering_lockers.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering_lockers.dm
@@ -30,8 +30,8 @@
 	new /obj/item/clothing/accessory/medal/engineering(src)
 	new /obj/item/holosign_creator/atmos(src)
 	new /obj/item/rcd/preloaded(src)
-	new /obj/item/organ/internal/cyberimp/brain/wire_interface(src)
 	new /obj/item/storage/bag/construction(src)
+	new /obj/item/gun/energy/gun/mini(src)
 
 
 /obj/structure/closet/secure_closet/engineering_electrical

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical_lockers.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical_lockers.dm
@@ -154,12 +154,12 @@
 	new /obj/item/flash(src)
 	new /obj/item/gun/syringe(src)
 	new /obj/item/reagent_containers/hypospray/cmo(src)
-	new /obj/item/organ/internal/cyberimp/eyes/hud/medical(src)
 	new /obj/item/door_remote/chief_medical_officer(src)
 	new /obj/item/reagent_containers/drinks/mug/cmo(src)
 	new /obj/item/clothing/accessory/medal/medical(src)
 	new /obj/item/storage/briefcase(src)
 	new /obj/item/clothing/mask/gas(src)
+	new /obj/item/gun/energy/gun/mini(src)
 
 
 /obj/structure/closet/secure_closet/animal

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -57,8 +57,8 @@
 	new /obj/item/laser_pointer(src)
 	new /obj/item/door_remote/research_director(src)
 	new /obj/item/reagent_containers/drinks/mug/rd(src)
-	new /obj/item/organ/internal/cyberimp/eyes/hud/diagnostic(src)
 	new /obj/item/clothing/accessory/medal/science(src)
+	new /obj/item/gun/energy/gun/mini(src)
 
 
 /obj/structure/closet/secure_closet/research_reagents

--- a/code/game/objects/structures/crates_lockers/closets/secure/security_lockers.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security_lockers.dm
@@ -60,7 +60,6 @@
 	new /obj/item/gun/energy/gun/hos(src)
 	new /obj/item/door_remote/head_of_security(src)
 	new /obj/item/reagent_containers/drinks/mug/hos(src)
-	new /obj/item/organ/internal/cyberimp/eyes/hud/security(src)
 	new /obj/item/clothing/accessory/medal/security(src)
 	new /obj/item/reagent_containers/drinks/flask/barflask(src)
 	new /obj/item/clothing/mask/gas/sechailer(src)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

This PR does the following:
- All heads of staff (barring the captain, HoS, and dignitaries) start with a miniature egun in their locker. This epistol is for self-defense use only: using it outside of that purpose is liable to receive an abuse of equipment charge, alongside potentially other charges.
- The CE, RD, CMO, HOP, Captain, and HOS all start with a cybernetic. The RD has a diagnostic HUD, CMO a medical HUD, HOP and Captain have a skillhud, HOS has a sechud, and the CE has a wire interface. The respective implants have been removed from their lockers.
- The QM and CE do not receive the meson eyes by default. This is because it may interfere with species traits, such as nian nightvision. Those implants remain in their lockers.
- Cybernetic revolution needed a few adjustments to accommodate for the above: the CE now has welding shield eyes, the RD now has a flash implant (similar to the warden). This is because they receive their previous cybernetic revolution implants by default now.

## Why It's Good For The Game

Command staff are currently rather defenseless for individuals trusted to lead entire departments while using highly valuable and experimental equipment. As the HOP is entrusted with an epistol despite not being mindshielded, so should the rest of the command staff. 

Likewise, most command staff start with cybernetic implants already within their locker, but not implanted. This often leads to said implants never actually being used, resulting in wasted space. Now they start with these implanted, giving them just a little bit more of an edge (and potentially allowing them a bit more freedom with their choice of eyewear.)

## Testing

Spawned as heads of staff. Verified the implants were installed. Checked locker. Had epistol. Didn't get arrested by beepsky for holding the epistol.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: All heads of staff now start with an epistol in their locker
add: All heads of staff, barring the QM, start with a HUD implant. The CE has a wire interface instead.
tweak: Adjusted CE and RD cybernetic revolution implants
remove: Removed most implants from head of staff lockers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
