### PR TITLE
fix strippable actions not working

### DIFF
--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -467,7 +467,7 @@
 				strippable_item.finish_unequip(owner, user)
 		if("alt")
 			var/key = params["key"]
-			var/datum/strippable_item/strippable_item = strippable.items[key]
+			var/datum/strippable_item/strippable_item = unfiltered_items[key]
 
 			if(isnull(strippable_item))
 				return


### PR DESCRIPTION
## What Does This PR Do
This PR fixes alternate strippable actions not working.
## Why It's Good For The Game
Bugfix.
## Testing
<img width="983" height="511" alt="2025_07_31__11_46_41__Paradise Station 13" src="https://github.com/user-attachments/assets/ddc886c4-c0f9-4257-bf8a-b98e220066b0" />
<img width="583" height="493" alt="2025_07_31__11_46_49__Paradise Station 13" src="https://github.com/user-attachments/assets/f8dcb35c-4f69-4eb6-9d69-bcb7f2388ec6" />
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Alternate actions on the strip menu, like setting suit sensors and modifying internals, should work as expected.
/:cl: