### PR TITLE
Gives trial admins the ability to change and edit names

### DIFF
--- a/code/datums/vv_core_topics.dm
+++ b/code/datums/vv_core_topics.dm
@@ -20,7 +20,8 @@
 
 		modify_variables(D, href_list["varnameedit"], 1)
 	if(href_list["varnamechange"] && href_list["datumchange"])
-		if(!check_rights(R_ADMIN|R_VAREDIT))	return
+		if(!check_rights(R_ADMIN | R_VAREDIT))
+			return
 
 		var/D = locateUID(href_list["datumchange"])
 		if(!istype(D,/datum) && !isclient(D))


### PR DESCRIPTION
## What Does This PR Do
Changes name changing permissions to allow trial mins to change and edit names.
## Why It's Good For The Game
It is good for the administration in doing their jobs.
## Testing
I haven't, but this should be standard. If this needs to be tested, I can go back and do it.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
NPFC
