### PR TITLE
re-enables signal emote for carbons

### DIFF
--- a/code/modules/mob/living/carbon/carbon_emote.dm
+++ b/code/modules/mob/living/carbon/carbon_emote.dm
@@ -140,10 +140,15 @@
 	message = "signs."
 	message_param = "signs the number %t."
 	param_desc = "number(0-10)"
-	// Humans get their own proc since they have fingers
-	mob_type_blacklist_typecache = list(/mob/living/carbon/human)
 	hands_use_check = TRUE
 	target_behavior = EMOTE_TARGET_BHVR_NUM
+
+/datum/emote/living/carbon/sign/run_emote(mob/user, params, type_override, intentional)
+	var/fingers = text2num(params)
+	if(fingers > 10)
+		to_chat(user, "<span class='warning'>You don't have enough fingers!</span>")
+		return TRUE
+	return ..()
 
 /datum/emote/living/carbon/faint
 	key = "faint"


### PR DESCRIPTION
## What Does This PR Do
Re-enables the signal emote for carbons. I did not find a replacement for the signal emote. Fixes #29757
## Why It's Good For The Game
More emotes.
## Images of changes

<img width="321" height="51" alt="image" src="https://github.com/user-attachments/assets/807158d5-26b6-4b9e-9c25-51101439918c" />

## Testing
Emoted with an invalid number, emoted with more than 10 fingers, emoted 10.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: Re-enabled signal emote for carbons.
/:cl: