### PR TITLE
fix cling power alt click not interrupting the alt click chain

### DIFF
--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -49,6 +49,7 @@
 	try_to_sting(owner)
 
 /datum/action/changeling/proc/try_to_sting(mob/user, mob/target)
+	. = TRUE // Value doesn't appear to matter here, but it matters for the middle-click override in AltClickOn inside click.dm
 	user.changeNext_click(5)
 	if(!can_sting(user, target))
 		return


### PR DESCRIPTION
## What Does This PR Do
Makes cling power sting attempts return true by default. Their value doesn't appear to be checked anywhere, but it matters for interrupting the MiddleClickOverride in AltClickOn. Fixes #30144
## Why It's Good For The Game
Prevents you from attempting actions on sting targets  (like medical exam perk)
## Testing
Loaded into game, ensured alt click was resolved.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Changeling power alt-clicks will no longer do unintended actions.
/:cl: