### PR TITLE
Makes Positronic Brain Speaker Active by Default

### DIFF
--- a/code/modules/mob/living/brain/robotic_brain.dm
+++ b/code/modules/mob/living/brain/robotic_brain.dm
@@ -202,7 +202,6 @@
 	searching_icon = "posibrain-searching"
 	occupied_icon = "posibrain-occupied"
 	desc = "A cube of shining metal, four inches to a side and covered in shallow grooves."
-	silenced = TRUE
 	requires_master = FALSE
 	ejected_flavor_text = "metal cube"
 	dead_icon = "posibrain"


### PR DESCRIPTION
## What Does This PR Do
Positronic brains can speak by default.
## Why It's Good For The Game
Consistency with robotic brains, who also start unmuted, and MMIs, who start unmuted.
Makes IPCs slightly less bad.
## Images of changes
<img width="307" height="301" alt="image" src="https://github.com/user-attachments/assets/2ae03ccc-3d15-41c0-9594-3d2f3674d3b5" />

## Testing
Spawned as an IPC, gibbed myself, spoke.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<img width="799" height="156" alt="image" src="https://github.com/user-attachments/assets/6c4901db-ecb7-41d8-bd44-932bacef8d8d" />

## Changelog
:cl:
tweak: Positronic brains can speak by default.
/:cl: