### PR TITLE
Fixes a Farragus External Airlock

### DIFF
--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -6859,7 +6859,7 @@
 "bev" = (
 /obj/effect/spawner/airlock/e_to_w/long,
 /turf/simulated/wall,
-/area/space/nearstation)
+/area/station/maintenance/security/aft_port)
 "bex" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/orange{
@@ -34984,7 +34984,7 @@
 /area/station/security/permabrig)
 "fRW" = (
 /turf/simulated/floor/plating/airless,
-/area/space/nearstation)
+/area/station/maintenance/security/aft_port)
 "fRZ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -96866,7 +96866,6 @@
 "sZY" = (
 /obj/structure/table/reinforced,
 /obj/item/ashtray/bronze{
-	pixel_y = 0;
 	pixel_x = 7
 	},
 /obj/item/reagent_containers/drinks/mug/qm{


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a nonfunctional external airlock door on Farragus by changing the area of the outer door from nearspace to maint.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Oversight bad.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<img width="96" height="128" alt="image" src="https://github.com/user-attachments/assets/99b3d40d-730b-4a20-acda-dfd7e36371c3" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Cycled door, it worked.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixes a broken external airlock on Farragus.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
