### PR TITLE
fix punpun uniform icon_state

### DIFF
--- a/code/modules/mob/living/carbon/human/npcs.dm
+++ b/code/modules/mob/living/carbon/human/npcs.dm
@@ -1,6 +1,7 @@
 /obj/item/clothing/under/punpun
 	name = "fancy uniform"
 	desc = "It looks like it was tailored for a monkey."
+	icon_state = "punpun"
 	item_color = "punpun"
 	species_restricted = list("Monkey")
 	species_exception = list(/datum/species/monkey)


### PR DESCRIPTION
## What Does This PR Do
returns punpuns uniform icon_state. fixes #30327 
## Why It's Good For The Game
item has uniform
## Images of changes

<img width="363" height="395" alt="image" src="https://github.com/user-attachments/assets/ab79c2ae-699a-43af-8f4c-c4a1b63ecf52" />

## Testing
Looked at uniform.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Pun-pun uniform has an icon again.
/:cl: