### PR TITLE
fix incorrect toolbelt in delta cargo

### DIFF
--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -11219,7 +11219,7 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/storage/belt,
+/obj/item/storage/belt/utility,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},

--- a/tools/maplint/lints/base_toolbelt.yml
+++ b/tools/maplint/lints/base_toolbelt.yml
@@ -1,0 +1,3 @@
+help: 'The base belt type is not mappable. For standard tool belts, use /obj/item/storage/belt/utility.'
+=/obj/item/storage/belt:
+  banned: true


### PR DESCRIPTION
## What Does This PR Do
This PR fixes a bad belt type in delta cargo, and adds a maplint preventing that type of belt from being mapped in again.
## Why It's Good For The Game
Belts should work, tools should fix common issues.
## Testing
Visual inspection.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Kerberos: The toolbelt in cargo now properly holds tools.
/:cl: