### PR TITLE
fix lavaland transitions

### DIFF
--- a/code/game/turfs/space/space_turf.dm
+++ b/code/game/turfs/space/space_turf.dm
@@ -51,16 +51,9 @@
 
 /turf/space/BeforeChange()
 	..()
-	var/datum/space_level/S = GLOB.space_manager.get_zlev(z)
-	S.remove_from_transit(src)
+
 	if(light_sources) // Turn off starlight, if present
 		set_light(0)
-
-/turf/space/AfterChange(ignore_air, keep_cabling = FALSE)
-	..()
-	var/datum/space_level/S = GLOB.space_manager.get_zlev(z)
-	S.add_to_transit(src)
-	S.apply_transition(src)
 
 /turf/space/proc/update_starlight()
 	if(GLOB.configuration.general.starlight)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -376,7 +376,10 @@
 	return W
 
 /turf/proc/BeforeChange()
-	return
+	SHOULD_CALL_PARENT(TRUE)
+	if("[z]" in GLOB.space_manager.z_list)
+		var/datum/space_level/S = GLOB.space_manager.get_zlev(z)
+		S.remove_from_transit(src)
 
 /turf/proc/is_safe()
 	return FALSE
@@ -402,6 +405,11 @@
 	if(!keep_cabling && !can_have_cabling())
 		for(var/obj/structure/cable/C in contents)
 			qdel(C)
+
+	if("[z]" in GLOB.space_manager.z_list)
+		var/datum/space_level/S = GLOB.space_manager.get_zlev(z)
+		S.add_to_transit(src)
+		S.apply_transition(src)
 
 /turf/simulated/AfterChange(ignore_air = FALSE, keep_cabling = FALSE)
 	..()


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the Lavaland turf transition failure. This was broken by my PR #30232, where some behavior for turfs did not get migrated to the proper type: https://github.com/ParadiseSS13/Paradise/pull/30232/files#diff-b3b30b7825a34bd41f8873e761bf3de38b8899fdefff7443f29578f54ce75716
## Why It's Good For The Game
Regression fix.
## Testing
In progress.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Bridges between Lavaland sectors should work as expected.
/:cl: