### PR TITLE
Adds new physique and height options to character creation

### DIFF
--- a/code/_globalvars/misc_globals.dm
+++ b/code/_globalvars/misc_globals.dm
@@ -60,9 +60,9 @@ GLOBAL_LIST_EMPTY(mod_link_ids)
 GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/atmospherics/supermatter_crystal)
 
 ///Global list for descriptors
-GLOBAL_LIST_INIT(character_physiques, list("rail thin", "thin", "average", "well-built", "muscular", "overweight"))
+GLOBAL_LIST_INIT(character_physiques, list("emaciated", "rail thin", "thin", "gaunt", "lanky", "scrawny", "average", "lean", "toned", "well-built", "muscular", "chiseled", "shredded", "chubby", "overweight"))
 
-GLOBAL_LIST_INIT(character_heights, list("very short", "short", "average height", "tall", "very tall"))
+GLOBAL_LIST_INIT(character_heights, list("miniscule", "very short", "short", "average height", "tall", "very tall", "humongous"))
 
 #define GLOBAL_SPARK_LIMIT 500
 /// Counter for the current amount of sparks


### PR DESCRIPTION
## What Does This PR Do
Adds multiple new physique and height options to the character creator menu.
## Why It's Good For The Game
More customization and ways to display character traits is a good thing.
## Images of changes
<img width="325" height="503" alt="image" src="https://github.com/user-attachments/assets/3addf1c2-7162-4932-ae1c-fd4296f2681b" />
<img width="317" height="372" alt="image" src="https://github.com/user-attachments/assets/9903647b-6c47-4656-8853-baea3bd8f514" />

## Testing
Joined. Ensured list loaded properly. Examined. Saw no errors.
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
add: New physique and height options have been added to the character creation menu.
/:cl:
