### PR TITLE
Matches Little-Little Fix+Tweak

### DIFF
--- a/code/game/objects/items/lighters.dm
+++ b/code/game/objects/items/lighters.dm
@@ -256,6 +256,7 @@
 	origin_tech = "materials=1"
 	attack_verb = null
 	var/is_unathi_fire = FALSE
+	scatter_distance = 10
 
 /obj/item/match/process()
 	var/turf/location = get_turf(src)
@@ -302,6 +303,8 @@
 		desc = "A match. This one has seen better days."
 		attack_verb = list("flicked")
 		STOP_PROCESSING(SSobj, src)
+		scatter_atom()
+		transform = turn(transform, rand(0, 360))
 		return TRUE
 
 /obj/item/match/dropped(mob/user)

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -192,7 +192,7 @@
 		new /obj/item/match(src)
 
 /obj/item/storage/fancy/matches/attackby__legacy__attackchain(obj/item/match/W, mob/user, params)
-	if(istype(W, /obj/item/match) && !W.lit)
+	if(istype(W, /obj/item/match) && (!W.lit && !W.burnt))
 		W.matchignite()
 		playsound(user.loc, 'sound/goonstation/misc/matchstick_light.ogg', 50, TRUE)
 	return


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

- Prevents burnt matches from playing ignition sound when interracting with matchbox;
- Matches now scatter within the tile when burnt (just like cig butts).

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

- Burnt matches shouldn't play ignition sound, they are already spent;
- Scatter thingy is cool for rubbish.

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

<img width="135" height="185" alt="изображение" src="https://github.com/user-attachments/assets/cb00ad2d-bf5b-4ca6-a517-18287dd16f00" />

## Testing

<!-- How did you test the PR, if at all? -->

- Burnt matches did't play any sounds when tried to interract with matchbox;
- Scattering works well.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Matches now scatter within the tile when burnt;
fix: Burnt matches no longer play ignition sound when attempting to interact with the matchbox.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
