### PR TITLE
Make Cavity Surgery steps show up on Surgery Computers again

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -513,7 +513,7 @@
  * *
  */
 /datum/surgery_step/proc/get_step_information(datum/surgery/surgery, with_tools = FALSE)
-	if(!with_tools)
+	if(!with_tools || accept_any_item || accept_hand)
 		return name
 
 	var/list/tools = list()


### PR DESCRIPTION
## What Does This PR Do
Make surgery computers recognise the Place Item/Extract Item step and show it instead of it being blank. Also fixes a related runtime.

Fixes #30076.

Massive thanks to @1080pCat for bringing this issue to my attention.

## Why It's Good For The Game

Surgery computer not telling you what steps to take makes new doctors harder to learn.

Runtimes are also quite bad.

## Images of changes

Before: 

<img width="648" height="458" alt="image" src="https://github.com/user-attachments/assets/4e213fa1-6173-4cc7-b7d9-80301130ac68" />


After: 

<img width="642" height="458" alt="image" src="https://github.com/user-attachments/assets/98085b4a-7f00-4d61-9e9a-80ecb2fb5c3a" />

## Testing

Loaded up testserver with changes, tried Cavity Implanting a skrell, the surgery was successful and the steps are shown correctly on the computer.

Tried inserting the NAD, a rollerbed (A Bulky item) and an item help with antidrop implant on, all failed. Tried inserting a cautery and it ended the surgery instead.

Tried inserting a Normal size item and it worked, tried taking it back out again and it showed up back in my hand.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Surgery Computers now recognise the Place Item/Extract Item steps again and display it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
