### PR TITLE
Fix: tail wag emote no longer stops when interacting with external wear

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -95,6 +95,8 @@
 	/// Same as tail but wing
 	var/wing
 
+	var/tail_wagging = FALSE
+
 	var/list/splinted_limbs = list() //limbs we know are splinted
 	var/original_eye_color = "#000000"
 

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -1310,6 +1310,12 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	apply_overlay(WING_LAYER)
 
 /mob/living/carbon/human/proc/update_tail_layer()
+	// If we're currently wagging, re-apply wagging with current settings
+	if(tail_wagging)
+		start_tail_wagging()
+		return
+
+	// Normal static tail update
 	remove_overlay(TAIL_UNDERLIMBS_LAYER) // SEW direction icons, overlayed by LIMBS_LAYER.
 	remove_overlay(TAIL_LAYER) /* This will be one of two things:
 							If the species' tail is overlapped by limbs, this will be only the N direction icon so tails
@@ -1396,6 +1402,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	apply_overlay(TAIL_UNDERLIMBS_LAYER)
 
 /mob/living/carbon/human/proc/start_tail_wagging()
+	tail_wagging = TRUE
 	remove_overlay(TAIL_UNDERLIMBS_LAYER) // SEW direction icons, overlayed by LIMBS_LAYER.
 	remove_overlay(TAIL_LAYER) /* This will be one of two things:
 							If the species' tail is overlapped by limbs, this will be only the N direction icon so tails
@@ -1475,6 +1482,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	apply_overlay(TAIL_UNDERLIMBS_LAYER)
 
 /mob/living/carbon/human/proc/stop_tail_wagging()
+	tail_wagging = FALSE
 	remove_overlay(TAIL_UNDERLIMBS_LAYER)
 	remove_overlay(TAIL_LAYER)
 	update_tail_layer() //just trigger a full update for normal stationary sprites


### PR DESCRIPTION
## What Does This PR Do
Fixes #18830.

Prevents the `*wag` tail emote from being forcibly stopped when you equip/unequip clothing.

## Why It's Good For The Game
This allows us to wag our tails uninterrupted!

## Images Of Changes
![ezgif-1b23e0e052c9cd](https://github.com/user-attachments/assets/9300029b-72c2-4df6-ad69-7cf138808c59)

## Testing
- Spawned as species with tails (Vox).
- `*wag` active, then:
  - Equip/unequip labcoats, jackets, suit jackets (zip/unzip), winter coats (hood toggle).
  - Verified wagging **continues**

## Changelog
:cl: GooeyPancake
fix: Tail wag emote no longer stops when equipping/unequipping or using actions on external wear
:/cl:
