### PR TITLE
Blob Split Population Requirement

### DIFF
--- a/code/_onclick/hud/blob_overmind.dm
+++ b/code/_onclick/hud/blob_overmind.dm
@@ -1,3 +1,5 @@
+#define BLOB_HIGHPOP_TRIGGER 60
+
 /atom/movable/screen/blob
 	icon = 'icons/mob/blob.dmi'
 
@@ -195,7 +197,9 @@
 	static_inventory += using
 
 	var/mob/camera/blob/B = user
-	if(!B.is_offspring) // Checks if the blob is an offspring, to not create split button if it is
+	if(!B.is_offspring && (length(GLOB.clients) > BLOB_HIGHPOP_TRIGGER)) // Checks if the blob is an offspring or below a population value, to not create split button if it is
 		using = new /atom/movable/screen/blob/split()
 		using.screen_loc = ui_acti
 		static_inventory += using
+
+#undef BLOB_HIGHPOP_TRIGGER


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Adds an extra check for blobs to be able to split, based on the current amount of connected players (similar to Tspider spawns). Currently this limit is only at 60.

## Why It's Good For The Game

Blobs need to have a bit of population-centered handicaps during lower population hours to assist with complete stomps. 

## Testing

Compiled, spawned a blob. 

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<img width="616" height="252" alt="image" src="https://github.com/user-attachments/assets/bfbcd118-2811-465c-a895-bd97d642f86b" />


## Changelog

:cl:
tweak: Blobs cannot split under 60 server population
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
