### PR TITLE
Improves buildmode logging

### DIFF
--- a/code/modules/buildmode/submodes/advanced.dm
+++ b/code/modules/buildmode/submodes/advanced.dm
@@ -48,6 +48,7 @@
 		else if(!isnull(obj_holder))
 			//we only want to set the direction of mobs or objects, not turfs or areas.
 			var/atom/movable/A = new obj_holder(get_turf(object))
+			A.admin_spawned = TRUE
 			if(istype(A))
 				A.setDir(BM.build_dir)
 				log_admin("Build Mode: [key_name(user)] modified [A]'s ([A.x],[A.y],[A.z]) dir to [BM.build_dir]")

--- a/code/modules/buildmode/submodes/area_edit.dm
+++ b/code/modules/buildmode/submodes/area_edit.dm
@@ -34,6 +34,7 @@
 		if(!area_name || !length(area_name))
 			return
 		stored_area = new area_type
+		stored_area.admin_spawned = TRUE
 		stored_area.powernet.equipment_powered = FALSE
 		stored_area.powernet.lighting_powered = FALSE
 		stored_area.powernet.environment_powered = FALSE

--- a/code/modules/buildmode/submodes/basic.dm
+++ b/code/modules/buildmode/submodes/basic.dm
@@ -42,8 +42,10 @@
 			qdel(object)
 	else if(isturf(object) && alt_click && left_click)
 		log_admin("Build Mode: [key_name(user)] built an airlock at ([object.x],[object.y],[object.z])")
-		new/obj/machinery/door/airlock(get_turf(object))
+		var/obj/machinery/door/airlock/A = new /obj/machinery/door/airlock(get_turf(object))
+		A.admin_spawned = TRUE
 	else if(isturf(object) && ctrl_click && left_click)
 		var/obj/structure/window/reinforced/WIN = new/obj/structure/window/reinforced(get_turf(object))
+		WIN.admin_spawned = TRUE
 		WIN.setDir(BM.build_dir)
 		log_admin("Build Mode: [key_name(user)] built a window at ([object.x],[object.y],[object.z])")

--- a/code/modules/buildmode/submodes/copy.dm
+++ b/code/modules/buildmode/submodes/copy.dm
@@ -20,7 +20,8 @@
 	if(left_click)
 		var/turf/T = get_turf(object)
 		if(stored)
-			DuplicateObject(stored, perfectcopy=1, sameloc=0,newloc=T)
+			var/obj/O = DuplicateObject(stored, perfectcopy=1, sameloc=0,newloc=T)
+			O.admin_spawned = TRUE
 	else if(right_click)
 		if(ismovable(object)) // No copying turfs for now.
 			to_chat(user, "<span class='notice'>[object] set as template.</span>")

--- a/code/modules/buildmode/submodes/fill.dm
+++ b/code/modules/buildmode/submodes/fill.dm
@@ -56,4 +56,5 @@
 					T.ChangeTurf(objholder)
 				else
 					var/obj/A = new objholder(T)
+					A.admin_spawned = TRUE
 					A.setDir(BM.build_dir)

--- a/code/modules/buildmode/submodes/portal.dm
+++ b/code/modules/buildmode/submodes/portal.dm
@@ -134,6 +134,7 @@
 // Spawns a portal between given origin and destination.
 /datum/buildmode_mode/portal/proc/spawn_portal(turf/origin, turf/destination, mob/user)
 	var/obj/effect/portal/advanced/bmportal = new /obj/effect/portal/advanced(origin, destination, null, lifetime)
+	bmportal.admin_spawned = TRUE
 	bmportal.icon = portal_icon
 	bmportal.icon_state = portal_icon_state
 	return bmportal


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Improves buildmode logging with admin_spawned var for several buildmodes.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->it clarifies that stuff created by buildmode are adminspawned

## Testing

<!-- How did you test the PR, if at all? -->
It works

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
