### PR TITLE
add access helpers to delta brig mule entrance

### DIFF
--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -59633,6 +59633,12 @@
 	id_tag = "Secure Gate";
 	name = "Security Blast Door"
 	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "hFR" = (


### PR DESCRIPTION
## What Does This PR Do
This PR adds the appropriate access helpers to delta brig.
## Why It's Good For The Game
Assistants should not be able to waltz into the brig.
## Images of changes
<img width="1041" height="602" alt="2025_09_04__08_45_37__paradise dme  deltastation dmm  - StrongDMM" src="https://github.com/user-attachments/assets/6ae0fd62-25f5-4b31-957a-7144713ffa15" />

## Testing
Visual inspection.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Kerberos: The brig MULEbot entrance is now properly access restricted.
/:cl: