### PR TITLE
fix picking up plants with bags

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -105,8 +105,8 @@
 
 	if(seed)
 		for(var/datum/plant_gene/trait/T in seed.genes)
-			T.on_attackby(src, used, user)
-		return ITEM_INTERACT_COMPLETE
+			if(T.on_attackby(src, used, user))
+				return ITEM_INTERACT_COMPLETE
 
 	return NONE
 

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -426,6 +426,7 @@
 			qdel(G)
 		else
 			to_chat(user, "<span class='warning'>You need five lengths of cable to make a [G] battery!</span>")
+		return TRUE
 
 
 /datum/plant_gene/trait/stinging


### PR DESCRIPTION
## What Does This PR Do
Currently only the battery plant trait uses on_attackby. If valid it'll return true and finish the interaction. Otherwise it continues. Fixes #30182

I could replace this with an istype for plant bags if thats better too.
## Why It's Good For The Game
Functional botany.
## Testing
Picked up plants with a plant bag.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Plant bags can pick up plants.
/:cl: