### PR TITLE
fix tamed slimes being repeatedly tameable

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/slime_mob.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime_mob.dm
@@ -409,7 +409,7 @@
 		new /obj/effect/temp_visual/heart(loc)
 		visible_message("<span class='notice'>[user] feeds the slime some plasma. It chirps happily!</span>", "<span class='notice'>[user] feeds you a few sheets of plasma! Yummy!!!</span>")
 		S.use(5)
-		if(Discipline)
+		if(Discipline && !trained)
 			trained = TRUE
 			name = "tamed [name]"
 		else

--- a/code/modules/mob/living/simple_animal/slime/slime_mob.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime_mob.dm
@@ -409,9 +409,10 @@
 		new /obj/effect/temp_visual/heart(loc)
 		visible_message("<span class='notice'>[user] feeds the slime some plasma. It chirps happily!</span>", "<span class='notice'>[user] feeds you a few sheets of plasma! Yummy!!!</span>")
 		S.use(5)
-		if(Discipline && !trained)
-			trained = TRUE
-			name = "tamed [name]"
+		if(Discipline)
+			if(!trained)
+				trained = TRUE
+				name = "tamed [name]"
 		else
 			discipline_slime(user, positive_reinforcement = TRUE)
 		return ITEM_INTERACT_COMPLETE


### PR DESCRIPTION
## What Does This PR Do
Fixes tamed slimes repeatedly having tamed added to their names when fed plasma. Fixes #30326
## Why It's Good For The Game
Bug
## Testing
Saw slime, fed slime plasma. Slime was tamed but it didn't become Tamed Tamed Tamed repeated feedings.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: You can no longer repeatedly tame tamed slimes.
/:cl: