### PR TITLE
Moves cameras to the new attack chain

### DIFF
--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -171,6 +171,7 @@
 	item_state = "camera"
 	w_class = WEIGHT_CLASS_SMALL
 	slot_flags = ITEM_SLOT_NECK
+	new_attack_chain = TRUE
 	var/list/matter = list("metal" = 2000)
 	var/pictures_max = 10
 	// cameras historically were varedited to start with 30 shots despite
@@ -244,10 +245,12 @@ GLOBAL_LIST_INIT(SpookyGhosts, list("ghost","shade","shade2","ghost-narsie","hor
 		size = nsize
 		to_chat(user, "<span class='notice'>Camera will now take [size]x[size] photos.</span>")
 
-/obj/item/camera/attack__legacy__attackchain(mob/living/carbon/human/M as mob, mob/user as mob)
-	return
+/obj/item/camera/pre_attack(atom/target, mob/living/user, params)
+	if(..() || ismob(target))
+		return FINISH_ATTACK
 
-/obj/item/camera/attack_self__legacy__attackchain(mob/user)
+/obj/item/camera/activate_self(mob/user)
+	. = ..()
 	if(on_cooldown)
 		to_chat(user, "<span class='notice'>[src] is still on cooldown!</span>")
 		return
@@ -258,17 +261,17 @@ GLOBAL_LIST_INIT(SpookyGhosts, list("ghost","shade","shade2","ghost-narsie","hor
 		icon_state = icon_off
 	to_chat(user, "You switch the camera [on ? "on" : "off"].")
 
-/obj/item/camera/attackby__legacy__attackchain(obj/item/I as obj, mob/user as mob, params)
-	if(istype(I, /obj/item/camera_film))
-		if(pictures_left)
+/obj/item/camera/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	if(istype(used, /obj/item/camera_film))
+		if(pictures_left > 0)
 			to_chat(user, "<span class='notice'>[src] still has some film in it!</span>")
-			return
-		to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
+			return ITEM_INTERACT_COMPLETE
+		to_chat(user, "<span class='notice'>You insert [used] into [src].</span>")
 		user.drop_item()
-		qdel(I)
+		qdel(used)
 		pictures_left = pictures_max
-		return
-	..()
+		return ITEM_INTERACT_COMPLETE
+	. = ..()
 
 
 /obj/item/camera/proc/get_icon(list/turfs, turf/center, mob/user)
@@ -401,25 +404,34 @@ GLOBAL_LIST_INIT(SpookyGhosts, list("ghost","shade","shade2","ghost-narsie","hor
 				mob_detail += "You can also see [A] on the photo[A:health < 75 ? " - [A] looks hurt":""].[holding ? " [holding]":"."]."
 	return mob_detail
 
-/obj/item/camera/afterattack__legacy__attackchain(atom/target, mob/user, flag)
-	if(!on || !pictures_left || ismob(target.loc))
-		return
+/obj/item/camera/interact_with_atom(atom/target, mob/living/user, list/modifiers)
+	if(take_photo(target, user))
+		return ITEM_INTERACT_COMPLETE
 
+/obj/item/camera/ranged_interact_with_atom(atom/target, mob/living/user, list/modifiers)
+	if(take_photo(target, user))
+		return ITEM_INTERACT_COMPLETE
+
+/obj/item/camera/proc/take_photo(atom/target, mob/user)
+	if(!on || (pictures_left <= 0) || ismob(target.loc))
+		return FALSE
+
+	pictures_left--
+	on = FALSE
+	on_cooldown = TRUE
 	playsound(loc, pick('sound/items/polaroid1.ogg', 'sound/items/polaroid2.ogg'), 75, TRUE, -3)
 	if(flashing_light)
 		set_light(3, 2, LIGHT_COLOR_TUNGSTEN)
 		sleep(0.2 SECONDS) //Allow lights to update before capturing image
 		addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, set_light), 0), 0.1 SECONDS)
 
-	captureimage(target, user, flag)
-	pictures_left--
-	to_chat(user, "<span class='notice'>[pictures_left] photos left.</span>")
+	captureimage(target, user)
+	to_chat(user, "<span class='notice'>[pictures_left] photo\s left.</span>")
 	icon_state = icon_off
-	on = FALSE
-	on_cooldown = TRUE
 
 	handle_haunt(user)
 	addtimer(CALLBACK(src, PROC_REF(reset_cooldown)), 6.4 SECONDS) // fucking magic numbers
+	return TRUE
 
 /obj/item/camera/proc/reset_cooldown()
 	icon_state = icon_on
@@ -433,7 +445,7 @@ GLOBAL_LIST_INIT(SpookyGhosts, list("ghost","shade","shade2","ghost-narsie","hor
 	var/can_see = (T in view(viewer)) //No x-ray vision cameras.
 	return can_see
 
-/obj/item/camera/proc/captureimage(atom/target, mob/user, flag)
+/obj/item/camera/proc/captureimage(atom/target, mob/user)
 	var/x_c = target.x - (size-1)/2
 	var/y_c = target.y + (size-1)/2
 	var/z_c	= target.z
@@ -449,10 +461,10 @@ GLOBAL_LIST_INIT(SpookyGhosts, list("ghost","shade","shade2","ghost-narsie","hor
 		y_c--
 		x_c = x_c - size
 
-	var/datum/picture/P = createpicture(target, user, turfs, mobs, flag, blueprints)
+	var/datum/picture/P = createpicture(target, user, turfs, mobs)
 	printpicture(user, P)
 
-/obj/item/camera/proc/createpicture(atom/target, mob/user, list/turfs, mobs, flag)
+/obj/item/camera/proc/createpicture(atom/target, mob/user, list/turfs, mobs)
 	var/icon/photoimage = get_icon(turfs, target, user)
 
 	var/icon/small_img = icon(photoimage)
@@ -534,19 +546,20 @@ GLOBAL_LIST_INIT(SpookyGhosts, list("ghost","shade","shade2","ghost-narsie","hor
 	. += "<span class='notice'><b>Alt-Shift-Click</b> [src] to print a specific photo.</span>"
 	. += "<span class='notice'><b>Ctrl-Shift-Click</b> [src] to delete a specific photo.</span>"
 
-/obj/item/camera/digital/afterattack__legacy__attackchain(atom/target, mob/user, flag)
+/obj/item/camera/digital/take_photo(atom/target, mob/user)
 	if(!on || !pictures_left || ismob(target.loc))
-		return
+		return FALSE
 
-	captureimage(target, user, flag)
+	captureimage(target, user)
 	playsound(loc, pick('sound/items/polaroid1.ogg', 'sound/items/polaroid2.ogg'), 75, TRUE, -3)
 
 	icon_state = icon_off
 	on = FALSE
 	on_cooldown = TRUE
 	addtimer(CALLBACK(src, PROC_REF(reset_cooldown)), 6.4 SECONDS) // magic numbers here too
+	return TRUE
 
-/obj/item/camera/digital/captureimage(atom/target, mob/user, flag)
+/obj/item/camera/digital/captureimage(atom/target, mob/user)
 	if(length(saved_pictures) >= max_storage)
 		to_chat(user, "<span class='notice'>Maximum photo storage capacity reached.</span>")
 		return
@@ -566,7 +579,7 @@ GLOBAL_LIST_INIT(SpookyGhosts, list("ghost","shade","shade2","ghost-narsie","hor
 		y_c--
 		x_c = x_c - size
 
-	var/datum/picture/P = createpicture(target, user, turfs, mobs, flag)
+	var/datum/picture/P = createpicture(target, user, turfs, mobs)
 	saved_pictures += P
 
 /obj/item/camera/digital/AltShiftClick(mob/user)

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -271,7 +271,7 @@ GLOBAL_LIST_INIT(SpookyGhosts, list("ghost","shade","shade2","ghost-narsie","hor
 		qdel(used)
 		pictures_left = pictures_max
 		return ITEM_INTERACT_COMPLETE
-	. = ..()
+	return ..()
 
 
 /obj/item/camera/proc/get_icon(list/turfs, turf/center, mob/user)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Moves cameras to the new attack chain

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
new attack chain

## Testing

<!-- How did you test the PR, if at all? -->
- [x] You can't it mobs with cameras
- [x] You can toggle it on and off with activate_self
- [x] More camera film can be put in it
- [x] Photos can be taken at range, and adjacent to you
- [x] You can't hit things while taking a picture
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
