### PR TITLE
Fixes double attack on malf secborg mobs

### DIFF
--- a/code/modules/awaymissions/mission_code/ruins/telecomns.dm
+++ b/code/modules/awaymissions/mission_code/ruins/telecomns.dm
@@ -350,11 +350,13 @@ GLOBAL_LIST_EMPTY(telecomms_trap_tank)
 	return ..()
 
 /mob/living/basic/hivebot/strong/malfborg/melee_attack(atom/target, list/modifiers, ignore_cooldown)
-	. = ..()
+	if(!early_melee_attack(target, modifiers, ignore_cooldown))
+		return FALSE
 	if(QDELETED(target))
-		return
+		return FALSE
 	face_atom(target)
 	baton.melee_attack_chain(src, target)
+	SEND_SIGNAL(src, COMSIG_HOSTILE_POST_ATTACKINGTARGET, target, TRUE)
 	return TRUE
 
 /mob/living/basic/hivebot/strong/malfborg/do_attack_animation(atom/A, visual_effect_icon, obj/item/used_item, no_effect)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Malf secborgs don't claw you while bashing you to death with a baton.

## Why It's Good For The Game

Bugs bad.

## Testing

https://github.com/user-attachments/assets/d545abf3-ed44-4939-b0e9-127d032d1443

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed malf borg mobs double attacking with their stun baton
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
