### PR TITLE
[FIX] Overlays no longer get stuck on botany trays and beakers

### DIFF
--- a/code/datums/components/action_item_overlay.dm
+++ b/code/datums/components/action_item_overlay.dm
@@ -71,9 +71,9 @@
 			return
 		current_button.cut_overlay(item_appearance)
 
-	var/mutable_appearance/muse_appearance = new(muse.appearance)
-	muse_appearance.plane = FLOAT_PLANE
-	muse_appearance.layer = FLOAT_LAYER
+	var/mutable_appearance/muse_appearance = mutable_appearance(muse.icon, muse.icon_state, FLOAT_LAYER, FLOAT_PLANE)
+	// muse_appearance.plane = FLOAT_PLANE
+	// muse_appearance.layer = FLOAT_LAYER
 	muse_appearance.pixel_x = 0
 	muse_appearance.pixel_y = 0
 

--- a/code/datums/components/action_item_overlay.dm
+++ b/code/datums/components/action_item_overlay.dm
@@ -72,8 +72,6 @@
 		current_button.cut_overlay(item_appearance)
 
 	var/mutable_appearance/muse_appearance = mutable_appearance(muse.icon, muse.icon_state, FLOAT_LAYER, FLOAT_PLANE)
-	// muse_appearance.plane = FLOAT_PLANE
-	// muse_appearance.layer = FLOAT_LAYER
 	muse_appearance.pixel_x = 0
 	muse_appearance.pixel_y = 0
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a bug that would cause overlays to get stuck .

Fixes: #29809 
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Overlays should work properly
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spam an action button while growing some plants
Remove the plants
Overlays all get removed properly.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Overlays no longer get stuck on botany trays and beakers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
