### PR TITLE
Xenobiology QOL tweaks

### DIFF
--- a/code/__HELPERS/trait_helpers.dm
+++ b/code/__HELPERS/trait_helpers.dm
@@ -316,6 +316,9 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 /// A surgical tool; If a surgical tool has this flag it can be used as an alternative to an open hand in surgery
 #define TRAIT_SURGICAL_OPEN_HAND "surgical_hand_alternative"
 
+/// Surgical tools with this trait have their prob_success set to 100 (but is still able to fail form other factors)
+#define TRAIT_SURGICAL_MAX_PROB	"surgical_max_prob"
+
 /// A wearable item that protects the covered areas from viral infection
 #define TRAIT_ANTI_VIRAL "anti_viral"
 

--- a/code/__HELPERS/trait_helpers.dm
+++ b/code/__HELPERS/trait_helpers.dm
@@ -317,7 +317,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_SURGICAL_OPEN_HAND "surgical_hand_alternative"
 
 /// Surgical tools with this trait have their prob_success set to 100 (but is still able to fail form other factors)
-#define TRAIT_SURGICAL_MAX_PROB	"surgical_max_prob"
+#define TRAIT_SURGICAL_CANNOT_FAIL	"surgical_cannot_fail"
 
 /// A wearable item that protects the covered areas from viral infection
 #define TRAIT_ANTI_VIRAL "anti_viral"

--- a/code/__HELPERS/trait_helpers.dm
+++ b/code/__HELPERS/trait_helpers.dm
@@ -316,7 +316,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 /// A surgical tool; If a surgical tool has this flag it can be used as an alternative to an open hand in surgery
 #define TRAIT_SURGICAL_OPEN_HAND "surgical_hand_alternative"
 
-/// Surgical tools with this trait have their prob_success set to 100 (but is still able to fail form other factors)
+/// Surgical tools with this trait have their prob_success set to 100 (but is still able to fail from other factors)
 #define TRAIT_SURGICAL_CANNOT_FAIL	"surgical_cannot_fail"
 
 /// A wearable item that protects the covered areas from viral infection

--- a/code/modules/mob/living/simple_animal/slime/slime_life.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime_life.dm
@@ -446,12 +446,12 @@
 				phrases += "What happened?"
 			if(!slimes_near)
 				phrases += "Lonely..."
-			if(stat == CONSCIOUS)
-				say (pick(phrases))
 			if(trained && prob(3))
 				phrases += "Treat? Have treat?"
 				phrases += "Can have treat?"
 				phrases += "Treat?..."
+			if(stat == CONSCIOUS)
+				say (pick(phrases))
 
 /mob/living/simple_animal/slime/proc/get_max_nutrition() // Can't go above it
 	if(is_adult)

--- a/code/modules/mob/living/simple_animal/slime/slime_life.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime_life.dm
@@ -448,6 +448,10 @@
 				phrases += "Lonely..."
 			if(stat == CONSCIOUS)
 				say (pick(phrases))
+			if(trained && prob(3))
+				phrases += "Treat? Have treat?"
+				phrases += "Can have treat?"
+				phrases += "Treat?..."
 
 /mob/living/simple_animal/slime/proc/get_max_nutrition() // Can't go above it
 	if(is_adult)

--- a/code/modules/mob/living/simple_animal/slime/slime_mob.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime_mob.dm
@@ -417,6 +417,7 @@
 		S.use(5)
 		if(Discipline)
 			trained = TRUE
+			name = "tamed [name]"
 		else
 			discipline_slime(user, positive_reinforcement = TRUE)
 		return ITEM_INTERACT_COMPLETE
@@ -431,7 +432,8 @@
 			Discipline = 0
 			return ITEM_INTERACT_COMPLETE
 		if(trained && prob(20)) // trained slimes are more resistant to losing discipline
-			trained = 0
+			trained = FALSE
+			name = initial(name)
 			visible_message("<span class='warning'>[src] gets spooked and cowers from [user]!</span>")
 
 /mob/living/simple_animal/slime/attacked_by(obj/item/I, mob/living/user)
@@ -455,6 +457,7 @@
 		if(trained && prob(75))
 			say("Ow! HEY!!!", pick(speak_emote))
 			trained = FALSE
+			name = initial(name)
 			rabid = TRUE
 	if(!client && Target && volume >= 3) // Like cats
 		Target = null

--- a/code/modules/research/xenobiology/xenobiology_dissections.dm
+++ b/code/modules/research/xenobiology/xenobiology_dissections.dm
@@ -26,6 +26,7 @@
 /obj/item/dissector/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_SURGICAL, ROUNDSTART_TRAIT)
+	ADD_TRAIT(src, TRAIT_SURGICAL_MAX_PROB, ROUNDSTART_TRAIT)
 	AddComponent(/datum/component/surgery_initiator)
 	RegisterSignal(src, COMSIG_BIT_ATTACH, PROC_REF(add_bit))
 	RegisterSignal(src, COMSIG_CLICK_ALT, PROC_REF(remove_bit))

--- a/code/modules/research/xenobiology/xenobiology_dissections.dm
+++ b/code/modules/research/xenobiology/xenobiology_dissections.dm
@@ -26,7 +26,7 @@
 /obj/item/dissector/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_SURGICAL, ROUNDSTART_TRAIT)
-	ADD_TRAIT(src, TRAIT_SURGICAL_MAX_PROB, ROUNDSTART_TRAIT)
+	ADD_TRAIT(src, TRAIT_SURGICAL_CANNOT_FAIL, ROUNDSTART_TRAIT)
 	AddComponent(/datum/component/surgery_initiator)
 	RegisterSignal(src, COMSIG_BIT_ATTACH, PROC_REF(add_bit))
 	RegisterSignal(src, COMSIG_CLICK_ALT, PROC_REF(remove_bit))

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -12,7 +12,6 @@
 	allowed_tools = list(
 		TOOL_SCALPEL = 100,
 		/obj/item/kitchen/knife = 90,
-		TOOL_DISSECTOR = 75,
 		/obj/item/kitchen/knife/shiv = 70,
 		/obj/item/shard = 60,
 		TOOL_WIRECUTTER = 35,

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -375,8 +375,7 @@
 		surgery.step_in_progress = FALSE
 		return SURGERY_INITIATE_INTERRUPTED
 
-	var/datum/surgery_step/step = surgery.get_surgery_step()
-	if(istype(step, /datum/surgery_step/generic/dissect) && tool.tool_behaviour == TOOL_DISSECTOR)
+	if(HAS_TRAIT(tool, TRAIT_SURGICAL_MAX_PROB))
 		prob_success = 100 // going to snowflake this in otherwise dissections fail repeatedtly with "proper" tools.
 
 	var/chem_check_result = chem_check(target)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -375,6 +375,10 @@
 		surgery.step_in_progress = FALSE
 		return SURGERY_INITIATE_INTERRUPTED
 
+	var/datum/surgery_step/step = surgery.get_surgery_step()
+	if(istype(step, /datum/surgery_step/generic/dissect) && tool.tool_behaviour == TOOL_DISSECTOR)
+		prob_success = 100 // going to snowflake this in otherwise dissections fail repeatedtly with "proper" tools.
+
 	var/chem_check_result = chem_check(target)
 	var/pain_mod = deal_pain(user, target, target_zone, tool, surgery)
 	prob_success *= pain_mod

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -375,7 +375,7 @@
 		surgery.step_in_progress = FALSE
 		return SURGERY_INITIATE_INTERRUPTED
 
-	if(HAS_TRAIT(tool, TRAIT_SURGICAL_MAX_PROB))
+	if(HAS_TRAIT(tool, TRAIT_SURGICAL_CANNOT_FAIL))
 		prob_success = 100 // going to snowflake this in otherwise dissections fail repeatedtly with "proper" tools.
 
 	var/chem_check_result = chem_check(target)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

This PR does a few small tweaks:

- Makes dissection managers not fail constantly when doing surgery, but quality is still tied to "failure rate" of tool used
- Due to this, dissector are no longer valid for use as a scalpel
- gives slimes a "Tamed" tag to their name when they are properly trained(for clarity)
- gives slimes some voice lines when they're tamed asking for treats

## Why It's Good For The Game

some small unintentional frustrations being removed

## Testing

tamed some slimes. dissected some goliaths

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Dissection managers do not fail constantly
tweak: Dissectors can no longer be used as a scalpel
tweak: Gave slimes a name tag and some voice lines when tamed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
