### PR TITLE
migrate duct tape to new attack chain

### DIFF
--- a/code/game/objects/items/tape.dm
+++ b/code/game/objects/items/tape.dm
@@ -7,14 +7,20 @@
 	w_class = WEIGHT_CLASS_TINY
 	amount = 25
 	max_amount = 25
+	new_attack_chain = TRUE
 
 /obj/item/stack/tape_roll/New(loc, amount=null)
 	..()
 	update_icon(UPDATE_ICON_STATE)
 
-/obj/item/stack/tape_roll/attack__legacy__attackchain(mob/living/carbon/human/M, mob/living/user)
-	if(!istype(M)) //What good is a duct tape mask if you are unable to speak?
+/obj/item/stack/tape_roll/interact_with_atom(atom/target, mob/living/user, list/modifiers)
+	if(isitem(target))
+		return ..()
+
+	. = ITEM_INTERACT_COMPLETE
+	if(!ishuman(target))
 		return
+	var/mob/living/carbon/human/M = target
 	if(M.wear_mask)
 		to_chat(user, "Remove [M.p_their()] mask first!")
 		return


### PR DESCRIPTION
## What Does This PR Do
Migrates duct tape to the new attack chain.
## Why It's Good For The Game
New attack chain good.
## Testing
Duct taped an item
Tried duct taping a non-human mob (no interaction)
Tried duct taping a human with a mask
Duct taped a human
Checked that duct tape has fingerprints added to it.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC