### PR TITLE
Allow poiniting on items inside deep mob's storage

### DIFF
--- a/code/modules/point/point.dm
+++ b/code/modules/point/point.dm
@@ -7,11 +7,11 @@
  *
  * Not intended as a replacement for the mob verb
  */
-/atom/movable/proc/point_at(atom/pointed_atom)
+/atom/movable/proc/point_at(atom/pointed_atom, make_bubble)
 	if(!isturf(loc))
 		return
 
-	if((pointed_atom in src) || (pointed_atom.loc in src))
+	if(make_bubble || (src != pointed_atom && contains(pointed_atom)))
 		create_point_bubble_from_atom(pointed_atom)
 		return
 
@@ -145,8 +145,9 @@
 /// possibly delayed verb that finishes the pointing process starting in [/mob/verb/pointed()].
 /// either called immediately or in the tick after pointed() was called, as per the [DEFAULT_QUEUE_OR_CALL_VERB()] macro
 /mob/proc/run_pointed(atom/A)
-	if(A.loc in src) // Object is inside a container on the mob. It's not part of the verb's list since it's not in view and requires middle clicking.
-		point_at(A)
+	var/check_if_inside = src != A && contains(A) // extra check so we don't display ourselves in a bubble
+	if(check_if_inside) // Object is inside a container on the mob. It's not part of the verb's list since it's not in view and requires middle clicking.
+		point_at(A, check_if_inside) // send check_if_inside so we don't perform same check twice
 		return TRUE
 
 	if(client && !(A in view(client.maxview(), src)))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Currently code doesn't support displaying items that are at least 2 layers deep inside ur mob. It affects: items inside boxes that are inside ur backpack, paradox bag, modsuit's bag and so on. This PR allows to display items that are located deeper than just ur mob or ur mob's contents

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

We should be able to display items that are located somewhere inside of our mob

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Clicked on a bananium (bananium is inside box, box is inside box, box is inside mod bag, mod bag is inside mod module, mod module is inside mod control, mod control is inside mob)

<img width="1822" height="1440" alt="image" src="https://github.com/user-attachments/assets/4ddbd057-53b0-4509-badd-eb74ff4ce20f" />

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: You may now click with MMB on items that are located inside your modsuit's backpack/paradox bag/box that is inside your backpack in order to show them in a point bubble
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
