### PR TITLE
adds documentation on what an exploit is

### DIFF
--- a/docs/contributing/exploits.md
+++ b/docs/contributing/exploits.md
@@ -29,7 +29,7 @@ themselves and others.
 Some examples of a mechanical exploit might be:
 
 1. A player finds an item that, when inserted into an autolathe, returns more
-   mats than it requires to print the item from the autolathe. In this way, by
+   materials than it requires to print the item from the autolathe. In this way, by
    constantly recycling and printing the same item, they are able to create an
    unbounded amount of material for free. This is an exploit because it subverts
    the intended design of the autolathe, which is that things should cost

--- a/docs/contributing/exploits.md
+++ b/docs/contributing/exploits.md
@@ -1,0 +1,67 @@
+# Exploits
+
+If you are filing an issue report you believe to be an exploit, please file it
+in the [Exploit Forum](https://www.paradisestation.org/forum/179-exploit-reports/).
+
+If you are unsure what an exploit is, read on.
+
+## Definition
+
+_Exploits_ refer to ways for players to:
+
+- gain an unintended or unexpectedly disproportionate mechanical advantage over
+  other players or some aspect of the game,
+- degrade or perversely affect the stability and performance of the game server,
+- or damage or destroy any of the services, infrastructure, or data used to run
+  Paradise and its associated tooling
+
+This definition is not exhaustive or exclusive. Ultimately issue managers,
+maintainers, and headcoders are responsible for determining if an issue is an
+exploit.
+
+Exploits are reported in a different venue than ordinary bugs or other game
+issues because the possibility exists that other players can reproduce the
+behavior and propagate knowledge of the advantage or destructive activity to
+themselves and others.
+
+## Examples
+
+Some examples of a mechanical exploit might be:
+
+1. A player finds an item that, when inserted into an autolathe, returns more
+   mats than it requires to print the item from the autolathe. In this way, by
+   constantly recycling and printing the same item, they are able to create an
+   unbounded amount of material for free. This is an exploit because it subverts
+   the intended design of the autolathe, which is that things should cost
+   consistent resources and should never lead to runaway amounts of materials
+   that would normally have to be mined or found elsewhere.
+
+2. A player finds that when holding a certain jetpack and wearing a certain
+   suit, that they move faster in space than they would otherwise. This is an
+   exploit because it makes them faster when they didn't actually do so in a way
+   the game intended. Note that whether or not there's a fair counter for this
+   behavior is irrelevant.
+
+Some examples of a server exploit might be:
+
+1. A player finds a command that, while only intended for admins, does not
+   perform a permissions check, leading to the ability for non-admins to execute
+   the command and potentially change player records or change the course of a
+   game not meant for non-admins to be able to do. This is an exploit because it
+   bypasses the permissions system, giving ordinary players privileged access to
+   game behavior.
+
+2. A player finds that when upgrading a certain machine that produces output,
+   the creation of so many of a certain kind of object causes server lag for all
+   players. This is an exploit because while the player may not have been
+   performing any malicious actions, a coding error causes performance issues in
+   an otherwise unremarkable situation, meaning the player can lag the server
+   and hurt the experience for players simply by performing the same otherwise
+   mundane action repeatedly.
+
+An example of an infrastructure exploit might be:
+
+1. A player finds that an API call to Parastats causes degraded service as the
+   API server attempts to fill the request, and them performs that call
+   repeatedly for no reason other than to cause performance issues for other
+   people attempting to access the server.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
       - 'Getting Started': './contributing/getting_started.md'
       - 'Reviewer Crash Course': './contributing/reviewer.md'
       - 'Writing Quality PRs': './contributing/quality_prs.md'
+      - 'Reporting Exploits': './contributing/exploits.md'
 
   - 'Coding':
       - 'Coding Quickstart': './coding/quickstart.md'


### PR DESCRIPTION
## What Does This PR Do
This PR adds a devdocs page defining an exploit at a basic level.
## Why It's Good For The Game
Nowhere do we have a good, exhaustive definition of an exploit with examples. It's on us to have this if we expect people to file bugs and exploits in their correct places. This can be linked in the issue report template at some point.
## Testing
Generated devdocs locally, proofread.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC