### PR TITLE
properly enable DB for tests

### DIFF
--- a/config/tests/config_unit_tests.toml
+++ b/config/tests/config_unit_tests.toml
@@ -11,4 +11,4 @@ maximum_lavaland_zlevels = 0
 enabled = false
 
 [database_configuration]
-enabled = true
+sql_enabled = true


### PR DESCRIPTION
## What Does This PR Do
This PR sets the proper name for the setting that enables the DB in the test config toml.
## Why It's Good For The Game
Expectation is that DB is functional in tests
## Testing
CI
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC