### PR TITLE
Emptying Lathed Welding Tools And Extinguishers

### DIFF
--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -38,11 +38,20 @@
 	var/low_fuel_changes_icon = TRUE
 	/// How often does the tool flash the user's eyes?
 	var/progress_flash_divisor = 1 SECONDS
+	/// If FALSE, welding tools wont appear prefilled by default
+	var/prefilled = TRUE
+
+/obj/item/weldingtool/empty
+	prefilled = FALSE
 
 /obj/item/weldingtool/Initialize(mapload)
 	. = ..()
-	create_reagents(maximum_fuel)
-	reagents.add_reagent("fuel", maximum_fuel)
+	if(!prefilled)
+		create_reagents(maximum_fuel)
+		reagents.add_reagent("fuel", 0)
+	else
+		create_reagents(maximum_fuel)
+		reagents.add_reagent("fuel", maximum_fuel)
 	update_icon()
 	RegisterSignal(src, COMSIG_BIT_ATTACH, PROC_REF(add_bit))
 	RegisterSignal(src, COMSIG_CLICK_ALT, PROC_REF(remove_bit))
@@ -257,6 +266,9 @@
 	materials = list(MAT_METAL = 400, MAT_GLASS = 300)
 	origin_tech = "engineering=2;plasmatech=2"
 
+/obj/item/weldingtool/largetank/empty
+	prefilled = FALSE
+
 /obj/item/weldingtool/largetank/cyborg
 	name = "integrated welding tool"
 	desc = "An integrated industrial welding tool used by construction and engineering robots. "
@@ -299,6 +311,9 @@
 	materials = list(MAT_METAL = 200, MAT_GLASS = 50)
 	low_fuel_changes_icon = FALSE
 
+/obj/item/weldingtool/mini/empty
+	prefilled = FALSE
+
 /obj/item/weldingtool/hugetank
 	name = "upgraded welding tool"
 	desc = "A large industrial welding tool with an even further upgraded fuel reservoir."
@@ -308,6 +323,9 @@
 	maximum_fuel = 80
 	materials = list(MAT_METAL=70, MAT_GLASS=120)
 	origin_tech = "engineering=3;plasmatech=2"
+
+/obj/item/weldingtool/hugetank/empty
+	prefilled = FALSE
 
 /obj/item/weldingtool/experimental
 	name = "experimental welding tool"

--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -41,16 +41,10 @@
 	/// If FALSE, welding tools wont appear prefilled by default
 	var/prefilled = TRUE
 
-/obj/item/weldingtool/empty
-	prefilled = FALSE
-
 /obj/item/weldingtool/Initialize(mapload)
 	. = ..()
-	if(!prefilled)
-		create_reagents(maximum_fuel)
-		reagents.add_reagent("fuel", 0)
-	else
-		create_reagents(maximum_fuel)
+	create_reagents(maximum_fuel)
+	if(prefilled)
 		reagents.add_reagent("fuel", maximum_fuel)
 	update_icon()
 	RegisterSignal(src, COMSIG_BIT_ATTACH, PROC_REF(add_bit))
@@ -256,6 +250,9 @@
 
 /obj/item/weldingtool/get_heat()
 	return tool_enabled * 2500
+
+/obj/item/weldingtool/empty
+	prefilled = FALSE
 
 /obj/item/weldingtool/largetank
 	name = "industrial welding tool"

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -26,7 +26,12 @@
 	var/precision = FALSE
 	/// Sets the `cooling_temperature` of the water reagent datum inside of the extinguisher when it is refilled.
 	var/cooling_power = 2
+	/// If FALSE, extinguishers wont appear prefilled by default
+	var/prefilled = TRUE
 	COOLDOWN_DECLARE(last_use)
+
+/obj/item/extinguisher/empty
+	prefilled = FALSE
 
 /obj/item/extinguisher/atmospherics
 	name = "atmospheric fire extinguisher"
@@ -38,6 +43,9 @@
 	dog_fashion = null
 	reagent_id = "firefighting_foam"
 	reagent_capacity = 65
+
+/obj/item/extinguisher/atmospherics/empty
+	prefilled = FALSE
 
 /obj/item/extinguisher/mini
 	name = "pocket fire extinguisher"
@@ -54,6 +62,9 @@
 	reagent_capacity = 30
 	dog_fashion = null
 
+/obj/item/extinguisher/mini/empty
+	prefilled = FALSE
+
 /obj/item/extinguisher/mini/cyborg
 	name = "integrated fire extinguisher"
 	desc = "A miniature fire extinguisher designed to store firefighting foam."
@@ -69,6 +80,9 @@
 
 /obj/item/extinguisher/Initialize(mapload)
 	. = ..()
+	if(!prefilled)
+		create_reagents(reagent_capacity)
+		reagents.add_reagent(reagent_id, 0)
 	if(!reagents)
 		create_reagents(reagent_capacity)
 		reagents.add_reagent(reagent_id, reagent_capacity)

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -31,7 +31,7 @@
 	id = "extinguisher"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 200)
-	build_path = /obj/item/extinguisher
+	build_path = /obj/item/extinguisher/empty
 	category = list("initial","Tools")
 
 /datum/design/multitool
@@ -63,7 +63,7 @@
 	id = "welding_tool"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 400, MAT_GLASS = 100)
-	build_path = /obj/item/weldingtool
+	build_path = /obj/item/weldingtool/empty
 	category = list("initial","Tools")
 
 /datum/design/mini_weldingtool
@@ -71,7 +71,7 @@
 	id = "mini_welding_tool"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 200, MAT_GLASS = 50)
-	build_path = /obj/item/weldingtool/mini
+	build_path = /obj/item/weldingtool/mini/empty
 	category = list("initial","Tools")
 
 /datum/design/screwdriver
@@ -789,7 +789,7 @@
 	id = "large_welding_tool"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 400, MAT_GLASS = 300)
-	build_path = /obj/item/weldingtool/largetank
+	build_path = /obj/item/weldingtool/largetank/empty
 	category = list("initial", "Tools")
 
 /datum/design/rcd


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Makes welding tools and extinguishers printed on Autolathe empty by adding /empty subtupe to some of them.

I haven't done same thing with experimental and alien welding tools from Protolathe since i see no point emptying self-refilling welding tools. Plus it causes a weird bug: they dont self-refill at fuel level 0 until manually refilled from fueltank.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

No welders and extinguishers coming out of Autolathe magically pre-filled with fuel/water.

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

Errrm dunno what i could put here...

## Testing

<!-- How did you test the PR, if at all? -->

Printed all awaiable welders and extinguisher on Autolathe. They appeared to be empty as intended.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

<img width="937" height="95" alt="изображение" src="https://github.com/user-attachments/assets/597ef485-d6da-4093-bd6e-081b98fa0ddf" />

## Changelog

:cl:
tweak: Welding tools and fire extinguishers printed on Autolathe now have no fuel/water.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
