### PR TITLE
Gives bookcases a description and additional information on examine.

### DIFF
--- a/code/modules/library/library_equipment.dm
+++ b/code/modules/library/library_equipment.dm
@@ -9,6 +9,7 @@
 
 /obj/structure/bookcase
 	name = "bookcase"
+	desc = "A set of shelves for storing books."
 	icon = 'icons/obj/library.dmi'
 	icon_state = "bookshelf"
 	anchored = TRUE
@@ -19,6 +20,12 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, RAD = 0, FIRE = 50, ACID = 0)
 	var/list/allowed_books = list(/obj/item/book, /obj/item/spellbook, /obj/item/storage/bible, /obj/item/tome) //Things allowed in the bookcase
 	var/material_type = /obj/item/stack/sheet/wood
+
+/obj/structure/bookcase/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>[src] is [anchored ? "bolted to the floor" : "unsecured"].</span>"
+	. += "<span class='notice'>It can be [anchored ? "<b>unanchored</b>" : "<b>anchored</b>"] with a wrench.</span>"
+	. += "<span class='notice'>It can be <b>desconstructed</b> with a screwdriver.</span>"
 
 /obj/structure/bookcase/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gives bookcases a description.

Bookcases now tell you the following information on examine:
- Is the bookcase anchored?
- How do you anchor/unanchor it?
- How do you deconstruct it?

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Stuff should have descriptions.

Randomly wacking an object to see what tool deconstructs it is annoying, especially when other objects DO tell you what tools to use.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Built a bookcase, wrenched it, unwrenched it, screwed it, examined it every step of the way.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Bookcases now have a description and tool information on examine.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
