### PR TITLE
Makes it slightly more obvious when mechs are sabotaged

### DIFF
--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -181,6 +181,9 @@
 		mech.occupant_message("<span class='danger'>Coordination system calibration failure. Manual restart required.</span>")
 		SEND_SOUND(mech.occupant, sound('sound/machines/warning-buzzer.ogg'))
 
+	do_sparks(3, FALSE, mech.loc)
+	var/obj/effect/temp_visual/emp/sabotage_overlay = new(mech.loc)
+	sabotage_overlay.layer = ABOVE_ALL_MOB_LAYER
 	charges_left--
 	if(charges_left < 1)
 		qdel(src)


### PR DESCRIPTION


## What Does This PR Do

Mechs now spark and have a twinkle effect when they are sabotaged via the mecha console, making it a little more obvious that something went wrong. 

## Why It's Good For The Game

more feedback for actions is good for gamesense

## Testing

made some mechs. added beacons. Sabotaged it all

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Mechs now spark and twinkle when sabotaged
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
