### PR TITLE
Makes some wizard disease admin-spreadable

### DIFF
--- a/code/datums/diseases/wizard_diseases.dm
+++ b/code/datums/diseases/wizard_diseases.dm
@@ -27,14 +27,17 @@
 	max_stages = 5
 	stage_prob = 5
 	spread_text = "Non-contagious"
-	spread_flags = SPREAD_NON_CONTAGIOUS
+	spread_flags = SPREAD_AIRBORNE
 	cure_text = "Pyrotech stabilizing agents"
 	agent = "Eruca Stomachum"
 	cures = list("stabilizing_agent")
 	viable_mobtypes = list(/mob/living/carbon/human)
-	desc = "A magic-infused disease that builds up VIRUS_DANGEROUSly high pressure bile within the stomach."
+	desc = "A magic-infused disease that builds up DANGEROUSLY high pressure bile within the stomach."
 	severity = VIRUS_DANGEROUS
 	virus_heal_resistant = TRUE
+
+/datum/disease/grut_gut/wizard_variant
+	spread_flags = SPREAD_NON_CONTAGIOUS
 
 /datum/disease/grut_gut/stage_act()
 	if(!..())
@@ -98,7 +101,7 @@
 	max_stages = 5
 	stage_prob = 5
 	spread_text = "Non-contagious"
-	spread_flags = SPREAD_NON_CONTAGIOUS
+	spread_flags = SPREAD_AIRBORNE
 	cure_text = "Acetaldehyde"
 	agent = "nasum magicum"
 	cures = list("acetaldehyde")
@@ -106,6 +109,9 @@
 	desc = "A magic-infused disease that replaces one's nose hairs with tiny wands. Avoid nasal irritants."
 	severity = VIRUS_DANGEROUS
 	virus_heal_resistant = TRUE
+
+/datum/disease/wand_rot/wizard_variant
+	spread_flags = SPREAD_NON_CONTAGIOUS
 
 /datum/disease/wand_rot/stage_act()
 	if(!..())
@@ -165,7 +171,7 @@
 	max_stages = 5
 	stage_prob = 5
 	spread_text = "Non-contagious"
-	spread_flags = SPREAD_NON_CONTAGIOUS
+	spread_flags = SPREAD_CONTACT_GENERAL
 	cure_text = "liquid dark matter"
 	agent = "Spatio Ventrem"
 	cures = list("liquid_dark_matter")
@@ -173,6 +179,9 @@
 	desc = "A magic-infused disease that resides in the gut, converting gastric juices into space-matter."
 	severity = VIRUS_DANGEROUS
 	virus_heal_resistant = TRUE
+
+/datum/disease/mystic_malaise/wizard_variant
+	spread_flags = SPREAD_NON_CONTAGIOUS
 
 /datum/disease/mystic_malaise/stage_act()
 	if(!..())

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -930,9 +930,9 @@ GLOBAL_LIST_EMPTY(multiverse)
 		/datum/disease/wizarditis/wizard_variant,
 		/datum/disease/berserker,
 		/datum/disease/appendicitis,
-		/datum/disease/grut_gut,
-		/datum/disease/wand_rot,
-		/datum/disease/mystic_malaise
+		/datum/disease/grut_gut/wizard_variant,
+		/datum/disease/wand_rot/wizard_variant,
+		/datum/disease/mystic_malaise/wizard_variant,
 	)
 	picked_disease = pick(possible_diseases)
 	return picked_disease

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -11,7 +11,7 @@ GLOBAL_LIST_EMPTY(current_pending_diseases)
 										/datum/disease/gbs, /datum/disease/transformation, /datum/disease/food_poisoning, /datum/disease/berserker, /datum/disease/zombie, /datum/disease/beesease/wizard_variant,
 										/datum/disease/cold9/wizard_variant, /datum/disease/fluspanish/wizard_variant, /datum/disease/kingstons_advanced/wizard_variant,
 										/datum/disease/dna_retrovirus/wizard_variant, /datum/disease/tuberculosis/wizard_variant, /datum/disease/wizarditis/wizard_variant, /datum/disease/anxiety/wizard_variant,
-										/datum/disease/grut_gut, /datum/disease/wand_rot, /datum/disease/mystic_malaise)
+										/datum/disease/grut_gut, /datum/disease/grut_gut/wizard_variant, /datum/disease/wand_rot, /datum/disease/wand_rot/wizard_variant,  /datum/disease/mystic_malaise, /datum/disease/mystic_malaise/wizard_variant)
 	var/static/list/transmissable_symptoms = list()
 	var/static/list/diseases_minor = list()
 	var/static/list/diseases_moderate_major = list()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Moves the plague talisman diseases under the wizard_variant subtype, giving these diseases their own spreadable version. These are admin use only however, due to their magical nature. 

## Why It's Good For The Game

A chance for crew to see them more, if admins want to be funny.

## Testing

infected two sets of monkeys. One spread, one didnt

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Added a spreadable version of the plague talisman diseases
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
