### PR TITLE
Fixes dead demon rendering when dying in a clown car

### DIFF
--- a/code/modules/mob/living/basic/basic_mob.dm
+++ b/code/modules/mob/living/basic/basic_mob.dm
@@ -285,6 +285,8 @@ RESTRICT_TYPE(/mob/living/basic)
 	if(HAS_TRAIT(src, TRAIT_XENOBIO_SPAWNED))
 		SSmobs.xenobiology_mobs--
 	if(basic_mob_flags & DEL_ON_DEATH)
+		if(istgvehicle(loc))
+			forceMove(get_turf(loc))
 		// From simplemob implementation; prevent infinite loops if the mob
 		// Destroy() is overridden in such a manner as to cause a call to
 		// death() again. One hopes this isn't still necessary but whatevs

--- a/code/modules/mob/living/basic/basic_mob.dm
+++ b/code/modules/mob/living/basic/basic_mob.dm
@@ -285,8 +285,8 @@ RESTRICT_TYPE(/mob/living/basic)
 	if(HAS_TRAIT(src, TRAIT_XENOBIO_SPAWNED))
 		SSmobs.xenobiology_mobs--
 	if(basic_mob_flags & DEL_ON_DEATH)
-		if(istgvehicle(loc))
-			forceMove(get_turf(loc))
+		// Moves them to their turf to prevent rendering problems
+		forceMove(get_turf(src))
 		// From simplemob implementation; prevent infinite loops if the mob
 		// Destroy() is overridden in such a manner as to cause a call to
 		// death() again. One hopes this isn't still necessary but whatevs

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -350,6 +350,8 @@
 	if(HAS_TRAIT(src, TRAIT_XENOBIO_SPAWNED))
 		SSmobs.xenobiology_mobs--
 	if(del_on_death)
+		if(istgvehicle(loc))
+			forceMove(get_turf(loc))
 		//Prevent infinite loops if the mob Destroy() is overridden in such
 		//a manner as to cause a call to death() again
 		del_on_death = FALSE

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -350,8 +350,8 @@
 	if(HAS_TRAIT(src, TRAIT_XENOBIO_SPAWNED))
 		SSmobs.xenobiology_mobs--
 	if(del_on_death)
-		if(istgvehicle(loc))
-			forceMove(get_turf(loc))
+		// Moves them to their turf to prevent rendering problems
+		forceMove(get_turf(src))
 		//Prevent infinite loops if the mob Destroy() is overridden in such
 		//a manner as to cause a call to death() again
 		del_on_death = FALSE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Shadow demons, slaughter demons, and any other basic or simple mob that deletes its corpse on death no longer breaks the client's rendering if they died while inside a clown car, vehicle, mech, or other object.

Fixes #29952

## Why It's Good For The Game

Bugs bad

## Testing

<!-- How did you test the PR, if at all? -->

Spawned as a shadow demon. Jumped into a clown car. Spawned lights. Burned to death. Did not have rendering break.

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed rendering breaking if a mob that deletes on death dies inside a TG vehicle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
