### PR TITLE
Fixes Stamps and Safe Dial Rendering

### DIFF
--- a/code/modules/asset_cache/assets/asset_paper.dm
+++ b/code/modules/asset_cache/assets/asset_paper.dm
@@ -1,6 +1,7 @@
 /datum/asset/simple/paper
-	// TODO: revrite stamp code to not rely on hardcoded stamp url or make TGUI for paper
+	//TODO: Move paper to TGUI. Period.
 	keep_local_name = TRUE
+	legacy = TRUE
 	assets = list(
 		"large_stamp-clown.png" = 'icons/paper_icons/large_stamp-clown.png',
 		"large_stamp-deny.png"= 'icons/paper_icons/large_stamp-deny.png',

--- a/code/modules/asset_cache/assets/asset_safe.dm
+++ b/code/modules/asset_cache/assets/asset_safe.dm
@@ -1,5 +1,6 @@
 /datum/asset/simple/safe
 	keep_local_name = TRUE
+	legacy = TRUE
 	assets = list(
 		"safe_dial.png" = 'icons/ui_icons/safe_dial.png'
 	)


### PR DESCRIPTION
## What Does This PR Do
Enables the legacy flag on a few simple assets.
## Why It's Good For The Game
Fixes asset delivery (hopefully) for a few things like stamps and the safe.
## Testing
Testing via TM

EDIT: Changes have fixed the problem.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog

:cl:
fix: Fixed Stamps and safe dial so they appear in game again.
/:cl: