### PR TITLE
Revenant Defile Tweaks

### DIFF
--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -260,7 +260,7 @@
 //Defile: Corrupts nearby stuff, unblesses floor tiles.
 /datum/spell/aoe/revenant/defile
 	name = "Defile"
-	desc = "Twists and corrupts the nearby area as well as dispelling holy auras on floors."
+	desc = "Twists and corrupts the nearby area as well as dispelling holy auras on floors. The presence of the living empowers the effects."
 	base_cooldown = 15 SECONDS
 	stun = 1 SECONDS
 	reveal = 4 SECONDS
@@ -280,7 +280,22 @@
 	for(var/turf/T in targets)
 		T.defile()
 		for(var/atom/A in T.contents)
+			if(istype(A, /obj/structure/window)) // we want to handle glass seperately
+				continue
 			A.defile()
+		for(var/mob/living/carbon/human/living in T.contents)
+			if(!living.mind || living.stat == DEAD) // shouldnt work on dead or mindless mobs
+				continue
+			var/obj/effect/warp_effect/supermatter/warp = new(T)
+			warp.pixel_x += 16
+			warp.pixel_y += 16
+			animate(warp, time = 0.9 SECONDS, transform = matrix().Scale(0.2,0.2))
+			for(var/obj/structure/window/W in range(2, living))
+				W.defile()
+			addtimer(CALLBACK(src, PROC_REF(delete_pulse), warp), 1 SECONDS)
+
+/datum/spell/aoe/revenant/defile/proc/delete_pulse(warp)
+	qdel(warp)
 
 //Malfunction: Makes bad stuff happen to robots and machines.
 /datum/spell/aoe/revenant/malfunction
@@ -524,6 +539,10 @@
 
 /obj/structure/closet/defile()
 	open()
+
+/obj/structure/morgue/defile()
+	if(!connected && prob(25))
+		toggle_tray()
 
 /turf/simulated/floor/defile()
 	..()

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -137,6 +137,12 @@
 				return
 
 /obj/structure/morgue/attack_hand(mob/user as mob)
+	toggle_tray()
+	add_fingerprint()
+	update_state()
+	return
+
+/obj/structure/morgue/proc/toggle_tray()
 	if(connected)
 		for(var/atom/movable/A in connected.loc)
 			if(!A.anchored)
@@ -148,10 +154,6 @@
 		playsound(loc, open_sound, 50, 1)
 		get_revivable(FALSE)
 		connect()
-
-	add_fingerprint(user)
-	update_state()
-	return
 
 /obj/structure/morgue/attack_ai(mob/user)
 	if(isrobot(user) && Adjacent(user)) //Robots can open/close it, but not the AI


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Revenant glassbreaks no longer are centered on the revenant. Instead, defile will cause crew within a nearby area to be the center of the glass breaks. The glass break range has been decreased from 4 to 3, however normal revenant defile range is unchanged. Additionally, adds a cosmetic effect around crew when defile is triggered for added feedback.

Additionally, defile can now open up bodybags and morgue trays at a 20% chance. 

## Why It's Good For The Game

Revenant's defile is far too opressive for a medium. For practically zero risk, the revenant can break every single window on station and make massive swaths of the station uninhabitable. Since this isnt targeting specific crew, all this is doing is annoying players by making many areas inaccessible, without generating bodies for the revenant. This also creates immense workloads on engineering with 50+ tiles of windows that require fixing, which can usually just be immediately re-broken unless they replace everything with walls. 

This change requires defile's glassbreak to be more targeted, and meant for targeting specific individuals rather than en-masse grief of the station (despite the common nickname "grief ghost"). 

## Images of changes

![dreamseeker_NhKy5M9W5D](https://github.com/user-attachments/assets/195398d7-9eee-4929-b84f-ae0d3697dda7)

## Testing

spawned in as a revenant, defiled a lot of people and tiles and opened up morgue trays.

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<img width="610" height="255" alt="image" src="https://github.com/user-attachments/assets/b508726f-7f5a-4749-905b-210f89410eb4" />

## Changelog

:cl:
tweak: Adjusted rev defile to only break glass around crew
tweak: Rev defile now opens morgue trays
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
