### PR TITLE
Fixes mind control font size

### DIFF
--- a/tgui/packages/tgui-panel/styles/tgchat/chat-default.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-default.scss
@@ -514,7 +514,7 @@ h2.alert {
 
 .mind_control {
   color: #a00d6f;
-  font-size: 3;
+  font-size: 120%;
   font-weight: bold;
   font-style: italic;
 }


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes a problem where abductor mind control objectives are absolutely tiny because their CSS has a font-size of 3 for some ungodly reason. It now has a120% font size, akin to userdanger, so the objective should be very visible.

## Why It's Good For The Game

Objectives should be legible.

## Testing

Compiled. It's a number change on a CSS sheet.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed abductor mind control objectives being too small to read.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
