### PR TITLE
fix help intent not refilling janicart

### DIFF
--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -71,7 +71,7 @@
 		return ITEM_INTERACT_COMPLETE
 
 	if(istype(used, /obj/item/reagent_containers))
-		return ITEM_INTERACT_SKIP_TO_AFTER_ATTACK
+		return ..()
 
 	if(my_bag)
 		if(my_bag.can_be_inserted(used))


### PR DESCRIPTION
## What Does This PR Do
lets buckets refill janicarts on any intent. Fixes #30155
## Why It's Good For The Game
cart full
## Testing
filled cart with bucket
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Makes it possible to fill janicarts on any intent.
/:cl: