### PR TITLE
Prevent observer *jumps from showing up in dchat

### DIFF
--- a/code/modules/mob/mob_emote.dm
+++ b/code/modules/mob/mob_emote.dm
@@ -213,6 +213,9 @@
 	audio_cooldown = 0.25 SECONDS
 
 /datum/emote/jump/run_emote(mob/user, params, type_override, intentional)
+	if(isobserver(user))
+		jump_animation(user)
+		return TRUE
 	. = ..()
 	if(!.)
 		return FALSE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

This aligns *jump to be a little closer to the other observer-usable emotes (flip and spin) which do not show up in dchat when performed by observers.

Because the emote has a default message, it's closer to 'flip' than 'spin' in this context, so using the same method as flip to prevent further processing beyond running the animation.


<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

A bit less noise in dchat, and aligns jump with the other observer-usable emotes in that sense.

## Testing

Joined, and successfully jumped.
Observed, and successfully jumped in silence.

## Declaration

- [ ] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Prevented parent run_emote code from running when jumping as an observer (like flip).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
