### PR TITLE
Fixes cyborgs who were emagged before picking a module correctly getting their items emagged

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_mob.dm
+++ b/code/modules/mob/living/silicon/robot/robot_mob.dm
@@ -678,6 +678,8 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	module.add_languages(src)
 	module.add_armor(src)
 	module.add_subsystems_and_actions(src)
+	if(emagged)
+		module.emag_act(src)
 	if(!static_radio_channels)
 		radio.config(module.channels)
 	rename_character(real_name, get_default_name())


### PR DESCRIPTION
## What Does This PR Do
Fixes cyborgs who got emagged before picking a module(most notably with medborg and the cyborg factory) not getting their modules emagged when they picked a module 
fixes #30096


## Why It's Good For The Game
Medborgs mainly, are meant to get their gripper, hypospray, and big defib emagged if they do, however there wasn't a check to make sure that they got their items emagged if they were before picking the medical module, this mainly popped up if you were transformed in a cyborg factory.

## Testing
Spawned a borg factory, ran into it, picked med module, checked my items, they were correctly emagged.
Spawned myself in as a normal borg, picked med module, checked if my items were emagged, they were not.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
fix: Fixes cyborgs who were emagged prior to picking a module failing to have their items emagged correctly.
/:cl: