### PR TITLE
Adds a chance to stab yourself in the foot while trying to put a knife in your boot if you're clumsy

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -691,7 +691,7 @@
 
 			var/stabbed_foot = pick("l_foot", "r_foot")
 			user.visible_message("<span class='notice'>[user] tries to place [I] into [src] but stabs their own foot!</span>", \
-			"<span class='warning'>You goto put [I] into [src], but miss the boot and stab your own foot!</span>")
+			"<span class='warning'>You go to put [I] into [src], but miss the boot and stab your own foot!</span>")
 			user.apply_damage(I.force, BRUTE, stabbed_foot)
 			user.drop_item(I)
 			return


### PR DESCRIPTION
## What Does This PR Do
Adds a 45% chance to stab your own foot if you have the clumsy gene when trying to put a combat knife into combat boots

## Why It's Good For The Game
this unironically came to me in a dream, so its gotta be a good idea.

But actually, clumsy interactions is always funny, or annoying, kinda what the gene is meant for. Putting a knife into your boot while clumsy just makes sense that you could stab your foot


## Testing
gave myself clumsy and a knife, tried to put the knife into my boot a few times, failed a few times, didn't a few times
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
(probably shouldn't right?)

## Changelog

:cl:
tweak: You can stab yourself in the foot if you have clumsy gene when trying to put a knife into your boot
/:cl:
