### PR TITLE
Removed admins should stay removed.

### DIFF
--- a/SQL/updates/69-70.sql
+++ b/SQL/updates/69-70.sql
@@ -12,7 +12,10 @@ CREATE TABLE `admin_ranks` (
 
 # Create official ranks for every existing display rank, with the minimum common permissions.
 INSERT INTO admin_ranks (name, default_permissions)
-SELECT admin_rank, BIT_AND(flags) FROM admin GROUP BY admin_rank;
+SELECT admin_rank, BIT_AND(flags) FROM admin
+# Admins in the "Removed" rank don't actually exist according to the old code, so don't give them a rank. Not having a rank will also stop them from getting extra_permissions later.
+WHERE admin_rank != "Removed"
+GROUP BY admin_rank;
 
 # Add new columns to admin table.
 ALTER TABLE admin


### PR DESCRIPTION
## What Does This PR Do
Adjusts the 69-70 SQL update script to properly remove rank and permissions from "Removed" admins.

## Why It's Good For The Game
This was an oversight in the original script: the old code would assign a "Removed" rank to admins who should not have powers anymore, and ignore any permissions set for them. The proper way to do this now is to not give them a rank or permissions at all. The updated script does that.

This has no impact on us, as we've already applied the script and corrected the issue, but will hopefully avoid some headaches for downstream servers.

## Testing
[db_update_test_mk2.txt](https://github.com/user-attachments/files/21706329/db_update_test_mk2.txt)

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
NPFC