### PR TITLE
fix admin equipment for shaft miner modsuit

### DIFF
--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -209,6 +209,9 @@
 	name = "Shaft Miner (Equipment + MODsuit)"
 	back = /obj/item/mod/control/pre_equipped/mining/asteroid
 	mask = /obj/item/clothing/mask/breath
+	suit = null
+	backpack = null
+	allow_backbag_choice = FALSE
 
 /datum/job/explorer
 	title = "Explorer"


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the "Shaft Miner (Equipment + MODSuit)" entry in the admin "Select Equipment" menu. This was still equipping a softsuit and backpack, which was clobbering the modsuit assignment.
## Why It's Good For The Game
Bugfix.
## Testing
Used select equipment menu, selected entry, ensured modsuit spawned, and miner equipment was placed in modsuit storage.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC