### PR TITLE
Fix armor penetration increasing armor

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -25,13 +25,12 @@
 		return 0
 	if(damage_type != BRUTE && damage_type != BURN)
 		return 0
-	var/armor_protection = 0
+	var/armor
 	if(damage_flag)
-		armor_protection = armor.getRating(damage_flag)
-	if(armor_protection)		//Only apply weak-against-armor/hollowpoint effects if there actually IS armor.
-		armor_protection = clamp((armor_protection * ((100 - armour_penetration_percentage) / 100)) - armour_penetration_flat, min(armor_protection, 0), 100)
-	var/damage_multiplier = (100 - armor_protection) / 100
-	return round(damage_amount * damage_multiplier, DAMAGE_PRECISION)
+		armor = src.armor.getRating(damage_flag)
+	if(armor > 0)		//Only apply weak-against-armor/hollowpoint effects if there actually IS armor.
+		armor = clamp(armor * (100 - armour_penetration_percentage) / 100 - armour_penetration_flat, 0, 100)
+	return round(damage_amount * (100 - armor) / 100, DAMAGE_PRECISION)
 
 /// returns the amount of damage required to destroy this object in a single hit.
 /obj/proc/calculate_oneshot_damage(damage_type, damage_flag = 0, attack_dir, armour_penetration_flat = 0, armour_penetration_percentage = 0)
@@ -42,13 +41,13 @@
 	if(damage_type != BRUTE && damage_type != BURN)
 		return INFINITY
 
-	var/armor_protection = 0
+	var/armor
 	if(damage_flag)
-		armor_protection = armor.getRating(damage_flag)
-	if(armor_protection)        // Only apply weak-against-armor/hollowpoint effects if there actually IS armor.
-		armor_protection = clamp((armor_protection * ((100 - armour_penetration_percentage) / 100)) - armour_penetration_flat, min(armor_protection, 0), 100)
+		armor = src.armor.getRating(damage_flag)
+	if(armor > 0)        // Only apply weak-against-armor/hollowpoint effects if there actually IS armor.
+		armor = clamp(armor * (100 - armour_penetration_percentage) / 100 - armour_penetration_flat, 0, 100)
 
-	var/damage_multiplier = (100 - armor_protection) / 100
+	var/damage_multiplier = (100 - armor) / 100
 	if(damage_multiplier <= 0)
 		return INFINITY
 

--- a/code/modules/mob/living/silicon/silicon_mob.dm
+++ b/code/modules/mob/living/silicon/silicon_mob.dm
@@ -312,12 +312,12 @@
 /mob/living/silicon/proc/run_armor(damage_amount, damage_type, damage_flag = 0, attack_dir, armour_penetration_flat = 0, armour_penetration_percentage = 0)
 	if(damage_type != BRUTE && damage_type != BURN)
 		return 0
-	var/armor_protection = 0
+	var/armor
 	if(damage_flag)
-		armor_protection = armor.getRating(damage_flag)
-	if(armor_protection)		//Only apply weak-against-armor/hollowpoint effects if there actually IS armor.
-		armor_protection = clamp((armor_protection * ((100 - armour_penetration_percentage) / 100)) - armour_penetration_flat, min(armor_protection, 0), 100)
-	return round(damage_amount * (100 - armor_protection) * 0.01, DAMAGE_PRECISION)
+		armor = src.armor.getRating(damage_flag)
+	if(armor > 0)		//Only apply weak-against-armor/hollowpoint effects if there actually IS armor.
+		armor = clamp(armor * (100 - armour_penetration_percentage) / 100 - armour_penetration_flat, 0, 100)
+	return round(damage_amount * (100 - armor) / 100, DAMAGE_PRECISION)
 
 /mob/living/silicon/apply_effect(effect = 0, effecttype = STUN, blocked = 0)
 	return FALSE //The only effect that can hit them atm is flashes and they still directly edit so this works for now


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Makes it so armor penetration doesn't affect negative or equal to 0 armor values, previously it would affect negative values as well
Also standardized these calculations to have `/ 100` instead of `* 0.01` because 100 is % we count as needed to be immune to damage and alues like 0.01 represent nothing by themselves

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

AP should decrease armor, not increase

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Calculated

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed an issue when armor penetration would increase your armor instead of decreasing it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
