### PR TITLE
Rotate captain's bed and move medchem intercom on Cyberiad.

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -25394,10 +25394,6 @@
 	layer = 4;
 	pixel_y = 32
 	},
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
-	},
 /turf/simulated/floor/engine,
 /area/station/medical/chemistry)
 "bLy" = (
@@ -25858,10 +25854,11 @@
 	},
 /area/station/hallway/primary/central/sw)
 "bNy" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/chem_dispenser,
+/obj/item/radio/intercom{
+	name = "east bump";
+	pixel_x = 28
+	},
 /turf/simulated/floor/engine,
 /area/station/medical/chemistry)
 "bNz" = (
@@ -26661,6 +26658,9 @@
 /area/station/medical/paramedic)
 "bQR" = (
 /obj/machinery/chem_heater,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/engine,
 /area/station/medical/chemistry)
 "bQS" = (
@@ -76246,9 +76246,7 @@
 	},
 /area/station/security/permabrig)
 "ryC" = (
-/obj/structure/bed{
-	dir = 1
-	},
+/obj/structure/bed,
 /obj/item/bedsheet/captain{
 	dir = 1
 	},


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Flips the Cyberiad captain's bed around so that the pillow is outside the blanket. Moves the medchem intercom and light south 1 tile each.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Fixes #30394
Fixes #29790 

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<img width="145" height="196" alt="2025-09-07 16_47_05-paradise dme  boxstation dmm  - StrongDMM" src="https://github.com/user-attachments/assets/7a73a843-929d-43fc-8168-d5a173c18f86" />
<img width="165" height="132" alt="2025-09-07 16_47_19-paradise dme  boxstation dmm  - StrongDMM" src="https://github.com/user-attachments/assets/131a96ff-5b96-4b43-9810-0835901a597a" />


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

Compiled and hosted Cyberiad. Joined as captain. Took a nap in the Captain's bed. Made a sugar pill in medchem and picked it up with the chemistry bag without any annoying message.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed captain's bed orientation on Cyberiad.
fix: Fixed intercom placement in Cyberiad medchem to prevent chemistry bag pickup fail message.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
