### PR TITLE
Fixes a runtime for runechat messages

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -167,7 +167,7 @@
 
 	// Translate any existing messages upwards, apply exponential decay factors to timers
 	message_loc = target
-	if(owned_by.seen_messages)
+	if(owned_by?.seen_messages)
 		var/idx = 1
 		var/combined_height = approx_lines
 		for(var/datum/chatmessage/m as anything in owned_by.seen_messages[message_loc])


### PR DESCRIPTION
## What Does This PR Do
Adds a null conditional operator to prevent a runtime.
```
[2025-08-07T08:28:25] Runtime in code/datums/chatmessage.dm:170: Cannot read null.seen_messages
   proc name: finish image generation (/datum/chatmessage/proc/finish_image_generation)
   src: /datum/chatmessage (/datum/chatmessage)
   call stack:
   /datum/chatmessage (/datum/chatmessage): finish_image_generation
   /datum/callback (/datum/callback): Invoke
   Runechat (/datum/controller/subsystem/timer/runechat): fire
   Runechat (/datum/controller/subsystem/timer/runechat): ignite
   Master (/datum/controller/master): RunQueue
   Master (/datum/controller/master): Loop
   Master (/datum/controller/master): StartProcessing
```

## Why It's Good For The Game
Less runtime and function behavior good.
## Testing
Haven't tested it yet (will end up TMing).
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC
