### PR TITLE
Migrates Surgery Tools, Nuke Kits, and Nuke Cores to the New Attack Chain

### DIFF
--- a/code/game/objects/items/theft_items.dm
+++ b/code/game/objects/items/theft_items.dm
@@ -1,8 +1,4 @@
 //Items for nuke theft, supermatter theft traitor objective
-
-
-// STEALING THE NUKE
-
 //the nuke core, base item
 /obj/item/nuke_core
 	name = "plutonium core"
@@ -12,6 +8,7 @@
 	inhand_icon_state = "plutoniumcore"
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	flags_2 = RAD_NO_CONTAMINATE_2 //This is made from radioactive material so cannot really be contaminated
+	new_attack_chain = TRUE
 	var/cooldown = 0
 	var/pulseicon = "plutonium_core_pulse"
 	// Is this made from radioactive material or not.
@@ -26,16 +23,11 @@
 /obj/item/nuke_core/Destroy()
 	return ..()
 
-/obj/item/nuke_core/attackby__legacy__attackchain(obj/item/nuke_core_container/container, mob/user)
-	if(istype(container))
-		container.load(src, user)
-	else
-		return ..()
-
 /obj/item/nuke_core/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is rubbing [src] against [user.p_themselves()]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return TOXLOSS
 
+// MARK: Plutonium core
 /// The steal objective, so it doesnt mess with the SM sliver on pinpointers and objectives
 /obj/item/nuke_core/plutonium
 
@@ -52,12 +44,39 @@
 	inhand_icon_state = "syringe_kit"
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF //Don't want people trying to break it open with acid, then destroying the core.
 	var/obj/item/nuke_core/plutonium/core
+	new_attack_chain = TRUE
 	var/dented = FALSE
 	var/cracked = FALSE
 
-/obj/item/nuke_core_container/Destroy()
-	QDEL_NULL(core)
-	return ..()
+/obj/item/nuke_core_container/examine(mob/user)
+	. = ..()
+	if(cracked) // Cracked open.
+		. += "<span class='warning'>It is broken, and can no longer store objects safely.</span>"
+	else if(dented) // Not cracked, but dented.
+		. += "<span class='notice'>[src] looks dented. Perhaps a bigger explosion may break it.</span>"
+	else // Not cracked or dented.
+		. += "<span class='notice'>Fine print on the box reads \"Syndicate Field Operations secure core extraction container. Guaranteed thermite proof, assistant proof, and explosive resistant.\"</span>"
+
+/obj/item/nuke_core_container/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	if(!istype(used, /obj/item/nuke_core/plutonium))
+		return ..()
+
+	var/obj/item/nuke_core/plutonium/core = used
+	if(cracked)
+		return ITEM_INTERACT_COMPLETE
+
+	if(!user.drop_item())
+		to_chat(user, "<span class='warning'>[core] is stuck to your hand!</span>")
+		return ITEM_INTERACT_COMPLETE
+
+	load(core, user)
+	return ITEM_INTERACT_COMPLETE
+
+/obj/item/nuke_core_container/attack_hand(mob/user)
+	if(cracked && core)
+		unload(user)
+	else
+		return ..()
 
 /obj/item/nuke_core_container/ex_act(severity)
 	switch(severity)
@@ -68,21 +87,9 @@
 			if(!dented)
 				dented = TRUE
 
-/obj/item/nuke_core_container/examine(mob/user)
-	. = ..()
-	if(cracked) // Cracked open.
-		. += "<span class='warning'>It is broken, and can no longer store objects safely.</span>"
-	else if(dented) // Not cracked, but dented.
-		. += "<span class='notice'>[src] looks dented. Perhaps a bigger explosion may break it.</span>"
-	else // Not cracked or dented.
-		. += "Fine print on the box reads \"Syndicate Field Operations secure core extraction container. Guaranteed thermite proof, assistant proof, and explosive resistant.\""
-
-/obj/item/nuke_core_container/attack_hand(mob/user)
-	if(cracked && core)
-		unload(user)
-	else
-		return ..()
-
+/obj/item/nuke_core_container/Destroy()
+	QDEL_NULL(core)
+	return ..()
 
 /obj/item/nuke_core_container/proc/load(obj/item/nuke_core/plutonium/new_core, mob/user)
 	if(core || !istype(new_core) || cracked)
@@ -111,16 +118,6 @@
 		if(ismob(loc))
 			to_chat(loc, "<span class='warning'>[src] is permanently sealed, [core]'s radiation is contained.</span>")
 
-/obj/item/nuke_core_container/attackby__legacy__attackchain(obj/item/nuke_core/plutonium/core, mob/user)
-	if(!istype(core) || cracked)
-		return ..()
-
-	if(!user.drop_item())
-		to_chat(user, "<span class='warning'>[core] is stuck to your hand!</span>")
-		return
-	else
-		load(core, user)
-
 /obj/item/nuke_core_container/proc/crack_open()
 	visible_message("<span class='boldnotice'>[src] bursts open!</span>")
 	if(core)
@@ -145,8 +142,7 @@
 	<li>???</li>\
 	</ul>"
 
-// STEALING SUPERMATTER.
-
+// MARK: Supermatter sliver
 /obj/item/paper/guides/antag/supermatter_sliver
 	info = "How to safely extract a supermatter sliver:<br>\
 	<ul>\
@@ -188,39 +184,54 @@
 		return TRUE
 	return FALSE
 
-/obj/item/nuke_core/supermatter_sliver/attackby__legacy__attackchain(obj/item/I, mob/living/user, params)
-	if(istype(I, /obj/item/retractor/supermatter))
-		var/obj/item/retractor/supermatter/tongs = I
+/obj/item/nuke_core/supermatter_sliver/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	if(istype(used, /obj/item/retractor/supermatter))
+		var/obj/item/retractor/supermatter/tongs = used
 		if(tongs.sliver)
 			to_chat(user, "<span class='warning'>[tongs] are already holding a supermatter sliver!</span>")
-			return FALSE
+			return ITEM_INTERACT_COMPLETE
+
 		forceMove(tongs)
 		tongs.sliver = src
 		tongs.update_icon(UPDATE_ICON_STATE)
 		to_chat(user, "<span class='notice'>You carefully pick up [src] with [tongs].</span>")
-	else if(istype(I, /obj/item/scalpel/supermatter) || istype(I, /obj/item/nuke_core_container/supermatter) || HAS_TRAIT(I, TRAIT_SUPERMATTER_IMMUNE)) // we don't want it to dust
-		return
-	else
-		if(issilicon(user))
-			to_chat(user, "<span class='userdanger'>You try to touch [src] with one of your modules. Error!</span>")
-			radiation_pulse(user, 2000, GAMMA_RAD)
-			playsound(src, 'sound/effects/supermatter.ogg', 50, TRUE)
-			user.dust()
-			qdel(src)
-			return
-		to_chat(user, "<span class='danger'>As it touches [src], both [src] and [I] burst into dust!</span>")
-		radiation_pulse(user, 400, GAMMA_RAD)
+		return ITEM_INTERACT_COMPLETE
+
+	if(istype(used, /obj/item/scalpel/supermatter) || istype(used, /obj/item/nuke_core_container/supermatter)) // we don't want it to dust
+		return ITEM_INTERACT_COMPLETE
+
+	if(user.status_flags & GODMODE || HAS_TRAIT(user, TRAIT_SUPERMATTER_IMMUNE))
+		return ITEM_INTERACT_COMPLETE
+
+	if(issilicon(user))
+		to_chat(user, "<span class='userdanger'>You try to touch [src] with [used]. ERROR!</span>")
+		radiation_pulse(user, 2000, GAMMA_RAD)
 		playsound(src, 'sound/effects/supermatter.ogg', 50, TRUE)
-		qdel(I)
+		user.dust()
 		qdel(src)
-		return ..()
+		return ITEM_INTERACT_COMPLETE
+
+	// Don't poke it with no-drops!
+	if(!user.drop_item())
+		radiation_pulse(user, 2000, GAMMA_RAD)
+		to_chat(user, "<span class='userdanger'>As it touches [src], both [src] and [used] burst into dust. The resonance then consumes you as well!</span>")
+		user.dust()
+	else
+		to_chat(user, "<span class='danger'>As it touches [src], both [src] and [used] burst into dust!</span>")
+		radiation_pulse(user, 400, GAMMA_RAD)
+		qdel(used)
+	playsound(src, 'sound/effects/supermatter.ogg', 50, TRUE)
+	qdel(src)
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/nuke_core/supermatter_sliver/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	if(!isliving(hit_atom))
 		return ..()
+
 	var/mob/living/victim = hit_atom
 	if(victim.incorporeal_move || victim.status_flags & GODMODE || HAS_TRAIT(victim, TRAIT_SUPERMATTER_IMMUNE)) //try to keep this in sync with supermatter's consume fail conditions
 		return ..()
+
 	var/mob/user = throwingdatum?.get_thrower()
 	if(user)
 		add_attack_logs(user, victim, "[victim] consumed by [src] thrown by [user] ")
@@ -241,8 +252,10 @@
 	..()
 	if(HAS_TRAIT(user, TRAIT_SUPERMATTER_IMMUNE))
 		return TRUE //yay sliver throwing memes!
+
 	if(!isliving(user) || user.status_flags & GODMODE) //try to keep this in sync with supermatter's consume fail conditions
 		return FALSE
+
 	user.visible_message("<span class='danger'>[user] reaches out and tries to pick up [src]. [user.p_their()] body starts to glow and bursts into flames before flashing into dust!</span>",
 			"<span class='userdanger'>You reach for [src] with your hands. That was dumb.</span>",
 			"<span class='hear'>Everything suddenly goes silent.</span>")
@@ -262,6 +275,7 @@
 /obj/item/nuke_core_container/supermatter/load(obj/item/retractor/supermatter/I, mob/user)
 	if(!istype(I) || !I.sliver || sliver)
 		return
+
 	I.sliver.forceMove(src)
 	sliver = I.sliver
 	I.sliver = null
@@ -285,6 +299,7 @@
 /obj/item/nuke_core_container/supermatter/unload(obj/item/retractor/supermatter/I, mob/user)
 	if(!istype(I) || I.sliver)
 		return
+
 	sliver.forceMove(I)
 	I.sliver = sliver
 	sliver = null
@@ -292,21 +307,23 @@
 	icon_state = "core_container_cracked_empty"
 	to_chat(user, "<span class='notice'>You carefully pick up [I.sliver] with [I].</span>")
 
-/obj/item/nuke_core_container/supermatter/attackby__legacy__attackchain(obj/item/retractor/supermatter/tongs, mob/user)
-	if(istype(tongs))
-		if(cracked)
-			//lets take that shard out
-			unload(tongs, user)
-		else
-			//try to load shard into core
-			load(tongs, user)
-	else
+/obj/item/nuke_core_container/supermatter/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	if(!istype(used, /obj/item/retractor/supermatter))
 		return ..()
+
+	var/obj/item/retractor/supermatter/tongs = used
+	if(cracked)
+		unload(tongs, user)
+		return ITEM_INTERACT_COMPLETE
+
+	load(tongs, user)
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/nuke_core_container/supermatter/attack_hand(mob/user)
 	if(cracked && sliver) //What did we say about touching the shard...
-		if(!isliving(user) || user.status_flags & GODMODE)
+		if(!isliving(user) || user.status_flags & GODMODE || HAS_TRAIT(user, TRAIT_SUPERMATTER_IMMUNE))
 			return FALSE
+
 		user.visible_message("<span class='danger'>[user] reaches out and tries to pick up [sliver]. [user.p_their()] body starts to glow and bursts into flames before flashing into dust!</span>",
 				"<span class='userdanger'>You reach for [sliver] with your hands. That was dumb.</span>",
 				"<span class='italics'>Everything suddenly goes silent.</span>")
@@ -317,7 +334,6 @@
 		user.dust()
 		icon_state = "core_container_cracked_empty"
 		qdel(sliver)
-
 	else
 		return ..()
 
@@ -363,12 +379,14 @@
 /obj/item/retractor/supermatter/update_icon_state()
 	icon_state = "[initial(icon_state)][sliver ? "_loaded" : ""]"
 
-/obj/item/retractor/supermatter/afterattack__legacy__attackchain(atom/O, mob/user, proximity)
+/obj/item/retractor/supermatter/interact_with_atom(atom/target, mob/living/user, list/modifiers)
 	. = ..()
 	if(!sliver)
 		return
-	if(proximity && ismovable(O) && O != sliver)
-		Consume(O, user)
+
+	if(ismovable(target) && target != sliver)
+		Consume(target, user)
+		return ITEM_INTERACT_COMPLETE
 
 /obj/item/retractor/supermatter/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum) // no instakill supermatter javelins
 	if(sliver)

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -10,6 +10,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	origin_tech = "materials=1;biotech=1"
 	tool_behaviour = TOOL_RETRACTOR
+	new_attack_chain = TRUE
 
 /obj/item/retractor/Initialize(mapload)
 	. = ..()
@@ -35,6 +36,7 @@
 	origin_tech = "materials=1;biotech=1"
 	attack_verb = list("attacked", "pinched")
 	tool_behaviour = TOOL_HEMOSTAT
+	new_attack_chain = TRUE
 
 /obj/item/hemostat/Initialize(mapload)
 	. = ..()
@@ -60,6 +62,7 @@
 	origin_tech = "materials=1;biotech=1"
 	attack_verb = list("burnt")
 	tool_behaviour = TOOL_CAUTERY
+	new_attack_chain = TRUE
 
 /obj/item/cautery/Initialize(mapload)
 	. = ..()
@@ -67,9 +70,11 @@
 	RegisterSignal(src, COMSIG_BIT_ATTACH, PROC_REF(add_bit))
 	RegisterSignal(src, COMSIG_CLICK_ALT, PROC_REF(remove_bit))
 
-/obj/item/cautery/attack__legacy__attackchain(mob/living/target, mob/living/user)
-	if(!cigarette_lighter_act(user, target))
-		return ..()
+/obj/item/cautery/interact_with_atom(atom/target, mob/living/user, list/modifiers)
+	if(cigarette_lighter_act(user, target))
+		return ITEM_INTERACT_COMPLETE
+
+	return ..()
 
 /obj/item/cautery/cigarette_lighter_act(mob/living/user, mob/living/target, obj/item/direct_attackby_item)
 	var/obj/item/clothing/mask/cigarette/cig = ..()
@@ -108,6 +113,7 @@
 	origin_tech = "materials=1;biotech=1"
 	attack_verb = list("drilled")
 	tool_behaviour = TOOL_DRILL
+	new_attack_chain = TRUE
 
 /obj/item/surgicaldrill/Initialize(mapload)
 	. = ..()
@@ -146,6 +152,7 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	tool_behaviour = TOOL_SCALPEL
+	new_attack_chain = TRUE
 
 /obj/item/scalpel/Initialize(mapload)
 	. = ..()
@@ -154,13 +161,11 @@
 	RegisterSignal(src, COMSIG_BIT_ATTACH, PROC_REF(add_bit))
 	RegisterSignal(src, COMSIG_CLICK_ALT, PROC_REF(remove_bit))
 
-
 /obj/item/scalpel/suicide_act(mob/user)
 	to_chat(viewers(user), pick("<span class='suicide'>[user] is slitting [user.p_their()] wrists with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>",
 						"<span class='suicide'>[user] is slitting [user.p_their()] throat with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>",
 						"<span class='suicide'>[user] is slitting [user.p_their()] stomach open with [src]! It looks like [user.p_theyre()] trying to commit seppuku!</span>"))
 	return BRUTELOSS
-
 
 /obj/item/scalpel/augment
 	desc = "Ultra-sharp blade attached directly to your bone for extra-accuracy."
@@ -178,9 +183,11 @@
 	hitsound = 'sound/weapons/sear.ogg'
 	materials = list(MAT_METAL = 2000, MAT_GLASS = 1000)
 
-/obj/item/scalpel/laser/attack__legacy__attackchain(mob/living/carbon/target, mob/living/user)
-	if(!cigarette_lighter_act(user, target))
-		return ..()
+/obj/item/scalpel/laser/interact_with_atom(atom/target, mob/living/user, list/modifiers)
+	if(cigarette_lighter_act(user, target))
+		return ITEM_INTERACT_COMPLETE
+
+	return ..()
 
 /obj/item/scalpel/laser/cigarette_lighter_act(mob/living/user, mob/living/target, obj/item/direct_attackby_item)
 	var/obj/item/clothing/mask/cigarette/cig = ..()
@@ -246,6 +253,7 @@
 	origin_tech = "biotech=1;combat=1"
 	attack_verb = list("attacked", "slashed", "sawed", "cut")
 	tool_behaviour = TOOL_SAW
+	new_attack_chain = TRUE
 
 /obj/item/circular_saw/Initialize(mapload)
 	. = ..()
@@ -271,6 +279,7 @@
 	throwforce = 1.0
 	origin_tech = "materials=1;biotech=1"
 	tool_behaviour = TOOL_BONEGEL
+	new_attack_chain = TRUE
 
 /obj/item/bonegel/Initialize(mapload)
 	. = ..()
@@ -292,6 +301,7 @@
 	origin_tech = "materials=1;biotech=1"
 	w_class = WEIGHT_CLASS_SMALL
 	tool_behaviour = TOOL_FIXOVEIN
+	new_attack_chain = TRUE
 
 /obj/item/fix_o_vein/Initialize(mapload)
 	. = ..()
@@ -317,6 +327,7 @@
 	attack_verb = list("attacked", "hit", "bludgeoned")
 	origin_tech = "materials=1;biotech=1"
 	tool_behaviour = TOOL_BONESET
+	new_attack_chain = TRUE
 
 /obj/item/bonesetter/Initialize(mapload)
 	. = ..()
@@ -337,6 +348,7 @@
 	attack_verb = list("slapped")
 	/// How effective this is at preventing infections during surgeries.
 	var/surgery_effectiveness = 0.9
+	new_attack_chain = TRUE
 
 /obj/item/surgical_drapes/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Migrates the scalpel, hemostat, retractor, surgical saw, surgical drill, fix-o-vein, bone gel, bone setter, and cautery to the new attack chain.

Migrates nuke cores and nuke core containers as well because they're horribly intermingled with the supermatter extraction tongs (a retractor subtype).

Makes supermatter immunity and godmode properly protect people from being dusted by supermatter slivers held by tongs or inside cracked containers.

If someone pokes a sliver with a nodrop item, they will get dusted too.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
New Attack Chain good

Supermatter immunity and godmode should protect against the supermatter in every circumstance.

Nodrop items being dusted should dust the user to prevent weird shit from happening.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Performed surgery with all of the surgery tools.
Lit a cigarette with a cautery.
Carved a supermatter sliver from the supermatter.
Grabbed with tongs.
Put in container.
Poked supermatter sliver with supermatter immunity and godmode, didn't die. Removed, did again, died.
Exploded filled supermatter container. Repeated above testing.
Poked a sliver with a random item, it got dusted.
Poked a sliver with a toolset implant item, I got dusted.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Supermatter immune individuals don't die to touching filled supermatter containers or being beaten by filled supermatter tongs.
add: Touching a supermatter sliver with nodrop items will dust you in addition to the item.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
