### PR TITLE
Adds Label Decals to the Atmospherics Gas Tanks

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -15267,6 +15267,9 @@
 /obj/machinery/atmospherics/portable/canister/nitrogen{
 	anchored = 1
 	},
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "n2_sensor"
+	},
 /turf/simulated/floor/engine/n2,
 /area/station/engineering/atmos)
 "bbN" = (
@@ -15280,6 +15283,9 @@
 "bbO" = (
 /obj/machinery/atmospherics/portable/canister/oxygen{
 	anchored = 1
+	},
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "o2_sensor"
 	},
 /turf/simulated/floor/engine/o2,
 /area/station/engineering/atmos)
@@ -15904,6 +15910,10 @@
 "bdG" = (
 /obj/machinery/atmospherics/portable/canister/air{
 	anchored = 1
+	},
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "air_sensor";
+	output = 127
 	},
 /turf/simulated/floor/engine/air,
 /area/station/engineering/atmos)
@@ -37652,7 +37662,12 @@
 	},
 /area/station/command/office/ce)
 "cIf" = (
-/obj/machinery/atmospherics/portable/canister/sleeping_agent,
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "n2o_sensor"
+	},
+/obj/machinery/atmospherics/portable/canister/sleeping_agent{
+	anchored = 1
+	},
 /turf/simulated/floor/engine/n20,
 /area/station/engineering/atmos)
 "cIg" = (
@@ -38601,7 +38616,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
 "cLV" = (
-/obj/machinery/atmospherics/portable/canister/toxins,
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "tox_sensor"
+	},
+/obj/machinery/atmospherics/portable/canister/toxins{
+	anchored = 1
+	},
 /turf/simulated/floor/engine/plasma,
 /area/station/engineering/atmos)
 "cLW" = (
@@ -39933,7 +39953,12 @@
 	},
 /area/station/engineering/smes)
 "cRi" = (
-/obj/machinery/atmospherics/portable/canister/carbon_dioxide,
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "co2_sensor"
+	},
+/obj/machinery/atmospherics/portable/canister/carbon_dioxide{
+	anchored = 1
+	},
 /turf/simulated/floor/engine/co2,
 /area/station/engineering/atmos)
 "cRj" = (
@@ -55235,9 +55260,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "hrg" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "air_sensor";
-	output = 127
+/obj/effect/turf_decal/alphanumeric/air{
+	dir = 1
 	},
 /turf/simulated/floor/engine/air,
 /area/station/engineering/atmos)
@@ -58677,8 +58701,8 @@
 /turf/simulated/floor/carpet,
 /area/station/command/office/captain)
 "jeG" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "n2o_sensor"
+/obj/effect/turf_decal/alphanumeric/nitrous_oxide{
+	dir = 8
 	},
 /turf/simulated/floor/engine/n20,
 /area/station/engineering/atmos)
@@ -60819,8 +60843,8 @@
 /turf/simulated/floor/engine/n2,
 /area/station/engineering/atmos)
 "khY" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "o2_sensor"
+/obj/effect/turf_decal/alphanumeric/oxygen{
+	dir = 1
 	},
 /turf/simulated/floor/engine/o2,
 /area/station/engineering/atmos)
@@ -66616,8 +66640,8 @@
 	},
 /area/station/medical/sleeper)
 "mVr" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "n2_sensor"
+/obj/effect/turf_decal/alphanumeric/nitrogen{
+	dir = 1
 	},
 /turf/simulated/floor/engine/n2,
 /area/station/engineering/atmos)
@@ -72613,8 +72637,8 @@
 /turf/simulated/floor/carpet,
 /area/station/command/office/hop)
 "pUX" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "co2_sensor"
+/obj/effect/turf_decal/alphanumeric/carbon_dioxide{
+	dir = 8
 	},
 /turf/simulated/floor/engine/co2,
 /area/station/engineering/atmos)
@@ -76557,6 +76581,12 @@
 	icon_state = "darkred"
 	},
 /area/station/hallway/secondary/exit)
+"rLI" = (
+/obj/effect/turf_decal/alphanumeric/mix{
+	dir = 8
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engineering/atmos)
 "rLK" = (
 /obj/machinery/newscaster/directional/west,
 /obj/structure/sink/directional/east,
@@ -82976,8 +83006,8 @@
 /turf/simulated/wall,
 /area/station/maintenance/disposal)
 "vdD" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "tox_sensor"
+/obj/effect/turf_decal/alphanumeric/plasma{
+	dir = 8
 	},
 /turf/simulated/floor/engine/plasma,
 /area/station/engineering/atmos)
@@ -125970,7 +126000,7 @@ cxO
 cQp
 cZS
 olG
-pRS
+rLI
 ecy
 cZS
 gMP
@@ -126227,7 +126257,7 @@ cxO
 cQp
 cZS
 cSs
-cSw
+pRS
 cSw
 cZS
 cWZ

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -12097,6 +12097,9 @@
 /obj/machinery/atmospherics/portable/canister/nitrogen{
 	anchored = 1
 	},
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "n2_sensor"
+	},
 /turf/simulated/floor/engine/n2,
 /area/station/engineering/atmos)
 "bOl" = (
@@ -12818,11 +12821,14 @@
 /obj/machinery/atmospherics/portable/canister/oxygen{
 	anchored = 1
 	},
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "o2_sensor"
+	},
 /turf/simulated/floor/engine/o2,
 /area/station/engineering/atmos)
 "bSo" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "o2_sensor"
+/obj/effect/turf_decal/alphanumeric/oxygen{
+	dir = 4
 	},
 /turf/simulated/floor/engine/o2,
 /area/station/engineering/atmos)
@@ -13316,6 +13322,10 @@
 /obj/machinery/atmospherics/portable/canister/air{
 	anchored = 1
 	},
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "air_sensor";
+	output = 127
+	},
 /turf/simulated/floor/engine/air,
 /area/station/engineering/atmos)
 "bUT" = (
@@ -13779,8 +13789,8 @@
 /turf/simulated/floor/engine/co2,
 /area/station/engineering/atmos)
 "bWO" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "co2_sensor"
+/obj/effect/turf_decal/alphanumeric/carbon_dioxide{
+	dir = 1
 	},
 /turf/simulated/floor/engine/co2,
 /area/station/engineering/atmos)
@@ -13799,8 +13809,8 @@
 /turf/simulated/floor/engine/plasma,
 /area/station/engineering/atmos)
 "bWR" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "tox_sensor"
+/obj/effect/turf_decal/alphanumeric/plasma{
+	dir = 1
 	},
 /turf/simulated/floor/engine/plasma,
 /area/station/engineering/atmos)
@@ -13819,8 +13829,8 @@
 /turf/simulated/floor/engine/n20,
 /area/station/engineering/atmos)
 "bWU" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "n2o_sensor"
+/obj/effect/turf_decal/alphanumeric/nitrous_oxide{
+	dir = 1
 	},
 /turf/simulated/floor/engine/n20,
 /area/station/engineering/atmos)
@@ -13953,6 +13963,9 @@
 /obj/machinery/atmospherics/portable/canister/carbon_dioxide{
 	anchored = 1
 	},
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "co2_sensor"
+	},
 /turf/simulated/floor/engine/co2,
 /area/station/engineering/atmos)
 "bXx" = (
@@ -13962,6 +13975,9 @@
 /obj/machinery/atmospherics/portable/canister/toxins{
 	anchored = 1
 	},
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "tox_sensor"
+	},
 /turf/simulated/floor/engine/plasma,
 /area/station/engineering/atmos)
 "bXz" = (
@@ -13970,6 +13986,9 @@
 "bXA" = (
 /obj/machinery/atmospherics/portable/canister/sleeping_agent{
 	anchored = 1
+	},
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "n2o_sensor"
 	},
 /turf/simulated/floor/engine/n20,
 /area/station/engineering/atmos)
@@ -29763,8 +29782,8 @@
 	},
 /area/station/service/chapel/office)
 "eMF" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "n2_sensor"
+/obj/effect/turf_decal/alphanumeric/nitrogen{
+	dir = 4
 	},
 /turf/simulated/floor/engine/n2,
 /area/station/engineering/atmos)
@@ -36799,9 +36818,8 @@
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/port2)
 "gtA" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "air_sensor";
-	output = 127
+/obj/effect/turf_decal/alphanumeric/air{
+	dir = 4
 	},
 /turf/simulated/floor/engine/air,
 /area/station/engineering/atmos)
@@ -105308,6 +105326,12 @@
 /obj/effect/turf_decal/box,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/external/southeast)
+"vaB" = (
+/obj/effect/turf_decal/alphanumeric/mix{
+	dir = 1
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engineering/atmos)
 "vaC" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/table,
@@ -153262,8 +153286,8 @@ bUW
 anq
 bWc
 fuk
+vaB
 bWX
-bXB
 bYf
 bDR
 ilx

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -3090,6 +3090,12 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/maintenance/fore2)
+"arn" = (
+/obj/effect/turf_decal/alphanumeric/mix{
+	dir = 4
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engineering/atmos)
 "aro" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/maintenance,
@@ -11926,6 +11932,10 @@
 /obj/machinery/atmospherics/portable/canister/air{
 	anchored = 1
 	},
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "air_sensor";
+	output = 127
+	},
 /turf/simulated/floor/engine/air,
 /area/station/engineering/atmos)
 "aVU" = (
@@ -12685,6 +12695,9 @@
 "aYv" = (
 /obj/machinery/atmospherics/portable/canister/carbon_dioxide{
 	anchored = 1
+	},
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "co2_sensor"
 	},
 /turf/simulated/floor/engine/co2,
 /area/station/engineering/atmos)
@@ -13476,6 +13489,9 @@
 /obj/machinery/atmospherics/portable/canister/oxygen{
 	anchored = 1
 	},
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "o2_sensor"
+	},
 /turf/simulated/floor/engine/o2,
 /area/station/engineering/atmos)
 "bca" = (
@@ -13922,6 +13938,9 @@
 "beF" = (
 /obj/machinery/atmospherics/portable/canister/toxins{
 	anchored = 1
+	},
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "tox_sensor"
 	},
 /turf/simulated/floor/engine/plasma,
 /area/station/engineering/atmos)
@@ -14513,6 +14532,9 @@
 "bht" = (
 /obj/machinery/atmospherics/portable/canister/nitrogen{
 	anchored = 1
+	},
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "n2_sensor"
 	},
 /turf/simulated/floor/engine/n2,
 /area/station/engineering/atmos)
@@ -15387,6 +15409,9 @@
 "bkw" = (
 /obj/machinery/atmospherics/portable/canister/sleeping_agent{
 	anchored = 1
+	},
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "n2o_sensor"
 	},
 /turf/simulated/floor/engine/n20,
 /area/station/engineering/atmos)
@@ -64195,8 +64220,8 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
 "jKW" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "tox_sensor"
+/obj/effect/turf_decal/alphanumeric/plasma{
+	dir = 4
 	},
 /turf/simulated/floor/engine/plasma,
 /area/station/engineering/atmos)
@@ -70681,8 +70706,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "mIh" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "n2_sensor"
+/obj/effect/turf_decal/alphanumeric/nitrogen{
+	dir = 8
 	},
 /turf/simulated/floor/engine/n2,
 /area/station/engineering/atmos)
@@ -80623,8 +80648,8 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
 "qWZ" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "o2_sensor"
+/obj/effect/turf_decal/alphanumeric/oxygen{
+	dir = 8
 	},
 /turf/simulated/floor/engine/o2,
 /area/station/engineering/atmos)
@@ -91552,9 +91577,8 @@
 	},
 /area/station/engineering/atmos)
 "vom" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "air_sensor";
-	output = 127
+/obj/effect/turf_decal/alphanumeric/air{
+	dir = 8
 	},
 /turf/simulated/floor/engine/air,
 /area/station/engineering/atmos)
@@ -93132,8 +93156,8 @@
 /turf/simulated/floor/engine,
 /area/station/medical/chemistry)
 "vXf" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "n2o_sensor"
+/obj/effect/turf_decal/alphanumeric/nitrous_oxide{
+	dir = 4
 	},
 /turf/simulated/floor/engine/n20,
 /area/station/engineering/atmos)
@@ -93183,8 +93207,8 @@
 	},
 /area/station/engineering/gravitygenerator)
 "vYt" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "co2_sensor"
+/obj/effect/turf_decal/alphanumeric/carbon_dioxide{
+	dir = 4
 	},
 /turf/simulated/floor/engine/co2,
 /area/station/engineering/atmos)
@@ -117919,7 +117943,7 @@ bkw
 biK
 aOg
 bpw
-bpv
+jGV
 bpv
 aOg
 abj
@@ -118176,7 +118200,7 @@ vXf
 tnu
 aOg
 ibK
-jGV
+arn
 xBO
 aOg
 abj

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -7981,7 +7981,12 @@
 	},
 /area/station/medical/reception)
 "bDz" = (
-/obj/machinery/atmospherics/portable/canister/carbon_dioxide,
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "co2_sensor"
+	},
+/obj/machinery/atmospherics/portable/canister/carbon_dioxide{
+	anchored = 1
+	},
 /turf/simulated/floor/engine/co2,
 /area/station/engineering/atmos)
 "bDA" = (
@@ -10712,6 +10717,10 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel,
+/area/station/engineering/atmos)
+"cdH" = (
+/obj/effect/turf_decal/alphanumeric/mix,
+/turf/simulated/floor/engine/airless,
 /area/station/engineering/atmos)
 "cdM" = (
 /obj/structure/cable{
@@ -16885,6 +16894,9 @@
 "dss" = (
 /obj/machinery/atmospherics/portable/canister/nitrogen{
 	anchored = 1
+	},
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "n2_sensor"
 	},
 /turf/simulated/floor/engine/n2,
 /area/station/engineering/atmos)
@@ -24036,6 +24048,10 @@
 	icon_state = "cafeteria"
 	},
 /area/station/security/permabrig)
+"ePR" = (
+/obj/effect/turf_decal/alphanumeric/mix,
+/turf/simulated/floor/engine/airless/nodecay,
+/area/station/engineering/atmos/asteroid_filtering)
 "ePU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/circuitboard/thermomachine,
@@ -29474,7 +29490,12 @@
 	},
 /area/station/hallway/secondary/entry)
 "fPw" = (
-/obj/machinery/atmospherics/portable/canister/sleeping_agent,
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "n2o_sensor"
+	},
+/obj/machinery/atmospherics/portable/canister/sleeping_agent{
+	anchored = 1
+	},
 /turf/simulated/floor/engine/n20,
 /area/station/engineering/atmos)
 "fPx" = (
@@ -40446,9 +40467,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/tools/auxiliary)
 "ibf" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "n2o_sensor"
-	},
+/obj/effect/turf_decal/alphanumeric/nitrous_oxide,
 /turf/simulated/floor/engine/n20,
 /area/station/engineering/atmos)
 "ibh" = (
@@ -44888,6 +44907,10 @@
 /obj/machinery/atmospherics/portable/canister/air{
 	anchored = 1
 	},
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "air_sensor";
+	output = 127
+	},
 /turf/simulated/floor/engine/air,
 /area/station/engineering/atmos)
 "iTx" = (
@@ -47630,9 +47653,7 @@
 	},
 /area/station/medical/storage)
 "jwh" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "n2_sensor"
-	},
+/obj/effect/turf_decal/alphanumeric/nitrogen,
 /turf/simulated/floor/engine/n2,
 /area/station/engineering/atmos)
 "jwm" = (
@@ -51247,10 +51268,7 @@
 	},
 /area/station/medical/surgery/secondary)
 "kgz" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "air_sensor";
-	output = 127
-	},
+/obj/effect/turf_decal/alphanumeric/air,
 /turf/simulated/floor/engine/air,
 /area/station/engineering/atmos)
 "kgB" = (
@@ -98135,7 +98153,12 @@
 /turf/simulated/floor/wood,
 /area/station/public/fitness)
 "twp" = (
-/obj/machinery/atmospherics/portable/canister/toxins,
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "tox_sensor"
+	},
+/obj/machinery/atmospherics/portable/canister/toxins{
+	anchored = 1
+	},
 /turf/simulated/floor/engine/airless/nodecay,
 /area/station/engineering/atmos/asteroid_filtering)
 "twq" = (
@@ -103086,6 +103109,9 @@
 /obj/machinery/atmospherics/portable/canister/oxygen{
 	anchored = 1
 	},
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "o2_sensor"
+	},
 /turf/simulated/floor/engine/o2,
 /area/station/engineering/atmos)
 "uwZ" = (
@@ -105245,9 +105271,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
 "uSE" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "co2_sensor"
-	},
+/obj/effect/turf_decal/alphanumeric/carbon_dioxide,
 /turf/simulated/floor/engine/co2,
 /area/station/engineering/atmos)
 "uSH" = (
@@ -111874,9 +111898,7 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
 "wiU" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "tox_sensor"
-	},
+/obj/effect/turf_decal/alphanumeric/plasma,
 /turf/simulated/floor/engine/airless/nodecay,
 /area/station/engineering/atmos/asteroid_filtering)
 "wiW" = (
@@ -116195,9 +116217,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/abandonedservers)
 "xgu" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "o2_sensor"
-	},
+/obj/effect/turf_decal/alphanumeric/oxygen,
 /turf/simulated/floor/engine/o2,
 /area/station/engineering/atmos)
 "xgv" = (
@@ -134973,8 +134993,8 @@ jnP
 aZS
 mjs
 cyu
-rjt
 fbb
+ePR
 eGJ
 aZS
 wXG
@@ -139135,8 +139155,8 @@ jnP
 aZS
 cEY
 wKB
-pSq
 jNm
+cdH
 lkm
 iZC
 mrw

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -395,8 +395,8 @@
 	},
 /area/station/hallway/secondary/entry/west)
 "aeZ" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "n2_sensor"
+/obj/effect/turf_decal/alphanumeric/nitrogen{
+	dir = 1
 	},
 /turf/simulated/floor/engine/n2,
 /area/station/engineering/atmos)
@@ -18715,6 +18715,9 @@
 /obj/machinery/atmospherics/portable/canister/sleeping_agent{
 	anchored = 1
 	},
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "n2o_sensor"
+	},
 /turf/simulated/floor/engine/n20,
 /area/station/engineering/atmos)
 "bRl" = (
@@ -20011,6 +20014,9 @@
 /obj/machinery/atmospherics/portable/canister/toxins{
 	anchored = 1
 	},
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "tox_sensor"
+	},
 /turf/simulated/floor/engine/plasma,
 /area/station/engineering/atmos)
 "bXB" = (
@@ -20950,6 +20956,9 @@
 "cci" = (
 /obj/machinery/atmospherics/portable/canister/carbon_dioxide{
 	anchored = 1
+	},
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "co2_sensor"
 	},
 /turf/simulated/floor/engine/co2,
 /area/station/engineering/atmos)
@@ -24168,6 +24177,9 @@
 /obj/machinery/atmospherics/portable/canister/nitrogen{
 	anchored = 1
 	},
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "n2_sensor"
+	},
 /turf/simulated/floor/engine/n2,
 /area/station/engineering/atmos)
 "cqM" = (
@@ -24180,6 +24192,9 @@
 "cqO" = (
 /obj/machinery/atmospherics/portable/canister/oxygen{
 	anchored = 1
+	},
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "o2_sensor"
 	},
 /turf/simulated/floor/engine/o2,
 /area/station/engineering/atmos)
@@ -24199,6 +24214,10 @@
 "cqR" = (
 /obj/machinery/atmospherics/portable/canister/air{
 	anchored = 1
+	},
+/obj/machinery/atmospherics/air_sensor{
+	autolink_id = "air_sensor";
+	output = 127
 	},
 /turf/simulated/floor/engine/air,
 /area/station/engineering/atmos)
@@ -25972,8 +25991,8 @@
 	},
 /area/station/hallway/supply/aft)
 "czb" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "n2o_sensor"
+/obj/effect/turf_decal/alphanumeric/nitrous_oxide{
+	dir = 8
 	},
 /turf/simulated/floor/engine/n20,
 /area/station/engineering/atmos)
@@ -43923,8 +43942,8 @@
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "hnm" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "co2_sensor"
+/obj/effect/turf_decal/alphanumeric/carbon_dioxide{
+	dir = 8
 	},
 /turf/simulated/floor/engine/co2,
 /area/station/engineering/atmos)
@@ -52435,8 +52454,8 @@
 	},
 /area/station/engineering/break_room)
 "knx" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "tox_sensor"
+/obj/effect/turf_decal/alphanumeric/plasma{
+	dir = 8
 	},
 /turf/simulated/floor/engine/plasma,
 /area/station/engineering/atmos)
@@ -55060,8 +55079,8 @@
 /turf/simulated/floor/wood,
 /area/station/command/office/hop)
 "liL" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "o2_sensor"
+/obj/effect/turf_decal/alphanumeric/oxygen{
+	dir = 1
 	},
 /turf/simulated/floor/engine/o2,
 /area/station/engineering/atmos)
@@ -57750,9 +57769,8 @@
 /turf/simulated/floor/wood,
 /area/station/medical/psych)
 "mgZ" = (
-/obj/machinery/atmospherics/air_sensor{
-	autolink_id = "air_sensor";
-	output = 127
+/obj/effect/turf_decal/alphanumeric/air{
+	dir = 1
 	},
 /turf/simulated/floor/engine/air,
 /area/station/engineering/atmos)
@@ -86935,6 +86953,12 @@
 "wUa" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/engimaint)
+"wUc" = (
+/obj/effect/turf_decal/alphanumeric/mix{
+	dir = 8
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engineering/atmos)
 "wUe" = (
 /obj/structure/closet/crate,
 /turf/simulated/floor/plating,
@@ -136886,7 +136910,7 @@ pqT
 abq
 bCM
 sHu
-rLw
+wUc
 cAX
 bCM
 mkK
@@ -137143,7 +137167,7 @@ ffA
 abq
 bCM
 bIx
-bOO
+rLw
 bOO
 bCM
 bPE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds the gas labels to every atmos tank.
Moves the gas sensor into the middle of the chamber.
Anchors all the canisters (box, emerald).
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This is the exact purpose of these particular decals.

Having both the label and tank as supporting visual cues to the tanks' purposes will make it slightly faster to comprehend for new atmos techs.

Centrally located sensors will be more accurate.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Box
<img width="544" height="768" alt="image" src="https://github.com/user-attachments/assets/215aae47-1c1a-495d-bbc8-edb2d0f13973" />
Cere
<img width="736" height="512" alt="image" src="https://github.com/user-attachments/assets/6f0e57fc-c32c-4694-aa9f-419561bd7ac0" />
Delta
<img width="1024" height="544" alt="image" src="https://github.com/user-attachments/assets/c1a58091-a1c3-4d60-b8e7-5862335c9b5b" />
Emerald
<img width="1504" height="1728" alt="image" src="https://github.com/user-attachments/assets/f487c915-b175-4063-b345-7b5b6f017ad4" />
<img width="800" height="96" alt="image" src="https://github.com/user-attachments/assets/8df15c48-c7b0-4c53-8d49-d605800ef5b1" />
Meta
<img width="640" height="800" alt="image" src="https://github.com/user-attachments/assets/88469a7e-d889-4a4e-8325-2f8c3305fed3" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Visual inspection.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Added label decals to every atmos gas tank.
tweak: Anchored all atmos gas tank display tanks.
tweak: Moved the atmos gas tank into the centre of the tank.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
