### PR TITLE
Xenos cant roll under 50 crew

### DIFF
--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -18,8 +18,8 @@
 	playercount = length(GLOB.clients)//grab playercount when event starts not when game starts
 	if(playercount >= highpop_trigger) //spawn with 4 if highpop
 		spawncount = 4
-	if(length(GLOB.crew_list) < 50) //manifest must have 50 crew to roll
-		//if xenos dont roll due to pop, try again to roll for a major in 60 seconds
+	if(length(GLOB.crew_list) < 50) // manifest must have 50 crew to roll
+		// if xenos dont roll due to pop, try again to roll for a major in 60 seconds
 		var/datum/event_container/EC = SSevents.event_containers[EVENT_LEVEL_MAJOR]
 		EC.next_event_time = world.time + 1 MINUTES
 		return

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -21,7 +21,7 @@
 	if(length(GLOB.crew_list) < 50) //manifest must have 50 crew to roll
 		//if xenos dont roll due to pop, try again to roll for a major in 60 seconds
 		var/datum/event_container/EC = SSevents.event_containers[EVENT_LEVEL_MAJOR]
-		EC.next_event_time = world.time + (60 * 10)
+		EC.next_event_time = world.time + 1 MINUTES
 		return
 	INVOKE_ASYNC(src, PROC_REF(spawn_xenos))
 

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -18,6 +18,11 @@
 	playercount = length(GLOB.clients)//grab playercount when event starts not when game starts
 	if(playercount >= highpop_trigger) //spawn with 4 if highpop
 		spawncount = 4
+	if(length(GLOB.crew_list) < 50) //manifest must have 50 crew to roll
+		//if xenos dont roll due to pop, try again to roll for a major in 60 seconds
+		var/datum/event_container/EC = SSevents.event_containers[EVENT_LEVEL_MAJOR]
+		EC.next_event_time = world.time + (60 * 10)
+		return
 	INVOKE_ASYNC(src, PROC_REF(spawn_xenos))
 
 /datum/event/alien_infestation/proc/spawn_xenos()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Title. Xenos will now re-roll the major if under 50 crew.

## Why It's Good For The Game

Xenos are far, far too strong for our current population levels. This also gives development somre more wiggle room in improving the antagonist.

## Testing

Compile, force alien infestation, confirm it re-rolls.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Alien infestation major midround will re-roll if under 50 people are on the manifest.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
