### PR TITLE
Adds a macro for 0 wait timers as END_OF_TICK

### DIFF
--- a/code/__DEFINES/callbacks.dm
+++ b/code/__DEFINES/callbacks.dm
@@ -5,3 +5,6 @@
 
 /// like CALLBACK but specifically for verb callbacks
 #define VERB_CALLBACK new /datum/callback/verb_callback
+
+// Wait of 0, but this wont actually do anything until the MC is firing
+#define END_OF_TICK(callback) addtimer(callback, 0)

--- a/code/__DEFINES/callbacks.dm
+++ b/code/__DEFINES/callbacks.dm
@@ -6,5 +6,5 @@
 /// like CALLBACK but specifically for verb callbacks
 #define VERB_CALLBACK new /datum/callback/verb_callback
 
-// Wait of 0, but this wont actually do anything until the MC is firing
+// This is used to delay a callback until the end of the tick or later, to ensure that some arbitrary specification is met first. (i.e. spawners spawning stuff)
 #define END_OF_TICK(callback) addtimer(callback, 0)

--- a/code/datums/components/shelved.dm
+++ b/code/datums/components/shelved.dm
@@ -50,7 +50,7 @@
 
 	// See /obj/structure/closet/Initialize for explanation of
 	// addtimer use here
-	addtimer(CALLBACK(src, PROC_REF(shelf_items)), 0)
+	END_OF_TICK(CALLBACK(src, PROC_REF(shelf_items)))
 
 /datum/component/shelver/proc/shelf_items()
 	var/obj/structure/structure_parent = parent

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -60,7 +60,7 @@
 		// This includes maint loot spawners. The problem with that is if a closet loads before a spawner,
 		// the loot will just be in a pile. Adding a timer with 0 delay will cause it to only take in contents once the MC has loaded,
 		// therefore solving the issue on mapload. During rounds, everything will happen as normal
-		addtimer(CALLBACK(src, PROC_REF(take_contents)), 0)
+		END_OF_TICK(CALLBACK(src, PROC_REF(take_contents)))
 	populate_contents() // Spawn all its stuff
 	update_icon() // Set it to the right icon if needed
 

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -71,7 +71,7 @@ GLOBAL_LIST_EMPTY(safes)
 	for(var/i in 1 to number_of_tumblers)
 		tumblers.Add(rand(0, 99))
 	if(mapload)
-		addtimer(CALLBACK(src, PROC_REF(take_contents)), 0)
+		END_OF_TICK(CALLBACK(src, PROC_REF(take_contents)))
 
 /obj/structure/safe/proc/take_contents()
 	// Put as many items on our turf inside as possible

--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -374,7 +374,7 @@
 
 /obj/item/book/random/Initialize(mapload)
 	. = ..()
-	addtimer(CALLBACK(src, PROC_REF(spawn_books)), 0)
+	END_OF_TICK(CALLBACK(src, PROC_REF(spawn_books)))
 
 /obj/item/book/random/proc/spawn_books()
 	var/list/books = GLOB.library_catalog.get_random_book(amount)

--- a/code/modules/library/library_computer.dm
+++ b/code/modules/library/library_computer.dm
@@ -49,7 +49,7 @@
 
 /obj/machinery/computer/library/Initialize(mapload)
 	. = ..()
-	addtimer(CALLBACK(src, PROC_REF(populate_booklist)), 0)
+	END_OF_TICK(CALLBACK(src, PROC_REF(populate_booklist)))
 
 /obj/machinery/computer/library/attack_ai(mob/user)
 	return attack_hand(user)

--- a/code/modules/library/library_equipment.dm
+++ b/code/modules/library/library_equipment.dm
@@ -24,7 +24,7 @@
 	. = ..()
 	if(mapload)
 		// same reasoning as closets
-		addtimer(CALLBACK(src, PROC_REF(take_contents)), 0)
+		END_OF_TICK(CALLBACK(src, PROC_REF(take_contents)))
 
 /obj/structure/bookcase/proc/take_contents()
 	for(var/obj/item/I in get_turf(src))
@@ -151,7 +151,7 @@
 
 /obj/structure/bookcase/random/Initialize(mapload)
 	. = ..()
-	addtimer(CALLBACK(src, PROC_REF(load_books)), 0)
+	END_OF_TICK(CALLBACK(src, PROC_REF(load_books)))
 	icon_state = "bookshelf" // to keep random_bookshelf icon for mappers
 
 /obj/structure/bookcase/random/proc/load_books()

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -377,7 +377,7 @@
 	..()
 	if(!activated || QDELETED(src))
 		return
-	addtimer(CALLBACK(src, PROC_REF(try_attach_to_owner)), 0) // Do this once the drop call stack is done. The holding limb might be getting removed
+	END_OF_TICK(CALLBACK(src, PROC_REF(try_attach_to_owner))) // Do this once the drop call stack is done. The holding limb might be getting removed
 
 /obj/item/rod_of_asclepius/proc/try_attach_to_owner()
 	if(!ishuman(owner) || QDELETED(owner))

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
@@ -263,7 +263,7 @@ Difficulty: Hard
 	. = ..()
 	var/newcolor = rgb(241, 137, 172)
 	add_atom_colour(newcolor, TEMPORARY_COLOUR_PRIORITY)
-	addtimer(CALLBACK(src, PROC_REF(beam_it_up)), 0)
+	END_OF_TICK(CALLBACK(src, PROC_REF(beam_it_up)))
 
 /obj/effect/vetus_laser/ex_act(severity)
 	return

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1374,7 +1374,7 @@
 /obj/structure/disposalpipe/trunk/Initialize(mapload)
 	. = ..()
 	dpdir = dir
-	addtimer(CALLBACK(src, PROC_REF(getlinked)), 0) // This has a delay of 0, but wont actually start until the MC is done
+	END_OF_TICK(CALLBACK(src, PROC_REF(getlinked)))
 
 	update()
 	return
@@ -1515,7 +1515,7 @@
 
 /obj/structure/disposaloutlet/Initialize(mapload)
 	. = ..()
-	addtimer(CALLBACK(src, PROC_REF(setup)), 0) // Wait of 0, but this wont actually do anything until the MC is firing
+	END_OF_TICK(CALLBACK(src, PROC_REF(setup)))
 
 /obj/structure/disposaloutlet/proc/setup()
 	target = get_ranged_target_turf(src, dir, 10)

--- a/code/modules/surgery/organs/subtypes/standard_organs.dm
+++ b/code/modules/surgery/organs/subtypes/standard_organs.dm
@@ -210,7 +210,7 @@
 	// we need to come back to this once the hand is actually removed/dead
 	if(!owner) // Rather not have this trigger on already removed limbs
 		return
-	addtimer(CALLBACK(owner, TYPE_PROC_REF(/mob/living/carbon/human, update_hands_hud), 0))
+	END_OF_TICK(CALLBACK(owner, TYPE_PROC_REF(/mob/living/carbon/human, update_hands_hud)))
 
 /obj/item/organ/external/hand/right
 	limb_name = "r_hand"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Adds a macro for 0 wait timers as END_OF_TICK. We often use this for stuff like lockers, etc that need to pick up things later. This is a more formalized way of doing that.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Better code quality

## Testing

<!-- How did you test the PR, if at all? -->
Compiles

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
