### PR TITLE
Fix Raw Gas Scan

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -712,22 +712,22 @@ SLIME SCANNER
  * Used in chat-based gas scans.
  */
 /proc/atmos_scan(mob/user, atom/target, silent = FALSE, print = TRUE, milla_turf_details = FALSE, detailed = FALSE)
-	var/datum/gas_mixture/gasmix
 	var/list/airs
 	var/list/milla = null
 	if(milla_turf_details && istype(target, /turf))
+		// This is one of the few times when it's OK to call MILLA directly, as we need more information than we normally keep, aren't trying to modify it, and don't need it to be synchronized with anything.
 		milla = new/list(MILLA_TILE_SIZE)
 		get_tile_atmos(target, milla)
-		gasmix = new()
-		gasmix.copy_from_milla(milla)
-		airs += gasmix
+
+		var/datum/gas_mixture/air = new()
+		air.copy_from_milla(milla)
+		airs = list(air)
 	else
-		gasmix = target.return_analyzable_air()
-		if(!istype(gasmix, /list))
-			gasmix = list(gasmix)
-		airs += gasmix
-		if(!gasmix)
+		airs = target.return_analyzable_air()
+		if(!airs)
 			return FALSE
+		if(!islist(airs))
+			airs = list(airs)
 
 	var/list/message = list()
 	if(!silent && isliving(user))


### PR DESCRIPTION
## What Does This PR Do
Fixes the Raw Gas Scan debug verb.

## Why It's Good For The Game
Debug tools should work.

## Testing
Did a raw gas scan.
Used an analyzer in normal mode on turf and pipe.
Used an analyzer in detailed mode on pipe.
Used ghost gas scan on turf and pipe.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
fix: The Raw Gas Scan debug verb no longer reports vacuum everywhere.
/:cl: