### PR TITLE
Adds a few mindflayer related items to the cryopod storage blacklist

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -243,7 +243,10 @@
 	// These items will NOT be preserved
 	var/list/do_not_preserve_items = list (
 		/obj/item/mmi/robotic_brain,
-		/obj/item/card/id/captains_spare/assigned
+		/obj/item/card/id/captains_spare/assigned,
+		/obj/item/gun/energy/laser/mounted,
+		/obj/item/gun/energy/gun/advtaser/mounted,
+		/obj/item/gun/magic/grapple,
 	)
 
 /obj/machinery/cryopod/right


### PR DESCRIPTION
## What Does This PR Do
Adds the grapple arm, intergrated laser(and advanced), and the shrapnel cannon to the cryopod item blacklist

## Why It's Good For The Game
These items are implants/not meant to exist outside of the body, so shouldn't be preserved.
fixes #30088

## Testing
cryoed with the items out, saw none entered the storage

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog

:cl:
fix: Fixed a few mindflayer related items being put into cryo storage 
/:cl: