### PR TITLE
Makes holo firelocks acidproof

### DIFF
--- a/code/game/objects/structures/holosigns.dm
+++ b/code/game/objects/structures/holosigns.dm
@@ -81,6 +81,7 @@
 	alpha = 150
 	flags_2 = RAD_PROTECT_CONTENTS_2 | RAD_NO_CONTAMINATE_2
 	rad_insulation_beta = RAD_LIGHT_INSULATION
+	resistance_flags = UNACIDABLE | ACID_PROOF
 
 /obj/structure/holosign/barrier/atmos/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## What Does This PR Do
Makes the atmos holosigns acid proof, preventing them from being destroyed from things like acid grenades.
## Why It's Good For The Game
It keeps them true to their intent.
## Testing
I haven't yet
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog

:cl:
tweak: Tweaked the atmos holosign by making it acidproof.
/:cl: