### PR TITLE
Fixes unintended behavior for xeno kidney organs

### DIFF
--- a/code/modules/research/xenobiology/xenobiology_organs.dm
+++ b/code/modules/research/xenobiology/xenobiology_organs.dm
@@ -855,7 +855,7 @@
 	hidden_origin_tech = TECH_TOXINS
 	hidden_tech_level = 6
 
-/obj/item/organ/internal/kidneys/xenobiology/shivering/on_life()
+/obj/item/organ/internal/kidneys/xenobiology/sweating/on_life()
 	. = ..()
 	if(owner.get_temperature() > owner.dna?.species.heat_level_1 - 40)
 		switch(organ_quality)


### PR DESCRIPTION
## What Does This PR Do
Fixes an xeno organ duplicate definition where shivering was called where sweating should have been.
## Why It's Good For The Game
Produces correct behavior based on conditions.
## Testing
I haven't yet. I was too busy watching the qualifier.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog

:cl:
fix: Fixed xeno kidney behavior based on body temperature
/:cl:
