### PR TITLE
Migrates the baseball bat to the new attack chain, and makes it use tg cooldowns

### DIFF
--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -191,7 +191,6 @@
 	flags_2 = RANDOM_BLOCKER_2
 	icon_state = "baseball_bat"
 	item_state = "baseball_bat"
-	var/deflectmode = FALSE // deflect small/medium thrown objects
 	force = 10
 	throwforce = 12
 	attack_verb = list("beat", "smacked")
@@ -202,6 +201,7 @@
 	var/throw_cooldown = 10 SECONDS
 	var/homerun_ready = FALSE
 	var/homerun_able = FALSE
+	var/deflectmode = FALSE // deflect small/medium thrown objects
 
 	new_attack_chain = TRUE
 

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -263,7 +263,7 @@
 		return ..()
 	to_chat(user, "<span class='warning'>You begin gathering strength...</span>")
 	playsound(get_turf(src), 'sound/magic/lightning_chargeup.ogg', 65, TRUE)
-	if(do_after_once(user, 9 SECONDS, target = user, hidden = TRUE))
+	if(do_after(user, 9 SECONDS, target = user, hidden = TRUE))
 		to_chat(user, "<span class='userdanger'>You gather power! Time for a home run!</span>")
 		homerun_ready = TRUE
 


### PR DESCRIPTION
## What Does This PR Do
Updates the baseball bat code, replaces alot of `1/0` with `TRUE/FALSE`
Migrates the bat to the new attack chain
Changes the cooldowns to use TG cooldowns
Slightly edits the baseball bat deflect cooldown message to just be minutes rather than minute:seconds, mainly because i dont know how i would get a proper minutes:seconds printout, but it doesn't need to be that exact anyway

## Why It's Good For The Game
more readable code
tg cooldowns are easier to work with, as well as the new attack chain

## Testing
whacked various mobs, with deflect mode on/off, checked the cooldowns on the deflect mode, all seemed to be working, though im not super familiar with the new attack chain stuff, so im not 100% on what i should be testing other than beating things up

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog

:cl:
tweak: The baseball bat gives a more general time while the deflect mode is on cooldown rather than exact minutes and seconds
/:cl:
