### PR TITLE
Swarming mobs now update their swarm appearance on initialize

### DIFF
--- a/code/datums/components/swarming.dm
+++ b/code/datums/components/swarming.dm
@@ -5,7 +5,8 @@
 	var/list/swarm_members = list()
 	var/static/list/swarming_loc_connections = list(
 		COMSIG_ATOM_EXITED = PROC_REF(leave_swarm),
-		COMSIG_ATOM_ENTERED = PROC_REF(join_swarm)
+		COMSIG_ATOM_ENTERED = PROC_REF(join_swarm),
+		COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON = PROC_REF(join_swarm)
 	)
 
 
@@ -26,7 +27,8 @@
 	swarm_members = null
 	return ..()
 
-/datum/component/swarming/proc/join_swarm(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
+/datum/component/swarming/proc/join_swarm(datum/source, atom/movable/arrived)
+	SIGNAL_HANDLER // COMSIG_ATOM_ENTERED + COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON
 	if(isliving(arrived))
 		var/mob/living/our_mob = arrived
 		if(our_mob.stat == DEAD)
@@ -40,6 +42,7 @@
 	other_swarm.swarm_members |= src
 
 /datum/component/swarming/proc/leave_swarm(datum/source, atom/movable/gone, direction)
+	SIGNAL_HANDLER // COMSIG_ATOM_EXITED
 	var/datum/component/swarming/other_swarm = gone.GetComponent(/datum/component/swarming)
 	if(!other_swarm || !(other_swarm in swarm_members))
 		return


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Swarming mobs now update their swarm appearance on initialize. No more 20 carps all on one tile without it being visually distinct.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Looks better.

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

https://github.com/user-attachments/assets/fee6365b-0c95-4ae4-a338-1d815c7781b9



## Testing

<!-- How did you test the PR, if at all? -->
See above

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Carps swarm when they're created.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
