### PR TITLE
Corrects a populate_contents() call in abadoned_engi_sat.dm

### DIFF
--- a/code/modules/awaymissions/mission_code/ruins/abandoned_engi_sat.dm
+++ b/code/modules/awaymissions/mission_code/ruins/abandoned_engi_sat.dm
@@ -5,6 +5,6 @@
 
 /obj/structure/closet/wardrobe/atmospherics_yellow/empty
 
-/obj/structure/closet/wardrobe/atmospherics_yellow/populate_contents()
+/obj/structure/closet/wardrobe/atmospherics_yellow/empty/populate_contents()
 	return
 


### PR DESCRIPTION
## What Does This PR Do
Makes the atmospherics_yellow wardrobe in the abandoned_engi_sat.dm use the empty subtype it has defined.
## Why It's Good For The Game
Removes a duplicate proc() definition in order to make way for new CI.
## Testing
I haven't yet.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC
