### PR TITLE
Fixes basic mob AI turning off after changing Z-level

### DIFF
--- a/code/datums/ai/ai_controller.dm
+++ b/code/datums/ai/ai_controller.dm
@@ -226,11 +226,7 @@ RESTRICT_TYPE(/datum/ai_controller)
 		SSai_controllers.ai_controllers_by_zlevel[old_turf.z] -= src
 	if(new_turf)
 		SSai_controllers.ai_controllers_by_zlevel[new_turf.z] += src
-		var/new_level_clients = length(SSmobs.clients_by_zlevel[new_turf.z])
-		if(new_level_clients)
-			set_ai_status(AI_STATUS_IDLE)
-		else
-			set_ai_status(AI_STATUS_OFF)
+		reset_ai_status()
 
 /// Abstract proc for initializing the pawn to the new controller
 /datum/ai_controller/proc/try_possess_pawn(atom/new_pawn)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Crossing a Z-level boundary or teleporting to a new z-level no longer causes basic mobs to get stuck on `AI_idle`

## Why It's Good For The Game

Mobs should still work when crossing z-levels

## Testing

Stuck a ton of carp in a locker. Crossed back and forth. Got attacked as expected.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed basic mob AI turning off when crossing Z-levels
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
