### PR TITLE
Fixes nian caterpillars becoming ravenous when fully fed

### DIFF
--- a/code/modules/mob/living/basic/friendly/nian_caterpillar.dm
+++ b/code/modules/mob/living/basic/friendly/nian_caterpillar.dm
@@ -191,8 +191,16 @@
 		/datum/ai_planning_subtree/random_speech/moth_caterpillar,
 		/datum/ai_planning_subtree/find_nearest_thing_which_attacked_me_to_flee,
 		/datum/ai_planning_subtree/flee_target,
-		/datum/ai_planning_subtree/find_food,
+		/datum/ai_planning_subtree/find_food/nian_caterpillar,
 	)
+
+/datum/ai_planning_subtree/find_food/nian_caterpillar
+
+/datum/ai_planning_subtree/find_food/nian_caterpillar/select_behaviors(datum/ai_controller/controller, seconds_per_tick)
+	var/mob/living/basic/nian_caterpillar/caterpillar = controller.pawn
+	if(caterpillar.nutrition >= caterpillar.nutrition_need)
+		return SUBTREE_RETURN_FINISH_PLANNING
+	return ..()
 
 /datum/ai_planning_subtree/random_speech/moth_caterpillar
 	speech_chance = 2

--- a/code/modules/mob/living/basic/friendly/nian_caterpillar.dm
+++ b/code/modules/mob/living/basic/friendly/nian_caterpillar.dm
@@ -199,6 +199,9 @@
 /datum/ai_planning_subtree/find_food/nian_caterpillar/select_behaviors(datum/ai_controller/controller, seconds_per_tick)
 	var/mob/living/basic/nian_caterpillar/caterpillar = controller.pawn
 	if(caterpillar.nutrition >= caterpillar.nutrition_need)
+		// Put eating on cooldown so it doesn't keep trying to eat.
+		var/food_cooldown = controller.blackboard[BB_EAT_FOOD_COOLDOWN] || EAT_FOOD_COOLDOWN
+		controller.set_blackboard_key(BB_NEXT_FOOD_EAT, world.time + food_cooldown)
 		return SUBTREE_RETURN_FINISH_PLANNING
 	return ..()
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes an issue where nian caterpillars when fully fed will start to eat everything quickly.

## Why It's Good For The Game

Bugs bad.

## Testing

Fed a nian caterpillar until it was sated. Didn't see it continue to eat.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed an issue where nian caterpillars ate tons of food after being fully fed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
