### PR TITLE
Shuts up mobs that aren't near anyone

### DIFF
--- a/code/datums/ai/basic_mobs/basic_subtrees/random_speech.dm
+++ b/code/datums/ai/basic_mobs/basic_subtrees/random_speech.dm
@@ -28,7 +28,10 @@
 /datum/ai_planning_subtree/random_speech/select_behaviors(datum/ai_controller/controller, seconds_per_tick)
 	if(!SPT_PROB(speech_chance, seconds_per_tick))
 		return
-	speak(controller)
+	for(var/mob/living/listener in hearers(11, controller.pawn))
+		if(listener.client && listener.stat != DEAD)
+			speak(controller)
+			return
 
 /// Actually perform an action
 /datum/ai_planning_subtree/random_speech/proc/speak(datum/ai_controller/controller)

--- a/code/modules/mob/living/basic/hostile/hivebot_ai.dm
+++ b/code/modules/mob/living/basic/hostile/hivebot_ai.dm
@@ -43,9 +43,11 @@
 	if(!SPT_PROB(relay_chance, seconds_per_tick))
 		return
 
-	if(controller.blackboard_key_exists(BB_HIVE_PARTNER))
-		controller.queue_behavior(/datum/ai_behavior/relay_message, BB_HIVE_PARTNER)
-		return SUBTREE_RETURN_FINISH_PLANNING
+	for(var/mob/living/listener in hearers(11, controller.pawn))
+		if(listener.client && listener.stat != DEAD)
+			if(controller.blackboard_key_exists(BB_HIVE_PARTNER))
+				controller.queue_behavior(/datum/ai_behavior/relay_message, BB_HIVE_PARTNER)
+				return SUBTREE_RETURN_FINISH_PLANNING
 	controller.queue_behavior(/datum/ai_behavior/find_and_set/hive_partner, BB_HIVE_PARTNER, /mob/living/basic/hivebot)
 
 /datum/ai_behavior/find_and_set/hive_partner


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Mobs that are not within 11 tiles of an individual that can hear them no longer proc misc dialogue.

## Why It's Good For The Game

Stops flooding admin logs with basic mob dialogue.

## Testing

Spawned mobs. They didn't talk unless I was controlling a mob near them.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Mobs no longer spam the chat when there's nobody around to actually hear them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
