### PR TITLE
add dmdoc and output dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,7 @@ _maps/map_files/**/*.mapmanipout.dmm
 
 # byond version manager tracking file
 .byondversion
+
+# dmdoc and output
+dmdoc.exe
+dmdoc/


### PR DESCRIPTION
## What Does This PR Do
This PR adds dmdoc.exe and dmdoc/ to gitignore.
## Why It's Good For The Game
Makes it easy to test dmdoc stuff and not get in the way of other branch shit going on.
## Testing
Checked contents of git status.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC