### PR TITLE
Removes carp spawners from Cargo Bay, Vault space on Delta

### DIFF
--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -145921,7 +145921,7 @@ mKm
 jsk
 aIk
 mKm
-aaZ
+aaa
 aaa
 eNt
 llR
@@ -145946,7 +145946,7 @@ eNt
 eNt
 aaa
 abj
-aaZ
+aaa
 abj
 aaa
 abj


### PR DESCRIPTION
## What Does This PR Do
Removes carp spawners from the Cargo Bay and Vault space on DeltaStation.
## Why It's Good For The Game
With carp being converted to basicmobs, having them spawn right next to a hallway and inside the cargo bay makes them incredibly effective at spacing the area and killing people. This applies to both roundstart carp spawns and the midround that spawns them.
## Images of changes
<img width="352" height="448" alt="image" src="https://github.com/user-attachments/assets/e54d3ecc-38d3-476c-8c56-cdafb3654aea" />
<img width="448" height="320" alt="image" src="https://github.com/user-attachments/assets/9ff75d5a-a199-41be-8883-507cdb1cc9e8" />

## Testing
Visual inspection. Spawned carp event. Nothing broke.
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog
:cl:
del: Carp can no longer spawn inside the cargo bay or vault space on the NSS Kerberos.
/:cl: