### PR TITLE
Fixes being unable to fill janitorial cart/mop bucket with water

### DIFF
--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -70,9 +70,6 @@
 	if(handle_janitorial_equipment(user, used))
 		return ITEM_INTERACT_COMPLETE
 
-	if(istype(used, /obj/item/reagent_containers))
-		return ITEM_INTERACT_SKIP_TO_AFTER_ATTACK
-
 	if(my_bag)
 		if(my_bag.can_be_inserted(used))
 			my_bag.handle_item_insertion(used, user)

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -28,11 +28,11 @@
 	if(user.a_intent != INTENT_HELP)
 		return ..()
 
+	if(istype(used, /obj/item/reagent_containers))
+		return ..()
+
 	if(handle_mop_interaction(user, used))
 		return ITEM_INTERACT_COMPLETE
-
-	if(istype(used, /obj/item/reagent_containers))
-		return ITEM_INTERACT_SKIP_TO_AFTER_ATTACK
 
 	return ..()
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #30155.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The mop is no longer dry and crusty.
It is now moist and soggy.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned a janicart and mop bucket.
Used a water bottle to fill them.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Janicarts and mop buckets can be filled with liquids again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
