### PR TITLE
Fixes oversights in salvage redemption machine

### DIFF
--- a/code/game/machinery/machine_frame.dm
+++ b/code/game/machinery/machine_frame.dm
@@ -1032,6 +1032,17 @@ to destroy them and players will be able to make replacements.
 	req_components = list(/obj/item/stock_parts/manipulator = 2, /obj/item/stack/cable_coil = 2)
 // End telecomms circuit boards
 
+/obj/item/circuitboard/salvage_redemption
+	board_name = "Salvage Redemption"
+	icon_state = "supply"
+	build_path = /obj/item/circuitboard/salvage_redemption
+	board_type = "machine"
+	origin_tech = "programming=1;engineering=2"
+	req_components = list(
+							/obj/item/stack/sheet/glass = 1,
+							/obj/item/stock_parts/scanning_module = 3,
+							/obj/item/stock_parts/manipulator = 1)
+
 /obj/item/circuitboard/smart_hopper
 	board_name = "Ore Redemption"
 	icon_state = "supply"

--- a/code/modules/mining/salvage_redemption.dm
+++ b/code/modules/mining/salvage_redemption.dm
@@ -22,7 +22,7 @@
 	. = ..()
 	// Stock parts
 	component_parts = list()
-	component_parts += new /obj/item/circuitboard/smart_hopper(null)
+	component_parts += new /obj/item/circuitboard/salvage_redemption(null)
 	component_parts += new /obj/item/stock_parts/scanning_module(null)
 	component_parts += new /obj/item/stock_parts/scanning_module(null)
 	component_parts += new /obj/item/stock_parts/scanning_module(null)
@@ -136,6 +136,7 @@
 	addtimer(CALLBACK(src, PROC_REF(print_slip), total_value, user), 2.5 SECONDS)
 
 /obj/machinery/salvage_redemption/proc/print_slip(total_value, mob/user)
+	animating = FALSE
 	// Print the credit slip
 	playsound(src, 'sound/machines/banknote_counter.ogg', 30, FALSE)
 	var/obj/item/credit_redemption_slip/slip = new /obj/item/credit_redemption_slip(src, total_value)

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -521,6 +521,16 @@
 	build_path = /obj/item/circuitboard/ore_redemption
 	category = list ("Misc. Machinery")
 
+/datum/design/salvage_redemption
+	name = "Machine Design (Salvage Redemption)"
+	desc = "The circuit board for a Salvage Redemption Machine."
+	id = "salvage_redemption"
+	req_tech = list("programming" = 2, "engineering" = 4, "plasmatech" = 3)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 1000)
+	build_path = /obj/item/circuitboard/salvage_redemption
+	category = list ("Misc. Machinery")
+
 /datum/design/smart_hopper
 	name = "Machine Design (Smart Hopper)"
 	desc = "The circuit board for a Smart Hopper."


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes two issues with the SRM:
- The SRM no longer gets locked in an animation state
- The SRM now has a proper circuitboard.

## Why It's Good For The Game

Bugs and oversights bad

## Testing

Compiled

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed SRM having the wrong circuitboard
fix: Fixed SRM getting stuck animating
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
