### PR TITLE
[FIX] Putting on an IAA badge can no longer cause a permanent speech bubble

### DIFF
--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -418,12 +418,14 @@
 /obj/item/clothing/accessory/legal_badge/on_attached(obj/item/clothing/under/S, mob/user)
 	..()
 	if(has_suit && ismob(has_suit.loc))
+		user.set_typing_indicator(FALSE)
 		var/mob/M = has_suit.loc
 		cached_bubble_icon = M.bubble_icon
 		M.bubble_icon = "legal"
 
 /obj/item/clothing/accessory/legal_badge/on_removed(mob/user)
 	if(has_suit && ismob(has_suit.loc))
+		user.set_typing_indicator(FALSE)
 		var/mob/M = has_suit.loc
 		M.bubble_icon = cached_bubble_icon
 	..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Putting on an IAA/magistrate badge while you are typing no longer causes you to have a permanent speech bubble above your head.

Fixes: #29950
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Typing indicator should only appear when you are actually typing, instead of being there all the time.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Start typing a message.
Put on the IAA badge.
The old speech indicator disappears.
Continue typing the message.
New typing indicator appears.
Take off the badge.
Old speech indicator appears again.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Putting on a legal badge while typing no longer causes a permanent speech bubble to appear above your head.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
