### PR TITLE
fix regenerative stasis popping when closing the alert prompt

### DIFF
--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -35,9 +35,9 @@
 		to_chat(user, "<span class='warning'>We are already regenerating.</span>")
 		return FALSE
 	if(!user.stat)//Confirmation for living changelings if they want to fake their death
-		switch(tgui_alert(user, "Are we sure we wish to fake our death?", "Fake Death", list("Yes", "No")))
-			if("No")
-				return FALSE
+		var/death_confirmation = tgui_alert(user, "Are we sure we wish to fake our death?", "Fake Death", list("Yes", "No"))
+		if(death_confirmation != "Yes")
+			return FALSE
 		// Do the checks again since we had user input
 		if(cling.owner != user.mind)
 			return FALSE


### PR DESCRIPTION
## What Does This PR Do
Closing a TGUI alert prompt makes it return null, which is different from `"No"`. Regenerative Stasis prompt now checks if the result is different from `"Yes"`. If it is, it fails. Fixes #30142
## Why It's Good For The Game
Popping an ability you clicked out of is weird.
## Testing
Clicked Regenerative Stasis 3 times.
First time I clicked "No". I didn't enter stasis.
Second time I clicked "X". I didn't enter stasis.
Third time I clicked "Yes". I entered stasis.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Closing the regenerative stasis prompt won't cause it to activate.
/:cl: