### PR TITLE
Makes smith bag craftable with leather

### DIFF
--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -144,6 +144,7 @@ GLOBAL_LIST_INIT(leather_recipes, list (
 		new /datum/stack_recipe("leather satchel", /obj/item/storage/backpack/satchel, 5),
 		new /datum/stack_recipe("briefcase", /obj/item/storage/briefcase, 4),
 		new /datum/stack_recipe("bandolier", /obj/item/storage/belt/bandolier, 5),
+		new /datum/stack_recipe("smith's bag", /obj/item/storage/bag/smith, 5),
 		)),
 	null,
 	new /datum/stack_recipe("card box", /obj/item/deck/holder, 1),


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Makes smith bags craftable for 5 leather under "leather storages".

## Why It's Good For The Game

Smith bags don't have a source to get more, unlike most other bags. This makes them more accessible. 

## Testing

Crafted bag with 5 leather.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<img width="594" height="184" alt="image" src="https://github.com/user-attachments/assets/e1b3c8b5-08e5-4f08-b88b-43d0214625cd" />


## Changelog

:cl:
add: Adds a way to craft smith bags using 5 leather.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
