### PR TITLE
Prevent landmarks from always hard deleting.

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -251,8 +251,8 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/newplayer_start) //Without this you sp
 
 /obj/effect/landmark/Destroy()
 	GLOB.landmarks_list -= src
-	..()
-	return QDEL_HINT_HARDDEL_NOW
+	tag = null
+	return ..()
 
 /obj/effect/landmark/proc/set_tag()
 	tag = "landmark*[name]"


### PR DESCRIPTION
## What Does This PR Do
Stops landmarks from insisting that they be hard deleted. They really don't need to be. The only thing really special about landmarks is their tag, so I unset that in Destroy instead.

## Why It's Good For The Game
Saves about 460 hard deletes during every server start.

## Testing
Started server. Less hard deletes.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
NPFC