### PR TITLE
Cleanups some autoinjector code

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -189,17 +189,8 @@
 	ignore_hypospray_immunity = TRUE
 	penetrate_everything = TRUE // Autoinjectors bypass everything.
 	container_type = DRAWABLE
-	flags = null
 
-/obj/item/reagent_containers/hypospray/autoinjector/mob_act(mob/target, mob/living/user)
-	if(!reagents.total_volume)
-		to_chat(user, "<span class='warning'>[src] is empty!</span>")
-		return TRUE
-	. = ..()
-	update_icon(UPDATE_ICON_STATE)
-
-/obj/item/reagent_containers/hypospray/autoinjector/activate_self(mob/user)
-	. = ..()
+/obj/item/reagent_containers/hypospray/autoinjector/on_reagent_change()
 	update_icon(UPDATE_ICON_STATE)
 
 /obj/item/reagent_containers/hypospray/autoinjector/update_icon_state()
@@ -210,7 +201,7 @@
 
 /obj/item/reagent_containers/hypospray/autoinjector/examine()
 	. = ..()
-	if(reagents && length(reagents.reagent_list))
+	if(length(reagents?.reagent_list))
 		. += "<span class='notice'>It is currently loaded.</span>"
 	else
 		. += "<span class='notice'>It is spent.</span>"
@@ -278,7 +269,7 @@
 	icon_state = "zombiepen"
 	amount_per_transfer_from_this = 15
 	volume = 15
-	container_type = null //No sucking out the reagent
+	container_type = NONE // No sucking out the reagent
 	list_reagents = list("zombiecure1" = 15)
 
 /obj/item/reagent_containers/hypospray/autoinjector/zombiecure/apply(mob/living/M, mob/user)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Cleanups what i noticed while doing stuff
Removes `flag = null` cos it's a bitflag which is `NONE` on `/atom`
Replaces `container_type = null` with `container_type = NONE` cos it's a bitflag var and it's better to keep it as a bitflag
Currently there is no reason to override `activate_self` and `mob_act` for autoinjectors, they do all the same stuff as their parent type, but also want to update the icon. So in order to update the icon, i move that to `on_reagent_change`, which covers way more cases when the icon should actually be updated

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Code is cleaner

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Icon updates whenever it should. Otherwise there is no changes

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Removing reagents from autoinjectors now also updates their sprite
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
