### PR TITLE
Slightly Remaps Meta Arrivals

### DIFF
--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -82,6 +82,13 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
+"abn" = (
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger{
+	pixel_y = 5
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/arrival/station)
 "abq" = (
 /obj/structure/lattice,
 /turf/space,
@@ -388,6 +395,9 @@
 /obj/machinery/camera{
 	c_tag = "Arrivals Hallway West 2";
 	dir = 5
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -1377,11 +1387,14 @@
 /turf/simulated/floor/wood,
 /area/station/hallway/primary/central/south)
 "aok" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "specops_home";
-	locked = 1
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "ferry_home";
+	name = "Port Bay 3 Airlock"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/hallway/secondary/entry/east)
 "aon" = (
 /obj/effect/spawner/random/fungus/frequent,
@@ -1674,13 +1687,12 @@
 "aqu" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/warden)
-"aqw" = (
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/east)
 "aqA" = (
 /obj/machinery/light/small{
 	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/west)
@@ -1836,6 +1848,10 @@
 /obj/structure/cable,
 /turf/space,
 /area/station/engineering/solar/fore_port)
+"arJ" = (
+/obj/structure/closet/wardrobe/grey,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/arrival/station)
 "arK" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	name = "Security Privacy Shutters";
@@ -2943,7 +2959,7 @@
 /turf/simulated/wall,
 /area/station/maintenance/fsmaint)
 "ayy" = (
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/station/hallway/secondary/entry/west)
 "ayA" = (
 /obj/structure/sign/electricshock,
@@ -4451,12 +4467,12 @@
 /turf/simulated/wall,
 /area/station/public/construction)
 "aHn" = (
-/obj/effect/landmark/spawner/late/crew,
-/obj/structure/chair/comfy/shuttle{
-	dir = 4;
-	name = "prisoner transfer chair"
+/obj/structure/closet/wardrobe/mixed,
+/obj/machinery/camera{
+	c_tag = "Arrivals Shuttle Fore";
+	dir = 6
 	},
-/turf/simulated/floor/mineral/titanium,
+/turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/arrival/station)
 "aHr" = (
 /obj/machinery/disposal,
@@ -5238,6 +5254,10 @@
 /obj/item/assembly/mousetrap/armed,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
+"aKm" = (
+/obj/structure/sign/pods,
+/turf/simulated/wall/r_wall,
+/area/station/hallway/secondary/entry/west)
 "aKq" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -7180,7 +7200,7 @@
 /area/station/engineering/engine/supermatter)
 "aTQ" = (
 /obj/effect/spawner/airlock/e_to_w,
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/station/hallway/secondary/entry/west)
 "aTR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -7279,9 +7299,6 @@
 	},
 /area/station/command/bridge)
 "aUl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -8166,10 +8183,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
-"aYt" = (
-/obj/machinery/door/airlock/titanium,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
 "aYA" = (
 /obj/effect/spawner/window/reinforced/tinted,
 /turf/simulated/floor/plating,
@@ -9038,6 +9051,16 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
+"bcw" = (
+/obj/machinery/computer/arcade{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Arrivals Shuttle Aft";
+	dir = 10
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/arrival/station)
 "bcC" = (
 /obj/item/radio/intercom{
 	name = "south bump";
@@ -9949,7 +9972,9 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/engine_foyer)
 "bfu" = (
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/hallway/secondary/entry/east)
 "bfw" = (
 /turf/simulated/wall,
@@ -11254,6 +11279,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "arrival"
@@ -11582,7 +11610,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/spawner/late/crew,
-/turf/simulated/floor/mineral/titanium,
+/turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/arrival/station)
 "bmf" = (
 /obj/structure/cable{
@@ -12107,9 +12135,6 @@
 	},
 /area/station/command/office/ce)
 "boc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /obj/machinery/atmospherics/portable/canister/air,
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -12496,11 +12521,14 @@
 /turf/simulated/floor/plating,
 /area/station/supply/sorting)
 "bpG" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/glass{
 	id_tag = "admin_home";
-	locked = 1
+	name = "Port Bay 1 Airlock"
 	},
-/turf/simulated/floor/plating,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/hallway/secondary/entry/west)
 "bpI" = (
 /obj/structure/extinguisher_cabinet{
@@ -12883,10 +12911,6 @@
 	icon_state = "dark"
 	},
 /area/station/turret_protected/ai)
-"brp" = (
-/obj/machinery/light,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
 "brq" = (
 /obj/structure/closet,
 /turf/simulated/floor/plating,
@@ -15288,9 +15312,6 @@
 	},
 /area/station/hallway/secondary/entry/east)
 "bAR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -18929,17 +18950,6 @@
 /obj/effect/spawner/random/dirt/maybe,
 /turf/simulated/floor/wood,
 /area/station/science/robotics/showroom)
-"bSf" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/landmark/spawner/late/crew,
-/obj/structure/chair/comfy/shuttle{
-	dir = 4;
-	name = "prisoner transfer chair"
-	},
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/arrival/station)
 "bSh" = (
 /turf/simulated/floor/plasteel,
 /area/station/command/teleporter)
@@ -19195,11 +19205,14 @@
 /turf/simulated/floor/plasteel,
 /area/station/security/checkpoint/secondary)
 "bTn" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "ferry_home";
-	locked = 1
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "specops_home";
+	name = "Port Bay 2 Airlock"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/hallway/secondary/entry/east)
 "bTA" = (
 /obj/machinery/firealarm/directional/east,
@@ -19403,10 +19416,6 @@
 	icon_state = "darkgrey"
 	},
 /area/station/ai_monitored/storage/eva)
-"bUP" = (
-/obj/structure/sign/pods,
-/turf/simulated/wall,
-/area/station/hallway/secondary/entry/west)
 "bUR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -20034,9 +20043,9 @@
 /turf/simulated/wall/r_wall,
 /area/station/science/storage)
 "bXH" = (
-/obj/machinery/door/airlock/titanium,
+/obj/machinery/door/airlock/titanium/glass,
 /obj/structure/fans/tiny,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/mineral/titanium,
 /area/shuttle/arrival/station)
 "bXI" = (
 /obj/structure/cable{
@@ -21749,6 +21758,10 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/medbay)
+"cfG" = (
+/obj/structure/shuttle/engine/huge,
+/turf/space,
+/area/space)
 "cfI" = (
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/nw)
@@ -22131,6 +22144,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"chr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/stripes/corner,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/west)
 "chs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/watertank,
@@ -23526,6 +23547,11 @@
 /obj/effect/landmark/spawner/xeno,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
+"cnM" = (
+/obj/structure/closet/wardrobe/green,
+/obj/machinery/requests_console/directional/north,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/arrival/station)
 "cnN" = (
 /turf/simulated/wall,
 /area/station/hallway/primary/fore/east)
@@ -27072,10 +27098,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/xenobiology)
-"cEr" = (
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/west)
 "cEt" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -28999,11 +29021,6 @@
 	icon_state = "dark"
 	},
 /area/station/medical/surgery/observation)
-"cNb" = (
-/obj/structure/chair/comfy/shuttle,
-/obj/effect/landmark/spawner/late/crew,
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/arrival/station)
 "cNc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light/small{
@@ -29378,6 +29395,15 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/misc_lab)
+"cOS" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/west)
 "cOT" = (
 /obj/item/target,
 /obj/structure/window/reinforced{
@@ -29811,6 +29837,9 @@
 /area/station/maintenance/solar_maintenance/aft_starboard)
 "cQY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/west)
 "cRc" = (
@@ -32748,6 +32777,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/west)
+"dmd" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/arrival/station)
 "dmg" = (
 /obj/machinery/door/airlock/public/glass{
 	autoclose = 0;
@@ -34368,6 +34404,20 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/science/research)
+"dUe" = (
+/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/closet/crate/internals,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/arrival/station)
 "dUv" = (
 /obj/machinery/door/airlock/engineering,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
@@ -35092,6 +35142,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/east)
 "eht" = (
@@ -35457,6 +35510,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -36123,6 +36179,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "arrival"
@@ -36717,6 +36774,14 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/test_chamber)
+"eIc" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/landmark/spawner/late/crew,
+/obj/structure/closet/walllocker/emerglocker/directional/west,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/arrival/station)
 "eIj" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -36885,6 +36950,17 @@
 	icon_state = "darkred"
 	},
 /area/station/security/storage)
+"eLs" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/landmark/spawner/late/crew,
+/obj/machinery/camera{
+	c_tag = "Arrivals Shuttle Fore Compartment";
+	dir = 8
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/arrival/station)
 "eLz" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -36920,16 +36996,6 @@
 /obj/effect/mapping_helpers/turfs/rust/maybe,
 /turf/simulated/wall/r_wall,
 /area/station/science/test_chamber)
-"eLW" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/landmark/spawner/late/crew,
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/arrival/station)
 "eMh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -37482,6 +37548,16 @@
 	icon_state = "white"
 	},
 /area/station/medical/reception)
+"eVt" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/landmark/spawner/late/crew,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/arrival/station)
 "eVu" = (
 /obj/machinery/computer/brigcells{
 	dir = 4
@@ -39258,13 +39334,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/atmos/control)
-"fDi" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating/airless,
-/area/shuttle/arrival/station)
 "fDr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
@@ -40531,7 +40600,7 @@
 	},
 /area/station/public/fitness)
 "gas" = (
-/obj/structure/table,
+/obj/machinery/door/airlock/titanium/glass,
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/arrival/station)
 "gaw" = (
@@ -40541,6 +40610,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
+"gaM" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/plating/airless,
+/area/shuttle/arrival/station)
 "gaZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
@@ -41092,6 +41165,11 @@
 	icon_state = "cafeteria"
 	},
 /area/station/science/break_room)
+"gjo" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/titanium/glass,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/arrival/station)
 "gjF" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -41410,12 +41488,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard2)
-"gqt" = (
-/obj/structure/table,
-/obj/item/crowbar/red,
-/obj/machinery/newscaster/directional/north,
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/arrival/station)
 "gqv" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -44722,12 +44794,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/virology)
-"hDj" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 1
-	},
-/turf/simulated/floor/plating/airless,
-/area/shuttle/arrival/station)
 "hDr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -45524,6 +45590,9 @@
 	icon_state = "darkblue"
 	},
 /area/station/command/bridge)
+"hSu" = (
+/turf/simulated/wall/r_wall,
+/area/station/hallway/secondary/entry/lounge)
 "hSz" = (
 /obj/structure/chair{
 	dir = 1
@@ -45737,7 +45806,7 @@
 /area/station/security/permabrig)
 "hXV" = (
 /obj/structure/sign/pods,
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/station/hallway/secondary/entry/east)
 "hXW" = (
 /obj/effect/turf_decal/stripes/line,
@@ -46625,6 +46694,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "arrival"
@@ -46747,6 +46817,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -46954,9 +47027,6 @@
 	},
 /area/station/service/chapel)
 "iuI" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/sign/directions/evac{
 	pixel_x = 32;
 	pixel_y = -8
@@ -46968,6 +47038,7 @@
 	pixel_x = 32;
 	pixel_y = 8
 	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "arrival"
@@ -47023,6 +47094,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/range)
+"ivC" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/arrival/station)
 "ivD" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -47267,6 +47342,14 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/engineering/hardsuitstorage)
+"iAd" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/landmark/spawner/late/crew,
+/obj/structure/closet/walllocker/emerglocker/directional/east,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/arrival/station)
 "iAo" = (
 /obj/structure/rack,
 /obj/item/tank/internals/emergency_oxygen,
@@ -48781,6 +48864,16 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/bluegrid/telecomms,
 /area/station/science/xenobiology)
+"jaQ" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/landmark/spawner/late/crew,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/arrival/station)
 "jba" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -49048,7 +49141,9 @@
 "jgq" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/hallway/secondary/entry/east)
 "jgD" = (
 /obj/item/shard,
@@ -49758,9 +49853,10 @@
 	},
 /area/station/security/execution)
 "jwr" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "arrival"
@@ -51427,6 +51523,11 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/lobby)
+"jUw" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/hallway/secondary/entry/west)
 "jUN" = (
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "psychoffice"
@@ -53782,9 +53883,6 @@
 	},
 /area/station/security/armory)
 "kNu" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/sign/directions/science{
 	pixel_x = -32;
 	pixel_y = -8
@@ -53795,6 +53893,9 @@
 /obj/structure/sign/directions/security{
 	pixel_x = -32;
 	pixel_y = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -56964,23 +57065,12 @@
 	icon_state = "arrivalcorner"
 	},
 /area/station/hallway/secondary/entry/west)
-"lSd" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
-	},
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/arrival/station)
 "lSe" = (
 /obj/structure/chair/comfy/shuttle{
-	dir = 4;
-	name = "prisoner transfer chair"
+	dir = 4
 	},
 /obj/effect/landmark/spawner/late/crew,
-/turf/simulated/floor/mineral/titanium,
+/turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/arrival/station)
 "lSg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
@@ -57043,6 +57133,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/east)
 "lTS" = (
@@ -59103,6 +59199,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/east)
 "mFx" = (
@@ -60454,7 +60553,9 @@
 "nbO" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/hallway/secondary/entry/west)
 "nbQ" = (
 /obj/structure/cable/yellow{
@@ -61472,6 +61573,12 @@
 "nvB" = (
 /turf/simulated/wall,
 /area/station/security/prison/cell_block/a)
+"nvJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/west)
 "nvN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/bluegrid,
@@ -61734,6 +61841,13 @@
 	icon_state = "darkyellow"
 	},
 /area/station/engineering/atmos/control)
+"nAY" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
+	name = "KEEP CLEAR: DOCKING AREA"
+	},
+/turf/simulated/wall/r_wall,
+/area/station/hallway/secondary/entry/east)
 "nBd" = (
 /obj/structure/cable/cyan{
 	icon_state = "0-8"
@@ -62255,6 +62369,18 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/carpet/royalblack,
 /area/station/supply/qm)
+"nKV" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/east)
 "nLf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/girder,
@@ -63209,6 +63335,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "arrival"
@@ -64057,11 +64189,8 @@
 	},
 /area/station/hallway/supply/port)
 "otf" = (
-/obj/effect/landmark/spawner/late/crew,
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/turf/simulated/floor/mineral/titanium,
+/obj/structure/closet/wardrobe/black,
+/turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/arrival/station)
 "otS" = (
 /obj/machinery/light/small{
@@ -64718,6 +64847,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"oGA" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
+	name = "KEEP CLEAR: DOCKING AREA"
+	},
+/turf/simulated/wall/r_wall,
+/area/station/hallway/secondary/entry/west)
 "oGB" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -65985,6 +66121,12 @@
 	icon_state = "darkblue"
 	},
 /area/station/security/armory)
+"pdB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/west)
 "pdE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -67916,6 +68058,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/north)
+"pQM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/east)
 "pQW" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
@@ -68028,6 +68176,15 @@
 /obj/machinery/economy/atm/directional/north,
 /turf/simulated/floor/wood,
 /area/station/service/cafeteria)
+"pSJ" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/regular,
+/obj/item/radio/intercom{
+	name = "east bump";
+	pixel_x = 28
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/arrival/station)
 "pSL" = (
 /obj/machinery/atmospherics/refill_station/plasma,
 /turf/simulated/floor/plasteel{
@@ -68199,6 +68356,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"pUA" = (
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/arrival/station)
 "pUF" = (
 /obj/structure/disposalpipe/segment/corner,
 /turf/simulated/floor/plasteel{
@@ -68498,6 +68658,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"qav" = (
+/obj/structure/closet/wardrobe/xenos,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/arrival/station)
 "qaz" = (
 /obj/structure/table,
 /obj/item/radio/intercom/department/security{
@@ -70571,6 +70735,9 @@
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/fore)
 "qMn" = (
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "arrival"
@@ -71056,6 +71223,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
+"qTT" = (
+/obj/machinery/ai_status_display,
+/turf/simulated/wall/mineral/titanium/nodiagonal,
+/area/shuttle/arrival/station)
 "qTX" = (
 /obj/machinery/atmospherics/refill_station/oxygen,
 /turf/simulated/floor/catwalk,
@@ -71091,6 +71262,9 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/research)
+"qVd" = (
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/theatre)
 "qVi" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -72403,6 +72577,18 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard)
+"rvH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/red/corner,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/east)
 "rvP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -72811,6 +72997,12 @@
 "rDA" = (
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
+"rDR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/west)
 "rEa" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -73082,12 +73274,6 @@
 /obj/machinery/atmospherics/unary/tank/air,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"rID" = (
-/obj/item/storage/firstaid/regular,
-/obj/structure/table,
-/obj/machinery/requests_console/directional/north,
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/arrival/station)
 "rIT" = (
 /obj/structure/table,
 /obj/item/geiger_counter,
@@ -73573,6 +73759,15 @@
 	icon_state = "caution"
 	},
 /area/station/engineering/transmission_laser)
+"rPs" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/east)
 "rPt" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -76066,6 +76261,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"sOi" = (
+/obj/machinery/status_display,
+/turf/simulated/wall/mineral/titanium/nodiagonal,
+/area/shuttle/arrival/station)
 "sOy" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -76556,6 +76755,12 @@
 /obj/machinery/camera{
 	c_tag = "Arrivals Hallway East 2";
 	dir = 9
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -77386,6 +77591,9 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/science/research)
+"tnO" = (
+/turf/simulated/wall/mineral/titanium/nodiagonal,
+/area/shuttle/arrival/station)
 "toc" = (
 /obj/structure/sign/electricshock,
 /turf/simulated/wall/r_wall,
@@ -79243,9 +79451,6 @@
 /area/station/medical/psych)
 "ubY" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "arrival"
@@ -79560,6 +79765,12 @@
 	icon_state = "red"
 	},
 /area/station/security/main)
+"uhq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/east)
 "uhI" = (
 /obj/effect/spawner/random/barrier/grille_maybe,
 /turf/simulated/floor/plasteel,
@@ -80211,6 +80422,15 @@
 	icon_state = "red"
 	},
 /area/station/security/checkpoint/secondary)
+"utr" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/west)
 "utu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -81088,6 +81308,13 @@
 /obj/structure/fans/tiny,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/pod_2)
+"uKz" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/effect/landmark/spawner/late/crew,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/arrival/station)
 "uLb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -81208,11 +81435,10 @@
 	},
 /area/station/hallway/primary/starboard)
 "uMS" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4;
-	name = "prisoner transfer chair"
+/obj/machinery/computer/arcade{
+	dir = 1
 	},
-/turf/simulated/floor/mineral/titanium,
+/turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/arrival/station)
 "uNe" = (
 /obj/structure/cable{
@@ -81252,15 +81478,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
-"uNP" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/arrival/station)
 "uNQ" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -82375,8 +82592,11 @@
 	},
 /area/station/hallway/secondary/exit)
 "vhk" = (
-/obj/effect/landmark/spawner/late/crew,
-/obj/structure/chair/comfy/shuttle,
+/obj/effect/landmark{
+	icon = 'icons/effects/spawner_icons.dmi';
+	icon_state = "spooky";
+	name = "Observer-Start"
+	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/arrival/station)
 "vih" = (
@@ -84403,7 +84623,7 @@
 /turf/simulated/floor/plating,
 /area/station/security/permabrig)
 "vXe" = (
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/station/hallway/secondary/entry/east)
 "vXg" = (
 /obj/structure/cable{
@@ -84561,6 +84781,20 @@
 /obj/item/flag/syndi,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
+"waR" = (
+/obj/structure/closet/crate/internals,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/arrival/station)
 "waX" = (
 /obj/effect/decal/cleanable/blood/writing,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -85594,6 +85828,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/station/science/testrange)
+"wuL" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/landmark/spawner/late/crew,
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/arrival/station)
 "wvo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -86463,6 +86708,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
+"wKi" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/landmark/spawner/late/crew,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/arrival/station)
 "wKE" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
@@ -88662,6 +88912,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/permabrig)
+"xxq" = (
+/obj/structure/closet/wardrobe/yellow,
+/obj/machinery/newscaster/directional/north,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/arrival/station)
 "xxA" = (
 /obj/structure/chair{
 	dir = 1
@@ -88874,16 +89129,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/brig)
-"xBw" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4;
-	name = "prisoner transfer chair"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/arrival/station)
 "xBG" = (
 /obj/effect/spawner/random/dirt/often,
 /mob/living/basic/lizard/wags_his_tail,
@@ -94676,7 +94921,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cfG
 aaa
 aaa
 aaa
@@ -100054,12 +100299,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-ayy
+arB
+arB
+arB
+arB
+abq
+oGA
 biC
 biC
 nlB
@@ -100069,7 +100314,7 @@ aaa
 nlB
 bpG
 bpG
-ayy
+oGA
 aaa
 aaa
 aaa
@@ -100311,21 +100556,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
+abq
 aaa
 aaa
 aaa
 aaa
 ayy
-qcE
-qcE
+jUw
+jUw
 nlB
 abq
 abq
 abq
 nlB
-qcE
-qcE
+jUw
+jUw
 ayy
 abq
 abq
@@ -100568,21 +100813,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
+abq
 aaa
 aaa
 aaa
 aaa
 ayy
-qcE
-qcE
+jUw
+jUw
 nlB
 nlB
 nlB
 nlB
 nlB
-qcE
-qcE
+jUw
+jUw
 ayy
 ayy
 ayy
@@ -100825,7 +101070,7 @@ fCU
 abq
 abq
 abq
-abq
+ayy
 ayy
 ayy
 ayy
@@ -101086,17 +101331,17 @@ aSq
 aSq
 aWG
 aqA
-ayy
+aKm
 jwr
-aCn
-aCn
-sgZ
+rDR
+rDR
+utr
 naz
 aCn
 oUe
-sgZ
-aCn
-aCn
+cOS
+rDR
+rDR
 aeX
 naz
 aCn
@@ -101342,7 +101587,7 @@ aSr
 bxR
 aUW
 brG
-qcE
+nvJ
 ejj
 aCn
 aCn
@@ -101599,17 +101844,17 @@ aSq
 aSq
 aSq
 aWG
-cEr
-bUP
+nvJ
+ayy
 qMn
 iuI
-aCn
+pdB
 obX
 dsj
 dsj
 dsj
 dsj
-dsj
+chr
 cQY
 iqP
 uIu
@@ -101853,7 +102098,7 @@ fCU
 abq
 abq
 abq
-abq
+ayy
 ayy
 ayy
 ayy
@@ -101861,12 +102106,12 @@ ayy
 ayy
 ayy
 nbO
-nlB
+ayy
 gBt
 kOe
 kOe
 kOe
-nlB
+ayy
 nbO
 ayy
 kOe
@@ -102110,21 +102355,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
+abq
 aaa
 aaa
 aaa
 aaa
 aaa
 ayy
-qcE
+jUw
+ayy
 nlB
 nlB
 nlB
 nlB
-nlB
-nlB
-qcE
+ayy
+jUw
 ayy
 ayy
 ayy
@@ -102367,7 +102612,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+ajo
 aaa
 aaa
 aaa
@@ -102375,20 +102620,20 @@ aaa
 aaa
 ayy
 nbO
-nlB
-aaa
-aaa
-aaa
-aaa
-nlB
+ayy
+ajo
+aef
+aef
+ajo
+ayy
 nbO
 ayy
-abq
-abq
-abq
-abq
-bfG
-bfG
+aaa
+aaa
+aaa
+ajo
+hSu
+hSu
 cUe
 kfo
 sEK
@@ -102626,25 +102871,25 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 bin
-bin
-bin
-bin
-bin
+tnO
+tnO
 bXH
-bin
+tnO
 biq
 biq
 biq
 biq
-bin
+tnO
 bXH
-bin
+tnO
+tnO
+tnO
+tnO
 aaa
-aaa
-aaa
-aaa
-bfG
+hSu
 rFj
 vzM
 kOX
@@ -102883,23 +103128,23 @@ aaa
 aaa
 aaa
 aaa
-hDj
+aaa
 bin
+tnO
 aHn
-aHn
-bSf
-bkb
 rUr
+pUA
+eVt
 lSe
 lSe
 lSe
 lSe
-rUr
-bkb
-bin
-aaa
-aaa
-aaa
+eVt
+pUA
+eIc
+abn
+dmd
+gaM
 aaa
 qrA
 sXa
@@ -103139,24 +103384,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-hDj
-fDi
-bkb
-bkb
-bkb
-bkb
-bkb
-bkb
-bkb
-bkb
-bkb
-bkb
-brp
 bin
-bin
-bin
-bin
+tnO
+tnO
+sOi
+qav
+bkb
+pUA
+pUA
+pUA
+pUA
+pUA
+pUA
+pUA
+pUA
+bkb
+dUe
+dmd
+gaM
 aaa
 qrA
 tPv
@@ -103396,24 +103641,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-hDj
-bin
-gqt
+biq
+eVt
+wuL
+tnO
+cnM
 bkb
-vhk
-bkb
-bkb
-cNb
-cNb
-cNb
-cNb
-bkb
-bkb
-bin
+pUA
+uKz
+uKz
+uKz
+uKz
+uKz
+uKz
+pUA
+wKi
 uMS
-xBw
-bin
+dmd
+gaM
 aaa
 qrA
 oNg
@@ -103653,24 +103898,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-hDj
-fDi
-gas
-bkb
-vhk
-bkb
-bkb
-cNb
-cNb
-cNb
-cNb
-bkb
-bkb
-aYt
-bkb
-bkb
 biq
+pUA
+pUA
+gas
+pUA
+vhk
+ivC
+uKz
+uKz
+uKz
+uKz
+uKz
+uKz
+ivC
+wKi
+bcw
+tnO
+tnO
 aaa
 qrA
 oNg
@@ -103910,24 +104155,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-hDj
-bin
-rID
+biq
+jaQ
+eLs
+tnO
+xxq
 bkb
-vhk
-bkb
-bkb
-cNb
-cNb
-cNb
-cNb
-bkb
-bkb
-bin
-lSd
-uNP
-bin
+pUA
+uKz
+uKz
+uKz
+uKz
+uKz
+uKz
+pUA
+wKi
+uMS
+dmd
+gaM
 aaa
 qrA
 oNg
@@ -104167,24 +104412,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-hDj
-fDi
-bkb
-bkb
-bkb
-bkb
-bkb
-bkb
-bkb
-bkb
-bkb
-bkb
-brp
 bin
-bin
-bin
-bin
+tnO
+tnO
+qTT
+arJ
+bkb
+pUA
+pUA
+pUA
+pUA
+pUA
+pUA
+pUA
+pUA
+bkb
+waR
+dmd
+gaM
 aaa
 qrA
 upc
@@ -104425,23 +104670,23 @@ aaa
 aaa
 aaa
 aaa
-hDj
+aaa
 bin
+tnO
 otf
-otf
-eLW
-bkb
 aoS
+pUA
+jaQ
 blS
 blS
 blS
 blS
-aoS
-bkb
-bin
-aaa
-aaa
-aaa
+jaQ
+pUA
+iAd
+pSJ
+dmd
+gaM
 aaa
 qrA
 wXk
@@ -104682,25 +104927,25 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 bin
-bin
-bin
-bin
-bin
-bXH
-bin
+tnO
+tnO
+gjo
+tnO
 biq
 biq
 biq
 biq
-bin
-bXH
-bin
+tnO
+gjo
+tnO
+tnO
+tnO
+tnO
 aaa
-aaa
-aaa
-aaa
-bfG
+hSu
 kDq
 vXk
 qIZ
@@ -104937,7 +105182,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+ajo
 aaa
 aaa
 aaa
@@ -104945,20 +105190,20 @@ aaa
 aaa
 vXe
 jgq
-mVN
-aaa
-aaa
-aaa
-aaa
-mVN
+vXe
+ajo
+aef
+aef
+ajo
+vXe
 jgq
 vXe
-abq
-abq
-abq
-abq
-bfG
-bfG
+aaa
+aaa
+aaa
+ajo
+hSu
+hSu
 cUe
 jgO
 xpA
@@ -105194,7 +105439,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+abq
 aaa
 aaa
 aaa
@@ -105202,19 +105447,19 @@ aaa
 aaa
 vXe
 bfu
+vXe
 mVN
 mVN
 mVN
 mVN
-mVN
-mVN
+vXe
 bfu
 vXe
 vXe
 vXe
 vXe
-bfG
-bfG
+hSu
+hSu
 ody
 btp
 knz
@@ -105451,7 +105696,7 @@ fCU
 abq
 abq
 abq
-abq
+vXe
 vXe
 vXe
 vXe
@@ -105459,12 +105704,12 @@ vXe
 vXe
 vXe
 jgq
-mVN
+vXe
 aSF
 mZP
 mZP
 mZP
-mVN
+vXe
 jgq
 vXe
 mZP
@@ -105715,14 +105960,14 @@ mFd
 vXe
 lnR
 kNu
-qFK
+uhq
+nKV
 qST
 qST
 qST
 qST
-qST
-qST
-qFK
+rPs
+uhq
 bkE
 qST
 qST
@@ -105968,7 +106213,7 @@ hfX
 tMb
 gEK
 uKy
-bfu
+pQM
 onD
 sKK
 dvn
@@ -106225,7 +106470,7 @@ hkF
 hkF
 hkF
 aKU
-aqw
+pQM
 hXV
 ios
 eya
@@ -106235,7 +106480,7 @@ vvx
 vvx
 vvx
 vvx
-vvx
+rvH
 lTI
 sYF
 uKl
@@ -106479,7 +106724,7 @@ fCU
 abq
 abq
 abq
-abq
+vXe
 vXe
 vXe
 vXe
@@ -106498,7 +106743,7 @@ vXe
 auu
 bAQ
 eFl
-bfG
+hSu
 hZZ
 niV
 bvD
@@ -106737,11 +106982,11 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 abq
 aaa
 aaa
-aaa
-aaa
 vXe
 bfu
 mVN
@@ -106755,8 +107000,8 @@ vXe
 vXe
 vXe
 vXe
-kme
-kme
+qVd
+qVd
 mPP
 xIX
 gUY
@@ -106994,12 +107239,12 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+ajo
 abq
-aaa
-aaa
-aaa
-aaa
-vXe
+abq
+nAY
 aok
 mVN
 aaa
@@ -107008,10 +107253,10 @@ aaa
 aaa
 mVN
 bTn
-vXe
-aaa
-aaa
-aaa
+nAY
+abq
+abq
+ajo
 kme
 vzc
 hOn
@@ -107251,20 +107496,20 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 abq
+aaa
+aaa
+aaa
+gkE
+aaa
 aaa
 aaa
 aaa
 aaa
 aaa
 bDO
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-gkE
 aaa
 aaa
 aaa
@@ -107508,9 +107753,9 @@ aaa
 aaa
 aaa
 aaa
-abq
 aaa
 aaa
+abf
 aaa
 aaa
 aaa
@@ -107765,9 +108010,9 @@ aaa
 aaa
 aaa
 aaa
-abq
 aaa
 aaa
+abf
 aaa
 aaa
 aaa
@@ -108019,12 +108264,12 @@ arB
 arB
 arB
 arB
+abf
+abf
+abf
 abq
 abq
-abq
-ajo
-aaa
-aaa
+abf
 aaa
 aaa
 aaa
@@ -108279,9 +108524,9 @@ aaa
 aaa
 aaa
 aaa
-abq
 aaa
 aaa
+abf
 aaa
 aaa
 aaa
@@ -108536,9 +108781,9 @@ aaa
 aaa
 aaa
 aaa
-abq
 aaa
 aaa
+abf
 aaa
 aaa
 aaa
@@ -108793,9 +109038,9 @@ aaa
 aaa
 aaa
 aaa
-abq
 aaa
 aaa
+abf
 aaa
 aaa
 aaa
@@ -109049,10 +109294,10 @@ bsA
 abW
 abW
 abW
-abq
-ajo
 aaa
 aaa
+aaa
+abf
 aaa
 aaa
 aaa
@@ -109307,9 +109552,9 @@ wab
 acI
 abW
 aaa
-abq
 aaa
 aaa
+abf
 aaa
 aaa
 aaa
@@ -109564,9 +109809,9 @@ eAt
 gCp
 abW
 aaa
-abq
 aaa
 aaa
+abf
 aaa
 aaa
 aaa
@@ -109821,9 +110066,9 @@ adi
 aJM
 abW
 abW
-abq
 aaa
 aaa
+abf
 aaa
 aaa
 aaa
@@ -110078,9 +110323,9 @@ rgu
 aJM
 pdc
 abW
+aaa
+aaa
 abq
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -110337,8 +110582,7 @@ wRL
 jfk
 abq
 abq
-abq
-abq
+ajo
 abq
 abq
 abq
@@ -110348,11 +110592,12 @@ abq
 abq
 abq
 abq
+abq
 ajo
 abq
 abq
 abq
-abq
+ajo
 lIM
 dEo
 xGT
@@ -110592,7 +110837,6 @@ uEB
 awA
 lmP
 gjF
-abq
 aaa
 aaa
 aaa
@@ -110600,6 +110844,7 @@ aaa
 aaa
 aaa
 abq
+aaa
 aaa
 aaa
 aaa
@@ -110855,8 +111100,8 @@ abW
 abW
 abW
 aaa
-aaa
 abq
+aaa
 aaa
 aaa
 aaa
@@ -111112,8 +111357,8 @@ efX
 ggM
 abW
 aaa
-aaa
 abq
+aaa
 aaa
 aaa
 aef


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds glass to the external airlocks.
Adds mapping lock helpers to the external airlocks.
Adds reinforced walls to the arrivals walls.
Adds some meteor grates.
Adds some docking beacon lights.
Swaps the arrivals shuttle with the shuttle found on Box and Cere
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Makes arrivals more resistant to damage, ideally this area should be safe for people joining the round. Explosions and meteor impacts are less likely to cause a breach, or to damage the arrivals shuttle itself. Other stations have similar levels of reinforcement at arrivals.

Standardizing the arrivals shuttle and dock dimensions will help in the event that we add a mobile arrivlals shuttle.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/1fb6965c-e8ee-4af5-b425-97cf93409e3b" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Visual inspection.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: reinforces the Meta arrivals area and swaps the shuttle.
tweak: adds glass to the Meta arrivals airlocks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
