### PR TITLE
Nerfs Poultices

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -256,8 +256,12 @@
 /obj/structure/stone_tile/cracked{
 	dir = 4
 	},
-/obj/item/seeds/comfrey,
-/obj/item/seeds/aloe,
+/obj/item/seeds/comfrey{
+	potency = 40
+	},
+/obj/item/seeds/aloe{
+	potency = 40
+	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "aN" = (

--- a/code/modules/hydroponics/grown/herbals.dm
+++ b/code/modules/hydroponics/grown/herbals.dm
@@ -22,7 +22,7 @@
 
 /obj/item/food/grown/comfrey/attack_self__legacy__attackchain(mob/user)
 	var/obj/item/stack/medical/bruise_pack/comfrey/C = new(get_turf(user))
-	C.heal_brute = seed.potency
+	C.heal_brute = seed.potency / 4
 	to_chat(user, "<span class='notice'>You mash [src] into a poultice.</span>")
 	user.drop_item()
 	qdel(src)
@@ -49,7 +49,7 @@
 
 /obj/item/food/grown/aloe/attack_self__legacy__attackchain(mob/user)
 	var/obj/item/stack/medical/ointment/aloe/A = new(get_turf(user))
-	A.heal_burn = seed.potency
+	A.heal_burn = seed.potency / 4
 	to_chat(user, "<span class='notice'>You mash [src] into a poultice.</span>")
 	user.drop_item()
 	qdel(src)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Poultices are no longer 1:1 for healing : potency. Now the amount of healing a poultice kit is 1/4 the potency of the plant, making a max-potency poultice just as effective as an advanced brute/burn kit and not 4x.

Increases base potency of ashwalker aloe and comfrey to 40 to account for this, so their roundstart healing is just as effective as it was before.

## Why It's Good For The Game

Basic plants should not be 4x as effective as space-age advanced medical kits. Especially when you can harvest a large number of 100-heal 6-use kits very quickly with maxed-out plants.

## Testing

Compiled.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<img width="1457" height="495" alt="image" src="https://github.com/user-attachments/assets/9931b92c-3dcb-421d-b011-dde5a0f6dec6" />


## Changelog

:cl:
tweak: Poultice potency scales 1:4 healing to potency.
tweak: Ashwalker aloe/comfrey starts at potency 40.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
