### PR TITLE
fix delta departures sand feature

### DIFF
--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -53019,7 +53019,7 @@
 "eGP" = (
 /obj/structure/flora/tree/palm,
 /obj/effect/overlay/coconut,
-/turf/simulated/floor/beach/away/sand,
+/turf/simulated/floor/desert_sand,
 /area/station/hallway/secondary/exit)
 "eHg" = (
 /obj/machinery/power/apc/directional/west,
@@ -53845,7 +53845,7 @@
 	pixel_x = -3;
 	pixel_y = 16
 	},
-/turf/simulated/floor/beach/away/sand,
+/turf/simulated/floor/desert_sand,
 /area/station/hallway/secondary/exit)
 "eXU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -62395,7 +62395,7 @@
 	pixel_x = -11;
 	pixel_y = -8
 	},
-/turf/simulated/floor/beach/away/sand,
+/turf/simulated/floor/desert_sand,
 /area/station/hallway/secondary/exit)
 "iQK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -63530,7 +63530,7 @@
 /turf/simulated/floor/plating,
 /area/station/command/bridge)
 "jrF" = (
-/turf/simulated/floor/beach/away/sand,
+/turf/simulated/floor/desert_sand,
 /area/station/hallway/secondary/exit)
 "jrI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -77571,7 +77571,7 @@
 /area/station/service/clown/secret)
 "pDt" = (
 /obj/item/beach_ball,
-/turf/simulated/floor/beach/away/sand,
+/turf/simulated/floor/desert_sand,
 /area/station/hallway/secondary/exit)
 "pDw" = (
 /obj/structure/disposalpipe/segment,
@@ -79097,7 +79097,7 @@
 /area/station/medical/virology)
 "qmJ" = (
 /obj/structure/flora/ausbushes/leafybush,
-/turf/simulated/floor/beach/away/sand,
+/turf/simulated/floor/desert_sand,
 /area/station/hallway/secondary/exit)
 "qmP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -81261,7 +81261,7 @@
 /area/station/hallway/primary/central/east)
 "rkH" = (
 /obj/item/camera,
-/turf/simulated/floor/beach/away/sand,
+/turf/simulated/floor/desert_sand,
 /area/station/hallway/secondary/exit)
 "rkJ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -93359,7 +93359,7 @@
 "wbL" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/item/stack/medical/ointment,
-/turf/simulated/floor/beach/away/sand,
+/turf/simulated/floor/desert_sand,
 /area/station/hallway/secondary/exit)
 "wbZ" = (
 /obj/machinery/atmospherics/portable/canister/carbon_dioxide,

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -48,6 +48,14 @@
 	barefootstep = FOOTSTEP_SAND
 	clawfootstep = FOOTSTEP_SAND
 
+/turf/simulated/floor/desert_sand
+	name = "sand"
+	icon = 'icons/misc/beach.dmi'
+	icon_state = "desert"
+	footstep = FOOTSTEP_SAND
+	barefootstep = FOOTSTEP_SAND
+	clawfootstep = FOOTSTEP_SAND
+
 /turf/simulated/floor/beach/pry_tile(obj/item/C, mob/user, silent = FALSE)
 	return
 


### PR DESCRIPTION
## What Does This PR Do
This PR replaces the sand in delta departures with a subtype that does not have a set atmos_mode.
## Why It's Good For The Game
Infinite air is bad.
## Testing
Visual inspection.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: The sand feature in Kerberos departures will no longer generate infinite atmos.
/:cl: