### PR TITLE
[FIX] Buildmode tilt TGUI alert runtime

### DIFF
--- a/code/modules/buildmode/submodes/tilt.dm
+++ b/code/modules/buildmode/submodes/tilt.dm
@@ -35,13 +35,13 @@
 	weaken_time = weaken_time SECONDS
 	knockdown_time = tgui_input_number(user, "How long to knockdown (in seconds)?", "Knockdown Time", 12)
 	knockdown_time = knockdown_time SECONDS
-	ignore_gravity = tgui_alert(user, "Ignore gravity?", "Ignore gravity", "Yes", "No") == "Yes"
-	should_rotate = tgui_alert(user, "Should it rotate on falling?", "Should rotate", "Yes", "No") == "Yes"
+	ignore_gravity = tgui_alert(user, "Ignore gravity?", "Ignore gravity", list("Yes", "No")) == "Yes"
+	should_rotate = tgui_alert(user, "Should it rotate on falling?", "Should rotate", list("Yes", "No")) == "Yes"
 	if(should_rotate)
 		rotation_angle = tgui_input_number(user, "Which angle to rotate at? (if empty, defaults to 90 degrees in either direction)", "Rotation angle", 0)
-		rightable = tgui_alert(user, "Should it be rightable with alt-click?", "Rightable", "Yes", "No") == "Yes"
+		rightable = tgui_alert(user, "Should it be rightable with alt-click?", "Rightable", list("Yes", "No")) == "Yes"
 		if(rightable)
-			block_interactions_until_righted = tgui_alert(user, "Should it block interactions until righted (by alt-clicking)?", "Block interactions", "Yes", "No") == "Yes"
+			block_interactions_until_righted = tgui_alert(user, "Should it block interactions until righted (by alt-clicking)?", "Block interactions", list("Yes", "No")) == "Yes"
 
 /datum/buildmode_mode/tilting/handle_click(mob/user, params, atom/movable/object)
 	var/list/pa = params2list(params)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a runtime in the buildmode setting for tilt. Settings for tilting should work properly again.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Things shouldn't runtime if we can help it.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Enter build mode, select tilt.
Right click
Go through the settings
No runtime
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
