### PR TITLE
Add safeguards to `share_many_airs`

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -662,7 +662,7 @@ What are the archived variables for?
 	private_hotspot_volume = milla[MILLA_INDEX_HOTSPOT_VOLUME]
 	private_fuel_burnt = milla[MILLA_INDEX_FUEL_BURNT]
 
-/proc/share_many_airs(list/mixtures)
+/proc/share_many_airs(list/mixtures, atom/root)
 	var/total_volume = 0
 	var/total_oxygen = 0
 	var/total_nitrogen = 0
@@ -691,8 +691,11 @@ What are the archived variables for?
 		total_sleeping_agent += G.private_sleeping_agent
 		total_agent_b += G.private_agent_b
 
-	if(total_volume <= 0)
+	if(total_volume == 0)
 		return
+
+	if(total_volume < 0 || isnan(total_volume) || !isnum(total_volume) || total_oxygen < 0 || isnan(total_oxygen) || !isnum(total_oxygen) || total_nitrogen < 0 || isnan(total_nitrogen) || !isnum(total_nitrogen) || total_toxins < 0 || isnan(total_toxins) || !isnum(total_toxins) || total_carbon_dioxide < 0 || isnan(total_carbon_dioxide) || !isnum(total_carbon_dioxide) || total_sleeping_agent < 0 || isnan(total_sleeping_agent) || !isnum(total_sleeping_agent) || total_agent_b < 0 || isnan(total_agent_b) || !isnum(total_agent_b))
+		CRASH("A pipenet with [length(mixtures)] connected airs is corrupt and cannot flow safely. Pipenet root is [root] at ([root.x], [root.y], [root.z]).")
 
 	// If we don't have a significant temperature difference, check for a significant gas amount difference.
 	if(!must_share)
@@ -736,6 +739,9 @@ What are the archived variables for?
 	temperature = TCMB
 	if(total_heat_capacity > 0)
 		temperature = total_thermal_energy/total_heat_capacity
+
+	if(temperature <= 0 || isnan(temperature) || !isnum(temperature))
+		CRASH("A pipenet with [length(mixtures)] connected airs is corrupt and cannot flow safely. Pipenet root is [root] at ([root.x], [root.y], [root.z]).")
 
 	// Update individual gas_mixtures by volume ratio.
 	for(var/datum/gas_mixture/G in mixtures)

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -232,7 +232,11 @@
 			if(C.connected_device)
 				GL += C.portableConnectorReturnAir()
 
-	share_many_airs(GL)
+	if(length(members))
+		share_many_airs(GL, members[1])
+	else if(length(other_atmosmch))
+		share_many_airs(GL, other_atmosmch[1])
+	// If neither has anything, GL will have no volumen, so nothing to share.
 
 /datum/pipeline/proc/add_ventcrawler(mob/living/crawler)
 	if(!(crawler in crawlers))


### PR DESCRIPTION
## What Does This PR Do
Adds a bunch of checks to `share_many_airs` to prevent it from corrupting all of the connected airs if anything connected is corrupted.

## Why It's Good For The Game
While this won't completely fix the NaN temperature/pressure we're seeing in pipes, it will at least make it easier to find the source, and also easier to fix if it does happen.

## Images of changes
<img width="642" height="62" alt="image" src="https://github.com/user-attachments/assets/e1b925b4-0a81-40de-a39b-11e5c58743ea" />

## Testing
Ran an SM with default pipes. Intentionally broke one of the gas mixtures. Got useful error message.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
fix: Made it easier to diagnose and fix a pipenet that's somehow gotten corrupted.
/:cl: