### PR TITLE
fix cooking step failures

### DIFF
--- a/code/modules/cooking/steps/recipe_step.dm
+++ b/code/modules/cooking/steps/recipe_step.dm
@@ -8,6 +8,12 @@ RESTRICT_TYPE(/datum/cooking/recipe_step)
 	if("optional" in options)
 		optional = options["optional"]
 
+/// See if the *used_item* meets the conditions for this recipe step. This will
+/// typically be something like ensuring that a recipe step for adding a
+/// specific kind of item has been passed an item of that type.
+///
+/// Returns one of [PCWJ_CHECK_INVALID], [PCWJ_CHECK_VALID], [PCWJ_CHECK_FULL],
+/// [PCWJ_CHECK_SILENT].
 /datum/cooking/recipe_step/proc/check_conditions_met(obj/used_item, datum/cooking/recipe_tracker/tracker)
 	SHOULD_CALL_PARENT(FALSE)
 	SHOULD_BE_PURE(TRUE)
@@ -26,7 +32,8 @@ RESTRICT_TYPE(/datum/cooking/recipe_step)
 /datum/cooking/recipe_step/proc/follow_step(obj/used_item, datum/cooking/recipe_tracker/tracker, mob/user)
 	return list()
 
-/// Special function to check if the step has been satisfied. Sometimed just following the step is enough, but not always.
+/// Special function to check if the step has been satisfied. Sometimes just
+/// following the step is enough, but not always.
 /datum/cooking/recipe_step/proc/is_complete(obj/added_item, datum/cooking/recipe_tracker/tracker, list/step_data)
 	return TRUE
 

--- a/code/tests/_game_test_puppeteer.dm
+++ b/code/tests/_game_test_puppeteer.dm
@@ -73,6 +73,11 @@
 	puppet.next_click = world.time
 	puppet.next_move = world.time
 
+/datum/test_puppeteer/proc/alt_click_on(target, params)
+	var/plist = params2list(params)
+	plist["alt"] = TRUE
+	click_on(target, list2params(plist))
+
 /datum/test_puppeteer/proc/spawn_mob_nearby(mob_type)
 	for(var/turf/T in RANGE_TURFS(1, puppet))
 		if(!T.is_blocked_turf())

--- a/code/tests/game_tests.dm
+++ b/code/tests/game_tests.dm
@@ -27,6 +27,7 @@
 #include "test_apc_construction.dm"
 #include "test_components.dm"
 #include "test_config_sanity.dm"
+#include "test_cooking.dm"
 #include "test_crafting_lists.dm"
 #include "test_dynamic_budget.dm"
 #include "test_elements.dm"

--- a/code/tests/test_cooking.dm
+++ b/code/tests/test_cooking.dm
@@ -5,7 +5,7 @@
 		PCWJ_ADD_ITEM(/obj/item/food/meat/human),
 		PCWJ_ADD_ITEM(/obj/item/food/meat/human),
 		PCWJ_ADD_REAGENT("water", 10),
-		PCWJ_USE_STOVE(J_MED, 2 SECONDS),
+		PCWJ_USE_STOVE(J_MED, 1 SECONDS),
 	)
 	appear_in_default_catalog = FALSE
 

--- a/code/tests/test_cooking.dm
+++ b/code/tests/test_cooking.dm
@@ -1,0 +1,53 @@
+/datum/cooking/recipe/test_soylent
+	container_type = /obj/item/reagent_containers/cooking/pot
+	product_type = /obj/item/food/soylentgreen
+	steps = list(
+		PCWJ_ADD_ITEM(/obj/item/food/meat/human),
+		PCWJ_ADD_ITEM(/obj/item/food/meat/human),
+		PCWJ_ADD_REAGENT("water", 10),
+		PCWJ_USE_STOVE(J_MED, 2 SECONDS),
+	)
+	appear_in_default_catalog = FALSE
+
+/datum/game_test/room_test/cooking/Run()
+	var/datum/test_puppeteer/player = new(src)
+	player.puppet.name = "Player"
+
+	// Burger
+	var/obj/structure/table/table = player.spawn_obj_nearby(__IMPLIED_TYPE__, SOUTH)
+	var/obj/item/reagent_containers/cooking/board/board = player.spawn_obj_nearby(__IMPLIED_TYPE__, SOUTH)
+	player.spawn_obj_in_hand(/obj/item/food/bun)
+	player.click_on(board)
+	TEST_ASSERT_LAST_CHATLOG(player, "You add the bun")
+	player.spawn_obj_in_hand(/obj/item/food/meat/patty)
+	player.click_on(board)
+	TEST_ASSERT_LAST_CHATLOG(player, "You add the patty")
+	player.spawn_obj_in_hand(/obj/item/food/grown/lettuce)
+	player.click_on(board)
+	TEST_ASSERT_LAST_CHATLOG(player, "You finish cooking with the cutting board")
+	player.alt_click_on(board)
+	TEST_ASSERT(locate(/obj/item/food/burger) in get_turf(board), "could not find completed burger")
+
+	// Soylent
+	var/obj/machinery/cooking/stovetop/stove = player.spawn_obj_nearby(__IMPLIED_TYPE__, EAST)
+	var/obj/item/reagent_containers/cooking/pot/pot = player.spawn_obj_in_hand(__IMPLIED_TYPE__)
+	player.click_on(table)
+	var/obj/item/food/meat/human/meat = player.spawn_obj_in_hand(__IMPLIED_TYPE__)
+	player.click_on(pot)
+	TEST_ASSERT_LAST_CHATLOG(player, "You add [meat]")
+	player.spawn_obj_in_hand(/obj/item/food/meat/human)
+	player.click_on(pot)
+	var/obj/item/reagent_containers/glass/beaker/beaker = player.spawn_obj_in_hand(__IMPLIED_TYPE__)
+	beaker.reagents.add_reagent("water", 10)
+	player.click_on(pot)
+	player.put_away(beaker)
+	player.click_on(pot)
+	player.click_on(stove, "icon-x=18&icon-y=18")
+	var/surface_idx = stove.clickpos_to_surface(list("icon-x" = 18, "icon-y" = 18))
+	var/datum/cooking_surface/surface = stove.surfaces[surface_idx]
+	surface.temperature = J_MED
+	surface.turn_on(player.puppet)
+	sleep(3 SECONDS)
+	surface.turn_off(player.puppet)
+	player.alt_click_on(stove, "icon-x=18&icon-y=18")
+	TEST_ASSERT(locate(/obj/item/food/soylentgreen) in stove.loc, "could not find complete soylent")


### PR DESCRIPTION
## What Does This PR Do
This PR fixes some behavior in the recipe tracker to handle situations with multiple valid step types. It also adds some more documentation around the cooking rework to try and help clarify some of the most finnicky code. Fixes #30297. In all honesty the existing code was more or less incomplete--situations like the bug being fixed just weren't a problem until I had to look deeper into it now.

A very small test suite is added for the soylent green recipe and a cutting board recipe, just to have a very basic sanity check.
## Why It's Good For The Game
Bugfix and lays down some expectations for recipe behavior.
## Testing
Manual recipe creation, and new test suite.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: The soylent green recipe should work as expected.
/:cl: