### PR TITLE
Fixes potatoes not becoming potato batteries

### DIFF
--- a/code/modules/hydroponics/grown/potato.dm
+++ b/code/modules/hydroponics/grown/potato.dm
@@ -37,7 +37,7 @@
 
 /obj/item/food/grown/potato/item_interaction(mob/living/user, obj/item/used, list/modifiers)
 	if(!used.sharp)
-		return NONE
+		return ..()
 
 	to_chat(user, "<span class='notice'>You cut the potato into wedges with [used].</span>")
 	var/obj/item/food/grown/potato/wedges/W = new /obj/item/food/grown/potato/wedges

--- a/code/modules/hydroponics/grown/pumpkin.dm
+++ b/code/modules/hydroponics/grown/pumpkin.dm
@@ -30,7 +30,7 @@
 
 /obj/item/food/grown/pumpkin/item_interaction(mob/living/user, obj/item/used, list/modifiers)
 	if(!used.sharp)
-		return NONE
+		return ..()
 
 	to_chat(user, "<span class='notice'>You carve a face into [src] with [used].</span>")
 	new carved_type(user.loc)

--- a/code/modules/hydroponics/grown/root.dm
+++ b/code/modules/hydroponics/grown/root.dm
@@ -31,7 +31,7 @@
 
 /obj/item/food/grown/carrot/item_interaction(mob/living/user, obj/item/used, list/modifiers)
 	if(!used.sharp)
-		return NONE
+		return ..()
 
 	to_chat(user, "<span class='notice'>You sharpen [src] into a shiv with [used].</span>")
 	var/obj/item/kitchen/knife/shiv/carrot/shiv = new ()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #30214.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Oversight bad.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Grab potatoe
add wyre
get potatoe batree
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Potatoes can now be turned into potato batteries again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
