### PR TITLE
adds a description to moth worms

### DIFF
--- a/code/modules/mob/living/basic/friendly/nian_caterpillar.dm
+++ b/code/modules/mob/living/basic/friendly/nian_caterpillar.dm
@@ -1,5 +1,6 @@
 /mob/living/basic/nian_caterpillar
 	name = "nian caterpillar"
+	desc = "Fluffier than clouds."
 	icon = 'icons/mob/monkey.dmi'
 	icon_state = "mothroach"
 	icon_living = "mothroach"
@@ -197,4 +198,3 @@
 	speech_chance = 2
 	emote_hear = list("flutters.", "chitters.", "chatters.")
 	emote_see = list("flutters.", "chitters.", "chatters.")
-


### PR DESCRIPTION
## What Does This PR Do
Gives moth wormes a description. Fixes #30315
## Why It's Good For The Game
No more issues.
## Images of changes

<img width="243" height="63" alt="image" src="https://github.com/user-attachments/assets/03159356-d551-4ac8-b147-4868d236ab85" />

## Testing
Image
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog

:cl:
fix: Moth caterpillars now have a description
/:cl: