### PR TITLE
Improves tend wound surgery scaling

### DIFF
--- a/code/modules/surgery/tending.dm
+++ b/code/modules/surgery/tending.dm
@@ -54,7 +54,7 @@
 		/obj/item/pen = 55
 	)
 
-	time = 1.5 SECONDS
+	time = 1.25 SECONDS
 	repeatable = TRUE
 
 	preop_sound = 'sound/surgery/retractor2.ogg'
@@ -176,7 +176,7 @@
 /datum/surgery_step/heal/brute
 	name = "tend wounds"
 	brute_damage_healed = 7
-	brute_damage_healmod = 0.25
+	brute_damage_healmod = 0.35
 
 /datum/surgery_step/heal/brute/get_progress(mob/user, mob/living/carbon/target, brute_healed, burn_healed)
 	if(!brute_healed)
@@ -210,7 +210,7 @@
 	name = "treat burns"
 	damage_name_pretty = "burns"
 	burn_damage_healed = 7
-	burn_damage_healmod = 0.25
+	burn_damage_healmod = 0.35
 
 /********************BURN STEPS********************/
 /datum/surgery_step/heal/burn/get_progress(mob/living/user, mob/living/carbon/target, brute_healed, burn_healed)


### PR DESCRIPTION
## What Does This PR Do
This improves the scaling of tend wounds surgery, making it more efficient for higher burn and brute damage.
This also removes the modifer for dead patients, meaning that tend wounds will work the same if the patient is alive or dead. In addtion, the time between healing steps has been reduces from 2.5 seconds to 1.25 seconds.

Current estimated break down for a patient with 350 Brute Damage using basic surgery tools:
```
350 damage: 7 + sqrt(350) * 0.35 = 13.6 per cycle
350 ÷ 13.6 ≈ 25.7 cycles needed
25.7 cycles × 1.25 seconds = 32.1 seconds
```
## Why It's Good For The Game
It gives some more use to the tend wound surgery in cases where menders or sutures are not feasible.
## Testing
Applied damage to mobs, and conducting both tend wounds and burn surgery.
To be further tested and adjusted via test merge.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<img width="386" height="83" alt="Screenshot 2025-08-18 at 4 30 52 AM" src="https://github.com/user-attachments/assets/8b7b893c-2fa5-428d-8c52-fffb06a13cb8" />


## Changelog

:cl:
tweak: Tweaked tend wound surgery scaling and removed dead modifier.
tweak: Decreased time between surgery steps from 2.5 -> 1.25 Seconds.
/:cl: