### PR TITLE
Changes Most BoxStation External Airlock ID Access Restrictions from Engineering to External Access

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -48828,6 +48828,9 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass,
 /area/station/hallway/secondary/exit)
+"eju" = (
+/turf/simulated/floor/plating/airless,
+/area/station/maintenance/aft)
 "ejF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
@@ -48882,6 +48885,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/science/storage)
+"ell" = (
+/turf/simulated/floor/plating/airless,
+/area/station/maintenance/asmaint)
 "elq" = (
 /obj/structure/cable,
 /obj/effect/spawner/window/reinforced/grilled,
@@ -49544,6 +49550,10 @@
 	icon_state = "whitegreenfull"
 	},
 /area/station/public/sleep)
+"eEy" = (
+/obj/effect/spawner/airlock/long,
+/turf/simulated/wall,
+/area/station/maintenance/apmaint)
 "eEA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -60502,7 +60512,7 @@
 	},
 /area/station/service/barber)
 "jVV" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "jWg" = (
@@ -61632,6 +61642,12 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/aft/south)
+"kzc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/maintenance/solar_maintenance/aft_port)
 "kzB" = (
 /obj/effect/spawner/random/food_or_drink/three_course_meal,
 /obj/structure/closet/crate/freezer,
@@ -63085,10 +63101,6 @@
 	icon_state = "purplecorner"
 	},
 /area/station/science/robotics)
-"liR" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "lje" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -70902,6 +70914,12 @@
 	},
 /turf/simulated/floor/transparent/glass,
 /area/station/hallway/primary/central/south)
+"oWU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/maintenance/solar_maintenance/aft_starboard)
 "oWV" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plating,
@@ -72942,11 +72960,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
-"qaB" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/effect/spawner/airlock,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "qaD" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -74223,6 +74236,9 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
+"qBB" = (
+/turf/simulated/floor/plating/airless,
+/area/station/maintenance/fsmaint)
 "qBI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -76099,7 +76115,7 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "ruY" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "rvo" = (
@@ -77081,6 +77097,12 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/xenobiology)
+"rTV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/maintenance/solar_maintenance/fore_port)
 "rUf" = (
 /obj/machinery/door/airlock/maintenance{
 	electrified_until = -1;
@@ -77995,7 +78017,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
 "ssO" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "ssQ" = (
@@ -80039,7 +80061,7 @@
 	},
 /area/station/hallway/secondary/entry)
 "tAH" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/fpmaint2)
 "tAS" = (
@@ -81462,6 +81484,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
+"ufm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/maintenance/solar_maintenance/fore_starboard)
 "ufq" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -87523,6 +87551,9 @@
 /obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hardsuitstorage)
+"xnh" = (
+/turf/simulated/floor/plating/airless,
+/area/station/maintenance/apmaint)
 "xnn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -89374,6 +89405,10 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/supply/qm)
+"yfj" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "yfn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -103315,10 +103350,10 @@ cgQ
 cgQ
 cgQ
 cgQ
-aaa
 aab
 aab
-aaa
+aab
+aab
 aaa
 aaa
 aaa
@@ -103573,9 +103608,9 @@ rcY
 emv
 cgQ
 lRv
-qaB
+lRv
+eEy
 aab
-aaa
 aaa
 aaa
 aaa
@@ -103764,7 +103799,7 @@ asb
 asb
 asb
 laU
-dap
+rTV
 bOY
 dap
 hoD
@@ -103829,10 +103864,10 @@ noP
 qFl
 ubK
 coL
-liR
 coL
+yfj
+xnh
 doE
-aaa
 aaa
 aaa
 aaa
@@ -107623,7 +107658,7 @@ aaa
 aaa
 doE
 doE
-aHS
+lcl
 lcl
 tAH
 aHS
@@ -107880,7 +107915,7 @@ aaa
 aaa
 aaa
 doE
-aHS
+lcl
 oxe
 lcl
 aHS
@@ -110276,7 +110311,7 @@ aab
 aab
 aaa
 swl
-ntD
+kzc
 xSF
 aab
 aab
@@ -131008,7 +131043,7 @@ azU
 awQ
 axq
 axq
-jOz
+ufm
 uDn
 jOz
 sDz
@@ -131378,7 +131413,7 @@ hzG
 cep
 ghR
 ssO
-cep
+eju
 doE
 aaa
 aaa
@@ -133064,7 +133099,7 @@ aqZ
 aaa
 aaa
 doE
-aGY
+qBB
 ruY
 aGY
 cZV
@@ -140369,7 +140404,7 @@ dfa
 tMT
 sTF
 qUj
-sTF
+oWU
 ddE
 ddE
 ddE
@@ -143927,7 +143962,7 @@ mpm
 fDJ
 aab
 unh
-csL
+ell
 unh
 ciY
 qlE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes most of the external airlocks to use external airlock access helpers on BoxStation.

Also puts an airless plating tile under the external door so a gush of magic space wind doesn't happen when the airlock first cycles into space.

Also slightly expands the disposals airlock.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
External airlocks not leading into engineering areas should not be using engineering access helpers, and should instead be using the external airlock access helper specifically designed for external airlocks.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Disposals airlock change:
<img width="192" height="224" alt="image" src="https://github.com/user-attachments/assets/d13b4e98-01ee-4108-b84b-83770b6837a7" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Non-engineering external airlocks now use external airlock access instead of engineering access on BoxStation.
tweak: Extended the disposals external airlock to a 1x2 on BoxStation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
