### PR TITLE
Adds speedbike examine text

### DIFF
--- a/code/modules/vehicle/speedbike.dm
+++ b/code/modules/vehicle/speedbike.dm
@@ -1,5 +1,6 @@
 /obj/tgvehicle/speedbike
 	name = "Speedbike"
+	desc = "A futuristic and incredibly fast hovering bike with a small thruster on the back."
 	icon = 'icons/obj/bike.dmi'
 	icon_state = "speedbike_blue"
 	layer = LYING_MOB_LAYER


### PR DESCRIPTION
## What Does This PR Do
Adds a description to the speedbike and its variants.
## Why It's Good For The Game
Previously, the speedbike did not have a description. Seeing the descriptions of basetypes is bad. Fixes #30160.
## Testing
Spawned bikes. Examined. Made sure nothing broke.
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
add: The Speedbike and Red Speedbike now have their own examine text.
/:cl: