### PR TITLE
make soylent test a bit smarter

### DIFF
--- a/code/tests/test_cooking.dm
+++ b/code/tests/test_cooking.dm
@@ -47,7 +47,12 @@
 	var/datum/cooking_surface/surface = stove.surfaces[surface_idx]
 	surface.temperature = J_MED
 	surface.turn_on(player.puppet)
-	sleep(3 SECONDS)
-	surface.turn_off(player.puppet)
-	player.alt_click_on(stove, "icon-x=18&icon-y=18")
-	TEST_ASSERT(locate(/obj/item/food/soylentgreen) in stove.loc, "could not find complete soylent")
+	var/attempt_count = 10
+	while(attempt_count)
+		sleep(1 SECONDS)
+		if(locate(/obj/item/food/soylentgreen) in pot)
+			surface.turn_off(player.puppet)
+			return
+		attempt_count--
+
+	TEST_FAIL("could not find complete soylent after 10 attempts")


### PR DESCRIPTION
## What Does This PR Do
This PR tries to make the soylent test a bit more resilient by checking for recipe completion once a second for 10 seconds, and only failing afterwards, as opposed to waiting a set number of seconds for the cooking process to run.
## Why It's Good For The Game
This test is flaky, if I can't make it not flaky, I'd rather not have it around, so this is my hacky attempt to fix it.
## Testing
Gonna test CI.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC