### PR TITLE
Fix engineering paychecks

### DIFF
--- a/code/game/jobs/job/engineering_jobs.dm
+++ b/code/game/jobs/job/engineering_jobs.dm
@@ -36,6 +36,7 @@
 	missing_limbs_allowed = FALSE
 	outfit = /datum/outfit/job/chief_engineer
 	important_information = "This role requires you to coordinate a department. You are required to be familiar with Standard Operating Procedure (Engineering), basic job duties, and act professionally (roleplay)."
+	standard_paycheck = CREW_PAY_HIGH
 
 /datum/outfit/job/chief_engineer
 	name = "Chief Engineer"
@@ -87,6 +88,7 @@
 	minimal_player_age = 7
 	exp_map = list(EXP_TYPE_CREW = 300)
 	outfit = /datum/outfit/job/engineer
+	standard_paycheck = CREW_PAY_MEDIUM
 
 /datum/outfit/job/engineer
 	name = "Station Engineer"
@@ -133,6 +135,7 @@
 	minimal_player_age = 7
 	exp_map = list(EXP_TYPE_CREW = 300)
 	outfit = /datum/outfit/job/atmos
+	standard_paycheck = CREW_PAY_MEDIUM
 
 /datum/outfit/job/atmos
 	name = "Life Support Specialist"


### PR DESCRIPTION
## What Does This PR Do
Fixes paychecks in engineering department. CE - 250 credits (high). Others - 200 credits (medium).

## Why It's Good For The Game
The department was overlooked in https://github.com/ParadiseSS13/Paradise/pull/29682.

## Testing
Got 250 credits in paycheck as CE.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl: Maxiemar
fix: Fixed engineering paychecks.
/:cl:
