### PR TITLE
Adds a toolbelt to DeltaStation cargo

### DIFF
--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -11215,6 +11215,7 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
+/obj/item/storage/belt,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},


### PR DESCRIPTION
## What Does This PR Do
Adds a single toolbelt to the cargo bay on DeltaStation.
## Why It's Good For The Game
Delta is the only map missing a cargo toolbelt. This is not good.
## Images of changes
<img width="256" height="224" alt="image" src="https://github.com/user-attachments/assets/503b830c-dc22-440e-9fd4-d89ab8ed8439" />

## Testing
Visual inspection.
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
add: Adds the missing toolbelt to DeltaStation's cargo bay.
/:cl: