### PR TITLE
Prevent qdeleted pipelines and machinery from sharing air.

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -676,7 +676,6 @@ What are the archived variables for?
 	var/temperature = null
 	for(var/datum/gas_mixture/G as anything in mixtures)
 		if(!istype(G))
-			stack_trace("share_many_airs had [G] in mixtures ([json_encode(mixtures)])")
 			continue
 		total_volume += G.volume
 

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -674,8 +674,8 @@ What are the archived variables for?
 
 	// Collect all the cheap data and check if there's a significant temperature difference.
 	var/temperature = null
-	for(var/datum/gas_mixture/G as anything in mixtures)
-		if(!istype(G))
+	for(var/datum/gas_mixture/G in mixtures)
+		if(QDELETED(G))
 			continue
 		total_volume += G.volume
 
@@ -696,8 +696,8 @@ What are the archived variables for?
 
 	// If we don't have a significant temperature difference, check for a significant gas amount difference.
 	if(!must_share)
-		for(var/datum/gas_mixture/G as anything in mixtures)
-			if(!istype(G))
+		for(var/datum/gas_mixture/G in mixtures)
+			if(QDELETED(G))
 				continue
 			if(abs(G.private_oxygen - total_oxygen * G.volume / total_volume) > 0.1)
 				must_share = TRUE
@@ -725,8 +725,8 @@ What are the archived variables for?
 	// Collect the more expensive data.
 	var/total_thermal_energy = 0
 	var/total_heat_capacity = 0
-	for(var/datum/gas_mixture/G as anything in mixtures)
-		if(!istype(G))
+	for(var/datum/gas_mixture/G in mixtures)
+		if(QDELETED(G))
 			continue
 		var/heat_capacity = G.heat_capacity()
 		total_heat_capacity += heat_capacity
@@ -738,8 +738,8 @@ What are the archived variables for?
 		temperature = total_thermal_energy/total_heat_capacity
 
 	// Update individual gas_mixtures by volume ratio.
-	for(var/datum/gas_mixture/G as anything in mixtures)
-		if(!istype(G))
+	for(var/datum/gas_mixture/G in mixtures)
+		if(QDELETED(G))
 			continue
 		G.private_oxygen = total_oxygen * G.volume / total_volume
 		G.private_nitrogen = total_nitrogen * G.volume / total_volume

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -200,15 +200,20 @@
 
 	for(var/i=1;i<=length(PL);i++)
 		var/datum/pipeline/P = PL[i]
-		if(!P)
-			return
+		if(!P || QDELETED(P))
+			continue
 		GL += P.air
 		GL += P.other_airs
+
 		for(var/obj/machinery/atmospherics/binary/valve/V in P.other_atmosmch)
+			if(QDELETED(V))
+				continue
 			if(V.open)
 				PL |= V.parent1
 				PL |= V.parent2
 		for(var/obj/machinery/atmospherics/trinary/tvalve/T in P.other_atmosmch)
+			if(QDELETED(T))
+				continue
 			if(!T.state)
 				if(src != T.parent2) // otherwise dc'd side connects to both other sides!
 					PL |= T.parent1
@@ -218,6 +223,8 @@
 					PL |= T.parent1
 					PL |= T.parent2
 		for(var/obj/machinery/atmospherics/unary/portables_connector/C in P.other_atmosmch)
+			if(QDELETED(C))
+				continue
 			if(C.connected_device)
 				GL += C.portableConnectorReturnAir()
 

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -25,6 +25,10 @@
 		P.parent = null
 	for(var/obj/machinery/atmospherics/A in other_atmosmch)
 		A.nullifyPipenet(src)
+
+	other_airs.Cut()
+	members.Cut()
+	other_atmosmch.Cut()
 	return ..()
 
 /datum/pipeline/process()//This use to be called called from the pipe networks

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -200,7 +200,7 @@
 
 	for(var/i=1;i<=length(PL);i++)
 		var/datum/pipeline/P = PL[i]
-		if(!P || QDELETED(P))
+		if(!istype(P) || QDELETED(P) || isnull(P.air))
 			continue
 		GL += P.air
 		GL += P.other_airs


### PR DESCRIPTION
## What Does This PR Do
* Removes a runtime in `share_many_airs` that does not and cannot provide any useful context for tracking down what it's complaining about. The runtime would trigger continuously for minutes once fired, and had an absurdly long message, flashbanging anyone with runtimes displayed in their chat log.
* Added some `QDELETED` checks to `/datum/pipeline/proc/reconcile_air`, which is the sole caller of `share_many_airs`. This prevents the nulls that were tripping the above runtime, and ensures that deleted valves and connectors do not transmit air.
* Removed `as anything` from `share_many_airs`, since we were doing `istype` immediately after anyway. Added QDELETED checking as well, for extra safety.

## Why It's Good For The Game
Runtimes bad, correctness good.

## Testing
Started an SM as AI, used buildmode to delete assorted pieces of the loop. No errors.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
NPFC