### PR TITLE
Removes the Innate 33% Damage Reduction for All Non-IPC Prosthetics. 

### DIFF
--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -818,8 +818,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 	..()
 	//robot limbs take reduced damage
 	if(!make_tough)
-		brute_mod = 0.66
-		burn_mod = 0.66
 		dismember_at_max_damage = TRUE
 	else
 		tough = TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the .33 Brute/Burn mod reduction to all Non-IPC robotic prosthetics.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Currently, if you are not an IPC (say, a Skrell) with prosthetic limbs, you had a round-start 33% burn and brute armor on those limbs, compared to anIPC using the same robotic limbs, which had none. This is because all robot prosthetics had this code snippet applied to them.

> /obj/item/organ/external/robotize(company, make_tough = FALSE, convert_all = TRUE)
	..()
	//robot limbs take reduced damage
	if(!make_tough)
		brute_mod = 0.66
		burn_mod = 0.66
		dismember_at_max_damage = TRUE

I consider this to be a hold-over of the times when IPCs took double damage, long ago. Removing it brings IPCs and non-IPCs closer together, without buffing all IPCs with an incredible 33% limb armor. I know, I wanted it too, but I am a humble servant of Managed Dem- Balance.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
See below.
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Beat a Skrell with 1 Augmented Right Leg and 1 left-arm prosthetic, and an IPC.
Used a 10 damage toolbox.
Testing damage applied to limbs.
<img width="452" height="630" alt="image" src="https://github.com/user-attachments/assets/4e49b8d9-964c-46d1-90d1-0b5231b99ce6" />

Magdumping a Skrell with a pulse rifle to make sure the Augmented Leg stays on but the Prosthetic Arm does not.
<img width="693" height="377" alt="image" src="https://github.com/user-attachments/assets/e715b7a6-ebaf-4cda-957a-881d77dd312f" />

<!-- How did you test the PR, if at all? -->

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<img width="1080" height="326" alt="image" src="https://github.com/user-attachments/assets/63750b0d-fb13-4a3c-8023-a2ab7f0c8be6" />

  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Removed Non-IPC 33% Damage Mod for Prosthetics
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
