### PR TITLE
Adds a cache to radiation waves

### DIFF
--- a/code/controllers/subsystem/SSradiation.dm
+++ b/code/controllers/subsystem/SSradiation.dm
@@ -33,6 +33,8 @@ PROCESSING_SUBSYSTEM_DEF(radiation)
 	if(world.time > last_rad_cache_update + rad_cache_update_interval)
 		refresh_rad_cache()
 		last_rad_cache_update = world.time
+	for(var/emission_type in GLOB.turf_rad_item_cache)
+		GLOB.turf_rad_item_cache["[emission_type]"] = list()
 	. = ..()
 
 /datum/controller/subsystem/processing/radiation/proc/get_turf_radiation(turf/place)

--- a/code/datums/radiation_wave.dm
+++ b/code/datums/radiation_wave.dm
@@ -1,3 +1,4 @@
+GLOBAL_LIST_INIT(turf_rad_item_cache, list("[ALPHA_RAD]" = list(), "[BETA_RAD]" = list(), "[GAMMA_RAD]" = list()))
 #define WRAP_INDEX(index, length)((index - 1) % length + 1)
 
 /datum/radiation_wave
@@ -83,11 +84,11 @@
 
 /// Calls rad act on each relevant atom in the turf and returns the resulting weight for that tile after reduction by insulation
 /datum/radiation_wave/proc/radiate(atom/source, turf/current_turf, weight, emission_type)
-	var/list/turf_atoms = list()
-	if(length(current_turf.contents))
-		turf_atoms = get_rad_contents(current_turf, emission_type)
-	else
-		turf_atoms = list(current_turf)
+	// populate cache if needed
+	if(!GLOB.turf_rad_item_cache["[emission_type]"][current_turf])
+		GLOB.turf_rad_item_cache["[emission_type]"][current_turf] = get_rad_contents(current_turf, emission_type)
+
+	var/list/turf_atoms = GLOB.turf_rad_item_cache["[emission_type]"][current_turf]
 	for(var/k in turf_atoms)
 		var/atom/thing = k
 		if(QDELETED(thing))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a cache so different radiation waves don't need to repeat get_rad_contents() on the same turf in the same tick.
The cache gets populated as rad waves pass over turfs and gets reset each time SSradiation fires.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
more performance
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
- Set the SM's EER to 5,000,000 and let it rip
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Radiation waves now cache the list of items they generate from turfs they pass along
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
