### PR TITLE
Makes basic mobs work with lazarus injectors

### DIFF
--- a/code/modules/mining/equipment/lazarus_injector.dm
+++ b/code/modules/mining/equipment/lazarus_injector.dm
@@ -18,42 +18,42 @@
 	if(!loaded)
 		return ITEM_INTERACT_COMPLETE
 	if(isliving(target))
+		var/mob/living/L = target
+		if(L.stat != DEAD)
+			to_chat(user, "<span class='notice'>[src] is only effective on the dead.</span>")
+			return ITEM_INTERACT_COMPLETE
+		if(!isanimal_or_basicmob(target))
+			to_chat(user, "<span class='notice'>[src] is only effective on lesser beings.</span>")
+			return ITEM_INTERACT_COMPLETE
 		if(isanimal(target))
 			var/mob/living/simple_animal/M = target
 			if(M.sentience_type != revive_type)
 				to_chat(user, "<span class='notice'>[src] does not work on this sort of creature.</span>")
 				return ITEM_INTERACT_COMPLETE
-			if(M.stat == DEAD)
-				M.faction = list("neutral")
-				M.revive()
-				M.AddElement(/datum/element/wears_collar)
-				if(ishostile(target))
-					var/mob/living/simple_animal/hostile/H = M
-					if(isretaliate(target))
-						// Clear the enemies list so we don't break windows
-						// to get to people we no longer hate.
-						var/mob/living/simple_animal/hostile/retaliate/R = H
-						R.enemies.Cut()
-
-					if(malfunctioning)
-						H.faction |= list("lazarus", "\ref[user]")
-						H.robust_searching = TRUE
-						H.friends += user
-						H.attack_same = TRUE
-						log_game("[user] has revived hostile mob [target] with a malfunctioning lazarus injector")
-					else
-						H.attack_same = FALSE
-				loaded = 0
-				user.visible_message("<span class='notice'>[user] injects [M] with [src], reviving it.</span>")
-				playsound(src,'sound/effects/refill.ogg',50,1)
-				icon_state = "lazarus_empty"
+			M.lazarus_revive(user, malfunctioning)
+			if(ishostile(target)) // Handling for simple mobs to make them not angry anymore
+				var/mob/living/simple_animal/hostile/H = M
+				if(isretaliate(target))
+					// Clear the enemies list so we don't break windows
+					// to get to people we no longer hate.
+					var/mob/living/simple_animal/hostile/retaliate/R = H
+					R.enemies.Cut()
+				if(malfunctioning)
+					H.robust_searching = TRUE
+					H.attack_same = TRUE
+				else
+					H.attack_same = FALSE
+		if(isbasicmob(target))
+			var/mob/living/basic/M = target
+			if(M.sentience_type != revive_type)
+				to_chat(user, "<span class='notice'>[src] does not work on this sort of creature.</span>")
 				return ITEM_INTERACT_COMPLETE
-			else
-				to_chat(user, "<span class='notice'>[src] is only effective on the dead.</span>")
-				return ITEM_INTERACT_COMPLETE
-		else
-			to_chat(user, "<span class='notice'>[src] is only effective on lesser beings.</span>")
-			return ITEM_INTERACT_COMPLETE
+			M.lazarus_revive(user, malfunctioning)
+		loaded = 0
+		user.visible_message("<span class='notice'>[user] injects [target] with [src], reviving it.</span>")
+		playsound(src,'sound/effects/refill.ogg',50,1)
+		icon_state = "lazarus_empty"
+		return ITEM_INTERACT_COMPLETE
 
 /obj/item/lazarus_injector/emag_act(mob/user)
 	if(!malfunctioning)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1342,6 +1342,15 @@
 /mob/living/proc/sec_hud_set_ID()
 	return
 
+/// Proc called when TARGETED by a lazarus injector
+/mob/living/proc/lazarus_revive(mob/living/reviver, malfunctioning)
+	revive()
+	befriend(reviver)
+	AddElement(/datum/element/wears_collar)
+	faction = (malfunctioning) ? list("lazarus", "\ref[reviver]") : list("neutral")
+	if(malfunctioning)
+		log_game("[reviver] has revived hostile mob [src] with a malfunctioning lazarus injector")
+
 /// Proc for giving a mob a new 'friend', generally used for AI control and
 /// targeting. Returns false if already friends or null if qdeleted.
 /mob/living/proc/befriend(mob/living/new_friend)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Lazarus injectors now work on basic mobs. Regular lazarus injectors make them neutral, while emagged injectors make them passive only to the user and other emagged lazarus mobs.

## Why It's Good For The Game

Lazarus injectors are meant to work with mobs. This makes them more useful given the transition to basic mobs.

## Testing

Killed a lot of watchers and goliaths. Verified functionality with both simple and basic mobs.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed lazarus injectors not working on basic mobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
