### PR TITLE
Fixes Abandoned Engi Satellite Secondary Airlock Spawning Wrong if Ruin is Rotated

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/abandoned_engi_sat.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/abandoned_engi_sat.dmm
@@ -7,11 +7,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/abandoned_engi_sat)
-"aA" = (
-/obj/effect/mapping_helpers/turfs/rust,
-/obj/effect/spawner/airlock/w_to_e,
-/turf/simulated/wall/r_wall,
-/area/ruin/space/abandoned_engi_sat)
 "aN" = (
 /obj/machinery/computer/nonfunctional,
 /turf/simulated/floor/plasteel{
@@ -419,6 +414,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/abandoned_engi_sat)
+"lg" = (
+/obj/effect/map_effect/dynamic_airlock/door/interior,
+/obj/machinery/access_button/offset/northwest,
+/obj/machinery/door/airlock/external/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ruin/space/abandoned_engi_sat)
 "lu" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -507,7 +511,7 @@
 	protected = 0
 	},
 /obj/structure/fans/tiny,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless,
 /area/ruin/space/abandoned_engi_sat)
 "nn" = (
 /obj/effect/mapping_helpers/turfs/burn,
@@ -581,6 +585,12 @@
 "qu" = (
 /obj/effect/mapping_helpers/turfs/rust,
 /turf/simulated/wall/r_wall,
+/area/ruin/space/abandoned_engi_sat)
+"qV" = (
+/obj/effect/map_effect/dynamic_airlock/door/exterior,
+/obj/machinery/access_button/offset/north,
+/obj/machinery/door/airlock/external/glass,
+/turf/simulated/floor/plating/airless,
 /area/ruin/space/abandoned_engi_sat)
 "rn" = (
 /mob/living/simple_animal/hostile/carp,
@@ -708,6 +718,11 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/effect/map_effect/dynamic_airlock/door,
+/obj/machinery/airlock_controller/air_cycler/directional/north,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/ruin/space/abandoned_engi_sat)
 "uU" = (
@@ -818,7 +833,7 @@
 	protected = 0
 	},
 /obj/structure/fans/tiny,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless,
 /area/ruin/space/abandoned_engi_sat)
 "yE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -892,7 +907,7 @@
 	protected = 0
 	},
 /obj/structure/fans/tiny,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless,
 /area/ruin/space/abandoned_engi_sat)
 "BR" = (
 /obj/structure/table,
@@ -1532,7 +1547,7 @@
 /obj/structure/sign/vacuum/external{
 	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -2487,8 +2502,8 @@ cm
 oL
 MK
 qu
-et
-aA
+lg
+qu
 LP
 LP
 LP
@@ -2555,7 +2570,7 @@ Bu
 qu
 yt
 qu
-et
+qV
 qu
 LP
 LP


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Converts the airlock spawner in the Abandoned Engi Sat into a dynamic airlock.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Allows the ruin to be rotated without the airlock bugging the hell out and spawning off to the side somewhere.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<img width="160" height="160" alt="image" src="https://github.com/user-attachments/assets/4ba7dab0-ea26-4bd4-b3b0-69e4dba0cd5c" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Looked at the airlock in differently rotated version of the ruin. Pushed some buttons. It worked.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: The abandoned engi sat secondary airlock no longer sometimes spawns off to the side from where it should.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
