### PR TITLE
Converts lightgeists to basic mob AI

### DIFF
--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/targeting.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/targeting.dm
@@ -17,6 +17,8 @@ GLOBAL_LIST_INIT(target_interested_atoms, typecacheof(list(
 	var/vision_range = 11
 	/// Blackboard key for aggro range, uses vision range if not specified
 	var/aggro_range_key = BB_AGGRO_RANGE
+	/// Can we target allies?
+	var/targets_allies = FALSE
 
 /datum/ai_behavior/find_potential_targets/get_cooldown(datum/ai_controller/cooldown_for)
 	if(cooldown_for.blackboard[BB_FIND_TARGETS_FIELD(type)])
@@ -55,7 +57,7 @@ GLOBAL_LIST_INIT(target_interested_atoms, typecacheof(list(
 	var/list/filtered_targets = list()
 
 	for(var/atom/pot_target in potential_targets)
-		if(ismob(pot_target) && living_mob.faction_check_mob(pot_target))
+		if(ismob(pot_target) && living_mob.faction_check_mob(pot_target) && !targets_allies)
 			continue
 		if(targeting_strategy.can_attack(living_mob, pot_target))//Can we attack it?
 			filtered_targets += pot_target
@@ -170,3 +172,6 @@ GLOBAL_LIST_INIT(target_interested_atoms, typecacheof(list(
 
 /datum/ai_behavior/find_potential_targets/bigger_range
 	vision_range = 16
+
+/datum/ai_behavior/find_potential_targets/allies
+	targets_allies = TRUE

--- a/code/datums/ai/basic_mobs/basic_subtrees/simple_find_target.dm
+++ b/code/datums/ai/basic_mobs/basic_subtrees/simple_find_target.dm
@@ -17,3 +17,8 @@
 
 /datum/ai_planning_subtree/simple_find_target/to_flee
 	target_key = BB_BASIC_MOB_FLEE_TARGET
+
+/datum/ai_planning_subtree/simple_find_target/target_allies
+
+/datum/ai_planning_subtree/simple_find_target/target_allies/select_behaviors(datum/ai_controller/controller, seconds_per_tick)
+	controller.queue_behavior(/datum/ai_behavior/find_potential_targets/allies, target_key, BB_TARGETING_STRATEGY, BB_BASIC_MOB_CURRENT_TARGET_HIDING_LOCATION)

--- a/code/modules/mining/lavaland/loot/colossus_loot.dm
+++ b/code/modules/mining/lavaland/loot/colossus_loot.dm
@@ -209,7 +209,7 @@
 			if(user)
 				to_chat(user, "<span class='warning'>[src] is no longer usable!</span>")
 			return
-		var/mob/living/simple_animal/hostile/lightgeist/W = new /mob/living/simple_animal/hostile/lightgeist(get_turf(loc))
+		var/mob/living/basic/lightgeist/W = new /mob/living/basic/lightgeist(get_turf(loc))
 		W.key = user.key
 
 /obj/machinery/anomalous_crystal/helpers/Topic(href, href_list)
@@ -221,63 +221,6 @@
 /obj/machinery/anomalous_crystal/helpers/Destroy()
 	GLOB.poi_list -= src
 	return ..()
-
-/mob/living/simple_animal/hostile/lightgeist
-	name = "lightgeist"
-	desc = "This small floating creature is a completely unknown form of life... being near it fills you with a sense of tranquility."
-	icon_state = "lightgeist"
-	icon_living = "lightgeist"
-	icon_dead = "butterfly_dead"
-	response_help = "waves away"
-	response_disarm = "brushes aside"
-	response_harm = "disrupts"
-	speak_emote = list("warps")
-	maxHealth = 2
-	health = 2
-	harm_intent_damage = 1
-	friendly = "mends"
-	density = FALSE
-	initial_traits = list(TRAIT_FLYING)
-	obj_damage = 0
-	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
-	ventcrawler = VENTCRAWLER_ALWAYS
-	mob_size = MOB_SIZE_TINY
-	gold_core_spawnable = HOSTILE_SPAWN
-
-	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
-	luminosity = 4
-	faction = list("neutral")
-	del_on_death = TRUE
-	unsuitable_atmos_damage = 0
-	minbodytemp = 0
-	maxbodytemp = 1500
-	environment_smash = 0
-	AIStatus = AI_OFF
-	stop_automated_movement = TRUE
-	var/heal_power = 5
-
-/mob/living/simple_animal/hostile/lightgeist/Initialize(mapload)
-	. = ..()
-	remove_verb(src, /mob/living/verb/pulled)
-	remove_verb(src, /mob/verb/me_verb)
-	var/datum/atom_hud/med_hud = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
-	med_hud.add_hud_to(src)
-
-/mob/living/simple_animal/hostile/lightgeist/Destroy()
-	var/datum/atom_hud/med_hud = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
-	med_hud.remove_hud_from(src)
-	return ..()
-
-/mob/living/simple_animal/hostile/lightgeist/AttackingTarget()
-	. = ..()
-	if(isliving(target) && target != src)
-		var/mob/living/L = target
-		if(L.stat != DEAD)
-			L.heal_overall_damage(heal_power, heal_power)
-			new /obj/effect/temp_visual/heal(get_turf(target), "#80F5FF")
-
-/mob/living/simple_animal/hostile/lightgeist/ghost()
-	qdel(src)
 
 /// Allows you to bodyjack small animals, then exit them at your leisure, but you can only do this once per activation. Because they blow up. Also, if the bodyjacked animal dies, SO DO YOU.
 /obj/machinery/anomalous_crystal/possessor

--- a/code/modules/mob/living/basic/friendly/lightgeist.dm
+++ b/code/modules/mob/living/basic/friendly/lightgeist.dm
@@ -1,0 +1,86 @@
+/mob/living/basic/lightgeist
+	name = "lightgeist"
+	desc = "This small floating creature is a completely unknown form of life... being near it fills you with a sense of tranquility."
+	icon_state = "lightgeist"
+	icon_living = "lightgeist"
+	icon_dead = "butterfly_dead"
+	response_help_continuous = "waves away"
+	response_help_simple = "wave away"
+	response_disarm_continuous = "brushes aside"
+	response_disarm_simple = "brush aside"
+	response_harm_continuous = "disrupts"
+	response_harm_simple = "disrupt"
+	speak_emote = list("warps")
+	maxHealth = 2
+	health = 2
+	harm_intent_damage = 1
+	melee_attack_cooldown_min = 1.5 SECONDS
+	melee_attack_cooldown_max = 2.5 SECONDS
+	friendly_verb_continuous = "mends"
+	friendly_verb_simple = "mend"
+	density = FALSE
+	initial_traits = list(TRAIT_FLYING)
+	obj_damage = 0
+	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
+	ventcrawler = VENTCRAWLER_ALWAYS
+	mob_size = MOB_SIZE_TINY
+	gold_core_spawnable = HOSTILE_SPAWN
+	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
+	luminosity = 4
+	faction = list("neutral")
+	basic_mob_flags = DEL_ON_DEATH
+	unsuitable_atmos_damage = 0
+	minimum_survivable_temperature = 0
+	maximum_survivable_temperature = 1500
+	ai_controller = /datum/ai_controller/basic_controller/lightgeist
+	var/heal_power = 5
+
+/mob/living/basic/lightgeist/Initialize(mapload)
+	. = ..()
+	remove_verb(src, /mob/living/verb/pulled)
+	remove_verb(src, /mob/verb/me_verb)
+	var/datum/atom_hud/med_hud = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
+	med_hud.add_hud_to(src)
+
+/mob/living/basic/lightgeist/Destroy()
+	var/datum/atom_hud/med_hud = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
+	med_hud.remove_hud_from(src)
+	return ..()
+
+/mob/living/basic/lightgeist/melee_attack(atom/target, list/modifiers, ignore_cooldown)
+	. = ..()
+	if(isliving(target) && target != src)
+		faction |= ref(target) // Anyone we heal will treat us as a friend
+		var/mob/living/L = target
+		if(L.stat != DEAD)
+			L.heal_overall_damage(heal_power, heal_power)
+			new /obj/effect/temp_visual/heal(get_turf(target), "#80F5FF")
+
+/mob/living/basic/lightgeist/ghost()
+	qdel(src)
+
+/datum/ai_controller/basic_controller/lightgeist
+	blackboard = list(
+		BB_TARGETING_STRATEGY = /datum/targeting_strategy/lightgeist,
+	)
+
+	ai_traits = AI_FLAG_STOP_MOVING_WHEN_PULLED
+	ai_movement = /datum/ai_movement/basic_avoidance
+	idle_behavior = /datum/idle_behavior/idle_random_walk/less_walking
+
+	planning_subtrees = list(
+		/datum/ai_planning_subtree/simple_find_target/target_allies,
+		/datum/ai_planning_subtree/basic_melee_attack_subtree, // We heal things by attacking them
+	)
+
+/// Attack only mobs who have damage that we can heal, I think this is specific enough not to be a generic type
+/datum/targeting_strategy/lightgeist
+	/// Types of mobs we can heal, not in a blackboard key because there is no point changing this at runtime because the component will already exist
+	var/heal_biotypes = MOB_ORGANIC | MOB_MINERAL
+
+/datum/targeting_strategy/lightgeist/can_attack(mob/living/living_mob, mob/living/target, vision_range)
+	if(!isliving(target) || target.stat == DEAD)
+		return FALSE
+	if(!(heal_biotypes & target.mob_biotypes))
+		return FALSE
+	return target.getBruteLoss() > 0 || target.getFireLoss() > 0

--- a/paradise.dme
+++ b/paradise.dme
@@ -2415,6 +2415,7 @@
 #include "code\modules\mob\living\basic\friendly\bunny.dm"
 #include "code\modules\mob\living\basic\friendly\butterfly.dm"
 #include "code\modules\mob\living\basic\friendly\cockroach.dm"
+#include "code\modules\mob\living\basic\friendly\lightgeist.dm"
 #include "code\modules\mob\living\basic\friendly\lizard.dm"
 #include "code\modules\mob\living\basic\friendly\penguin.dm"
 #include "code\modules\mob\living\basic\friendly\sloth.dm"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Makes lightgheists basic mobs, and gives them a special controller that targets allies to heal them.

## Why It's Good For The Game

Basic AI is good.

## Testing

Approached lightgeist while injured. Was healed.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Converted lightgeists to basic mobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
