### PR TITLE
Tweaks C-Foam to immobilization from paralyze

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -1410,7 +1410,7 @@
 	refresh_overlay()
 
 	if(foam_level == 5)
-		owner.Immobilize(4 SECONDS)
+		owner.Immobilize(5 SECONDS)
 
 /datum/status_effect/c_foamed/proc/refresh_overlay()
 	// Refresh overlay

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -1410,7 +1410,7 @@
 	refresh_overlay()
 
 	if(foam_level == 5)
-		owner.Paralyse(4 SECONDS)
+		owner.Immobilize(4 SECONDS)
 
 /datum/status_effect/c_foamed/proc/refresh_overlay()
 	// Refresh overlay


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Changes the C-foam launcher from a 4 second paralysis to a 5 second immobilization.

## Why It's Good For The Game

For 30 TC, the C-foam has the stunning power similar to a 60TC E-bow (made worse by the fact it sleeps instead of stuns), plus the added utility of a VERY long slowdown and the ability to block up doorways. This makes it a bit more of a niche of slowing anything its shot at without hardstunning people indefinitely. As-is, this item could (theoretically) keep a 4 man team of officers hard-stunned until you run out of ammo. 

## Testing

Shot some people with c-foam, wiggles about and shot some lasers while waiting to get free. 

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<img width="614" height="159" alt="image" src="https://github.com/user-attachments/assets/8b361051-1b01-4e68-9211-bf912304a92f" />

## Changelog

:cl:
tweak: converts c-foam hard stun into an immobilization
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
