### PR TITLE
re-adds eating cooldown

### DIFF
--- a/code/modules/food_and_drinks/food_base.dm
+++ b/code/modules/food_and_drinks/food_base.dm
@@ -176,6 +176,7 @@
 	if(user.a_intent == INTENT_HARM && force)
 		return NONE
 
+	user.changeNext_move(CLICK_CD_MELEE)
 	if(reagents && !reagents.total_volume)	// Shouldn't be needed but it checks to see if it has anything left in it.
 		to_chat(user, "<span class='warning'>None of [src] left, oh no!</span>")
 		qdel(src)
@@ -231,7 +232,7 @@
 				TrashItem.forceMove(loc)
 			qdel(src)
 		return ITEM_INTERACT_COMPLETE
-	
+
 	return NONE
 
 /obj/item/food/proc/generate_trash(atom/location)


### PR DESCRIPTION
## What Does This PR Do
Re-adds eating cooldown after it was lost in the food migration.
## Why It's Good For The Game
You cant guzzle down 30lbs of beef patties in 5 seconds.
## Testing
Spammed eating, spammed force-feed, beated a person with a baguette.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Eating has a cooldown again.
/:cl: