### PR TITLE
Reenables MC Debug and Profile Code in the topleft file menu.

### DIFF
--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -98,8 +98,8 @@ GLOBAL_PROTECT(href_token)
 	owner.update_active_keybindings()
 	if(rights & (R_DEBUG | R_VIEWRUNTIMES))
 		// Enable the buttons they should have.
-		winset(owner, "debugmcbutton", "is-disabled=true")
-		winset(owner, "profilecode", "is-disabled=true")
+		winset(owner, "debugmcbutton", "is-disabled=false")
+		winset(owner, "profilecode", "is-disabled=false")
 	GLOB.admins |= owner
 	GLOB.de_admins -= ckey
 	GLOB.de_mentors -= ckey


### PR DESCRIPTION
## What Does This PR Do
Code should've set it to enabled if a person had the required ranks, but it actually set disabled to true again. This pr fixes it! Fixes #30128
## Why It's Good For The Game
Easier access to debugging tools for devs.
## Images of changes
With Admin
<img width="212" height="185" alt="image" src="https://github.com/user-attachments/assets/4826641d-c606-4c0c-8e42-0476b66e767b" />

Without admin
<img width="210" height="185" alt="image" src="https://github.com/user-attachments/assets/49919ad5-5c02-46f1-ac95-8c5ea777cc1e" />
## Testing
Images. Accessed it with admin, couldnt access it without admin.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
npfc