### PR TITLE
Fixes central atmospheric computer not opening air alarm panels for non-AI silicons unless they have direct line of sight of the air alarm

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -778,12 +778,17 @@ GLOBAL_LIST_INIT(aalarm_modes, list(
 	return thresholds
 
 /obj/machinery/alarm/ui_state(mob/user)
-	if(is_ai(user))
-		var/mob/living/silicon/ai/AI = user
-		if(!AI.lacks_power() || AI.apc_override)
-			return GLOB.always_state
+	if(issilicon(user))
+		if(is_ai(user))
+			var/mob/living/silicon/ai/AI = user
+			if(!AI.lacks_power() || AI.apc_override)
+				return GLOB.always_state
+		else
+			for(var/obj/machinery/computer/atmoscontrol/AC in view(user.client.maxview(), user))
+				if(!AC.stat)
+					return GLOB.always_state
 
-	else if(ishuman(user))
+	if(ishuman(user))
 		for(var/obj/machinery/computer/atmoscontrol/AC in range(1, user))
 			if(!AC.stat)
 				return GLOB.always_state


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #28283.
Fixes #25953.

Fixes an issue with the central atmospheric computer where any non-AI silicon that tried to open an air alarm from the interface would fail unless the air alarm was within their direct line of sight. This issue was introduced at some point during the TGUI updates of 2024 (TGUI 4 I think).

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bugs are bad.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Accessed an air alarm as a skrell. Walked away and the UI closed.
Accessed the central air computer as a skrell. Opened an air alarm remotely with it.

Accessed an air alarm as a cyborg. Walked away and the UI became inactive as soon as it was no longer in view.
Accessed the central air computer as a cyborg. Opened an air alarm remotely with it.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Cyborgs can use the central atmospherics computer to remotely control air alarms without needing to be able to see them, again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
