### PR TITLE
Fixes electrocution effect

### DIFF
--- a/code/game/objects/effects/temporary_visuals/misc_visuals.dm
+++ b/code/game/objects/effects/temporary_visuals/misc_visuals.dm
@@ -517,14 +517,6 @@
 		animate(get_filter("ray"), offset = 10, time = 10 SECONDS, loop = -1)
 		animate(offset = 0, time = 10 SECONDS)
 
-/obj/effect/temp_visual/electrocution
-	name = "electrocution"
-	icon_state = "electrocution"
-
-/obj/effect/temp_visual/electrocution/Initialize(mapload, set_duration)
-	duration = set_duration
-	. = ..()
-
 /obj/effect/temp_visual/warning
 	name = "warning"
 	icon = 'icons/effects/96x96.dmi'

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -188,6 +188,7 @@
 	// Moderate shock - Stun, knockdown, funny effect
 	var/should_stun = FALSE
 	var/stun_dur = 0 SECONDS
+	var/icon/overlay_icon = null
 	if(shock_damage >= SHOCK_MODERATE)
 		should_stun = (!(flags & SHOCK_TESLA) || siemens_coeff > 0.5) && !(flags & SHOCK_NOSTUN)
 		if(should_stun)
@@ -196,8 +197,8 @@
 		if(shock_damage >= SHOCK_FLASH) // Arc flash explosion is instant, don't wait for the secondary shock and bypass the effect
 			stun_dur = 0
 		else
-			var/obj/effect/temp_visual/electrocution/shock_effect = new /obj/effect/temp_visual/electrocution(loc, stun_dur)
-			shock_effect.setDir(dir)
+			overlay_icon = new('icons/effects/effects.dmi', "electrocution")
+			overlays += overlay_icon
 		emote("scream")
 		AdjustStuttering(4 SECONDS)
 
@@ -212,13 +213,15 @@
 			throw_dir = get_dir(shock_source.loc, src)
 			throw_distance = round(shock_damage / 10)
 
-	addtimer(CALLBACK(src, PROC_REF(secondary_shock), jitter_amount, should_stun, throw_dir, throw_distance), stun_dur)
+	addtimer(CALLBACK(src, PROC_REF(secondary_shock), jitter_amount, should_stun, throw_dir, throw_distance, overlay_icon), stun_dur)
 	return shock_damage
 
 /// Called after electrocute_act to apply secondary effects
-/mob/living/carbon/proc/secondary_shock(jitter_amount, should_stun, throw_dir, throw_distance)
+/mob/living/carbon/proc/secondary_shock(jitter_amount, should_stun, throw_dir, throw_distance, overlay_icon)
 	if(jitter_amount)
 		AdjustJitter(jitter_amount)
+	if(overlay_icon)
+		overlays -= overlay_icon
 	if(should_stun)
 		KnockDown(6 SECONDS)
 	if(throw_dir && throw_distance && !HAS_TRAIT(src, TRAIT_MAGPULSE)) // Don't yeet if they're wearing magboots


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Changes the electrocution skeleton from an effect to an overlay. Fixes #29937

## Why It's Good For The Game

People getting electrocuted should see their skeleton in whatever orientation their body is, even if lying down or moving

## Images of changes

<img width="271" height="209" alt="image" src="https://github.com/user-attachments/assets/6dbace3c-499a-44a7-893d-5523f0c4d4b5" />

## Testing

Shocked a door. Got electrocuted.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixes electrocution effect
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
