### PR TITLE
ensures dvorak always drops loot

### DIFF
--- a/code/modules/awaymissions/mission_code/ruins/telecomns.dm
+++ b/code/modules/awaymissions/mission_code/ruins/telecomns.dm
@@ -151,20 +151,24 @@ GLOBAL_LIST_EMPTY(telecomms_trap_tank)
 	universal_speak = TRUE
 	universal_understand = TRUE
 	var/has_died = FALSE // fucking decoy silicons are weird.
+	var/turf/our_death_turf // Don't ask, see above.
 
 /mob/living/silicon/decoy/telecomms/death(gibbed)
 	if(has_died)
 		return ..()
 	has_died = TRUE
+	if(!our_death_turf)
+		our_death_turf = get_turf(src)
 	for(var/obj/structure/telecomms_doomsday_device/D in GLOB.telecomms_doomsday_device)
 		D.start_the_party()
 		break
-	new /obj/item/documents/syndicate/dvorak_blackbox(get_turf(src))
+	new /obj/item/documents/syndicate/dvorak_blackbox(our_death_turf)
 	if(prob(50))
 		if(prob(80))
-			new /obj/item/ai_upgrade/surveillance_upgrade(get_turf(src))
+			new /obj/item/ai_upgrade/surveillance_upgrade(our_death_turf)
 		else // 10% chance
-			new /obj/item/ai_upgrade/malf_upgrade(get_turf(src))
+			new /obj/item/ai_upgrade/malf_upgrade(our_death_turf)
+	our_death_turf = null
 	return ..()
 
 /obj/structure/telecomms_trap_tank


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
ensures dvorak always drops loot by getting the turf before during the long period of setting up the doomsday mechanics it no longer has a turf to get.
invoke async probably would have worked but anyways

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
loot should drop

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
killing dvorak in the ruin repeatedly (restarting each time), loot dropped every time

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Ensures dvorak always drops loot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
