### PR TITLE
Pre_attack return now allows for melee cooldowns

### DIFF
--- a/code/__DEFINES/dcs/attack_chain_signals.dm
+++ b/code/__DEFINES/dcs/attack_chain_signals.dm
@@ -60,8 +60,9 @@
 // signal interceptors because they're not meant to be combined, and to mesh better with
 // historical use of return values in attack chain procs.
 
-#define CONTINUE_ATTACK		0	//! Continue the attack chain, i.e. allow other signals to respond.
-#define FINISH_ATTACK		1	//! Do not continue the attack chain.
+#define CONTINUE_ATTACK			0		//! Continue the attack chain, i.e. allow other signals to respond.
+#define FINISH_ATTACK			(1<<0)	//! Do not continue the attack chain.
+#define MELEE_COOLDOWN_PREATTACK	(1<<1)	//! Apply a CLICK_CD_MELEE cooldown.
 
 // Legacy-only, do not use in new code
 

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -23,7 +23,10 @@
 			return
 
 	// Attack phase
-	if(pre_attack(target, user, params))
+	var/pre_attack_result = pre_attack(target, user, params)
+	if(pre_attack_result & MELEE_COOLDOWN_PREATTACK)
+		user.changeNext_move(CLICK_CD_MELEE)
+	if(pre_attack_result & FINISH_ATTACK)
 		return
 
 	var/resolved = target.new_attack_chain \

--- a/code/game/objects/items/cigs.dm
+++ b/code/game/objects/items/cigs.dm
@@ -124,7 +124,6 @@ LIGHTERS ARE IN LIGHTERS.DM
 
 	var/mob/living/target = A
 	if(target.on_fire)
-		user.changeNext_move(CLICK_CD_MELEE)
 		user.do_attack_animation(target)
 		if(target != user)
 			user.visible_message(
@@ -138,7 +137,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 				"<span class='notice'>You quickly whip out [src] and nonchalantly light it with your own burning body. Clearly, you have your priorities straight.</span>"
 			)
 		light(user, user)
-		return FINISH_ATTACK
+		return FINISH_ATTACK | MELEE_COOLDOWN_PREATTACK
 
 	// The above section doesn't check for carbons to allow ALL burning bodies to be used.
 	if(!iscarbon(A))
@@ -361,10 +360,10 @@ LIGHTERS ARE IN LIGHTERS.DM
 		)
 		if(!do_after(user, 5 SECONDS, target = target))
 			return ITEM_INTERACT_COMPLETE
-	
+
 	else
 		to_chat(user, "<span_class='notice'>You eat [src].</span>")
-		
+
 	playsound(user.loc, 'sound/items/eatfood.ogg', 50, 0)
 
 	// A SPICY candy!

--- a/code/game/objects/items/robot/cyborg_gripper.dm
+++ b/code/game/objects/items/robot/cyborg_gripper.dm
@@ -169,16 +169,14 @@
 	return TRUE
 
 /obj/item/gripper/pre_attack(atom/A, mob/living/user, params)
-	// This is required to avoid hypersonic interaction speed.
-	user.changeNext_move(CLICK_CD_MELEE)
+	. = FINISH_ATTACK | MELEE_COOLDOWN_PREATTACK
 	if(gripped_item)
 		gripped_item.attack(A, user)
-		return TRUE
+		return
 
 	if(!ismob(A))
 		return ..()
 
-	. = TRUE
 	var/mob/living/target = A
 	// If a human target is horizonal, try to help them up. Unless you're trying to kill them.
 	if(ishuman(target) && user.a_intent == INTENT_HELP && can_help_up)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -212,7 +212,6 @@
 	if(!ismob(A))
 		return
 
-	user.changeNext_move(CLICK_CD_MELEE)
 	var/mob/living/target = A
 
 	if(user.a_intent == INTENT_HARM)
@@ -225,7 +224,7 @@
 			"<span class='danger'>[target == user ? "You prod yourself" : "[user] has prodded you"] with [src]. Luckily it was off.</span>"
 			)
 		playsound(loc, 'sound/weapons/tap.ogg', 50, TRUE, -1)
-		return FINISH_ATTACK
+		return FINISH_ATTACK | MELEE_COOLDOWN_PREATTACK
 
 	// Only human mobs can be stunned.
 	if(!ishuman(target))
@@ -235,11 +234,11 @@
 			"<span class='danger'>[target == user ? "You prod yourself" : "[user] has prodded you"] with [src]. It doesn't seem to have an effect.</span>"
 		)
 		playsound(loc, 'sound/weapons/tap.ogg', 50, TRUE, -1)
-		return FINISH_ATTACK
+		return FINISH_ATTACK | MELEE_COOLDOWN_PREATTACK
 
 	if(baton_stun(target, user))
 		user.do_attack_animation(target)
-	return FINISH_ATTACK
+	return FINISH_ATTACK | MELEE_COOLDOWN_PREATTACK
 
 /obj/item/melee/baton/after_attack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()

--- a/code/game/objects/items/weapons/teleprod.dm
+++ b/code/game/objects/items/weapons/teleprod.dm
@@ -6,15 +6,16 @@
 	origin_tech = "combat=2;bluespace=4;materials=3"
 
 /obj/item/melee/baton/cattleprod/teleprod/pre_attack(atom/A, mob/living/user, params)
-	if(..())
-		return FINISH_ATTACK
+	. = ..()
+	if(.)
+		return
 
 	if(!turned_on)
-		return FINISH_ATTACK
+		return FINISH_ATTACK | MELEE_COOLDOWN_PREATTACK
 
 	if(!ismob(A))
 		return
-	
+
 	var/mob/living/carbon/M
 	if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
 		user.visible_message(

--- a/code/modules/mod/mod_paint.dm
+++ b/code/modules/mod/mod_paint.dm
@@ -16,14 +16,14 @@
 	var/obj/item/mod/control/mod = attacked_atom
 	if(mod.active || mod.activating)
 		to_chat(user, "<span class='warning'>Deactivate the suit!</span>")
-		return TRUE
+		return FINISH_ATTACK
 	if(!istype(mod.theme, compatible_theme))
 		to_chat(user, "<span class='warning'>Theme is not compatible!</span>")
-		return TRUE
+		return FINISH_ATTACK
 	mod.set_mod_skin(skin)
 	to_chat(user, "<span class='notice'>You apply the theme to [mod].</span>")
 	qdel(src)
-	return TRUE
+	return FINISH_ATTACK
 
 /obj/item/mod/skin_applier/asteroid
 	skin = "asteroid"

--- a/code/modules/projectiles/guns/energy/special_eguns.dm
+++ b/code/modules/projectiles/guns/energy/special_eguns.dm
@@ -138,7 +138,7 @@
 	if(istype(A, /obj/machinery/hydroponics))
 		// Calling afterattack from pre_attack looks stupid, but afterattack with proximity FALSE is what makes the gun fire, and we're returning FALSE to cancel the melee attack.
 		afterattack__legacy__attackchain(A, user, FALSE, params)
-		return FALSE
+		return CONTINUE_ATTACK
 	return ..()
 
 //////////////////////////////

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -177,7 +177,7 @@
 	if(isitem(target) && !(isstorage(target) && !istype(target,/obj/item/storage/box) && !istype(target, /obj/item/shipping_package)))
 		var/obj/item/O = target
 		if(!use(1))
-			return FALSE
+			return CONTINUE_ATTACK
 
 		var/obj/item/small_delivery/P = new /obj/item/small_delivery(get_turf(O.loc)) //Aaannd wrap it up!
 		if(!isturf(O.loc))
@@ -196,24 +196,24 @@
 	else if(istype(target, /obj/structure/closet/crate))
 		var/obj/structure/big_delivery/D = wrap_closet(target, user)
 		if(!D)
-			return FALSE
+			return CONTINUE_ATTACK
 		D.icon_state = "deliverycrate"
 
 	else if(istype(target, /obj/structure/closet))
 		var/obj/structure/closet/C = target
 		var/obj/structure/big_delivery/D = wrap_closet(target, user)
 		if(!D)
-			return FALSE
+			return CONTINUE_ATTACK
 		D.init_welded = C.welded
 		C.welded = TRUE
 
 	else if(target.GetComponent(/datum/component/two_handed))
 		to_chat(user, "<span class='notice'>[target] is too unwieldy to wrap effectively.</span>")
-		return FALSE
+		return CONTINUE_ATTACK
 
 	else
 		to_chat(user, "<span class='notice'>The object you are trying to wrap is unsuitable for the sorting machinery.</span>")
-		return FALSE
+		return CONTINUE_ATTACK
 
 	user.visible_message("<span class='notice'>[user] wraps [target].</span>")
 	user.create_attack_log("<font color='blue'>Has used [name] on [target]</font>")
@@ -222,7 +222,7 @@
 	if(amount <= 0 && QDELETED(src)) //if we used our last wrapping paper, drop a cardboard tube
 		var/obj/item/c_tube/T = new(get_turf(user))
 		user.put_in_active_hand(T)
-	return FALSE
+	return CONTINUE_ATTACK
 
 // Separate proc to avoid copy pasting the code twice
 /obj/item/stack/package_wrap/proc/wrap_closet(obj/structure/closet/C, mob/user)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Pre_attack return now allows for melee cooldowns. Use the new `MELEE_COOLDOWN_PREATTACK` define to do so. Applies it in multiple places.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Code readability and reliability.

## Testing

<!-- How did you test the PR, if at all? -->
Couldnt spam baton someone, cyborg gripper worked properly.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
