### PR TITLE
Fixes fleshlings not dropping the regen mesh on butcher

### DIFF
--- a/code/modules/awaymissions/mission_code/ruins/deepstorage.dm
+++ b/code/modules/awaymissions/mission_code/ruins/deepstorage.dm
@@ -19,7 +19,7 @@
 	move_resist = MOVE_FORCE_VERY_STRONG
 	pull_force = MOVE_FORCE_VERY_STRONG
 	deathmessage = "collapses into a pile of gibs. From the looks of it this is the deadest it can get... "
-	butcher_results = list(/obj/item/regen_mesh)
+	butcher_results = list(/obj/item/regen_mesh = 1)
 	/// Is the boss charging right now?
 	var/charging = FALSE
 	/// Did our boss die?


### PR DESCRIPTION

## What Does This PR Do
fixes #30102

## Why It's Good For The Game
bugs bad, rare one of a kind(mostly) item, you should be able to obtain it

## Testing
killed and butchered the fleshling, got the organ
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog

:cl:
fix: Fixed fleshlings not dropping the regenerative mesh on butcher
/:cl:
