### PR TITLE
Adds no-harm check to ai retaliate, adjusts clown AI

### DIFF
--- a/code/datums/components/ai_retaliate_advanced.dm
+++ b/code/datums/components/ai_retaliate_advanced.dm
@@ -33,5 +33,10 @@
 	if(!victim.ai_controller)
 		return
 
+	if(isanimal_or_basicmob(attacker)) // Don't retaliate on nuzzles
+		var/mob/living/M = attacker
+		if(M.a_intent == INTENT_HELP)
+			return
+
 	victim.ai_controller.insert_blackboard_key_lazylist(BB_BASIC_MOB_RETALIATE_LIST, attacker)
 	post_retaliate_callback?.InvokeAsync(attacker)

--- a/code/datums/elements/ai_retaliate.dm
+++ b/code/datums/elements/ai_retaliate.dm
@@ -24,4 +24,8 @@
 
 	if(victim == attacker)
 		return
+	if(isanimal_or_basicmob(attacker)) // Don't retaliate on nuzzles
+		var/mob/living/M = attacker
+		if(M.a_intent == INTENT_HELP)
+			return
 	victim.ai_controller?.insert_blackboard_key_lazylist(BB_BASIC_MOB_RETALIATE_LIST, attacker)

--- a/code/modules/mob/living/basic/retaliate/clown.dm
+++ b/code/modules/mob/living/basic/retaliate/clown.dm
@@ -41,7 +41,13 @@
 /mob/living/basic/clown/proc/retaliate_callback(mob/living/attacker)
 	if(!istype(attacker))
 		return
+	if(attacker.ai_controller) // Don't chain retaliates.
+		var/list/shitlist = attacker.ai_controller.blackboard[BB_BASIC_MOB_RETALIATE_LIST]
+		if(locate(src) in shitlist)
+			return
 	for(var/mob/living/basic/clown/harbringer in oview(src, 7))
+		if(harbringer == attacker) // Do not commit suicide attacking yourself
+			continue
 		harbringer.ai_controller.insert_blackboard_key_lazylist(BB_BASIC_MOB_RETALIATE_LIST, attacker)
 
 /mob/living/basic/clown/goblin


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes bugs in AI clown code by both:
1. AI retaliate components and elements now factor in nuzzles from basic mobs to ensure they don't attack for that
2. Clown AI in particular now has checks to ensure it doesn't "chain retaliate" and doesn't commit suicide from guilt.

## Why It's Good For The Game

Fixes #30159 

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

Spawned clowns. Nuzzled one. Didn't get attacked. Attacked one. Got mobbed. They didn't have a brawl to the death or any suicides.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed retaliates triggering on nuzzles
fix: Fixed clown mobs having highlander brawls if one attacks another and committing suicide from guilt.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
