### PR TITLE
fix give click intercept not cancelling attack

### DIFF
--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -84,6 +84,7 @@
 
 
 /datum/click_intercept/give/InterceptClickOn(mob/user, params, atom/object)
+	. = TRUE
 	if(user == object || !ishuman(object))
 		return
 	var/mob/living/carbon/human/receiver = object


### PR DESCRIPTION
## What Does This PR Do
Give actions click intercept will now return true, preventing the attack from happening.
## Why It's Good For The Game
Trying to give someone something currently also beats them.
## Testing
Tried giving an item to a mob, it didn't beat the mob.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Giving items will no longer beat people.
/:cl: