### PR TITLE
Warp cubes require do_after on station

### DIFF
--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -291,6 +291,11 @@
 		return
 	if(SEND_SIGNAL(user, COMSIG_MOVABLE_TELEPORTING, get_turf(linked)) & COMPONENT_BLOCK_TELEPORT)
 		return FALSE
+	if(is_station_level(user.z) && !iswizard(user)) // specifically not station (isntead of lavaland) so it works for explorers potentially
+		user.visible_message("<span class='warning'>[user] begins to channel the [name]!</span>", "<span class='warning'>You begin channeling [name], cutting through the interferance of the station!</span>")
+		if(!do_after_once(user, 4 SECONDS, TRUE, src, allow_moving = TRUE, must_be_held = TRUE))
+			return
+	user.visible_message("<span class='warning'>[user] disappears in a puff of smoke!</span>")
 
 	var/datum/effect_system/smoke_spread/smoke = new
 	smoke.set_up(1, FALSE, user)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

If you are not a wizard, warp cubes now require a 4 second do_after in order to teleport (on par with hiero staff) when on the station Z level. You do not need to be standing still to channel the cubes, but it must be in-hand.

## Why It's Good For The Game

Having an instant out button is not healthy for the game, and causes severe escalation to combat cube users. 

## Testing

spawned in some cubes and teleported about. Then did it on lavaland

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<img width="610" height="255" alt="image" src="https://github.com/user-attachments/assets/b3d3af2c-b45e-4f60-b03d-dcfbe45b3dea" />

## Changelog

:cl:
tweak: warp cubes now require channeling for non-wizards while on station
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
