### PR TITLE
Remaps the Space Around BoxStation Atmos

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -22563,10 +22563,6 @@
 	icon_state = "browncorner"
 	},
 /area/station/hallway/primary/central/west)
-"bzN" = (
-/obj/effect/spawner/airlock/w_to_e/long,
-/turf/simulated/wall/r_wall,
-/area/station/engineering/ai_transit_tube)
 "bzO" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
@@ -38995,7 +38991,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 10
 	},
-/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "cNF" = (
@@ -39663,10 +39659,10 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
 "cQp" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "cQq" = (
@@ -40971,8 +40967,8 @@
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
 "cUV" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/hidden/green{
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
 /turf/space,
@@ -41983,10 +41979,10 @@
 	},
 /area/station/engineering/atmos)
 "cZh" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "cZj" = (
@@ -42415,11 +42411,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "dba" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "dbb" = (
@@ -42901,11 +42897,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
 "dcS" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "dcT" = (
@@ -44193,7 +44189,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 6
 	},
-/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "diw" = (
@@ -44373,16 +44369,16 @@
 	},
 /area/station/turret_protected/aisat/interior)
 "diU" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "dja" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "djb" = (
@@ -44579,8 +44575,8 @@
 /turf/simulated/floor/carpet/grimey,
 /area/station/turret_protected/aisat/interior)
 "djE" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "djF" = (
@@ -45557,7 +45553,8 @@
 /obj/machinery/atmospherics/unary/outlet_injector/on{
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/space,
 /area/station/maintenance/aft)
 "dni" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -50936,10 +50933,10 @@
 	},
 /area/station/hallway/secondary/exit)
 "fmG" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "fmH" = (
@@ -52818,6 +52815,11 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/distribution)
+"ggX" = (
+/obj/effect/map_effect/dynamic_airlock,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage)
 "ggY" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -53902,7 +53904,8 @@
 /obj/machinery/atmospherics/unary/outlet_injector/on{
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/space,
 /area/station/turret_protected/aisat/interior)
 "gJD" = (
 /turf/simulated/floor/plasteel{
@@ -54079,7 +54082,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 9
 	},
-/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "gNX" = (
@@ -55044,6 +55047,12 @@
 	icon_state = "cafeteria"
 	},
 /area/station/service/kitchen)
+"hlk" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/map_effect/dynamic_airlock/door/exterior,
+/obj/machinery/access_button/offset/north,
+/turf/simulated/floor/plating/airless,
+/area/station/maintenance/storage)
 "hlm" = (
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
@@ -56265,10 +56274,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
-"hSD" = (
-/obj/structure/grille,
-/turf/simulated/wall,
-/area/space/nearstation)
 "hSU" = (
 /obj/structure/railing{
 	dir = 8
@@ -60433,6 +60438,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
+"jWk" = (
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "atmos";
+	name = "Atmos Blast Door"
+	},
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/distribution)
 "jWI" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance,
@@ -63421,6 +63438,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/meeting_room)
+"lsd" = (
+/obj/machinery/atmospherics/portable/canister/air,
+/obj/machinery/atmospherics/unary/portables_connector,
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage)
 "lsk" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
@@ -65059,6 +65081,15 @@
 	icon_state = "bar"
 	},
 /area/station/security/permabrig)
+"mgH" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/sign/vacuum/external{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage)
 "mgJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/vomit,
@@ -66272,6 +66303,11 @@
 	icon_state = "cafeteria"
 	},
 /area/station/science/break_room)
+"mMe" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/space,
+/area/space/nearstation)
 "mMk" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/fyellow{
@@ -68851,9 +68887,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/incinerator)
-"oej" = (
-/turf/space,
-/area/space/nearstation)
 "oem" = (
 /obj/machinery/computer/arcade/recruiter{
 	dir = 4
@@ -75630,10 +75663,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "rmn" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 10
 	},
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "rmH" = (
@@ -77345,6 +77378,11 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
+"sgT" = (
+/obj/structure/grille/broken,
+/obj/effect/mapping_helpers/turfs/damage,
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
 "shh" = (
 /obj/machinery/alarm/directional/north,
 /obj/machinery/economy/vending/janidrobe,
@@ -79389,10 +79427,12 @@
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "tkW" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/map_effect/dynamic_airlock/door/interior,
+/obj/machinery/door/airlock/external/glass,
+/obj/machinery/access_button/offset/northwest,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage)
 "tle" = (
@@ -80567,6 +80607,12 @@
 	icon_state = "white"
 	},
 /area/station/science/hallway)
+"tQm" = (
+/obj/effect/map_effect/dynamic_airlock,
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage)
 "tQB" = (
 /obj/effect/mapping_helpers/airlock/access/any/command/captain,
 /obj/machinery/door/firedoor,
@@ -80676,7 +80722,11 @@
 /turf/simulated/floor/plating,
 /area/station/science/xenobiology)
 "tSo" = (
-/turf/simulated/floor/plating/airless,
+/obj/effect/map_effect/dynamic_airlock,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/storage)
 "tSu" = (
 /obj/structure/table,
@@ -82770,10 +82820,6 @@
 	icon_state = "barber"
 	},
 /area/station/service/barber)
-"uZe" = (
-/obj/structure/grille/broken,
-/turf/simulated/wall,
-/area/space/nearstation)
 "uZi" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable,
@@ -83102,14 +83148,6 @@
 /obj/structure/chair,
 /turf/simulated/floor/wood,
 /area/station/maintenance/asmaint)
-"vhp" = (
-/obj/structure/sign/vacuum/external{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/portable/canister/air,
-/obj/machinery/atmospherics/unary/portables_connector,
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage)
 "vhH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -84944,11 +84982,11 @@
 	},
 /area/station/science/toxins/mixing)
 "wdL" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "wem" = (
@@ -85471,6 +85509,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
+"wrT" = (
+/obj/effect/map_effect/dynamic_airlock,
+/obj/machinery/airlock_controller/air_cycler/directional/north,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage)
 "wrU" = (
 /turf/simulated/wall,
 /area/station/supply/expedition)
@@ -87742,10 +87786,10 @@
 /turf/simulated/floor/grass,
 /area/station/hallway/secondary/exit)
 "xzG" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5
 	},
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "xAn" = (
@@ -121882,9 +121926,9 @@ dcq
 dcq
 dcq
 dcq
-vhp
-stm
-xyl
+ddr
+ddr
+mgH
 jae
 eLY
 dcq
@@ -122139,9 +122183,9 @@ cZS
 cZS
 cZS
 cZS
-dcq
-ddr
-bzN
+lsd
+stm
+dOc
 dOc
 dfQ
 dcq
@@ -122411,9 +122455,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aab
+aab
+aab
 aaa
 aaa
 aaa
@@ -122653,8 +122697,8 @@ mVr
 bbM
 dlv
 cZS
-dcq
-ddr
+ggX
+tQm
 dOc
 jhW
 dfT
@@ -122668,9 +122712,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+afX
+afX
+sgT
 aaa
 aaa
 aaa
@@ -122910,7 +122954,7 @@ qRU
 dkO
 dkO
 cZS
-dcq
+wrT
 tSo
 dOc
 obR
@@ -122925,9 +122969,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+afX
+dmD
+afX
 aaa
 aaa
 aaa
@@ -123167,8 +123211,8 @@ cZS
 cZS
 cZS
 cZS
-aab
-aaa
+dcq
+hlk
 dOc
 fXw
 pyD
@@ -123182,11 +123226,11 @@ aaa
 aaa
 aaa
 aaa
+afX
+dmD
+sgT
+aaa
 abp
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -123424,8 +123468,8 @@ oLk
 dkT
 dkT
 cZS
-aab
-aaa
+doE
+doE
 dOc
 hKO
 nAZ
@@ -123439,9 +123483,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+afX
+dmD
+afX
 aaa
 aaa
 aaa
@@ -123681,24 +123725,24 @@ khY
 bbO
 dlw
 cZS
-aab
+doE
 aaa
 aaa
 nOO
 aaa
+aaa
 aab
 aaa
 aaa
+mMe
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+afX
+dmD
+afX
 aaa
 aaa
 aaa
@@ -123938,24 +123982,24 @@ oCa
 dkT
 dkT
 cZS
-aab
-aab
-aab
+doE
+aaa
+aaa
 nOO
+aaa
+aaa
 aab
-aab
+aaa
+aaa
+afX
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+afX
+afX
+afX
 aaa
 aaa
 aaa
@@ -124195,24 +124239,24 @@ cZS
 cZS
 cZS
 cZS
+doE
 aaa
-aab
 aaa
 nOO
 aaa
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aab
 aaa
 aaa
+afX
 aaa
 aaa
 aaa
+aaa
+aaa
+aab
+aab
+aab
 aaa
 aaa
 aaa
@@ -124452,17 +124496,17 @@ tGy
 dkV
 dkV
 cZS
-aaa
-aab
-aaa
+doE
+doE
+doE
 nOO
-aaa
+doE
+doE
+doE
 aab
-aaa
-aaa
-aaa
-aaa
-aaa
+aab
+mMe
+aab
 aab
 dpd
 dpd
@@ -124471,7 +124515,7 @@ dpd
 dpd
 dpd
 aab
-aaa
+aab
 aab
 dqL
 aab
@@ -124709,14 +124753,14 @@ hrg
 bdG
 dlx
 cZS
-aaa
 aab
+aaa
 aaa
 nOO
-aaa
+doE
+doE
+doE
 aab
-aaa
-aaa
 iUc
 iUc
 iUc
@@ -124966,9 +125010,9 @@ khK
 dkV
 dkV
 cZS
+aab
 aaa
-aab
-aab
+aaa
 nOO
 dmB
 mUw
@@ -125200,7 +125244,7 @@ tyM
 eiE
 ggS
 lFP
-ggS
+jWk
 kwQ
 kYB
 xgY
@@ -125223,8 +125267,8 @@ cZS
 cZS
 cZS
 cZS
-aaa
 aab
+aaa
 aaa
 nOO
 wza
@@ -125454,13 +125498,13 @@ cKi
 cAv
 cxO
 cQp
-oej
+aab
 cQp
-oej
+aab
 cUV
-oej
+aab
 cQp
-oej
+aab
 cZh
 cNE
 dba
@@ -125475,14 +125519,14 @@ djE
 djE
 djE
 gNQ
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aab
-aaa
+aab
+aab
+aab
+aab
+aab
+aab
+aab
 nOO
 wza
 dnW
@@ -125728,17 +125772,17 @@ jYu
 nZP
 jYu
 cZS
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aab
 aaa
 aaa
 aab
+aaa
+aaa
+aab
+aaa
+aaa
+aab
+aaa
 vHd
 saB
 jmM
@@ -125985,17 +126029,17 @@ hWr
 pUX
 pxv
 cZS
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aab
 aaa
 aaa
 aab
+aaa
+aaa
+aab
+aaa
+aaa
+aab
+aaa
 wza
 xkm
 bfm
@@ -126242,16 +126286,16 @@ dem
 cRi
 dem
 cZS
+aab
 aaa
-hSD
-hSD
-hSD
-hSD
-hSD
-hSD
-hSD
-uZe
 aaa
+aab
+aaa
+aaa
+aab
+aaa
+aaa
+aab
 diu
 qgC
 nrh
@@ -126499,16 +126543,16 @@ dem
 deY
 dem
 cZS
+aab
+aaa
 aaa
 aab
 aaa
 aaa
-aaa
-aaa
+aab
 aaa
 aaa
 aab
-aaa
 cQp
 wza
 ocf
@@ -127021,9 +127065,9 @@ dgS
 dgS
 dgS
 dgS
-aaa
-aaa
 aab
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -127278,9 +127322,9 @@ dcV
 ddf
 ddn
 dgS
-aaa
-aaa
 aab
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -127535,9 +127579,9 @@ dcz
 giX
 ddo
 dgS
-dgT
-aaa
 aab
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -127793,7 +127837,7 @@ ddp
 tbr
 xTb
 dnd
-dgT
+aab
 aab
 aab
 aab
@@ -128314,10 +128358,10 @@ dgS
 dgS
 dnx
 doE
-aaa
-aaa
-aaa
-aaa
+aab
+aab
+aab
+aab
 aaa
 aaa
 aaa
@@ -128571,11 +128615,11 @@ dne
 qIz
 dnI
 doE
-aaa
-aaa
-aaa
-aaa
-aaa
+aab
+aab
+dmD
+dmD
+afX
 aaa
 aaa
 aaa
@@ -128828,11 +128872,11 @@ dgS
 dgS
 dnx
 doE
-aaa
-aaa
-aaa
-aaa
-aaa
+aab
+aab
+dmD
+afX
+afX
 aaa
 aaa
 aaa
@@ -129087,8 +129131,8 @@ doE
 doE
 aaa
 aaa
-aaa
-aaa
+afX
+afX
 aaa
 aaa
 aaa
@@ -129337,11 +129381,11 @@ dkP
 glM
 chf
 aab
-aaa
 aab
 aab
 aab
-aaa
+aab
+aab
 aaa
 aaa
 aaa
@@ -129595,7 +129639,7 @@ dlM
 chf
 chf
 aab
-aab
+aaa
 aaa
 aaa
 aaa
@@ -129851,7 +129895,7 @@ cep
 cep
 cep
 chf
-aaa
+aab
 aaa
 aaa
 aaa
@@ -130108,7 +130152,7 @@ cyJ
 cyJ
 cep
 klf
-aaa
+aab
 aaa
 aaa
 aaa
@@ -130622,11 +130666,11 @@ cep
 cYj
 csK
 klf
-aaa
-aaa
-aaa
-aaa
-aaa
+aab
+aab
+aab
+aab
+aab
 aaa
 aaa
 aaa
@@ -131654,7 +131698,7 @@ klf
 aab
 aab
 aab
-aaa
+aab
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes a meteor shield surrounded on all sides by walls.

Adds new meteor shielding off to the southern and south-eastern approaches to atmospherics that will actually prevent a flying space cow from instantly destroying the station's air supply.

Replaces all the lattices under atmospherics piping with catwalks.

Converts the atmos maint airlock to a dynamic airlock.

Adds some lattices to the newly opened up space.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Dynamic airlocks avoid needing to do weird hacky stuff with non-standard airlock shapes.

The meteor shield in the atmos cove was taking up space that could have been used to lay more pipe. It's now much more useful space for atmos projects.

The new meteor shields will actually do the job of the old one.

The area looks subjectively more aesthetic than before.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<img width="1120" height="1504" alt="image" src="https://github.com/user-attachments/assets/c166ba10-791d-44d2-9c8f-ff2e08952a07" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Visual inspection. Cycled the airlock.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Remapped the area around Cyberiad atmospherics space.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
