### PR TITLE
Refactors destroy() in vent_scrubber.dm

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -53,20 +53,18 @@
 	name = "[initial_loc.name] Air Scrubber #[length(initial_loc.scrubbers)]"
 
 /obj/machinery/atmospherics/unary/vent_scrubber/Destroy()
-	. = ..()
+	if(initial_loc)
+		initial_loc.scrubbers -= src
+
 	GLOB.all_scrubbers -= src
+
+	return ..()
 
 /obj/machinery/atmospherics/unary/vent_scrubber/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>This filters the atmosphere of harmful gas. Filtered gas goes straight into the connected pipenet. Controlled by an Air Alarm.</span>"
 	if(welded)
 		. += "It seems welded shut."
-
-/obj/machinery/atmospherics/unary/vent_scrubber/Destroy()
-	if(initial_loc)
-		initial_loc.scrubbers -= src
-
-	return ..()
 
 /obj/machinery/atmospherics/unary/vent_scrubber/update_overlays()
 	. = ..()


### PR DESCRIPTION
## What Does This PR Do
This cleans up procs in vent_scrubber.dm by handling it under one definition instead of two.
## Why It's Good For The Game
What is good for the codebase is good for the game. This prepares us for new CI to detect and prevent duplicate proc definitions.
## Testing
Compiles.
Deleted a few active scrubbers.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC