### PR TITLE
fix next layer not getting set in collect_nested_mobs

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -151,7 +151,8 @@
 	for(var/depth in 1 to recursion_limit)
 		var/list/layer = next_layer
 		next_layer = list()
-		for(var/thing in layer)
+		for(var/atom/thing in layer)
+			next_layer += thing.contents
 			if(!ismob(thing))
 				continue
 			var/mob/this_mob = thing


### PR DESCRIPTION
## What Does This PR Do
Makes `collect_nested_mobs` set its next layer, so it s actually recursively going through things. Fixes #29957
## Why It's Good For The Game
Proc does what it should do. Holoparas can hear and see stuff when inside host.
## Images of changes

<img width="333" height="125" alt="Screenshot_20250809_222921" src="https://github.com/user-attachments/assets/26cbbae4-38f0-40bf-b34b-a4c3336c958b" />

## Testing
Tested each message type while inside the host and outside the host.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Holoparas can hear emotes, messages and actions inside hosts again.
/:cl: