### PR TITLE
Wind no longer acts on mobs not on turf

### DIFF
--- a/code/datums/weather/weather_types/lavaland_weather.dm
+++ b/code/datums/weather/weather_types/lavaland_weather.dm
@@ -447,7 +447,7 @@
 		update_areas()
 	if(!istype(target)) // lets not push around lavaland mobs
 		return
-	if(!is_mecha_occupant(target)) // mecha's occupants are unaffected
+	if(!is_mecha_occupant(target) && isturf(target.loc)) // only affected if outside and not dead.
 		target.air_push(wind_dir, MOVE_FORCE_NORMAL * 2)
 
 #undef ROCKFALL_DELAY


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Prevents mobs inside things (like legions) from being pushed out of said thing.

## Why It's Good For The Game

bugfix good

## Testing

compiled, ran a storm

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: lavaland wind no longer pushes mobs inside things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
