### PR TITLE
Fixes Frag Grenade Behavior

### DIFF
--- a/code/game/objects/items/weapons/grenades/frag.dm
+++ b/code/game/objects/items/weapons/grenades/frag.dm
@@ -27,7 +27,7 @@
 	shrapnel_contained = 50
 	embedded_type = /obj/item/projectile/bullet/pellet/rubber/stinger
 
-/obj/item/grenade/frag/prime()
+/obj/item/grenade/frag/stinger/prime()
 	update_mob()
 	explosion(loc, 0, 0, 0, 0, DEFAULT_SHRAPNEL_RANGE + 2, cause = name, breach = FALSE)
 	create_shrapnel(loc, shrapnel_contained, shrapnel_type = embedded_type)


### PR DESCRIPTION
## What Does This PR Do
Returns the behavior of the frag grenade to what it should be. 
## Why It's Good For The Game
Because a frag grenade should be a frag grenade and not a stinger grenade.
## Testing
I haven't done it yet, I was not at my desktop for this one.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog

:cl:
fix: Fixed frag grenade acting like a stinger grenade
/:cl:
