### PR TITLE
Adds Tradeband to Traders

### DIFF
--- a/code/modules/events/traders.dm
+++ b/code/modules/events/traders.dm
@@ -81,6 +81,7 @@ GLOBAL_LIST_INIT(unused_trade_stations, list("sol"))
 			M.ckey = C.ckey // must be before equipOutfit, or that will runtime due to lack of mind
 			dust_if_respawnable(C)
 			M.equipOutfit(T.trader_outfit)
+			M.add_language("Tradeband")
 			M.dna.species.after_equip_job(null, M)
 			for(var/datum/objective/O in trader_objectives)
 				M.mind.objective_holder.add_objective(O) // traders dont have a team, so we manually have to add this objective to all of their minds, without setting an owner


### PR DESCRIPTION
## What Does This PR Do

Adds Tradeband to all Traders.

## Why It's Good For The Game

Why would the Traders not know the language of Business?

## Testing

Spawned in as Trader, checked Tradeband was in Known Languages, spoke Tradeband.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<img width="448" height="100" alt="image" src="https://github.com/user-attachments/assets/92403ae9-e3d0-4095-9fe3-e520fdaa62fc" />
<img width="888" height="94" alt="image" src="https://github.com/user-attachments/assets/3293fed8-7fbb-40f1-ab39-9c282085b455" />

## Changelog

:cl:
tweak: Added Tradeband as a Known Language to all Trader types
/:cl:
