### PR TITLE
Adjsuts revenant possessed objects

### DIFF
--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -370,34 +370,7 @@
 /datum/spell/aoe/revenant/haunt_object/proc/make_spooky(obj/item/item_to_possess, mob/living/simple_animal/revenant/user)
 	new /obj/effect/temp_visual/revenant(get_turf(item_to_possess)) // Thematic spooky visuals
 	var/mob/living/basic/possessed_object/revenant/possessed_object = new(item_to_possess) // Begin haunting object
-	set_outline(possessed_object)
-	ADD_TRAIT(possessed_object, TRAIT_DODGE_ALL_OBJECTS, "Revenant")
-	addtimer(CALLBACK(src, PROC_REF(begin_poltergheist), possessed_object, user), 1 SECONDS, TIMER_UNIQUE) // Short warm-up for floaty ambience
 	addtimer(CALLBACK(possessed_object, TYPE_PROC_REF(/mob/living/basic/possessed_object, death)), 70 SECONDS, TIMER_UNIQUE) // De-haunt the object
-
-/// Gives it AI
-/datum/spell/aoe/revenant/haunt_object/proc/begin_poltergheist(mob/living/basic/possessed_object/possessed_object, mob/living/simple_animal/revenant/user)
-	possessed_object.ai_controller = new /datum/ai_controller/basic_controller/revenant(possessed_object)
-
-/datum/ai_controller/basic_controller/revenant
-	blackboard = list(
-		BB_TARGETING_STRATEGY = /datum/targeting_strategy/basic,
-	)
-
-	ai_movement = /datum/ai_movement/basic_avoidance
-	idle_behavior = null
-	planning_subtrees = list(
-		/datum/ai_planning_subtree/simple_find_target,
-		/datum/ai_planning_subtree/attack_obstacle_in_path,
-		/datum/ai_planning_subtree/swirl_around_target,
-		/datum/ai_planning_subtree/basic_melee_attack_subtree,
-	)
-
-/// Sets the glow on the haunted object, scales up based on throwforce
-/datum/spell/aoe/revenant/haunt_object/proc/set_outline(mob/living/basic/possessed_object/possessed_object)
-	possessed_object.remove_filter("haunt_glow")
-	var/outline_size = min((possessed_object.possessed_item.throwforce / 15) * 3, 3)
-	possessed_object.add_filter("haunt_glow", 2, list("type" = "outline", "color" = "#7A4FA9", "size" = outline_size)) // Give it spooky purple outline
 
 /// Stop all attack timers cast by the previous spell use
 /datum/spell/aoe/revenant/haunt_object/proc/stop_timers()

--- a/code/modules/mob/living/basic/posessed_object.dm
+++ b/code/modules/mob/living/basic/posessed_object.dm
@@ -191,8 +191,8 @@
 	return possessed_item.throw_impact(hit_atom, throwingdatum)
 
 /mob/living/basic/possessed_object/revenant
-	maxHealth = 100
-	health = 100
+	maxHealth = 69
+	health = 60
 	melee_attack_cooldown_min = 4 SECONDS
 	melee_attack_cooldown_max = 5 SECONDS
 	faction = list("revenant")
@@ -200,6 +200,7 @@
 	a_intent = INTENT_HARM
 	escape_chance = 100
 	revenant_possessed = TRUE
+	ai_controller = /datum/ai_controller/basic_controller/revenant
 
 /mob/living/basic/possessed_object/revenant/Initialize(mapload)
 	. = ..()
@@ -207,3 +208,24 @@
 	throwforce = min(possessed_item.throwforce + 5, 15) // Damage it should do? throwforce+5 or 15, whichever is lower
 	melee_damage_lower = min(possessed_item.throwforce + 5, 15)
 	melee_damage_upper = melee_damage_lower
+	var/outline_size = min((throwforce / 15) * 3, 3)
+	add_filter("haunt_glow", 2, list("type" = "outline", "color" = "#7A4FA9", "size" = outline_size)) // Give it spooky purple outline
+	ADD_TRAIT(src, TRAIT_DODGE_ALL_OBJECTS, "Revenant")
+	ai_controller.set_ai_status(AI_STATUS_OFF)
+	addtimer(CALLBACK(src, PROC_REF(begin_poltergheist)), 1 SECONDS, TIMER_UNIQUE) // Short warm-up for floaty ambience
+
+/mob/living/basic/possessed_object/revenant/proc/begin_poltergheist()
+	ai_controller.set_ai_status(AI_STATUS_ON)
+
+/datum/ai_controller/basic_controller/revenant
+	blackboard = list(
+		BB_TARGETING_STRATEGY = /datum/targeting_strategy/basic,
+	)
+	ai_movement = /datum/ai_movement/jps
+	idle_behavior = null
+	planning_subtrees = list(
+		/datum/ai_planning_subtree/simple_find_target,
+		/datum/ai_planning_subtree/attack_obstacle_in_path,
+		/datum/ai_planning_subtree/swirl_around_target,
+		/datum/ai_planning_subtree/basic_melee_attack_subtree,
+	)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Does the following:
- Reduces health of revenant objects by 40, from 100 to 60.
- Fixes issues with the glow
- Gives them JPS movement to fix them getting stuck
- Moves a lot of the mob prep to the mob itself

## Why It's Good For The Game

Bugs bad. Balance good.

## Testing

Possessed objects. Watched them beta up a monkey.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Gave possessed objects JPS movement and less health
fix: Possessed objects are less likely to have AI failures and their glow is better
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
