### PR TITLE
Fix for non-TGUI multiline input clearing fields on cancel.

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -63,6 +63,8 @@
 	if(no_trim)
 		return copytext(html_encode(name), 1, max_length)
 	else
+		if(isnull(name))
+			return null
 		return trim(html_encode(name), max_length)
 
 //Runs byond's sanitization proc along-side strip_html_simple


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Currently if not using TGUI for multiline inputs, hitting 'cancel' clears the field.
Expected behavior is that hitting cancel should leave the field unmodified.

This has been done by ensuring the null from cancelling doesn't get converted to HTML (which consequently produces an empty string).  Upstream code depends on this null being preserved to avoid clearing the field.

Also this adds a newline to the bottom of the modified file, per current .editorconfig standards.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
In the past this has led to nuking some rather lengthy flavor text by hitting cancel, making me reluctant to add text to those fields at all.

While this is not an issue with the current incarnation of TGUI, it's still nice to fix this as a fall-back.

## Testing
No bad behavior to be seen so far.  Editing records in the player profile can be modified as expected, and cancel now doesn't clear the field.

The only reference to the modified function contains that intentional null-handling, so I can't really think of any problems this would create.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Allow stripped_multiline_input to correctly handle the null from cancelling, which is handled upstream.  This prevents the field from being cleared on cancel due to html_encode changing the null to an empty string.
fix: Added newline per current .editorconfig
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
