### PR TITLE
Increases animation temperature threshold and reduces animation time for HE pipes

### DIFF
--- a/code/modules/atmospherics/machinery/pipes/simple/pipe_simple_he.dm
+++ b/code/modules/atmospherics/machinery/pipes/simple/pipe_simple_he.dm
@@ -37,7 +37,7 @@
 
 	//Heat causes pipe to glow
 	if(pipe_air.temperature() && (icon_temperature > 500 || pipe_air.temperature() > 500)) //glow starts at 500K
-		if(abs(pipe_air.temperature() - icon_temperature) > 10)
+		if(abs(pipe_air.temperature() - icon_temperature) > 50)
 			icon_temperature = pipe_air.temperature()
 
 			var/h_r = heat2color_r(icon_temperature)
@@ -50,7 +50,7 @@
 				h_g = 64 + (h_g - 64) * scale
 				h_b = 64 + (h_b - 64) * scale
 
-			animate(src, color = rgb(h_r, h_g, h_b), time = 20, easing = SINE_EASING)
+			animate(src, color = rgb(h_r, h_g, h_b), time = 5, easing = SINE_EASING)
 
 	//burn any mobs buckled based on temperature
 	if(has_buckled_mobs())


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
HE pipe colour animation is now 0.5 seconds, down from 2, and only happens at 50K thresholds, up from 10K. This is to fix the issue of HE pipes causing lag due to high network traffic from a large amount of animations
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Less lag more good. Also looks a bit better
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

https://github.com/user-attachments/assets/8aa20693-ae82-44e7-9ac5-f8e5fd6f30c5


<img width="917" height="53" alt="image" src="https://github.com/user-attachments/assets/9a185753-fa88-4bf9-b701-bf117b3758ef" />

<img width="899" height="42" alt="image" src="https://github.com/user-attachments/assets/0c658fed-04a5-486b-839a-933094019451" />


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->




## Testing
- Made a heat cycling contraption and connected from another PC to test network usage. It went down from 19mb/s to around 0.4 mb/s
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: HE pipes no longer cause lag(hopefully)
tweak: HE pipes now animate at 50K intervals and for 0.5 seconds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
