### PR TITLE
Make get_open_turf respect the airtightness of anything in the turf.

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -26,7 +26,7 @@
 
 /proc/get_open_turf_in_dir(atom/center, dir)
 	var/turf/T = get_ranged_target_turf(center, dir, 1)
-	if(T && !T.density)
+	if(T && !T.density && !(locate(/obj/structure/window) in T))
 		return T
 
 /proc/get_adjacent_open_turfs(atom/center)

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -26,7 +26,23 @@
 
 /proc/get_open_turf_in_dir(atom/center, dir)
 	var/turf/T = get_ranged_target_turf(center, dir, 1)
-	if(T && !T.density && !(locate(/obj/structure/window) in T))
+	if(T)
+		var/list/milla = new/list(MILLA_TILE_SIZE)
+		get_tile_atmos(T, milla)
+
+		var/checked_dir
+		switch(dir)
+			if(NORTH)
+				checked_dir = MILLA_NORTH
+			if(EAST)
+				checked_dir = MILLA_EAST
+			if(SOUTH)
+				checked_dir = MILLA_SOUTH
+			if(WEST)
+				checked_dir = MILLA_WEST
+
+		if(milla[MILLA_INDEX_AIRTIGHT_DIRECTIONS] & checked_dir)
+			return
 		return T
 
 /proc/get_adjacent_open_turfs(atom/center)


### PR DESCRIPTION
## What Does This PR Do
Replaces the turf density check for open turf to use Millas airtight index. This lets things like Windows, airlocks, walls, anything else that might be airtight, to report as such. Fixes firelocks they shouldnt affecting areas they shouldnt. Fixes #30126
## Why It's Good For The Game
Makes firelocks less janky. They will now respect airtightness of airlocks, windows and other things that block air.
## Images of changes

<img width="1165" height="774" alt="image" src="https://github.com/user-attachments/assets/08b3f42e-b06c-4f24-942e-3b9e95cc15f9" />

<img width="1069" height="967" alt="image" src="https://github.com/user-attachments/assets/8435f83e-5a7a-4b48-80c0-83251e699ab2" />

## Testing
Activated firealarms in 2 problematic areas (pictured above). Previously, in both images, the airlock next to the window would end up being activated by the rooms fire alarm. Now as you can see, it doesnt.

I replaced the 2 windows in the images with 2 border windows. One was oriented in a way which would block air, the other was oriented in a way which would let air through. The firelocks reacted appropriately. The one where air was blocked, the firelock didnt connect. The one where air wasnt blocked, the firelock connected.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: Firelocks now respect the airtightness of windows and airlocks.
/:cl: