### PR TITLE
Fix roundstart antags with dynamic

### DIFF
--- a/code/game/gamemodes/dynamic/antag_rulesets.dm
+++ b/code/game/gamemodes/dynamic/antag_rulesets.dm
@@ -112,7 +112,10 @@
 		return antag_cost * antag_amount // shitty refund for now
 
 /datum/ruleset/proc/roundstart_can_apply(datum/mind/antag)
-	if(EXCLUSIVE_OR(antag.current.client.prefs.active_character.species in banned_species, banned_species_only))
+	var/client/antag_client = GLOB.directory[ckey(antag.key)]
+	if(!antag_client)
+		CRASH("Null client for key [antag.key] during dynamic antag assignment.")
+	if(EXCLUSIVE_OR(antag_client.prefs.active_character.species in banned_species, banned_species_only))
 		SEND_SIGNAL(src, COMSIG_RULESET_FAILED_SPECIES)
 		return FALSE
 	if(antag.special_role) // You can only have 1 antag roll at a time, sorry

--- a/data/mode.txt
+++ b/data/mode.txt
@@ -1,1 +1,1 @@
-extended
+dynamic


### PR DESCRIPTION
## What Does This PR Do
Fix roundstart antags with dynamic.

## Why It's Good For The Game
Antags are kind of important.

## Testing
Manually called the proc on traitor and changeling rulesets, targeting myself with a human and a machine active character. Returned false for machine+changeling, true otherwise.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
fix: Fixed roundstart antags not spawning in any dynamic round.
/:cl: