### PR TITLE
Blobs can use verb to split

### DIFF
--- a/code/_onclick/hud/blob_overmind.dm
+++ b/code/_onclick/hud/blob_overmind.dm
@@ -195,7 +195,7 @@
 	static_inventory += using
 
 	var/mob/camera/blob/B = user
-	if(!B.is_offspring && (length(GLOB.clients) > GLOB.configuration.event.blob_highpop_trigger)) // Checks if the blob is an offspring or below a population value, to not create split button if it is
+	if(!B.is_offspring && (length(GLOB.clients) >= GLOB.configuration.event.blob_highpop_trigger)) // Checks if the blob is an offspring or below a population value, to not create split button if it is
 		using = new /atom/movable/screen/blob/split()
 		using.screen_loc = ui_acti
 		static_inventory += using

--- a/code/modules/events/blob/blob_powers.dm
+++ b/code/modules/events/blob/blob_powers.dm
@@ -385,6 +385,9 @@
 	if(is_offspring)
 		to_chat(src, "<span class='warning'>You cannot split as an offspring of another Blob.</span>")
 		return
+	if(length(GLOB.clients) < GLOB.configuration.event.blob_highpop_trigger)
+		to_chat(src, "<span class='warning'>There isnt enough organic matter on this station to justify a second core.</span>")
+		return
 
 	var/obj/structure/blob/N = (locate(/obj/structure/blob) in T)
 	if(!N)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Blobs dont get a split button anymore, this removes their ability to use verbs to bypass it. 

## Why It's Good For The Game

bugfix good.

## Testing

loaded up, couldnt split. 

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Blobs cannot use verbs to bypass the split consciousness pop cap
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
