### PR TITLE
Semi-port jump emote from TG.

### DIFF
--- a/code/__DEFINES/emotes_defines.dm
+++ b/code/__DEFINES/emotes_defines.dm
@@ -76,7 +76,7 @@
 #define EMOTE_ACT_STOP_EXECUTION 1
 
 /// List of emotes useable by ghosties
-#define USABLE_DEAD_EMOTES list("*flip", "*spin")
+#define USABLE_DEAD_EMOTES list("*flip", "*spin", "*jump")
 
 // Strings used for the rock paper scissors emote and status effect
 #define RPS_EMOTE_ROCK 		"rock"

--- a/code/datums/keybindings/emote_keybinds.dm
+++ b/code/datums/keybindings/emote_keybinds.dm
@@ -17,6 +17,10 @@
 	linked_emote = /datum/emote/spin
 	name = "Spin"
 
+/datum/keybinding/emote/jump
+	linked_emote = /datum/emote/jump
+	name = "Jump"
+
 /datum/keybinding/emote/blush
 	linked_emote = /datum/emote/living/blush
 	name = "Blush"
@@ -40,10 +44,6 @@
 /datum/keybinding/emote/dance
 	linked_emote = /datum/emote/living/dance
 	name = "Dance"
-
-/datum/keybinding/emote/jump
-	linked_emote = /datum/emote/living/jump
-	name = "Jump"
 
 /datum/keybinding/emote/deathgasp
 	linked_emote = /datum/emote/living/deathgasp

--- a/code/modules/mob/living/living_emote.dm
+++ b/code/modules/mob/living/living_emote.dm
@@ -56,11 +56,6 @@
 	key_third_person = "dances"
 	message = "dances around happily."
 
-/datum/emote/living/jump
-	key = "jump"
-	key_third_person = "jumps"
-	message = "jumps!"
-
 /datum/emote/living/deathgasp
 	key = "deathgasp"
 	key_third_person = "deathgasps"

--- a/code/modules/mob/mob_emote.dm
+++ b/code/modules/mob/mob_emote.dm
@@ -200,3 +200,48 @@
 	if(istype(L))
 		L.Dizzy(24 SECONDS)
 		L.Confused(24 SECONDS)
+
+/datum/emote/jump
+	key = "jump"
+	key_third_person = "jumps"
+	message = "jumps!"
+	age_based = FALSE
+	emote_type = EMOTE_VISIBLE | EMOTE_FORCE_NO_RUNECHAT
+	mob_type_allowed_typecache = list(/mob/living, /mob/dead/observer)
+	mob_type_blacklist_typecache = list(/mob/living/brain, /mob/camera, /mob/living/silicon/ai)
+	mob_type_ignore_stat_typecache = list(/mob/dead/observer)
+	cooldown = 0.25 SECONDS // bhop until you're stamina-less if you want lmao
+	audio_cooldown = 0.25 SECONDS
+
+/datum/emote/jump/run_emote(mob/user, params, type_override, intentional)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	jump_animation(user)
+	if(isliving(user))
+		var/mob/living/L = user
+		L.adjustStaminaLoss(30)
+
+/datum/emote/jump/proc/jump_animation(mob/user)
+	var/original_transform = user.transform
+	animate(user, transform = user.transform.Translate(0, 8), time = 0.15 SECONDS, flags = ANIMATION_PARALLEL, easing = QUAD_EASING|EASE_OUT)
+	animate(transform = original_transform, time = 0.15 SECONDS, easing = QUAD_EASING|EASE_IN)
+
+/datum/emote/jump/get_sound(mob/user)
+	return 'sound/weapons/thudswoosh.ogg'
+
+// Avoids playing sounds if we're a ghost
+/datum/emote/jump/should_play_sound(mob/user, intentional)
+	if(isliving(user))
+		return ..()
+	return FALSE
+
+/datum/emote/jump/can_run_emote(mob/user, intentional)
+	if(user.buckled || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !isturf(user.loc))
+		return FALSE
+	if(isliving(user))
+		var/mob/living/L = user
+		if(IS_HORIZONTAL(L))
+			return FALSE
+	return ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->The jump emote will actually make you jump into the air.
Jumping will launch you 8 pixels into the air, before bringing you back down. It will do 30 stamina damage, but has a very low cooldown (b-hoppers beware). Ghosts can use this emote too.

You cannot jump while cuffed, stunned, buckled, or horizontal. You can also can only do it in turfs, so you can't jump inside a locker.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->More visual emotes is good! Like spin and flip.

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

https://github.com/user-attachments/assets/60742ba9-4f72-448f-95d9-c81fa49b6a4d



## Testing

<!-- How did you test the PR, if at all? -->
See above

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<img width="343" height="68" alt="image" src="https://github.com/user-attachments/assets/1cad59ee-55dc-4d4f-bd26-49837985220d" />

## Changelog

:cl:
tweak: The jump emote now actually makes you jump!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
