### PR TITLE
fix minebots aggroing on owner

### DIFF
--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/targeting.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/targeting.dm
@@ -55,6 +55,8 @@ GLOBAL_LIST_INIT(target_interested_atoms, typecacheof(list(
 	var/list/filtered_targets = list()
 
 	for(var/atom/pot_target in potential_targets)
+		if(ismob(pot_target) && living_mob.faction_check_mob(pot_target))
+			continue
 		if(targeting_strategy.can_attack(living_mob, pot_target))//Can we attack it?
 			filtered_targets += pot_target
 			continue
@@ -103,6 +105,8 @@ GLOBAL_LIST_INIT(target_interested_atoms, typecacheof(list(
 			continue
 		if(!strategy.can_attack(pawn, maybe_target))
 			continue
+		if(ismob(maybe_target) && pawn.faction_check_mob(maybe_target))
+			continue
 		valid_found = TRUE
 		break
 	if(!valid_found)
@@ -133,7 +137,13 @@ GLOBAL_LIST_INIT(target_interested_atoms, typecacheof(list(
 			continue
 		if(!strategy.can_attack(pawn, maybe_target))
 			continue
+		if(ismob(maybe_target) && pawn.faction_check_mob(maybe_target))
+			continue
 		accepted_targets += maybe_target
+
+	if(!length(accepted_targets))
+		finish_action(controller, succeeded = FALSE)
+		return
 
 	// Alright, we found something acceptable, let's use it yeah?
 	var/atom/target = pick_final_target(controller, accepted_targets)


### PR DESCRIPTION
## What Does This PR Do
This PR adds faction checks to the "find potential targets" subtree, ensuring that players who pass faction checks (like the miners who spawned their pet minebot) do not get selected as a valid target. Fixes #29878.
## Why It's Good For The Game
Bugfix.
## Testing
Spawned mining cube and activated it. Spawned an abandoned minebot. Ensured that my minebot did not start targeting me.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Minebots should no longer attack their owner after being aggroed by an enemy.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
