### PR TITLE
IPCs no longer suffer brain damage when shocked

### DIFF
--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -190,7 +190,6 @@
 /datum/species/machine/spec_electrocute_act(mob/living/carbon/human/H, shock_damage, source, siemens_coeff, flags)
 	if(flags & SHOCK_ILLUSION)
 		return
-	H.adjustBrainLoss(shock_damage)
 	H.adjust_nutrition(shock_damage)
 
 /datum/species/machine/handle_mutations_and_radiation(mob/living/carbon/human/H)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Title.

## Why It's Good For The Game

While it existed as a drawback for how quickly IPCs can repair burn damage from shocks, such advantages are rendered rather moot by the multitude of ways non-IPCs can also recover from burns that are as quick to use (burn trauma kits), and as plentiful and as easily available as cable (uplift smooths, which can even be added to your loadout).

## Testing

Simple deletion of code with known function, no need for testing.

## Declaration

- [ ] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<img width="918" height="111" alt="image" src="https://github.com/user-attachments/assets/5eac974d-d905-4b83-aabb-eaf931db4e8f" />


## Changelog

:cl: Killfish
del: IPCs no longer take brain damage from shocks.
/:cl:
