### PR TITLE
Upgrades the AI Sat Transit Tubes

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -52469,10 +52469,7 @@
 	layer = 4;
 	pixel_y = 32
 	},
-/obj/structure/transit_tube_pod{
-	dir = 4
-	},
-/obj/structure/transit_tube/station/reverse/flipped{
+/obj/structure/transit_tube/station/dispenser/reverse/flipped{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -67233,11 +67230,8 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
 "nrh" = (
-/obj/structure/transit_tube_pod{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/structure/transit_tube/station/reverse,
+/obj/structure/transit_tube/station/dispenser/reverse,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/aisat/interior)
 "nrD" = (

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -25262,7 +25262,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/transit_tube/station/dispenser{
+/obj/structure/transit_tube/station/dispenser/flipped{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel/dark,

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -11160,9 +11160,6 @@
 /turf/simulated/floor/plasteel/goonplaque,
 /area/station/hallway/primary/fore/east)
 "aTl" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/structure/transit_tube/horizontal,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -24575,9 +24572,6 @@
 	},
 /area/station/engineering/control)
 "bRT" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/structure/table/reinforced,
 /obj/machinery/light/small{
 	dir = 1
@@ -25259,10 +25253,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat)
 "bTU" = (
-/obj/structure/transit_tube/station{
-	dir = 8
-	},
-/obj/structure/transit_tube_pod,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -25271,6 +25261,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/transit_tube/station/dispenser{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat)
@@ -25290,9 +25283,6 @@
 	},
 /area/station/hallway/primary/port/east)
 "bUc" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/ai_transit_tube)
@@ -26633,18 +26623,15 @@
 	},
 /area/station/security/storage)
 "bZf" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/space/nearstation)
+/obj/effect/spawner/window/reinforced/grilled,
+/turf/simulated/floor/plating,
+/area/station/engineering/ai_transit_tube)
 "bZj" = (
 /obj/structure/grille,
 /obj/effect/turf_decal/stripes/line,
@@ -56054,15 +56041,9 @@
 	},
 /area/station/public/fitness)
 "fRW" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/space,
-/area/space/nearstation)
+/obj/effect/spawner/window/reinforced/grilled,
+/turf/simulated/floor/plating,
+/area/station/engineering/ai_transit_tube)
 "fSk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -76844,6 +76825,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
+"pnY" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/transit_tube/curved{
+	dir = 4
+	},
+/turf/space,
+/area/space/nearstation)
 "pog" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80675,15 +80663,10 @@
 	},
 /area/station/medical/virology)
 "qYL" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/transit_tube/curved{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/space,
-/area/space/nearstation)
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/structure/transit_tube/horizontal,
+/turf/simulated/floor/plating,
+/area/station/engineering/ai_transit_tube)
 "qYT" = (
 /obj/machinery/light{
 	dir = 1
@@ -95234,13 +95217,10 @@
 	},
 /area/station/medical/chemistry)
 "wOE" = (
-/obj/structure/transit_tube_pod{
-	dir = 8
-	},
 /obj/machinery/ai_status_display{
 	pixel_y = -32
 	},
-/obj/structure/transit_tube/station/reverse/flipped,
+/obj/structure/transit_tube/station/dispenser/reverse/flipped,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
@@ -112796,7 +112776,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+tOF
 aaa
 kTj
 vuY
@@ -113053,8 +113033,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+tOF
+abj
 xqE
 giK
 xLV
@@ -113310,7 +113290,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+tOF
 aaa
 xqE
 abj
@@ -113319,7 +113299,7 @@ abj
 xMr
 abj
 aaa
-aaa
+tOF
 aaa
 aaa
 aaa
@@ -113567,7 +113547,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+sso
 aaa
 xqE
 abj
@@ -113576,7 +113556,7 @@ fIk
 xLV
 abj
 aaa
-aaa
+sso
 aaa
 aaa
 aaa
@@ -113824,16 +113804,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+sso
+abj
 bVf
 abj
 abj
 hFE
 abj
 abj
-aaa
-aaa
+abj
+tOF
 aaa
 aaa
 aaa
@@ -114081,7 +114061,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+tOF
 aaa
 xqE
 abj
@@ -114090,7 +114070,7 @@ nmF
 aaa
 abj
 aaa
-aaa
+tOF
 aaa
 aaa
 aaa
@@ -114338,7 +114318,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+tOF
 aaa
 xqE
 abj
@@ -114347,7 +114327,7 @@ nmF
 aaa
 abj
 aaa
-aaa
+tOF
 aaa
 aaa
 aaa
@@ -114595,16 +114575,16 @@ aaZ
 aaa
 aaa
 aaa
-aaa
-aaa
+tOF
+abj
 xqE
 abj
 abj
 hFE
 abj
 abj
-aaa
-aaa
+abj
+sso
 aaa
 aaa
 aaa
@@ -114852,7 +114832,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+sso
 aaa
 xqE
 abj
@@ -114861,7 +114841,7 @@ nmF
 aaa
 abj
 aaa
-aaa
+tOF
 aaa
 aaa
 aaa
@@ -115109,7 +115089,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+tOF
 aaa
 xqE
 abj
@@ -115118,7 +115098,7 @@ nmF
 aaa
 abj
 aaa
-aaa
+sso
 aaa
 aaa
 aaa
@@ -115366,16 +115346,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+tOF
+abj
 xqE
 abj
 abj
 hFE
 abj
 abj
-aaa
-aaa
+abj
+sso
 aaa
 aaa
 aaa
@@ -115623,7 +115603,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+sso
 aaa
 xqE
 abj
@@ -115632,7 +115612,7 @@ nmF
 aaa
 abj
 aaa
-aaa
+tOF
 aaa
 aaa
 aaa
@@ -115889,7 +115869,7 @@ nmF
 aaa
 abj
 aaa
-aaa
+tOF
 aaa
 aaa
 aaa
@@ -116145,8 +116125,8 @@ abj
 hFE
 abj
 abj
-aaa
-aaa
+abj
+tOF
 aaa
 aaa
 aaa
@@ -116403,7 +116383,7 @@ nmF
 aaa
 abj
 aaa
-aaa
+tOF
 aaa
 aaa
 aaa
@@ -116660,7 +116640,7 @@ nmF
 aaa
 abj
 aaa
-aaa
+tOF
 aaa
 aaa
 aaa
@@ -116916,8 +116896,8 @@ abj
 hFE
 abj
 abj
-aaa
-aaa
+abj
+sso
 aaa
 aaa
 aaa
@@ -117174,7 +117154,7 @@ nmF
 aaa
 abj
 aaa
-aaa
+sso
 aaa
 aaa
 aaa
@@ -119483,7 +119463,7 @@ dVS
 kmy
 abj
 fYS
-nmF
+giK
 abj
 bXU
 bZk
@@ -119740,8 +119720,8 @@ vcx
 qGf
 abj
 fYS
-giK
-abj
+acF
+pnY
 bXU
 bZl
 kxe
@@ -119995,7 +119975,7 @@ bwN
 bJZ
 bVt
 qGf
-abj
+qGf
 bZf
 fRW
 qYL

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -5369,11 +5369,8 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
 "beV" = (
-/obj/structure/transit_tube/station{
+/obj/structure/transit_tube/station/dispenser{
 	dir = 1
-	},
-/obj/structure/transit_tube_pod{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -10309,6 +10306,7 @@
 /obj/structure/transit_tube/curved{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "bZD" = (
@@ -12732,6 +12730,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/dorms/port)
+"czI" = (
+/obj/structure/transit_tube/curved/flipped{
+	dir = 1
+	},
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/space/nearstation)
 "czK" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -15197,6 +15202,13 @@
 "daJ" = (
 /turf/simulated/floor/carpet/grimey,
 /area/station/service/bar)
+"daM" = (
+/obj/structure/transit_tube/curved{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/space/nearstation)
 "daQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -24371,6 +24383,11 @@
 	icon_state = "green"
 	},
 /area/station/command/bridge)
+"eUr" = (
+/obj/structure/transit_tube/curved/flipped,
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/space/nearstation)
 "eUB" = (
 /obj/structure/table/wood,
 /obj/item/eftpos,
@@ -31040,12 +31057,6 @@
 	icon_state = "escape"
 	},
 /area/station/hallway/secondary/exit)
-"ghg" = (
-/obj/structure/transit_tube/curved/flipped{
-	dir = 1
-	},
-/turf/space,
-/area/space/nearstation)
 "ghi" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -43203,6 +43214,11 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/command/teleporter)
+"iDi" = (
+/obj/structure/transit_tube/curved,
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/space/nearstation)
 "iDm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -82451,10 +82467,8 @@
 /turf/simulated/floor/engine,
 /area/station/science/misc_lab)
 "quR" = (
-/obj/structure/lattice,
-/obj/structure/transit_tube/curved/flipped{
-	dir = 1
-	},
+/obj/structure/lattice/catwalk,
+/obj/structure/transit_tube,
 /turf/space,
 /area/space/nearstation)
 "qvk" = (
@@ -83646,6 +83660,7 @@
 /area/station/service/library)
 "qHs" = (
 /obj/structure/transit_tube/diagonal/topleft,
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "qHD" = (
@@ -89558,10 +89573,7 @@
 	},
 /area/station/medical/chemistry)
 "rOk" = (
-/obj/structure/transit_tube_pod{
-	dir = 4
-	},
-/obj/structure/transit_tube/station,
+/obj/structure/transit_tube/station/dispenser,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -94713,6 +94725,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
 "sPc" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/transit_tube/curved/flipped,
 /turf/space,
 /area/space/nearstation)
@@ -101379,6 +101392,7 @@
 /obj/structure/transit_tube/diagonal/topleft{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "ueb" = (
@@ -101737,6 +101751,11 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/control)
+"uid" = (
+/obj/structure/transit_tube,
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/space/nearstation)
 "uiH" = (
 /obj/structure/chair/sofa/corner{
 	dir = 1;
@@ -108647,8 +108666,8 @@
 /turf/simulated/floor/carpet,
 /area/station/public/mrchangs)
 "vDx" = (
-/obj/structure/lattice,
 /obj/structure/transit_tube/junction/flipped,
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "vDA" = (
@@ -111540,7 +111559,7 @@
 /obj/structure/transit_tube/junction/flipped{
 	dir = 1
 	},
-/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "wfQ" = (
@@ -121455,8 +121474,10 @@
 	},
 /area/station/security/prisonershuttle)
 "yip" = (
-/obj/structure/lattice,
-/obj/structure/transit_tube/diagonal/topleft,
+/obj/structure/lattice/catwalk,
+/obj/structure/transit_tube/curved{
+	dir = 8
+	},
 /turf/space,
 /area/space/nearstation)
 "yiq" = (
@@ -164690,17 +164711,17 @@ wDu
 jnP
 jnP
 jnP
-jnP
-jnP
-jnP
-jnP
-jnP
-jnP
-jnP
-jnP
-jnP
-jnP
-jnP
+wXf
+wXf
+wXf
+wXf
+wXf
+wXf
+wXf
+wXf
+wXf
+wXf
+wXf
 jnP
 jnP
 jnP
@@ -164948,15 +164969,15 @@ jnP
 jnP
 jnP
 jnP
+aZS
 jnP
 jnP
 jnP
+aZS
 jnP
 jnP
 jnP
-jnP
-jnP
-jnP
+aZS
 jnP
 jnP
 jnP
@@ -165972,15 +165993,15 @@ cQi
 egV
 riH
 xVI
-lju
-ghg
+uid
+czI
+tHM
 jnP
-wXf
+jnP
 jnP
 jnP
 jnP
 aZS
-jnP
 jnP
 jnP
 jnP
@@ -166229,15 +166250,15 @@ pYE
 flb
 oCC
 eJG
-jnP
-jnP
+aZS
+tHM
 qHs
+tHM
 aZS
-tEb
-jnP
-jnP
 aZS
-jnP
+aZS
+aZS
+aZS
 jnP
 jnP
 jnP
@@ -166488,15 +166509,15 @@ beV
 eJG
 aZS
 aZS
-aZS
+tHM
 vDx
-iWM
+uid
 quR
+czI
+tHM
 aZS
-aZS
-aZS
-aZS
-aZS
+jnP
+jnP
 jnP
 jnP
 aZS
@@ -166743,20 +166764,20 @@ cAE
 cbB
 uBd
 eJG
-jnP
-jnP
+aZS
+tHM
 udY
+tHM
 aZS
-tEb
-jnP
-yip
-jnP
-jnP
-jnP
 aZS
-wXf
+tHM
+daM
 aZS
-cLk
+aZS
+jnP
+jnP
+tHM
+iDi
 jLp
 qyt
 jkd
@@ -167000,20 +167021,20 @@ cAE
 odG
 ecq
 pgp
-lju
+uid
 bZs
+tHM
 jnP
-wXf
 jnP
 jnP
 aZS
 yip
+tHM
 aZS
-wXf
-wXf
 aZS
+tHM
 udY
-aZS
+tHM
 aoy
 ceu
 htN
@@ -167258,18 +167279,18 @@ cAE
 cAE
 cAE
 aZS
-aZS
-aZS
-aZS
-aZS
 jnP
 jnP
-aZS
+jnP
+jnP
+jnP
+jnP
+tHM
 sPc
-lju
-lju
+uid
+uid
 wfN
-jnP
+tHM
 aZS
 aoy
 rOk
@@ -167523,11 +167544,11 @@ aZS
 aZS
 aZS
 aZS
-wXf
-wXf
 aZS
+aZS
+tHM
 qHs
-aZS
+tHM
 aoy
 asn
 jCk
@@ -167782,9 +167803,9 @@ jnP
 aZS
 jnP
 jnP
-wXf
-aZS
-lLu
+jnP
+tHM
+eUr
 xxl
 hLb
 bEB
@@ -168292,12 +168313,12 @@ ewS
 nuJ
 aZS
 aZS
-aZS
-aZS
-aZS
-aZS
-aZS
-aZS
+wXf
+wXf
+wXf
+wXf
+wXf
+wXf
 aZS
 aZS
 aZS
@@ -168548,9 +168569,9 @@ lkR
 bNJ
 nuJ
 nuJ
-jnP
-jnP
 aZS
+jnP
+jnP
 jnP
 jnP
 jnP
@@ -168806,8 +168827,8 @@ sHN
 ugn
 nuJ
 aZS
-aZS
-aZS
+jnP
+jnP
 jnP
 jnP
 jnP

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -13682,11 +13682,10 @@
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "buN" = (
-/obj/structure/transit_tube_pod,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/transit_tube/station{
+/obj/structure/transit_tube/station/dispenser{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -50610,12 +50609,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft2)
 "jKS" = (
-/obj/structure/transit_tube/station/reverse/flipped{
-	dir = 1
-	},
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_y = 32
+	},
+/obj/structure/transit_tube/station/dispenser/reverse/flipped{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -13685,7 +13685,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/transit_tube/station/dispenser{
+/obj/structure/transit_tube/station/dispenser/flipped{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gives all the AI sat transit tubes tube dispenser stations.

Rearranges the grilles of the Emerald transit tube and slightly changes its shape.

Thickens the windows of the Delta minisat access area (and thereby removes an instance of 2 directional windows being on the same tile).

Adds some (battered) grilles to either side of the Delta transit tube.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Faster, much more responsive transit tubes that are less frustrating to use.

Double stacked windows on the same tile are bad.

Delta has a very long and exposed transit tube, so a little bit of extra protection is merited.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Box
<img width="480" height="96" alt="image" src="https://github.com/user-attachments/assets/81bac39b-60a3-41d2-a79f-59cb5ca318d7" />
Meta
<img width="992" height="96" alt="image" src="https://github.com/user-attachments/assets/88c1f01f-32f6-4e68-b1a6-6aff02eab7e0" />
Delta
<img width="1152" height="384" alt="image" src="https://github.com/user-attachments/assets/8e58c6cc-218f-4952-ae12-4cd68bb98fd5" />
Emerald
<img width="544" height="640" alt="image" src="https://github.com/user-attachments/assets/80f244a3-131b-43e8-9146-f22e03772e6b" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Visual inspection.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: The AI sat transit tubes now use tube dispenser stations for increased ease of use.
tweak: Delta Station transit tube slightly remapped.
tweak: Emerald Station transit tube slightly remapped.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
