### PR TITLE
Saner FLW links.

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1722,20 +1722,24 @@
 		show_player_panel(M)
 
 	else if(href_list["adminplayerobservefollow"])
+		if(isnewplayer(usr))
+			to_chat(usr, "<span class='warning'>You cannot follow anyone from the lobby!</span>")
+			return
+
 		var/client/C = usr.client
 		if(!isobserver(usr))
-			if(!check_rights(R_ADMIN|R_MOD)) // Need to be mod or admin to aghost
+			if(!check_rights(R_ADMIN|R_MOD, show_msg=FALSE)) // Need to be mod or admin to aghost
+				to_chat(usr, "<span class='warning'>You must be an observer to follow someone!</span>")
 				return
 			C.admin_ghost()
-		var/mob/M = locateUID(href_list["adminplayerobservefollow"])
 
-		if(!ismob(M))
+		var/mob/target = locateUID(href_list["adminplayerobservefollow"])
+		if(!ismob(target))
 			to_chat(usr, "<span class='warning'>This can only be used on instances of type /mob</span>")
 			return
 
-		var/mob/dead/observer/A = C.mob
-		sleep(2)
-		A.ManualFollow(M)
+		var/mob/dead/observer/ghost = C.mob
+		ghost.ManualFollow(target)
 
 	else if(href_list["check_antagonist"])
 		check_antagonists()

--- a/code/modules/mob/dead/observer/observer_base.dm
+++ b/code/modules/mob/dead/observer/observer_base.dm
@@ -540,8 +540,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set desc = "Orbits the specified movable atom."
 	set category = null
 
-	// this usr check is apparently necessary for security
-	if(!isobserver(usr))
+	// this check is apparently necessary for security
+	if(!isobserver(src))
 		return
 
 	return do_manual_follow(target)


### PR DESCRIPTION
## What Does This PR Do
Admin FLW links will no longer runtime if you are an observer.
Admin FLW links will now give a nicer message if you click them while alive and unable to aghost.
Admin FLW links will successfully follow after triggering an aghost.
Admin FLW links will now work slightly faster, as there was a pointless `sleep(2)` in them.

## Why It's Good For The Game
Runtimes bad. Working things good.

## Testing
Tried to FLW myself from the lobby.
Tried to use an old FLW link while de-adminned.
Used a FLW link to immediately start orbiting my body.
Tried to FLW out of my body with only mentor permissions.

The mentor one is a bit odd, since they can use OBS, but it at least demonstrated that the permissions check worked.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog
:cl:
fix: Admin FLW links work the first time, even if they trigger an aghost.
/:cl: