### PR TITLE
The 2FA warning now prompts the user to the correct menu to setup 2FA

### DIFF
--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -79,7 +79,7 @@ GLOBAL_PROTECT(href_token)
 		restricted_by_2fa = TRUE
 		if(!delay_2fa_complaint)
 			// And tell them about it.
-			to_chat(owner,"<span class='boldannounceooc'><big>You do not have 2FA enabled. Admin verbs will be unavailable until you have enabled 2FA.</big></span>") // Very fucking obvious
+			to_chat(owner,"<span class='boldannounceooc'><big>You do not have 2FA enabled. Admin verbs will be unavailable until you have enabled 2FA.\nTo setup 2FA, head to the following menu: <a href='byond://?_src_=prefs;preference=tab;tab=[TAB_GAME]'>Game Preferences</a>")  // Very fucking obvious
 
 	// Regardless of client, tell BYOND if they should have profiler access.
 	if(rights & (R_DEBUG | R_VIEWRUNTIMES))

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -79,7 +79,7 @@ GLOBAL_PROTECT(href_token)
 		restricted_by_2fa = TRUE
 		if(!delay_2fa_complaint)
 			// And tell them about it.
-			to_chat(owner,"<span class='boldannounceooc'><big>You do not have 2FA enabled. Admin verbs will be unavailable until you have enabled 2FA.\nTo setup 2FA, head to the following menu: <a href='byond://?_src_=prefs;preference=tab;tab=[TAB_GAME]'>Game Preferences</a>")  // Very fucking obvious
+			to_chat(owner,"<span class='boldannounceooc'><big>You do not have 2FA enabled. Admin verbs will be unavailable until you have enabled 2FA.\nTo setup 2FA, head to the following menu: <a href='byond://?_src_=prefs;preference=tab;tab=[TAB_GAME]'>Game Preferences</a></span>")  // Very fucking obvious
 
 	// Regardless of client, tell BYOND if they should have profiler access.
 	if(rights & (R_DEBUG | R_VIEWRUNTIMES))

--- a/code/modules/client/2fa.dm
+++ b/code/modules/client/2fa.dm
@@ -61,7 +61,7 @@
 		prefs.save_preferences(src)
 		prefs.ShowChoices(usr)
 		if(holder && holder.restricted_by_2fa)
-			reload_one_admin(ckey)
+			reload_one_admin(ckey, silent = TRUE)
 			to_chat(usr, "<span class='notice'>2fa configured, admin verbs enabled.")
 		alert(usr, "Congratulations. 2FA is now setup properly for your account. In preferences, you can change whether you want it to ask for a code on every connection or only when your IP changes")
 		return
@@ -114,7 +114,7 @@
 			prefs.save_preferences(src)
 			prefs.ShowChoices(usr)
 			if(holder && holder.needs_2fa())
-				reload_one_admin(ckey)
+				reload_one_admin(ckey, silent = TRUE)
 			alert(usr, "2FA disabled successfully")
 
 /client/proc/has_2fa()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -452,8 +452,7 @@
 		to_chat(src, "The queue server is currently [SSqueue.queue_enabled ? "<font color='green'>enabled</font>" : "<font color='disabled'>disabled</font>"], with a threshold of <b>[SSqueue.queue_threshold]</b>. This <b>[SSqueue.persist_queue ? "will" : "will not"]</b> persist through rounds.")
 
 	if(holder && holder.restricted_by_2fa)
-		to_chat(src,"<span class='boldannounceooc'><big>You do not have 2FA enabled. Admin verbs will be unavailable until you have enabled 2FA.</big></span>") // Very fucking obvious
-
+		to_chat(src,"<span class='boldannounceooc'><big>You do not have 2FA enabled. Admin verbs will be unavailable until you have enabled 2FA.\nTo setup 2FA, head to the following menu: <a href='byond://?_src_=prefs;preference=tab;tab=[TAB_GAME]'>Game Preferences</a>")  // Very fucking obvious
 	// Tell client about their connection
 	to_chat(src, "<span class='notice'>You are currently connected [prefs.server_region ? "via the <b>[prefs.server_region]</b> relay" : "directly"] to Paradise.</span>")
 	to_chat(src, "<span class='notice'>You can change this using the <code>Change Region</code> verb in the OOC tab, as selecting a region closer to you may reduce latency.</span>")

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -452,7 +452,7 @@
 		to_chat(src, "The queue server is currently [SSqueue.queue_enabled ? "<font color='green'>enabled</font>" : "<font color='disabled'>disabled</font>"], with a threshold of <b>[SSqueue.queue_threshold]</b>. This <b>[SSqueue.persist_queue ? "will" : "will not"]</b> persist through rounds.")
 
 	if(holder && holder.restricted_by_2fa)
-		to_chat(src,"<span class='boldannounceooc'><big>You do not have 2FA enabled. Admin verbs will be unavailable until you have enabled 2FA.\nTo setup 2FA, head to the following menu: <a href='byond://?_src_=prefs;preference=tab;tab=[TAB_GAME]'>Game Preferences</a>")  // Very fucking obvious
+		to_chat(src,"<span class='boldannounceooc'><big>You do not have 2FA enabled. Admin verbs will be unavailable until you have enabled 2FA.\nTo setup 2FA, head to the following menu: <a href='byond://?_src_=prefs;preference=tab;tab=[TAB_GAME]'>Game Preferences</a></span>")  // Very fucking obvious
 	// Tell client about their connection
 	to_chat(src, "<span class='notice'>You are currently connected [prefs.server_region ? "via the <b>[prefs.server_region]</b> relay" : "directly"] to Paradise.</span>")
 	to_chat(src, "<span class='notice'>You can change this using the <code>Change Region</code> verb in the OOC tab, as selecting a region closer to you may reduce latency.</span>")


### PR DESCRIPTION
## What Does This PR Do
Makes it so the message telling the user that they need 2FA to use some admin commands now prompts them to the correct menu using a chat link rather than just telling them to set it up
From request of funnyman, also makes the reload admin verbs when you do set it up silent so it doesn't tell every admin that their verbs were reloaded

## Why It's Good For The Game
Being told to setup something that you're not told *where* to set the thing up isn't good, i personally thought i had to setup 2fa on the byond account side of things rather than in game, so telling the person where they can setup 2fa is good.
Also every admin being told that their verbs were reloaded when someone setup 2fa isn't the best, as its a little confusing 

## Testing
For the 2FA setup prompt a flipped a var to make the warning popup even if the server didn't need it
Checked the message, got the new text, saw the link, clicked it, and it opened the correct menu 

For the verb reloading, i cant really test that, but its just a copy paste from another spot [line 228 holder2.dm](https://github.com/ParadiseSS13/Paradise/blob/65b673273ee96e89cac83ffa4618dbcda0b5ca5e/code/modules/admin/holder2.dm#L228) so i dont see why it wouldn't work. 

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
NPFC
