### PR TITLE
Fixes diagonal wall floor appearance for grey trade ships

### DIFF
--- a/_maps/map_files/shuttles/trader/trader_base_techno.dmm
+++ b/_maps/map_files/shuttles/trader/trader_base_techno.dmm
@@ -37,7 +37,7 @@
 	id_tag = "trader_privacy";
 	name = "Privacy Shutters"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/mineral/abductor,
 /area/shuttle/trade/sol)
 "j" = (
 /obj/machinery/flasher_button{
@@ -260,7 +260,7 @@
 /area/shuttle/trade/sol)
 "O" = (
 /obj/effect/spawner/window/reinforced/plasma/grilled,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/mineral/abductor,
 /area/shuttle/trade/sol)
 "P" = (
 /obj/structure/chair/comfy/shuttle{


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Ensures that some of the corner walls within the ship have the proper floor type underneath instead of base hull.

It does this by ensuring the turf under the windows are not base hull and instead are alien flooring like the rest of the ship.

## Why It's Good For The Game

Consistency good

## Images of changes

<img width="925" height="103" alt="image" src="https://github.com/user-attachments/assets/0df19b66-2072-466c-be9c-58c9acf20210" />

## Testing

Compiled. Fix was tested live and found to be successful.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed diagonal walls on grey trade ship having the wrong floor type
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
