### PR TITLE
Adds Power Cells to the Protolathe's Stock Parts Menu

### DIFF
--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -11,7 +11,7 @@
 	materials = list(MAT_METAL = 700, MAT_GLASS = 50)
 	construction_time=100
 	build_path = /obj/item/stock_parts/cell/empty
-	category = list("Misc","Power","Stock Parts","Machinery","initial")
+	category = list("Misc", "Power", "Stock Parts", "Machinery", "initial")
 
 /datum/design/high_cell
 	name = "High-Capacity Power Cell"
@@ -22,7 +22,7 @@
 	materials = list(MAT_METAL = 700, MAT_GLASS = 60)
 	construction_time=100
 	build_path = /obj/item/stock_parts/cell/high/empty
-	category = list("Misc","Power","Stock Parts")
+	category = list("Misc", "Power", "Stock Parts")
 
 /datum/design/hyper_cell
 	name = "Hyper-Capacity Power Cell"
@@ -33,7 +33,7 @@
 	materials = list(MAT_METAL = 700, MAT_GOLD = 150, MAT_SILVER = 150, MAT_GLASS = 70)
 	construction_time=100
 	build_path = /obj/item/stock_parts/cell/hyper/empty
-	category = list("Misc","Power","Stock Parts")
+	category = list("Misc", "Power", "Stock Parts")
 
 /datum/design/super_cell
 	name = "Super-Capacity Power Cell"
@@ -44,7 +44,7 @@
 	materials = list(MAT_METAL = 700, MAT_GLASS = 70)
 	construction_time=100
 	build_path = /obj/item/stock_parts/cell/super/empty
-	category = list("Misc","Power","Stock Parts")
+	category = list("Misc", "Power", "Stock Parts")
 
 /datum/design/bluespace_cell
 	name = "Bluespace Power Cell"
@@ -55,7 +55,7 @@
 	materials = list(MAT_METAL = 800, MAT_GOLD = 120, MAT_GLASS = 160, MAT_DIAMOND = 160, MAT_TITANIUM = 300, MAT_BLUESPACE = 100)
 	construction_time=100
 	build_path = /obj/item/stock_parts/cell/bluespace/empty
-	category = list("Misc","Power","Stock Parts")
+	category = list("Misc", "Power", "Stock Parts")
 
 /datum/design/pacman
 	name = "Machine Board (PACMAN-type Generator)"

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -11,7 +11,7 @@
 	materials = list(MAT_METAL = 700, MAT_GLASS = 50)
 	construction_time=100
 	build_path = /obj/item/stock_parts/cell/empty
-	category = list("Misc","Power","Machinery","initial")
+	category = list("Misc","Power","Stock Parts","Machinery","initial")
 
 /datum/design/high_cell
 	name = "High-Capacity Power Cell"
@@ -22,7 +22,7 @@
 	materials = list(MAT_METAL = 700, MAT_GLASS = 60)
 	construction_time=100
 	build_path = /obj/item/stock_parts/cell/high/empty
-	category = list("Misc","Power")
+	category = list("Misc","Power","Stock Parts")
 
 /datum/design/hyper_cell
 	name = "Hyper-Capacity Power Cell"
@@ -33,7 +33,7 @@
 	materials = list(MAT_METAL = 700, MAT_GOLD = 150, MAT_SILVER = 150, MAT_GLASS = 70)
 	construction_time=100
 	build_path = /obj/item/stock_parts/cell/hyper/empty
-	category = list("Misc","Power")
+	category = list("Misc","Power","Stock Parts")
 
 /datum/design/super_cell
 	name = "Super-Capacity Power Cell"
@@ -44,7 +44,7 @@
 	materials = list(MAT_METAL = 700, MAT_GLASS = 70)
 	construction_time=100
 	build_path = /obj/item/stock_parts/cell/super/empty
-	category = list("Misc","Power")
+	category = list("Misc","Power","Stock Parts")
 
 /datum/design/bluespace_cell
 	name = "Bluespace Power Cell"
@@ -55,7 +55,7 @@
 	materials = list(MAT_METAL = 800, MAT_GOLD = 120, MAT_GLASS = 160, MAT_DIAMOND = 160, MAT_TITANIUM = 300, MAT_BLUESPACE = 100)
 	construction_time=100
 	build_path = /obj/item/stock_parts/cell/bluespace/empty
-	category = list("Misc","Power")
+	category = list("Misc","Power","Stock Parts")
 
 /datum/design/pacman
 	name = "Machine Board (PACMAN-type Generator)"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Power cells now appear in the protolathe's Stock Parts category.

They still appear under Power as well.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
A lot of scientists forget to print cells when filling their RPEDs for upgrade runs. Several machines use cells, including chem masters, borg chargers, and SMESs.

Even for those that know to print off cells, having them available under stock parts reduces the amount of menu navigation required to print off all the supplies they need for an upgrade run.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in. Maxed out research levels.
Checked power and stock parts menus in the protolathe.
Saw cells in both menus.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Power cells now appear under the stock parts menu of the protolathe in addition to the power menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
