### PR TITLE
Dev perms no longer require 2FA

### DIFF
--- a/code/__DEFINES/admin_defines.dm
+++ b/code/__DEFINES/admin_defines.dm
@@ -47,6 +47,7 @@
 
 #define R_HOST			(~0) // Sum of all permissions to allow easy setting.
 
+#define ADMIN_PERMS_2FALESS (R_MENTOR|R_DEV_TEAM|R_VIEWRUNTIMES)
 
 #define ADMIN_QUE(user,display) "<a href='byond://?_src_=holder;adminmoreinfo=[user.UID()]'>[display]</a>"
 #define ADMIN_FLW(user,display) "<a href='byond://?_src_=holder;adminplayerobservefollow=[user.UID()]'>[display]</a>"

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -75,7 +75,7 @@ GLOBAL_PROTECT(href_token)
 	// Check for 2fa, if required.
 	if(needs_2fa() && istype(owner) && !owner.has_2fa())
 		// Disable most permissions.
-		rights = rights & (R_MENTOR | R_VIEWRUNTIMES)
+		rights = rights & ADMIN_PERMS_2FALESS
 		restricted_by_2fa = TRUE
 		if(!delay_2fa_complaint)
 			// And tell them about it.
@@ -105,7 +105,7 @@ GLOBAL_PROTECT(href_token)
 	GLOB.de_mentors -= ckey
 
 /datum/admins/proc/needs_2fa()
-	if((rights & (R_MENTOR | R_VIEWRUNTIMES)) == rights)
+	if((rights & ADMIN_PERMS_2FALESS) == rights)
 		// No significant permissions.
 		return FALSE
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Dev perms no longer require 2FA

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Currently, mentors do not need dev perms and they have much less permissions than devs. If we want to give this right more verbs, I'm perfectly fine with 2FA being upgraded for it. I don't think it should be a requirement until then (but we should encourage it). 

## Testing

<!-- How did you test the PR, if at all? -->
didn't
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
