### PR TITLE
fix melee attacks not working with tendrils

### DIFF
--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -44,6 +44,7 @@ GLOBAL_LIST_EMPTY(tendrils)
 	return ..()
 
 /obj/structure/spawner/lavaland/attacked_by(obj/item/attacker, mob/living/user)
+	. = ..()
 	SEND_SIGNAL(src, COMSIG_SPAWNER_SET_TARGET, user)
 
 /obj/structure/spawner/lavaland/bullet_act(obj/item/projectile/P)


### PR DESCRIPTION
## What Does This PR Do
This PR ensures that attacks from melee items properly cause damage to tendrils. #30365 most likely introduced this.
## Why It's Good For The Game
Bugfix.
## Testing
Spawned tendrils, ensured that melee weapons on both old and new attack chains caused damage to the tendril.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Melee attacks properly damage Lavaland tendrils again.
/:cl: