### PR TITLE
Does the changes to the scryer system I forgot to do

### DIFF
--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -92,8 +92,8 @@
 	var/current_disguise = FALSE
 	/// The MODlink datum, letting us call people from the suit.
 	var/datum/mod_link/mod_link
-	/// The starting MODlink frequency, overridden on subtypes that want it to be something.
-	var/starting_frequency = null
+	/// The starting MODlink frequency, by default NT to make it easier for everyone to use.
+	var/starting_frequency = MODLINK_FREQ_NANOTRASEN
 
 /obj/item/mod/control/serialize()
 	var/list/data = ..()

--- a/code/modules/mod/mod_link.dm
+++ b/code/modules/mod/mod_link.dm
@@ -139,7 +139,7 @@
 	/// The MODlink datum we operate.
 	var/datum/mod_link/mod_link
 	/// Initial frequency of the MODlink.
-	var/starting_frequency
+	var/starting_frequency = MODLINK_FREQ_NANOTRASEN
 	/// An additional name tag for the scryer, seen as "MODlink scryer - [label]"
 	var/label
 
@@ -240,7 +240,7 @@
 /obj/item/clothing/neck/link_scryer/process()
 	if(!mod_link.link_call)
 		return
-	cell.use(200)
+	cell.use(50)
 
 /obj/item/clothing/neck/link_scryer/attackby__legacy__attackchain(obj/item/O, mob/user, params)
 	. = ..()
@@ -327,9 +327,6 @@
 /obj/item/clothing/neck/link_scryer/proc/on_user_set_dir(atom/source, dir, newdir)
 	SIGNAL_HANDLER // COMSIG_ATOM_DIR_CHANGE
 	on_user_set_dir_generic(mod_link, newdir || SOUTH)
-
-/obj/item/clothing/neck/link_scryer/loaded
-	starting_frequency = MODLINK_FREQ_NANOTRASEN
 
 /obj/item/clothing/neck/link_scryer/loaded/Initialize(mapload)
 	. = ..()

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -1,5 +1,4 @@
 /obj/item/mod/control/pre_equipped
-	starting_frequency = MODLINK_FREQ_NANOTRASEN
 	/// The skin we apply to the suit, defaults to the default_skin of the theme.
 	var/applied_skin
 	/// The MOD core we apply to the suit.


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Constructed modsuits / printed mod scryers start linked. This makes them not require having to find someone with a modsuit to set them up, needlessly complicating the system.
The neck scryers use 1/4th the power now, going from 100 seconds to 400 seconds with the standard 10k battery.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
They are very inconvient to use on rounds without the trait, leading to them rarely getting setup.
Additionally during the trait, they run out of juice far too fast. This should help.

## Testing

<!-- How did you test the PR, if at all? -->
Built modsuit / modlink, linked.
I didn't test the power drain, but the math checks out. If 50 is not 1/4th of 200, we have an issue.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Modsuits and mod scryers that are built / printed start on the NT network.
tweak: Mod scryers had their power leak fixed, and now NT assures you they last 4 times as long as the previous models.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
