### PR TITLE
fix paper wrapping crates

### DIFF
--- a/_maps/map_files/tests/test_attack_chain_structures.dmm
+++ b/_maps/map_files/tests/test_attack_chain_structures.dmm
@@ -175,6 +175,10 @@
 /obj/structure/ai_core,
 /turf/simulated/floor/plasteel,
 /area/game_test)
+"Pr" = (
+/obj/structure/closet/crate/sci,
+/turf/simulated/floor/plasteel,
+/area/game_test)
 "QL" = (
 /obj/structure/disposalconstruct,
 /turf/simulated/floor/plating,
@@ -399,7 +403,7 @@ le
 rT
 yd
 rT
-rT
+Pr
 rT
 rT
 Od

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -316,7 +316,7 @@
 		emag_act(user)
 		return ITEM_INTERACT_COMPLETE
 	else if(istype(W, /obj/item/stack/package_wrap))
-		return ITEM_INTERACT_COMPLETE
+		return
 	else if(user.a_intent != INTENT_HARM)
 		closed_item_click(user)
 		return ITEM_INTERACT_COMPLETE

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -149,6 +149,7 @@
 	amount = 25
 	max_amount = 25
 	resistance_flags = FLAMMABLE
+	var/wrap_time = 2 SECONDS
 	var/static/list/no_wrap = list(/obj/item/small_delivery, /obj/structure/big_delivery, /obj/item/evidencebag, /obj/structure/closet/body_bag)
 
 /obj/item/stack/package_wrap/pre_attack(atom/atom_target, mob/living/user, params)
@@ -233,12 +234,12 @@
 		to_chat(user, "<span class='warning'>You need more paper.</span>")
 		return
 	// Checking these again since it's after a delay
+	var/wrap_do_after = wrap_time
 	if(user.mind && HAS_TRAIT(user.mind, TRAIT_PACK_RAT))
-		if(!do_after_once(user, 0.75 SECONDS, target = C) || C.opened || !use(3))
-			return
-	else
-		if(!do_after_once(user, 2 SECONDS, target = C) || C.opened || !use(3))
-			return
+		wrap_do_after *= 0.375
+	if(!do_after_once(user, wrap_do_after, target = C) || C.opened || !use(3))
+		return
+
 	var/obj/structure/big_delivery/P = new(get_turf(C))
 	P.wrapped = C
 	C.loc = P

--- a/code/tests/attack_chain/test_attack_chain_structures.dm
+++ b/code/tests/attack_chain/test_attack_chain_structures.dm
@@ -322,3 +322,9 @@
 	var/obj/water_cooler = teleport_to_first(player, /obj/structure/reagent_dispensers/water_cooler)
 	player.click_on(water_cooler)
 	TEST_ASSERT_LAST_CHATLOG(player, "You fill [bucket] with 20 units of the contents of [water_cooler]")
+	player.drop_held_item()
+
+	crate = teleport_to_first(player, /obj/structure/closet/crate/sci)
+	player.spawn_fast_tool(/obj/item/stack/package_wrap)
+	player.click_on(crate)
+	TEST_ASSERT_LAST_CHATLOG(player, "[player.puppet] wraps [crate]")


### PR DESCRIPTION
## What Does This PR Do
This PR fixes wrapping paper not working on crates. It also adds a test to ensure this works as expected. It moves the do_after timer to the wrapping paper and then scales that number if one has the pack rat trait by a factor that matches the previous hardcoded amounts.
## Why It's Good For The Game
Bugfix.
## Testing
In-game and CI.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Crates can now properly be wrapped in wrapping paper.
/:cl: