### PR TITLE
Changes the description of the Value Pak PDA cart to not lie to the player and gives CC the better value pak and explosion immunity

### DIFF
--- a/code/modules/pda/cart.dm
+++ b/code/modules/pda/cart.dm
@@ -235,7 +235,7 @@
 
 /obj/item/cartridge/captain
 	name = "Value-PAK Cartridge"
-	desc = "A data cartridge for portable microcomputers. Has everything except a signaler system."
+	desc = "A data cartridge for portable microcomputers. Has every single app included, now that's real value!
 	icon_state = "cart-c"
 	programs = list(
 		new /datum/data/pda/app/power,
@@ -262,24 +262,6 @@
 	icon_state = "cart-h"
 	programs = list(
 		new /datum/data/pda/app/crew_records/security,
-		new /datum/data/pda/app/status_display
-	)
-
-/obj/item/cartridge/centcom
-	name = "Value-PAK Cartridge"
-	desc = "Now with 200% more value!"
-	icon_state = "cart-c"
-	programs = list(
-		new /datum/data/pda/app/power,
-		new /datum/data/pda/utility/scanmode/halogen,
-		new /datum/data/pda/utility/scanmode/gas,
-		new /datum/data/pda/app/crew_records/medical,
-		new /datum/data/pda/utility/scanmode/medical,
-		new /datum/data/pda/utility/scanmode/reagent,
-		new /datum/data/pda/app/crew_records/security,
-		new /datum/data/pda/app/secbot_control,
-		new /datum/data/pda/app/janitor,
-		new /datum/data/pda/app/supply,
 		new /datum/data/pda/app/status_display
 	)
 

--- a/code/modules/pda/pdas.dm
+++ b/code/modules/pda/pdas.dm
@@ -106,7 +106,7 @@
 	default_pen = /obj/item/pen/fancy
 
 /obj/item/pda/heads/ert
-	default_cartridge = /obj/item/cartridge/centcom
+	default_cartridge = /obj/item/cartridge/captain
 	detonate = FALSE
 	default_pen = /obj/item/pen/multi/fountain
 
@@ -202,7 +202,8 @@
 	icon_state = "pda-genetics"
 
 /obj/item/pda/centcom
-	default_cartridge = /obj/item/cartridge/centcom
+	default_cartridge = /obj/item/cartridge/captain
+	detonate = FALSE
 	icon_state = "pda-h"
 	default_pen = /obj/item/pen/multi/gold
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The Value Pak PDA cart no longer lies about not having a signaller when it clearly has a signaller.

Removed the centcom version of the value pak, gives them the captain version instead so they also get a signaller.

Gives ERT PDA the same version of PDA cart.

Makes the CC PDA immune to being blown up like the captain's PDA.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The game should not lie to the player.

CC shouldn't be getting worse equipment than some random captain.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in and inspected PDA cart.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Value Pak PDA cart no longer erroniously claims there's not a signaller app on it.
tweak: CC PDA now has a signaler and is immune to being exploded.
tweak: ERT PDA now has a signaller.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
