### PR TITLE
fix extinguishers not going into backpack when safety is off

### DIFF
--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -89,7 +89,7 @@
 
 /obj/item/extinguisher/interact_with_atom(atom/target, mob/living/user, list/modifiers)
 	. = ..()
-	if(isstorage(target))
+	if(isstorage(target) || istype(target, /atom/movable/screen))
 		return
 
 	if(attempt_refill(target, user))

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -89,6 +89,9 @@
 
 /obj/item/extinguisher/interact_with_atom(atom/target, mob/living/user, list/modifiers)
 	. = ..()
+	if(isstorage(target))
+		return
+
 	if(attempt_refill(target, user))
 		return ITEM_INTERACT_COMPLETE
 


### PR DESCRIPTION
## What Does This PR Do
Lets extinguishers get stored when clicking a backpack with the safety off. Fixes #28457
## Why It's Good For The Game
Mechanical restrictions on storing unsafetied extinguishers weren't intended in the original PR.
## Testing
I put an active extinguisher inside a backpack.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Unsafetied extinguishers can be clicked into storage again.
/:cl: