### PR TITLE
Refactors large crates. Adds sound and makes them not-instant.

### DIFF
--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -38,7 +38,11 @@
 /obj/structure/largecrate/crowbar_act(mob/living/user, obj/item/I)
 	. = TRUE
 	if(!I.use_tool(src, user, 20, volume = I.tool_volume))
-		return
+		return TRUE
+	break_open()
+	user.visible_message("<span class='notice'>[user] pries [src] open.</span>", \
+						"<span class='notice'>You pry open [src].</span>", \
+						"<span class='notice'>You hear splitting wood.</span>")
 	if(manifest)
 		manifest.forceMove(loc)
 		manifest = null
@@ -48,10 +52,10 @@
 	for(var/O in contents)
 		var/atom/movable/A = O
 		A.forceMove(T)
-	user.visible_message("<span class='notice'>[user] pries [src] open.</span>", \
-						"<span class='notice'>You pry open [src].</span>", \
-						"<span class='notice'>You hear splitting wood.</span>")
 	qdel(src)
+
+/obj/structure/largecrate/proc/break_open()
+	return
 
 /obj/structure/largecrate/Destroy()
 	var/turf/src_turf = get_turf(src)
@@ -64,60 +68,42 @@
 /obj/structure/largecrate/lisa
 	icon_state = "lisacrate"
 
-/obj/structure/largecrate/lisa/crowbar_act(mob/living/user, obj/item/I)
-	if(!I.use_tool(src, user, I.tool_volume))
-		return
+/obj/structure/largecrate/lisa/break_open()
 	new /mob/living/simple_animal/pet/dog/corgi/lisa(loc)
-	return ..()
 
 /obj/structure/largecrate/cow
 	name = "cow crate"
 	icon_state = "lisacrate"
 
-/obj/structure/largecrate/cow/crowbar_act(mob/living/user, obj/item/I)
-	if(!I.use_tool(src, user, I.tool_volume))
-		return
+/obj/structure/largecrate/cow/break_open()
 	new /mob/living/basic/cow(loc)
-	return ..()
 
 /obj/structure/largecrate/goat
 	name = "goat crate"
 	icon_state = "lisacrate"
 
-/obj/structure/largecrate/goat/crowbar_act(mob/living/user, obj/item/I)
-	if(!I.use_tool(src, user, I.tool_volume))
-		return
+/obj/structure/largecrate/goat/break_open()
 	new /mob/living/simple_animal/hostile/retaliate/goat(loc)
-	return ..()
 
 /obj/structure/largecrate/chick
 	name = "chicken crate"
 	icon_state = "lisacrate"
 
-/obj/structure/largecrate/chick/crowbar_act(mob/living/user, obj/item/I)
-	if(!I.use_tool(src, user, I.tool_volume))
-		return
+/obj/structure/largecrate/chick/break_open()
 	var/num = rand(4, 6)
 	for(var/i in 1 to num)
 		new /mob/living/simple_animal/chick(loc)
-	return ..()
 
 /obj/structure/largecrate/cat
 	name = "cat crate"
 	icon_state = "lisacrate"
 
-/obj/structure/largecrate/cat/crowbar_act(mob/living/user, obj/item/I)
-	if(!I.use_tool(src, user, I.tool_volume))
-		return
+/obj/structure/largecrate/cat/break_open()
 	new /mob/living/simple_animal/pet/cat(loc)
-	return ..()
 
 /obj/structure/largecrate/secway
 	name = "secway crate"
 
-/obj/structure/largecrate/secway/crowbar_act(mob/living/user, obj/item/I)
-	if(!I.use_tool(src, user, I.tool_volume))
-		return
+/obj/structure/largecrate/secway/break_open()
 	new /obj/vehicle/secway(loc)
 	new /obj/item/key/security(loc)
-	return ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Refactors large crates. It will now make a sound consistently on breaking them open. It now takes 2 seconds instead of instantly.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->It makes the boxes more consistent with how other large wooden boxes are opened.

## Testing

<!-- How did you test the PR, if at all? -->
Broke open goat boxes and secway and chicken boxes. All of em worked.

## Declaration

- [ ] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Large wooden crates will make a sound when being broken open with a crowbar.
tweak: Large wooden crates now take 2 seconds to break open instead of being instant.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
