### PR TITLE
Standardize air alarm buildstages to defines for clarity

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -220,7 +220,7 @@ GLOBAL_LIST_INIT(aalarm_modes, list(
 		if(direction)
 			setDir(direction)
 
-		buildstage = 0
+		buildstage = AIR_ALARM_FRAME
 		wiresexposed = TRUE
 		set_pixel_offsets_from_dir(24, -24, 24, -24)
 
@@ -251,7 +251,7 @@ GLOBAL_LIST_INIT(aalarm_modes, list(
 	GLOB.air_alarm_repository.update_cache(src)
 
 /obj/machinery/alarm/process()
-	if((stat & (NOPOWER|BROKEN)) || shorted || buildstage != 2 || init_tick == SSair.milla_tick)
+	if((stat & (NOPOWER|BROKEN)) || shorted || buildstage != AIR_ALARM_READY || init_tick == SSair.milla_tick)
 		return
 
 	var/turf/simulated/location = loc
@@ -558,7 +558,7 @@ GLOBAL_LIST_INIT(aalarm_modes, list(
 ///////////////
 
 /obj/machinery/alarm/attack_ai(mob/user)
-	if(buildstage != 2)
+	if(buildstage != AIR_ALARM_READY)
 		return
 
 	add_hiddenprint(user)
@@ -574,7 +574,7 @@ GLOBAL_LIST_INIT(aalarm_modes, list(
 	return interact(user)
 
 /obj/machinery/alarm/interact(mob/user)
-	if(buildstage != 2)
+	if(buildstage != AIR_ALARM_READY)
 		return
 
 	if(wiresexposed)
@@ -814,7 +814,7 @@ GLOBAL_LIST_INIT(aalarm_modes, list(
 		return !locked
 
 /obj/machinery/alarm/ui_status(mob/user, datum/ui_state/state)
-	if(buildstage != 2)
+	if(buildstage != AIR_ALARM_READY)
 		return UI_CLOSE
 
 	if(aidisabled && (is_ai(user) || isrobot(user)))
@@ -1047,7 +1047,7 @@ GLOBAL_LIST_INIT(aalarm_modes, list(
 				to_chat(user, "<span class='notice'>You insert [used] into [src].</span>")
 				playsound(get_turf(src), used.usesound, 50, TRUE)
 				qdel(used)
-				buildstage = 1
+				buildstage = AIR_ALARM_UNWIRED
 				update_icon(UPDATE_ICON_STATE)
 				return ITEM_INTERACT_COMPLETE
 	return ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Previously, the `buildstage` variable in `code/modules/atmospherics/machinery/airalarm.dm` had assignments and checks that were mixed: some were clear defines (e.g. `AIR_ALARM_READY`) and some were flat numerals (e.g. `2`). This standardizes all of them so that the meaning is always clear.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Clear code is better code.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted, assembled an air alarm, and broke it with a welder. I examined it at various points during the process. It seemed fine.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

NPFC
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
