### PR TITLE
Turning Roundstart Handheld GPS' Off

### DIFF
--- a/code/modules/awaymissions/mission_code/ruins/gps_ruin.dm
+++ b/code/modules/awaymissions/mission_code/ruins/gps_ruin.dm
@@ -7,6 +7,7 @@
 	icon_state = "gps_console"
 	anchored = TRUE
 	local = TRUE
+	tracking = TRUE
 	gpstag = "Unknown Signal"
 
 /obj/item/gps/ruin/attack_hand(mob/user)

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -213,6 +213,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/economy/vending/wallmed/survival_pod,
 	icon = 'icons/obj/lavaland/pod_computer.dmi'
 	anchored = TRUE
 	density = TRUE
+	tracking = TRUE
 	pixel_y = -32
 	light_power = 1.4
 	light_range = MINIMUM_USEFUL_LIGHT_RANGE

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -16,7 +16,7 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	slot_flags = ITEM_SLOT_BELT
 	origin_tech = "materials=2;magnets=1;bluespace=2"
 	/// Whether the GPS is on.
-	var/tracking = TRUE
+	var/tracking = FALSE
 	/// The tag that is visible to other GPSes.
 	var/gpstag = "COM0"
 	/// Whether to only list signals that are on the same Z-level.
@@ -193,7 +193,6 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	icon_state = "gps-m"
 	gpstag = "MOD0"
 	desc = "A positioning system helpful for rescuing trapped or injured miners, after you have become lost from rolling around at the speed of sound."
-	tracking = FALSE
 
 /obj/item/gps/mod/ui_state()
 	return GLOB.deep_inventory_state
@@ -203,11 +202,13 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	gpstag = "BORG0"
 	desc = "A mining cyborg internal positioning system. Used as a recovery beacon for damaged cyborg assets, or a collaboration tool for mining teams."
 	flags = NODROP
+	tracking = TRUE
 
 /obj/item/gps/internal
 	icon_state = null
 	flags = ABSTRACT
 	local = TRUE
+	tracking = TRUE
 	gpstag = "Eerie Signal"
 	desc = "Report to a coder immediately."
 	invisibility = INVISIBILITY_MAXIMUM
@@ -227,6 +228,7 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	desc = "This admin-spawn GPS unit leaves the coordinates visible \
 		on any turf that it passes over, for debugging. Especially useful \
 		for marking the area around the transition edges."
+	tracking = TRUE
 	var/list/turf/tagged
 
 /obj/item/gps/visible_debug/Initialize(mapload)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Turning off handheld GPS devices by default, getting rid of spam in signals list.

Internal GPS (that one mostly used in lavaland bosses), cyborgs GPS, survival pods GPS and debug GPS are still on by default.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Less unused GPS signals in list, making it easier to find that one you need.

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

No GPS devices active by default on Lavaland, except megafauna and other shit.
<img width="903" height="611" alt="изображение" src="https://github.com/user-attachments/assets/0deecc97-8a36-4dc0-b6c1-779582a9caec" />

GPS signals from space ruins still works well
<img width="734" height="647" alt="изображение" src="https://github.com/user-attachments/assets/15e879cf-d21d-4dba-bdb7-eb9bdf413d17" />

## Testing

<!-- How did you test the PR, if at all? -->

Tested on local server. GPS that should have been turned off turned off. GPS that should have stayed on still stay on. Images from tests are above.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Handheld GPS devices now are turned off by default.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
