### PR TITLE
Fixes nullspace inventory issue

### DIFF
--- a/code/game/objects/items/storage/storage_base.dm
+++ b/code/game/objects/items/storage/storage_base.dm
@@ -169,11 +169,11 @@
 		return
 	if(!M.restrained() && !M.stat)
 		switch(over_object.name)
-			if("r_hand")
+			if("r_hand" && M.has_right_hand)
 				if(!M.unequip(src))
 					return
 				M.put_in_r_hand(src)
-			if("l_hand")
+			if("l_hand" && M.has_left_hand)
 				if(!M.unequip(src))
 					return
 				M.put_in_l_hand(src)

--- a/code/game/objects/items/storage/storage_base.dm
+++ b/code/game/objects/items/storage/storage_base.dm
@@ -170,11 +170,11 @@
 	if(!M.restrained() && !M.stat)
 		switch(over_object.name)
 			if("r_hand")
-				if(!M.can_use_hand("r_hand") || !M.unequip(src))
+				if(!M.has_right_hand() || !M.unequip(src))
 					return
 				M.put_in_r_hand(src)
 			if("l_hand")
-				if(!M.can_use_hand("l_hand") || !M.unequip(src))
+				if(!M.has_left_hand() || !M.unequip(src))
 					return
 				M.put_in_l_hand(src)
 		add_fingerprint(usr)

--- a/code/game/objects/items/storage/storage_base.dm
+++ b/code/game/objects/items/storage/storage_base.dm
@@ -169,12 +169,12 @@
 		return
 	if(!M.restrained() && !M.stat)
 		switch(over_object.name)
-			if("r_hand" && M.has_right_hand)
-				if(!M.unequip(src))
+			if("r_hand")
+				if(!M.can_use_hand("r_hand") || !M.unequip(src))
 					return
 				M.put_in_r_hand(src)
-			if("l_hand" && M.has_left_hand)
-				if(!M.unequip(src))
+			if("l_hand")
+				if(!M.can_use_hand("l_hand") || !M.unequip(src))
 					return
 				M.put_in_l_hand(src)
 		add_fingerprint(usr)

--- a/code/modules/mob/inventory_procs.dm
+++ b/code/modules/mob/inventory_procs.dm
@@ -23,6 +23,13 @@
 	if(I)
 		I.equip_to_best_slot(src)
 
+/mob/proc/can_use_hand(hand_name)
+	if(hand_name == "r_hand")
+		return has_right_hand()
+	if(hand_name == "l_hand")
+		return has_left_hand()
+	return FALSE
+
 /mob/proc/is_in_active_hand(obj/item/I)
 	var/obj/item/item_to_test = get_active_hand()
 

--- a/code/modules/mob/inventory_procs.dm
+++ b/code/modules/mob/inventory_procs.dm
@@ -23,13 +23,6 @@
 	if(I)
 		I.equip_to_best_slot(src)
 
-/mob/proc/can_use_hand(hand_name)
-	if(hand_name == "r_hand")
-		return has_right_hand()
-	if(hand_name == "l_hand")
-		return has_left_hand()
-	return FALSE
-
 /mob/proc/is_in_active_hand(obj/item/I)
 	var/obj/item/item_to_test = get_active_hand()
 


### PR DESCRIPTION
## What Does This PR Do
Prevents dragging items being nullspaced when they are dragged to a slot with a missing hand from inventory.
Fixes https://github.com/ParadiseSS13/Paradise/issues/30086
## Why It's Good For The Game
Missing items bad. Potential exploits also bad.
## Testing
Chopped off hand, tried to drag a belt into that slot.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
fix: Fixed nullspacing inventory items with missing hand.
/:cl: