### PR TITLE
Fixes gutlunch controllers

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -674,7 +674,10 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/newplayer_start) //Without this you sp
 
 /obj/effect/landmark/mob_spawner/gutlunch/Initialize(mapload)
 	if(prob(5))
-		mobtype = /mob/living/basic/mining/gutlunch/gubbuck
+		if(prob(50))
+			mobtype = /mob/living/basic/mining/gutlunch/gubbuck
+		else
+			mobtype = /mob/living/basic/mining/gutlunch/guthen
 	. = ..()
 
 /obj/effect/landmark/mob_spawner/abandoned_minebot

--- a/code/modules/mob/living/basic/mining/gutlunch.dm
+++ b/code/modules/mob/living/basic/mining/gutlunch.dm
@@ -25,6 +25,8 @@
 	loot = list(/obj/effect/decal/cleanable/blood/gibs)
 	deathmessage = "is pulped into bugmash."
 
+	ai_controller = /datum/ai_controller/basic_controller/gutlunch
+
 	var/list/food_types = list(
 		/obj/effect/decal/cleanable/blood/gibs,
 		/obj/item/organ/internal/eyes,


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Gives basic gutlunches a controller, and allows guthens into the spawn chance. During the intial conversion, only the subtypes got controllers.

## Why It's Good For The Game

Mobs should work as expected.

## Testing

Started game, checked if gutlunch had an AI controller. It did.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Made it so guthens could spawn instead of only gubbucks
fix: Fixed basic gutlunches having no controller
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
