### PR TITLE
Fix !merge_upstream

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,9 @@
 ## Merge hooks, run tools/hooks/install.bat or install.sh to set up
 *.dmm text eol=lf merge=dmm
 *.dmi binary merge=dmi
+
+## WARNING: DEPRECATED
+## Uncomment then run "bash tgui/bin/tgui --install-git-hooks" to activate
 ## TGUI bundle merge drivers
-*.bundle.* binary merge=tgui-merge-bundle
-*.chunk.* binary merge=tgui-merge-bundle
+#*.bundle.* binary merge=tgui-merge-bundle
+#*.chunk.* binary merge=tgui-merge-bundle

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,5 +5,5 @@
 ## WARNING: DEPRECATED
 ## Uncomment then run "bash tgui/bin/tgui --install-git-hooks" to activate
 ## TGUI bundle merge drivers
-#*.bundle.* binary merge=tgui-merge-bundle
-#*.chunk.* binary merge=tgui-merge-bundle
+*.bundle.* binary # merge=tgui-merge-bundle
+*.chunk.* binary # merge=tgui-merge-bundle

--- a/.github/workflows/merge_upstream_master.yml
+++ b/.github/workflows/merge_upstream_master.yml
@@ -89,7 +89,6 @@ jobs:
           # Install Tools
           chmod +x tools/bootstrap/python
           bash tools/hooks/install.sh
-          bash tgui/bin/tgui --install-git-hooks
           chmod +x tools/hooks/*.merge tgui/bin/tgui
 
           # Actual Merge
@@ -109,17 +108,31 @@ jobs:
           fi
 
           git merge FETCH_HEAD
-          git push origin
+          exit_code=0
+          merge_conflicts=$(git diff --name-only --diff-filter=U --exit-code) || exit_code=$?
+          if [ "$exit_code" -eq 0 ] ; then
+            exit 0
+          else
+            if grep -v ^tgui/public/ <<< "$merge_conflicts" ; then
+              gh pr comment ${{ github.event.issue.html_url }} --body "GitHub Actions can not merge upstream into this branch as some conflicted files can not be resolved automatically."
+              exit 1
+            fi
+            if [[ -n "$(grep ^tgui/public/ <<< "$merge_conflicts")" ]] ; then
+              echo 'REBUILD_TGUI=true' >>> "$GITHUB_ENV"
+            fi
+          fi
 
       - name: Rebuild TGUI
+        if: ${{ env.REBUILD_TGUI }}
         run: |
-          if git diff-tree --name-only -r $(git rev-parse HEAD~2) | grep "tgui/public/" ; then
-            bash tgui/bin/tgui
-            git commit -m "Rebuild TGUI"
+          bash tgui/bin/tgui
+          git merge --continue
+
+      - name: Push Changes
+        run: |
+          if [[ -n "$(git rev-list -1 @{u}..)" ]]; then
             git push origin
           else
-            echo "No changes to rebuild TGUI"
-          fi
 
       - name: Notify Failure
         if: failure() && env.FAIL_NOTIFIED != 'true'

--- a/tgui/bin/tgui
+++ b/tgui/bin/tgui
@@ -114,6 +114,7 @@ task-validate-build() {
 
 ## Installs merge drivers and git hooks
 task-install-git-hooks() {
+  echo "tgui: WARNING: tgui bundle merge drivers are deprecated. Please modify .gitattributes to continue using them"
   cd "${base_dir}"
   local git_root
   local git_base_dir

--- a/tgui/bin/tgui_.ps1
+++ b/tgui/bin/tgui_.ps1
@@ -101,6 +101,7 @@ function task-validate-build {
 
 ## Installs merge drivers and git hooks
 function task-install-git-hooks () {
+  Write-Output "tgui: WARNING: tgui bundle merge drivers are deprecated. Please modify .gitattributes to continue using them"
   Set-Location $global:basedir
   git config --replace-all merge.tgui-merge-bundle.driver "tgui/bin/tgui --merge=bundle %P %A"
   Write-Output "tgui: Merge drivers have been successfully installed!"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Deprecates the tgui bundle merge driver. I dislike the merge driver for the following reasons,
  - The merge driver runs once for every single conflicted bundle file. For instance, if `tgui.bundle.css` and `tgui.bundle.js` are both conflicted, then two Yarn builds will be triggered by the merge driver. Two or more Yarn builds are excessive because just one Yarn build already rewrites all of the bundle files and resolves any conflicts. Locking the bundle files such that only one Yarn build is triggered even if multiple files are conflicted involves non-trivial code which I am not willing to implement
  - The merge driver runs asynchronously. Merge drivers should never run asynchronously. Merge drivers must resolve the conflicts before the merge commit is created, and running asynchronously means that the merge commit will be created and committed before the merge driver finishes
- Updated the `!merge_upstream` upstream command to build tgui directly instead of waiting on the merge driver, and hopefully fix the command
- Updated the `!merge_upstream` command to put pushing commits on its own step. Doing this allows the tgui build to run first, then continue the merging process and create only one merge commit that is pushed at the end of the workflow
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Decreases overhead when merging tgui PRs by removing the need to wait for the author to rebuild the tgui bundle
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I am unable to test this locally. However, this reuses some code that I've previously seen working, and it makes sense to the best of my knowledge
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
