### PR TITLE
Slight Touchup of the Default Emergency Shuttle

### DIFF
--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -8950,14 +8950,6 @@
 /obj/structure/flora/rock/pile/largejungle,
 /turf/simulated/floor/grass/jungle,
 /area/wizard_station)
-"Ef" = (
-/obj/structure/table/reinforced,
-/obj/structure/closet/walllocker/emerglocker/directional/north,
-/obj/machinery/recharger,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/shuttle/escape)
 "Eh" = (
 /obj/item/stack/rods/ten,
 /obj/item/wirecutters,
@@ -9065,7 +9057,6 @@
 /turf/simulated/floor/carpet/arcade,
 /area/ghost_bar)
 "EF" = (
-/obj/structure/closet/walllocker/emerglocker/directional/north,
 /obj/machinery/cell_charger{
 	pixel_y = 11
 	},
@@ -10372,7 +10363,6 @@
 /area/centcom/specops)
 "IR" = (
 /obj/structure/table/reinforced,
-/obj/structure/closet/walllocker/emerglocker/directional/north,
 /turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "IS" = (
@@ -10603,11 +10593,6 @@
 	icon_state = "cafeteria"
 	},
 /area/tdome/tdomeobserve)
-"JC" = (
-/obj/structure/closet/walllocker/emerglocker/directional/south,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/shuttle/escape)
 "JD" = (
 /obj/machinery/computer/shuttle/ferry,
 /turf/simulated/floor/plasteel{
@@ -12918,14 +12903,6 @@
 /obj/machinery/door/airlock/titanium/glass{
 	id_tag = "s_docking_airlock"
 	},
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 16;
-	height = 21;
-	id = "emergency_away";
-	name = "emergency centcom";
-	width = 41
-	},
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "QI" = (
@@ -14010,11 +13987,6 @@
 /obj/item/lighter,
 /turf/simulated/floor/wood,
 /area/centcom/control)
-"Uo" = (
-/obj/structure/closet/walllocker/emerglocker/directional/north,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/shuttle/escape)
 "Up" = (
 /obj/item/caution/proximity_sign,
 /obj/item/caution/proximity_sign,
@@ -50917,7 +50889,7 @@ LJ
 ND
 LN
 od
-Uo
+iH
 SF
 ff
 ff
@@ -50931,7 +50903,7 @@ ff
 ff
 ff
 VO
-JC
+zI
 od
 Iv
 Zp
@@ -51935,7 +51907,7 @@ aN
 aN
 rK
 od
-Ef
+LP
 Fn
 Gs
 Hl
@@ -53487,7 +53459,7 @@ LU
 LU
 od
 od
-Uo
+zI
 Wc
 LR
 LR
@@ -53501,7 +53473,7 @@ LR
 LR
 xk
 VP
-JC
+zI
 od
 Iv
 Zp
@@ -54767,10 +54739,10 @@ aN
 aN
 aN
 od
-Uo
+zI
 Mc
 NM
-JC
+zI
 od
 Rf
 ST

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -326,14 +326,6 @@
 /obj/machinery/computer/arcade/orion_trail,
 /turf/simulated/floor/carpet/arcade,
 /area/syndicate_mothership)
-"bf" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cmo"
-	},
-/area/shuttle/escape)
 "bg" = (
 /obj/machinery/abductor/pad{
 	team = 4
@@ -1433,9 +1425,25 @@
 /obj/machinery/poolcontroller/invisible,
 /turf/simulated/floor/beach/away/water,
 /area/ninja/holding)
+"ff" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/shuttle/escape)
 "fg" = (
 /turf/simulated/wall/indestructible/wood,
 /area/ninja/holding)
+"fh" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/computer/med_data,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "darkblue"
+	},
+/area/shuttle/escape)
 "fi" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -1517,9 +1525,8 @@
 /area/wizard_station)
 "fy" = (
 /obj/machinery/sleeper,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cmo"
@@ -1606,10 +1613,11 @@
 	pixel_x = -2;
 	pixel_y = 4
 	},
-/obj/machinery/light/small,
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
+/obj/machinery/light/small{
+	dir = 4
 	},
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "fO" = (
 /obj/structure/rack,
@@ -2554,6 +2562,12 @@
 	},
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/syndicate)
+"iH" = (
+/obj/effect/turf_decal/delivery/partial{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/shuttle/escape)
 "iI" = (
 /obj/structure/table,
 /obj/item/aicard,
@@ -3111,6 +3125,16 @@
 /obj/item/gun/projectile/automatic/sniper_rifle/syndicate,
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership)
+"kx" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/computer/aifixer,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkpurple";
+	dir = 9
+	},
+/area/shuttle/escape)
 "ky" = (
 /obj/machinery/economy/vending/syndicigs,
 /turf/simulated/floor/plasteel/dark,
@@ -3989,6 +4013,10 @@
 /obj/item/kirbyplants/large,
 /turf/simulated/floor/plasteel/dark,
 /area/tdome/tdomeadmin)
+"nj" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/simulated/floor/plasteel,
+/area/shuttle/escape)
 "nk" = (
 /obj/machinery/atmospherics/portable/canister/oxygen{
 	name = "Canister: \[O2] (CRYO)"
@@ -4478,6 +4506,13 @@
 	icon_state = "cafeteria"
 	},
 /area/tdome/tdomeobserve)
+"oL" = (
+/obj/machinery/light,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/shuttle/escape)
 "oM" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/beer{
@@ -4557,6 +4592,13 @@
 	},
 /turf/simulated/floor/backrooms_carpet,
 /area/backrooms)
+"pa" = (
+/obj/machinery/computer/robotics,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkpurple";
+	dir = 5
+	},
+/area/shuttle/escape)
 "pe" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes/cigpack_robustgold{
@@ -4606,6 +4648,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/wizard_station)
+"pn" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/optable,
+/turf/simulated/floor/plasteel{
+	icon_state = "cmo"
+	},
+/area/shuttle/escape)
 "po" = (
 /turf/simulated/wall/indestructible/fakeglass,
 /area/trader_station/sol)
@@ -4845,11 +4896,10 @@
 	},
 /area/holodeck/source_thunderdomecourt)
 "ql" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/drinks/mug/med,
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
 	icon_state = "cmo"
 	},
@@ -4947,8 +4997,10 @@
 /area/syndicate_mothership)
 "qF" = (
 /obj/structure/table/reinforced,
+/obj/item/storage/surgical_tray{
+	pixel_y = 8
+	},
 /obj/item/clothing/gloves/color/latex/nitrile,
-/obj/item/clothing/mask/breath,
 /turf/simulated/floor/plasteel{
 	icon_state = "cmo"
 	},
@@ -5059,6 +5111,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/admin)
+"qW" = (
+/obj/machinery/computer/emergency_shuttle,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "darkblue"
+	},
+/area/shuttle/escape)
 "qX" = (
 /obj/structure/rack,
 /obj/item/ammo_box/magazine/smgm45,
@@ -5380,6 +5439,9 @@
 /obj/machinery/computer/shuttle/syndicate/drop_pod,
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/assault_pod)
+"rK" = (
+/turf/simulated/wall/mineral/titanium,
+/area/space/centcomm)
 "rL" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -6948,6 +7010,12 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/syndicate_mothership)
+"xh" = (
+/obj/structure/bed/roller,
+/turf/simulated/floor/plasteel{
+	icon_state = "whiteblue"
+	},
+/area/shuttle/escape)
 "xi" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/simulated/floor/wood,
@@ -6959,6 +7027,12 @@
 /obj/structure/flora/grass/green,
 /turf/simulated/floor/plating/asteroid/snow,
 /area/syndicate_mothership)
+"xk" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/shuttle/escape)
 "xl" = (
 /obj/structure/table,
 /obj/item/card/id/silver{
@@ -7295,6 +7369,13 @@
 /obj/structure/marker_beacon/dock_marker,
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation/centcom)
+"yD" = (
+/obj/machinery/computer/communications,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "darkblue"
+	},
+/area/shuttle/escape)
 "yE" = (
 /obj/structure/flora/tree/pine{
 	pixel_x = 1
@@ -7473,6 +7554,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/ghost_bar)
+"zm" = (
+/obj/machinery/light{
+	dir = 1;
+	on = 1
+	},
+/obj/structure/chair/comfy/shuttle,
+/turf/simulated/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
 "zn" = (
 /obj/structure/sign/bobross,
 /turf/simulated/wall/indestructible/riveted,
@@ -7572,6 +7661,19 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/wood,
 /area/ghost_bar)
+"zI" = (
+/obj/structure/closet/crate/internals,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plasteel,
+/area/shuttle/escape)
 "zK" = (
 /obj/machinery/door_control/no_emag/no_cyborg{
 	pixel_x = 24;
@@ -7640,6 +7742,13 @@
 /obj/machinery/iv_drip,
 /turf/simulated/floor/plasteel/dark,
 /area/admin)
+"Ab" = (
+/obj/machinery/computer/crew,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "darkblue"
+	},
+/area/shuttle/escape)
 "Ac" = (
 /obj/structure/table/wood/fancy/royalblack,
 /obj/item/radio/uplink/admin{
@@ -8843,11 +8952,10 @@
 /area/wizard_station)
 "Ef" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/structure/closet/walllocker/emerglocker/directional/north,
+/obj/machinery/recharger,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "vault"
+	icon_state = "dark"
 	},
 /area/shuttle/escape)
 "Eh" = (
@@ -8887,11 +8995,12 @@
 /turf/simulated/floor/wood,
 /area/centcom/evac)
 "Em" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/red,
-/obj/item/restraints/handcuffs,
-/obj/item/flash,
-/turf/simulated/floor/plasteel/dark,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/shuttle/escape)
 "Ep" = (
 /obj/structure/chair/comfy/black{
@@ -8900,15 +9009,8 @@
 /turf/simulated/floor/transparent/glass,
 /area/centcom/specops)
 "Eq" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/o2{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/computer/operating{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -8928,13 +9030,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/suppy)
-"Et" = (
-/obj/machinery/computer/robotics,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "darkblue"
-	},
-/area/shuttle/escape)
 "Eu" = (
 /obj/structure/rack,
 /obj/item/clothing/under/color/red,
@@ -8955,31 +9050,10 @@
 /obj/effect/landmark/spawner/commando_manual,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
-"Ew" = (
-/obj/machinery/computer/crew,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkblue"
-	},
-/area/shuttle/escape)
 "Ex" = (
 /obj/machinery/status_display/supply_display,
 /turf/simulated/wall/indestructible/riveted,
 /area/centcom/suppy)
-"Ez" = (
-/obj/machinery/computer/emergency_shuttle,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkblue"
-	},
-/area/shuttle/escape)
-"EA" = (
-/obj/machinery/computer/communications,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "darkblue"
-	},
-/area/shuttle/escape)
 "EB" = (
 /obj/machinery/door/airlock/hatch/syndicate{
 	req_access = null
@@ -8990,18 +9064,18 @@
 /obj/machinery/prize_counter,
 /turf/simulated/floor/carpet/arcade,
 /area/ghost_bar)
-"EE" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
-/turf/simulated/floor/plasteel/dark,
-/area/shuttle/escape)
 "EF" = (
+/obj/structure/closet/walllocker/emerglocker/directional/north,
+/obj/machinery/cell_charger{
+	pixel_y = 11
+	},
+/obj/item/stock_parts/cell/high{
+	pixel_y = 11
+	},
+/obj/item/storage/toolbox/mechanical,
 /obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "vault"
+	icon_state = "dark"
 	},
 /area/shuttle/escape)
 "EG" = (
@@ -9120,6 +9194,10 @@
 	icon_state = "blue"
 	},
 /area/holodeck/source_knightarena)
+"Ff" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/simulated/floor/plasteel,
+/area/shuttle/escape)
 "Fg" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -9147,14 +9225,22 @@
 /area/ghost_bar)
 "Fn" = (
 /obj/structure/table/reinforced,
-/obj/machinery/recharger,
+/obj/item/restraints/handcuffs,
+/obj/item/flash,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "vault"
+	icon_state = "dark"
 	},
 /area/shuttle/escape)
 "Fo" = (
-/turf/simulated/floor/plasteel/dark,
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 29;
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/shuttle/escape)
 "Fp" = (
 /obj/machinery/door/window/classic/reversed{
@@ -9167,12 +9253,6 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
-"Fq" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/shuttle/escape)
 "Fr" = (
 /obj/machinery/economy/vending/clothing,
 /turf/simulated/floor/plasteel{
@@ -9253,10 +9333,9 @@
 /area/syndicate_mothership)
 "FB" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/fancy/donut_box,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "vault"
+	icon_state = "dark"
 	},
 /area/shuttle/escape)
 "FC" = (
@@ -9535,9 +9614,6 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/official/nanotrasen_logo/directional/west,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkred"
@@ -9560,10 +9636,7 @@
 	pixel_x = -28
 	},
 /obj/machinery/recharge_station,
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
-	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "Gx" = (
 /obj/structure/fence/cut/large,
@@ -9573,16 +9646,15 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel/dark,
-/area/shuttle/escape)
-"GA" = (
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 29;
-	pixel_y = -60
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plasteel/dark,
+/area/shuttle/escape)
+"Gz" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "GB" = (
 /turf/simulated/floor/plasteel{
@@ -9618,16 +9690,15 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel/dark,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/shuttle/escape)
 "GJ" = (
 /obj/machinery/computer/station_alert{
 	dir = 8
 	},
 /obj/structure/sign/poster/official/nanotrasen_logo/directional/east,
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkyellow"
@@ -10133,7 +10204,9 @@
 	name = "Escape Shuttle Cockpit"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/shuttle/escape)
 "Ip" = (
 /obj/machinery/recharger/wallcharger/upgraded{
@@ -10299,9 +10372,7 @@
 /area/centcom/specops)
 "IR" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/structure/closet/walllocker/emerglocker/directional/north,
 /turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "IS" = (
@@ -10317,17 +10388,11 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/regular,
 /obj/machinery/light{
-	dir = 8
+	dir = 1;
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
-	},
-/area/shuttle/escape)
-"IV" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "blue"
+	icon_state = "dark"
 	},
 /area/shuttle/escape)
 "IW" = (
@@ -10344,6 +10409,10 @@
 	icon_state = "vault"
 	},
 /area/centcom/specops)
+"IZ" = (
+/obj/effect/spawner/window/shuttle,
+/turf/simulated/floor/plating,
+/area/space/centcomm)
 "Jb" = (
 /obj/effect/mapping_helpers/airlock/access/all/centcomm/specops,
 /obj/machinery/door/airlock/external{
@@ -10363,10 +10432,13 @@
 /obj/structure/closet/fireaxecabinet{
 	pixel_x = 32
 	},
+/obj/machinery/light{
+	dir = 1;
+	on = 1
+	},
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "dark"
 	},
 /area/shuttle/escape)
 "Jf" = (
@@ -10396,12 +10468,7 @@
 "Jk" = (
 /obj/item/storage/firstaid/o2,
 /obj/structure/table,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
-	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "Jl" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
@@ -10493,10 +10560,12 @@
 /turf/simulated/floor/wood,
 /area/ghost_bar)
 "Jz" = (
-/obj/structure/chair/comfy/shuttle,
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
+/obj/machinery/light{
+	dir = 1;
+	on = 1
 	},
+/obj/structure/chair/comfy/shuttle,
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "JA" = (
 /obj/structure/sign/securearea{
@@ -10535,18 +10604,9 @@
 	},
 /area/tdome/tdomeobserve)
 "JC" = (
-/obj/structure/closet/crate/internals,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
-	},
+/obj/structure/closet/walllocker/emerglocker/directional/south,
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "JD" = (
 /obj/machinery/computer/shuttle/ferry,
@@ -10625,10 +10685,10 @@
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/gamma/space)
 "JO" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/medic,
-/obj/item/storage/belt/medical,
-/obj/machinery/light,
+/obj/machinery/status_display{
+	pixel_x = -32
+	},
+/obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
 	icon_state = "cmo"
 	},
@@ -10830,9 +10890,7 @@
 /area/ghost_bar)
 "Ku" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/iv_bag/blood/random,
-/obj/item/reagent_containers/iv_bag/blood/random,
-/obj/item/reagent_containers/iv_bag/blood/random,
+/obj/item/defibrillator/loaded,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whiteblue"
@@ -10917,7 +10975,10 @@
 	pixel_x = 29;
 	pixel_y = -30
 	},
-/obj/structure/bed/roller,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/iv_bag/blood/o_minus,
+/obj/item/reagent_containers/iv_bag/blood/o_minus,
+/obj/item/reagent_containers/iv_bag/blood/o_minus,
 /turf/simulated/floor/plasteel{
 	icon_state = "cmo"
 	},
@@ -11277,8 +11338,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "dark"
 	},
 /area/shuttle/escape)
 "LQ" = (
@@ -11290,6 +11350,7 @@
 /area/tdome/arena)
 "LR" = (
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/shuttle/escape)
@@ -11311,8 +11372,10 @@
 /obj/machinery/door/airlock/titanium/glass{
 	name = "Emergency Airlock Access"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/security/doors,
-/turf/simulated/floor/plasteel,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/shuttle/escape)
 "LV" = (
 /turf/simulated/floor/lava/lava_land_surface,
@@ -11344,16 +11407,19 @@
 	},
 /area/shuttle/escape)
 "Mc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
 /area/shuttle/escape)
 "Md" = (
-/obj/machinery/door/airlock/external{
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external/glass{
 	id_tag = "s_docking_airlock"
 	},
-/obj/structure/fans/tiny,
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "Me" = (
@@ -11848,12 +11914,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/doors,
 /turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"NG" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/shuttle/escape)
 "NH" = (
 /turf/simulated/floor/plasteel/stairs/left{
 	dir = 8
@@ -11892,6 +11952,9 @@
 	},
 /area/centcom/gamma)
 "NM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -11984,13 +12047,6 @@
 /obj/machinery/mecha_part_fabricator/upgraded,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
-"Od" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Escape Shuttle Infirmary"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/simulated/floor/plasteel,
-/area/shuttle/escape)
 "Of" = (
 /obj/item/kirbyplants/large,
 /turf/simulated/floor/plasteel{
@@ -12196,13 +12252,10 @@
 	},
 /area/centcom/specops)
 "OI" = (
-/obj/machinery/door/airlock/titanium{
-	aiControlDisabled = 1;
-	hackProof = 1;
-	id_tag = "s_docking_airlock";
-	name = "Shuttle Hatch"
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "OJ" = (
 /obj/structure/chair/comfy/shuttle{
@@ -12232,19 +12285,12 @@
 "ON" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "OO" = (
 /obj/item/kirbyplants/large,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "redcorner"
+	icon_state = "dark"
 	},
 /area/shuttle/escape)
 "OP" = (
@@ -12315,7 +12361,7 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "dark"
 	},
 /area/shuttle/escape)
 "OY" = (
@@ -12325,10 +12371,7 @@
 "OZ" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
-	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "Pa" = (
 /obj/effect/turf_decal/delivery/white/partial,
@@ -12338,29 +12381,12 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
-	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "Pd" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/indestructible/riveted,
 /area/tdome/tdomeadmin)
-"Pe" = (
-/obj/structure/closet/crate/internals,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
-	},
-/area/shuttle/escape)
 "Pf" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -12565,6 +12591,11 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/centcom/control)
+"PL" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/shuttle/escape)
 "PM" = (
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/metal/fifty,
@@ -12694,9 +12725,9 @@
 /obj/machinery/door/airlock/command/glass{
 	name = "Escape Shuttle Cockpit"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/security/doors,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	icon_state = "dark"
 	},
 /area/shuttle/escape)
 "Qg" = (
@@ -12879,15 +12910,13 @@
 /area/centcom/evac)
 "QH" = (
 /obj/docking_port/mobile/emergency{
-	dwidth = 11;
+	dwidth = 12;
 	height = 18;
-	width = 29
+	timid = 1;
+	width = 30
 	},
-/obj/machinery/door/airlock/titanium{
-	aiControlDisabled = 1;
-	hackProof = 1;
-	id_tag = "s_docking_airlock";
-	name = "Shuttle Hatch"
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock"
 	},
 /obj/docking_port/stationary{
 	dir = 4;
@@ -12897,7 +12926,7 @@
 	name = "emergency centcom";
 	width = 41
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "QI" = (
 /obj/machinery/door_control/no_emag{
@@ -12929,23 +12958,6 @@
 	icon_state = "green"
 	},
 /area/centcom/evac)
-"QP" = (
-/obj/structure/closet/crate/internals,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
-	},
-/area/shuttle/escape)
 "QQ" = (
 /turf/simulated/floor/holofloor{
 	icon = 'icons/turf/floors/plating.dmi';
@@ -12954,9 +12966,10 @@
 /area/holodeck/source_desert)
 "QR" = (
 /obj/machinery/mech_bay_recharge_port,
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
+/obj/machinery/light/small{
+	dir = 8
 	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "QS" = (
 /obj/structure/curtain/open/shower,
@@ -13036,9 +13049,10 @@
 	dir = 4;
 	pixel_y = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "Rg" = (
 /obj/effect/spawner/window,
@@ -13369,6 +13383,12 @@
 	icon_state = "red"
 	},
 /area/centcom/evac)
+"Sg" = (
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock"
+	},
+/turf/simulated/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
 "Sh" = (
 /obj/structure/table/wood,
 /obj/item/storage/bag/dice,
@@ -13468,6 +13488,15 @@
 /obj/structure/sign/nosmoking_2,
 /turf/simulated/wall/indestructible/riveted,
 /area/ghost_bar)
+"SC" = (
+/obj/machinery/light{
+	dir = 1;
+	on = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/shuttle/escape)
 "SD" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -13530,16 +13559,29 @@
 /obj/structure/reagent_dispensers/fueltank/chem{
 	pixel_x = -32
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "SP" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "browncorner"
 	},
 /area/shuttle/escape)
 "SQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "browncorner"
@@ -13564,9 +13606,12 @@
 /turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/supply)
 "ST" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
+/obj/structure/table,
+/obj/item/storage/firstaid/machine,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "SV" = (
 /turf/simulated/wall/indestructible/fakeglass,
@@ -13820,7 +13865,7 @@
 	name = "Escape Shuttle Infirmary"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	icon_state = "white"
 	},
 /area/shuttle/escape)
 "TT" = (
@@ -13965,6 +14010,11 @@
 /obj/item/lighter,
 /turf/simulated/floor/wood,
 /area/centcom/control)
+"Uo" = (
+/obj/structure/closet/walllocker/emerglocker/directional/north,
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/shuttle/escape)
 "Up" = (
 /obj/item/caution/proximity_sign,
 /obj/item/caution/proximity_sign,
@@ -13987,9 +14037,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
 "Ur" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 28
-	},
+/obj/machinery/sleeper,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "whiteblue"
@@ -14055,8 +14103,16 @@
 /turf/simulated/floor/plasteel/freezer,
 /area/admin)
 "UF" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/o2{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = 3
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whiteblue"
@@ -14359,27 +14415,30 @@
 /turf/simulated/floor/plating,
 /area/centcom/evac)
 "VO" = (
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
-	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "VP" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
+/obj/machinery/light{
+	dir = 4
 	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "VQ" = (
 /obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/window/full/shuttle,
-/turf/simulated/floor/grass/no_creep,
+/turf/simulated/floor/grass,
 /area/shuttle/escape)
 "VR" = (
 /obj/machinery/processor,
@@ -14457,6 +14516,13 @@
 /obj/effect/landmark/spawner/ertdirector,
 /turf/simulated/floor/carpet,
 /area/centcom/specops)
+"Wc" = (
+/obj/item/kirbyplants/large,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/shuttle/escape)
 "Wd" = (
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/centcom/control)
@@ -14526,9 +14592,8 @@
 /area/centcom/specops)
 "Wq" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
-	},
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "Wr" = (
 /obj/structure/table/reinforced,
@@ -15007,15 +15072,6 @@
 	icon_state = "vault"
 	},
 /area/centcom/specops)
-"XB" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
-	},
-/area/shuttle/escape)
 "XC" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -15042,10 +15098,11 @@
 /area/centcom/evac)
 "XH" = (
 /obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/window/full/shuttle,
-/turf/simulated/floor/grass/no_creep,
+/turf/simulated/floor/grass,
 /area/shuttle/escape)
 "XI" = (
 /obj/item/clipboard,
@@ -15070,9 +15127,10 @@
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
+/obj/machinery/light/small{
+	dir = 8
 	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "XM" = (
 /turf/simulated/wall/indestructible/fakeglass,
@@ -15090,9 +15148,8 @@
 /obj/item/crowbar,
 /obj/item/wrench,
 /obj/item/radio,
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
-	},
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "XQ" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -15415,7 +15472,7 @@
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
 "YT" = (
-/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
 /turf/simulated/floor/plasteel{
 	icon_state = "cmo"
 	},
@@ -15429,31 +15486,9 @@
 	icon_state = "greencorner"
 	},
 /area/centcom/evac)
-"YV" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
-	},
-/area/shuttle/escape)
 "YW" = (
 /obj/structure/extinguisher_cabinet,
 /turf/simulated/wall/mineral/titanium,
-/area/shuttle/escape)
-"YX" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
-	},
 /area/shuttle/escape)
 "YY" = (
 /obj/item/radio/intercom{
@@ -15461,9 +15496,7 @@
 	pixel_x = -28
 	},
 /obj/machinery/recharge_station,
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
-	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "YZ" = (
 /obj/machinery/economy/vending/syndisnack,
@@ -15480,9 +15513,8 @@
 	pixel_x = 4;
 	pixel_y = -4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
-	},
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "Zc" = (
 /obj/structure/table/wood,
@@ -50626,7 +50658,7 @@ od
 od
 od
 od
-OI
+Sg
 od
 QH
 od
@@ -50885,19 +50917,19 @@ LJ
 ND
 LN
 od
-QL
+Uo
 SF
-VO
-VO
-VO
+ff
+ff
+ff
 SJ
-QL
-QL
-QL
+iH
+Gz
+iH
 SJ
-VO
-VO
-VO
+ff
+ff
+ff
 VO
 JC
 od
@@ -51394,24 +51426,24 @@ aN
 aN
 od
 od
-IS
+zm
 LN
 LN
 OJ
 vy
 Mb
 LR
-VP
-VP
-VP
-YV
-VP
+xk
+xk
+xk
+xk
+xk
 LR
-VP
-VP
-VP
-YV
-VP
+xk
+xk
+xk
+xk
+xk
 LR
 Pb
 vy
@@ -51646,8 +51678,8 @@ aN
 aN
 aN
 od
-od
 vy
+od
 od
 od
 od
@@ -51670,7 +51702,7 @@ VQ
 Xm
 XH
 LR
-XB
+Pb
 od
 ux
 ux
@@ -51901,7 +51933,7 @@ aN
 aN
 aN
 aN
-aN
+rK
 od
 Ef
 Fn
@@ -51915,17 +51947,17 @@ ON
 od
 Mb
 LR
-VO
-VO
-VO
-YX
-VO
+ff
+ff
+ff
+ff
+ff
 LR
-VO
-VO
-VO
-YX
-VO
+ff
+ff
+ff
+ff
+ff
 LR
 Pb
 od
@@ -52158,10 +52190,10 @@ aN
 aN
 aN
 aN
-aN
-vy
+IZ
+kx
 Em
-Fo
+PL
 Gy
 Gy
 od
@@ -52170,7 +52202,7 @@ vy
 NF
 od
 od
-Mb
+SC
 LR
 LR
 LR
@@ -52185,7 +52217,7 @@ LR
 LR
 LR
 Pb
-vy
+od
 Iv
 Zp
 aN
@@ -52415,31 +52447,31 @@ aN
 aN
 aN
 aN
-aN
-vy
-Et
-Fq
-Fo
-Fo
+IZ
+pa
+Em
+PL
+PL
+PL
 Ik
 IU
 LP
-NG
+PL
 OO
 vy
 Mb
 LR
-VP
-VP
-VP
-YV
-VP
+xk
+xk
+xk
+xk
+xk
 LR
-VP
-VP
-VP
-YV
-VP
+xk
+xk
+xk
+xk
+xk
 LR
 Pb
 od
@@ -52672,19 +52704,19 @@ aN
 aN
 aN
 aN
-aN
-vy
-Ew
-Fq
-Fo
-Fo
+IZ
+yD
+Em
+PL
+PL
+PL
 Io
-IV
-LR
-LR
-Mb
+PL
+PL
+PL
+PL
 Qf
-Mb
+Ff
 LR
 VQ
 Xm
@@ -52929,31 +52961,31 @@ aN
 aN
 aN
 aN
-aN
-vy
-Ez
-Fq
-Fo
-Fo
+IZ
+qW
+Em
+PL
+PL
+PL
 Io
-IV
-LR
-LR
-Mb
+PL
+PL
+PL
+PL
 Qf
-Mb
+Ff
 LR
-VO
-VO
-VO
-YX
-VO
+ff
+ff
+ff
+ff
+ff
 LR
-VO
-VO
-VO
-YX
-VO
+ff
+ff
+ff
+ff
+ff
 LR
 Pb
 vy
@@ -53186,16 +53218,16 @@ aN
 aN
 aN
 aN
-aN
-vy
-EA
-Fq
-GA
+IZ
+Ab
+Em
+PL
+PL
 Fo
 Ik
 Je
-LS
-LZ
+PL
+PL
 OX
 vy
 Mb
@@ -53212,7 +53244,7 @@ LR
 LR
 LR
 LR
-XB
+Pb
 od
 ux
 ux
@@ -53443,10 +53475,10 @@ aN
 aN
 aN
 aN
-aN
-vy
-EE
-Fo
+IZ
+fh
+Em
+PL
 GI
 GI
 od
@@ -53455,22 +53487,22 @@ LU
 LU
 od
 od
-QP
-SJ
-QL
-QL
-VP
-VP
-VP
-VP
-VP
-VP
+Uo
+Wc
 LR
 LR
+xk
+xk
+xk
 VP
+xk
+xk
+LR
+LR
+xk
 VP
 JC
-vy
+od
 Iv
 Zp
 aN
@@ -53700,7 +53732,7 @@ aN
 aN
 aN
 aN
-aN
+rK
 od
 EF
 FB
@@ -53725,7 +53757,7 @@ vy
 TS
 TS
 vy
-Ik
+Zu
 od
 od
 Iv
@@ -53959,15 +53991,15 @@ aN
 aN
 aN
 od
-od
 vy
+od
 od
 od
 od
 Jz
 Mb
 NI
-Pb
+oL
 od
 QR
 SN
@@ -53976,12 +54008,12 @@ QL
 XL
 YY
 Gw
-od
-bf
+Zu
+we
 FK
 VM
 VM
-ir
+xh
 ql
 JO
 od
@@ -54221,11 +54253,11 @@ aN
 aN
 od
 od
-Jz
+nj
 Mb
 NI
 Pb
-Ik
+od
 Rc
 SP
 VU
@@ -54233,7 +54265,7 @@ VU
 VU
 VU
 bc
-Od
+TS
 Ly
 FK
 VM
@@ -54478,11 +54510,11 @@ aN
 aN
 aN
 vy
-Jz
+nj
 Mb
 NI
 Pb
-od
+Ik
 Re
 SQ
 Wh
@@ -54490,7 +54522,7 @@ Wh
 Wh
 Wh
 Cr
-Od
+TS
 Ly
 FK
 VM
@@ -54735,25 +54767,25 @@ aN
 aN
 aN
 od
-JC
+Uo
 Mc
 NM
-Pe
+JC
 od
 Rf
 ST
 Wq
-JC
+zI
 XP
 Za
 fN
-Zu
+od
 fy
 Ur
 UF
 Ku
 Eq
-we
+pn
 qF
 od
 Iv
@@ -55010,7 +55042,7 @@ od
 vy
 vy
 vy
-vy
+od
 od
 od
 od

--- a/_maps/map_files/shuttles/emergency_cyb.dmm
+++ b/_maps/map_files/shuttles/emergency_cyb.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "ab" = (
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/escape)
@@ -11,48 +11,49 @@
 /area/shuttle/escape)
 "ae" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "vault"
-	},
-/area/shuttle/escape)
-"af" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/red,
-/obj/item/restraints/handcuffs,
-/obj/item/flash,
+/obj/structure/closet/walllocker/emerglocker/directional/north,
+/obj/machinery/recharger,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/shuttle/escape)
+"af" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/computer/med_data,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "darkblue"
+	},
+/area/shuttle/escape)
 "ag" = (
-/obj/machinery/computer/robotics,
+/obj/structure/bed/roller,
+/turf/simulated/floor/plasteel{
+	icon_state = "whiteblue"
+	},
+/area/shuttle/escape)
+"ah" = (
+/obj/machinery/computer/communications,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkblue"
 	},
 /area/shuttle/escape)
-"ah" = (
-/obj/machinery/computer/crew,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkblue"
-	},
-/area/shuttle/escape)
 "ai" = (
-/obj/machinery/computer/emergency_shuttle,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/optable,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkblue"
+	icon_state = "cmo"
 	},
 /area/shuttle/escape)
 "aj" = (
-/obj/machinery/computer/communications,
+/obj/machinery/computer/robotics,
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "darkblue"
+	icon_state = "darkpurple";
+	dir = 5
 	},
 /area/shuttle/escape)
 "ak" = (
@@ -63,20 +64,25 @@
 	},
 /area/shuttle/escape)
 "al" = (
+/obj/structure/closet/walllocker/emerglocker/directional/north,
+/obj/machinery/cell_charger{
+	pixel_y = 11
+	},
+/obj/item/stock_parts/cell/high{
+	pixel_y = 11
+	},
+/obj/item/storage/toolbox/mechanical,
 /obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "vault"
+	icon_state = "dark"
 	},
 /area/shuttle/escape)
 "am" = (
 /obj/structure/table/reinforced,
-/obj/machinery/recharger,
+/obj/item/restraints/handcuffs,
+/obj/item/flash,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "vault"
+	icon_state = "dark"
 	},
 /area/shuttle/escape)
 "an" = (
@@ -93,12 +99,10 @@
 	},
 /area/shuttle/escape)
 "ap" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "vault"
+/obj/effect/turf_decal/delivery/partial{
+	dir = 4
 	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "ar" = (
 /obj/machinery/computer/security{
@@ -119,14 +123,13 @@
 	},
 /area/shuttle/escape)
 "at" = (
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 29;
-	pixel_y = -60
+/obj/machinery/light{
+	dir = 8
 	},
+/obj/machinery/computer/aifixer,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkpurple";
+	dir = 9
 	},
 /area/shuttle/escape)
 "au" = (
@@ -163,18 +166,24 @@
 /turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "aA" = (
-/obj/machinery/light,
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/obj/structure/closet/crate/internals,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "aB" = (
-/obj/machinery/light,
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 29;
+	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -198,10 +207,13 @@
 	name = "Escape Shuttle Cockpit"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/shuttle/escape)
 "aG" = (
 /obj/structure/table/reinforced,
+/obj/structure/closet/walllocker/emerglocker/directional/north,
 /turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "aH" = (
@@ -228,14 +240,7 @@
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
-	},
-/area/shuttle/escape)
-"aM" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "blue"
+	icon_state = "dark"
 	},
 /area/shuttle/escape)
 "aN" = (
@@ -258,8 +263,7 @@
 	},
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "dark"
 	},
 /area/shuttle/escape)
 "aS" = (
@@ -273,32 +277,16 @@
 	on = 1
 	},
 /obj/structure/chair/comfy/shuttle,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
-	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "aU" = (
 /obj/structure/chair/comfy/shuttle,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
-	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "aV" = (
-/obj/structure/closet/crate/internals,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
-	},
+/obj/structure/closet/walllocker/emerglocker/directional/south,
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "aW" = (
 /obj/item/radio/intercom{
@@ -320,8 +308,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "dark"
 	},
 /area/shuttle/escape)
 "ba" = (
@@ -341,7 +328,9 @@
 	name = "Emergency Airlock Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/shuttle/escape)
 "bf" = (
 /turf/simulated/floor/plasteel{
@@ -354,17 +343,20 @@
 	},
 /area/shuttle/escape)
 "bh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
 /area/shuttle/escape)
 "bi" = (
-/obj/machinery/door/airlock/external{
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external/glass{
 	id_tag = "s_docking_airlock"
 	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "bj" = (
 /obj/machinery/door/airlock/security/glass{
@@ -374,9 +366,10 @@
 /turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "bk" = (
+/obj/machinery/computer/crew,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "redcorner"
+	dir = 9;
+	icon_state = "darkblue"
 	},
 /area/shuttle/escape)
 "bl" = (
@@ -386,6 +379,9 @@
 	},
 /area/shuttle/escape)
 "bm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -395,13 +391,10 @@
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/shuttle/escape)
 "bo" = (
-/obj/machinery/door/airlock/titanium{
-	aiControlDisabled = 1;
-	hackProof = 1;
-	id_tag = "s_docking_airlock";
-	name = "Shuttle Hatch"
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "bp" = (
 /obj/structure/table/reinforced,
@@ -411,8 +404,7 @@
 "br" = (
 /obj/item/kirbyplants/large,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "redcorner"
+	icon_state = "dark"
 	},
 /area/shuttle/escape)
 "bu" = (
@@ -432,13 +424,12 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "dark"
 	},
 /area/shuttle/escape)
 "by" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
-/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "bz" = (
@@ -446,31 +437,17 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
-	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "bA" = (
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
-	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "bB" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
-	},
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "bC" = (
 /obj/machinery/door/airlock/command/glass{
@@ -478,24 +455,20 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/doors,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "dark"
 	},
 /area/shuttle/escape)
 "bD" = (
-/obj/machinery/door/airlock/titanium{
-	aiControlDisabled = 1;
-	hackProof = 1;
-	id_tag = "s_docking_airlock";
-	name = "Shuttle Hatch"
-	},
 /obj/docking_port/mobile/emergency{
-	dwidth = 11;
+	dwidth = 12;
 	height = 18;
 	timid = 1;
-	width = 29
+	width = 30
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock"
+	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "bE" = (
 /turf/simulated/floor/plasteel,
@@ -511,10 +484,7 @@
 /area/shuttle/escape)
 "bG" = (
 /obj/machinery/mech_bay_recharge_port,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
-	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "bH" = (
 /obj/machinery/computer/mech_bay_power_console,
@@ -533,10 +503,10 @@
 	dir = 4;
 	pixel_y = 8
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "bJ" = (
 /obj/item/kirbyplants/large,
@@ -556,45 +526,52 @@
 /obj/structure/reagent_dispensers/fueltank/chem{
 	pixel_x = -32
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "bM" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "browncorner"
 	},
 /area/shuttle/escape)
 "bN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "browncorner"
 	},
 /area/shuttle/escape)
 "bO" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+/obj/structure/table,
+/obj/item/storage/firstaid/machine,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "bP" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
-	},
+/obj/structure/closet/walllocker/emerglocker/directional/north,
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "bQ" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
-	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "bR" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -624,10 +601,8 @@
 /area/shuttle/escape)
 "bV" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
-	},
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "bX" = (
 /obj/machinery/ai_status_display,
@@ -648,10 +623,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
-	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "ca" = (
 /obj/structure/closet/crate,
@@ -662,10 +634,8 @@
 /obj/item/crowbar,
 /obj/item/wrench,
 /obj/item/radio,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
-	},
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "cb" = (
 /obj/item/kirbyplants/large,
@@ -681,10 +651,7 @@
 	pixel_x = -28
 	},
 /obj/machinery/recharge_station,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
-	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "ce" = (
 /obj/structure/closet/crate/engineering,
@@ -697,20 +664,15 @@
 	pixel_x = 4;
 	pixel_y = -4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
-	},
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "cf" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
 	},
 /obj/machinery/recharge_station,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
-	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "cg" = (
 /turf/simulated/floor/plasteel{
@@ -735,11 +697,11 @@
 	pixel_x = -2;
 	pixel_y = 4
 	},
-/obj/machinery/light/small,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+/obj/machinery/light/small{
+	dir = 4
 	},
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "cj" = (
 /obj/machinery/light{
@@ -754,31 +716,25 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
-	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "cl" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Escape Shuttle Infirmary"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "cm" = (
 /obj/structure/sign/greencross,
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/escape)
 "co" = (
-/obj/machinery/sleeper{
-	dir = 4
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cmo"
-	},
+/turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "cp" = (
 /turf/simulated/floor/plasteel{
@@ -787,6 +743,9 @@
 /area/shuttle/escape)
 "cq" = (
 /obj/machinery/sleeper,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cmo"
 	},
@@ -804,25 +763,17 @@
 	},
 /area/shuttle/escape)
 "ct" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 28
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
-	},
+/obj/machinery/sleeper,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "whiteblue"
 	},
 /area/shuttle/escape)
 "cu" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Escape Shuttle Infirmary"
-	},
+/obj/machinery/computer/emergency_shuttle,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	dir = 5;
+	icon_state = "darkblue"
 	},
 /area/shuttle/escape)
 "cv" = (
@@ -831,8 +782,16 @@
 	},
 /area/shuttle/escape)
 "cw" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/o2{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = 3
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whiteblue"
@@ -840,9 +799,7 @@
 /area/shuttle/escape)
 "cx" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/iv_bag/blood/random,
-/obj/item/reagent_containers/iv_bag/blood/random,
-/obj/item/reagent_containers/iv_bag/blood/random,
+/obj/item/defibrillator/loaded,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whiteblue"
@@ -854,15 +811,8 @@
 	},
 /area/shuttle/escape)
 "cz" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/o2{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/computer/operating{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -876,17 +826,13 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
-	},
+/turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "cB" = (
-/obj/structure/table/reinforced,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/reagent_containers/drinks/mug/med,
+/obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
 	icon_state = "cmo"
 	},
@@ -898,15 +844,16 @@
 	},
 /area/shuttle/escape)
 "cD" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/medic,
-/obj/item/storage/belt/medical,
+/obj/machinery/status_display{
+	pixel_x = -32
+	},
+/obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
 "cE" = (
-/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
 /turf/simulated/floor/plasteel{
 	icon_state = "cmo"
 	},
@@ -918,15 +865,20 @@
 	pixel_x = 29;
 	pixel_y = -30
 	},
-/obj/structure/bed/roller,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/iv_bag/blood/o_minus,
+/obj/item/reagent_containers/iv_bag/blood/o_minus,
+/obj/item/reagent_containers/iv_bag/blood/o_minus,
 /turf/simulated/floor/plasteel{
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
 "cG" = (
 /obj/structure/table/reinforced,
+/obj/item/storage/surgical_tray{
+	pixel_y = 8
+	},
 /obj/item/clothing/gloves/color/latex/nitrile,
-/obj/item/clothing/mask/breath,
 /turf/simulated/floor/plasteel{
 	icon_state = "cmo"
 	},
@@ -941,11 +893,12 @@ aa
 aa
 aa
 aa
+aa
 ab
 ab
 ab
 ab
-bo
+co
 ab
 bD
 ab
@@ -972,25 +925,26 @@ aa
 aa
 aa
 aa
+aa
 ab
 aG
 aW
 az
 aH
 ab
-bE
+bP
 bJ
-bP
-bP
-bP
+cr
+cr
+cr
 cb
-bE
+ap
 cj
-bE
+ap
 cb
-bP
-bP
-bP
+cr
+cr
+cr
 cA
 aV
 ab
@@ -998,6 +952,7 @@ bu
 bw
 "}
 (3,1,1) = {"
+aa
 aa
 aa
 aa
@@ -1023,12 +978,13 @@ ba
 ba
 ba
 ba
-bB
+bA
 ac
 bu
 bw
 "}
 (4,1,1) = {"
+aa
 aa
 aa
 aa
@@ -1054,15 +1010,16 @@ bQ
 bQ
 bQ
 ba
-bB
+bA
 ac
 bu
 bw
 "}
 (5,1,1) = {"
-ab
+aa
 ab
 ac
+ab
 ab
 ab
 ab
@@ -1085,12 +1042,13 @@ bR
 bX
 bY
 ba
-bB
+bA
 ab
 cH
 cH
 "}
 (6,1,1) = {"
+ab
 ab
 ae
 am
@@ -1104,29 +1062,30 @@ bp
 ab
 bg
 ba
-bP
-bP
-bP
-bP
-bP
-ba
-bP
 cr
-bP
-bP
-bP
+cr
+cr
+cr
+cr
 ba
-bB
+cr
+cr
+cr
+cr
+cr
+ba
+bA
 ab
 bu
 bw
 "}
 (7,1,1) = {"
 ac
-af
+at
+ao
 an
 as
-aA
+as
 ab
 ab
 ac
@@ -1147,21 +1106,22 @@ ba
 ba
 ba
 ba
-bB
-ac
+bA
+ab
 bu
 bw
 "}
 (8,1,1) = {"
 ac
-ag
+aj
 ao
+an
 an
 an
 aD
 aL
 aY
-bk
+an
 br
 ac
 bg
@@ -1178,7 +1138,7 @@ bQ
 bQ
 bQ
 ba
-bB
+bA
 ab
 cH
 cH
@@ -1189,13 +1149,14 @@ ah
 ao
 an
 an
+an
 aF
-aM
-ba
-ba
-bg
+an
+an
+an
+an
 bC
-bg
+bB
 ba
 bR
 bX
@@ -1209,52 +1170,54 @@ bR
 aD
 bY
 ba
-bB
+bA
 ac
 bu
 bw
 "}
 (10,1,1) = {"
 ac
-ai
+cu
 ao
 an
 an
+an
 aF
-aM
-ba
-ba
-bg
+an
+an
+an
+an
 bC
-bg
-ba
-bP
-bP
-bP
-bP
-bP
-ba
-bP
-bP
-bP
-bP
-bP
-ba
 bB
+ba
+cr
+cr
+cr
+cr
+cr
+ba
+cr
+cr
+cr
+cr
+cr
+ba
+bA
 ac
 bu
 bw
 "}
 (11,1,1) = {"
 ac
-aj
+bk
 ao
-at
 an
+an
+aB
 aD
 aR
-bd
-bf
+an
+an
 bx
 ac
 bg
@@ -1271,27 +1234,28 @@ ba
 ba
 ba
 ba
-bB
+bA
 ab
 cH
 cH
 "}
 (12,1,1) = {"
 ac
-ak
+af
+ao
 an
 au
-aB
+au
 ab
 ab
 be
 be
 ab
 ab
-aV
+bP
 bK
-bE
-bE
+ba
+ba
 bQ
 bQ
 bQ
@@ -1303,14 +1267,15 @@ ba
 bQ
 ck
 aV
-ac
+ab
 bu
 bw
 "}
 (13,1,1) = {"
 ab
+ab
 al
-ap
+ak
 ax
 aC
 ab
@@ -1329,19 +1294,20 @@ ab
 ab
 cm
 ac
-cu
-cu
+cl
+cl
 ac
-aD
+cm
 ab
 ab
 bu
 bw
 "}
 (14,1,1) = {"
-ab
+aa
 ab
 ac
+ab
 ab
 ab
 ab
@@ -1357,12 +1323,12 @@ bE
 bZ
 cd
 cf
-ab
-co
+cm
+cC
 cs
 cv
 cv
-cy
+ag
 cB
 cD
 ab
@@ -1370,6 +1336,7 @@ cH
 cH
 "}
 (15,1,1) = {"
+aa
 aa
 aa
 aa
@@ -1406,12 +1373,13 @@ aa
 aa
 aa
 aa
+aa
 ac
 aU
 bg
 bl
-bB
-ab
+bA
+aD
 bH
 bN
 bU
@@ -1437,8 +1405,9 @@ aa
 aa
 aa
 aa
+aa
 ab
-aV
+bP
 bh
 bm
 aV
@@ -1446,17 +1415,17 @@ ab
 bI
 bO
 bV
-aV
+aA
 ca
 ce
 ci
-cm
+ab
 cq
 ct
 cw
 cx
 cz
-cC
+ai
 cG
 ab
 bu
@@ -1468,6 +1437,7 @@ aa
 aa
 aa
 aa
+aa
 ab
 ac
 bi
@@ -1487,7 +1457,7 @@ ab
 ac
 ac
 ac
-ac
+ab
 ab
 ab
 ab

--- a/_maps/map_files/shuttles/emergency_cyb.dmm
+++ b/_maps/map_files/shuttles/emergency_cyb.dmm
@@ -484,6 +484,9 @@
 /area/shuttle/escape)
 "bG" = (
 /obj/machinery/mech_bay_recharge_port,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "bH" = (

--- a/_maps/map_files/shuttles/emergency_cyb.dmm
+++ b/_maps/map_files/shuttles/emergency_cyb.dmm
@@ -9,14 +9,6 @@
 /obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
-"ae" = (
-/obj/structure/table/reinforced,
-/obj/structure/closet/walllocker/emerglocker/directional/north,
-/obj/machinery/recharger,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/shuttle/escape)
 "af" = (
 /obj/machinery/light{
 	dir = 4
@@ -64,7 +56,6 @@
 	},
 /area/shuttle/escape)
 "al" = (
-/obj/structure/closet/walllocker/emerglocker/directional/north,
 /obj/machinery/cell_charger{
 	pixel_y = 11
 	},
@@ -213,7 +204,6 @@
 /area/shuttle/escape)
 "aG" = (
 /obj/structure/table/reinforced,
-/obj/structure/closet/walllocker/emerglocker/directional/north,
 /turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "aH" = (
@@ -281,11 +271,6 @@
 /area/shuttle/escape)
 "aU" = (
 /obj/structure/chair/comfy/shuttle,
-/turf/simulated/floor/plasteel,
-/area/shuttle/escape)
-"aV" = (
-/obj/structure/closet/walllocker/emerglocker/directional/south,
-/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "aW" = (
@@ -563,11 +548,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel,
-/area/shuttle/escape)
-"bP" = (
-/obj/structure/closet/walllocker/emerglocker/directional/north,
-/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "bQ" = (
@@ -935,7 +915,7 @@ aW
 az
 aH
 ab
-bP
+ap
 bJ
 cr
 cr
@@ -949,7 +929,7 @@ cr
 cr
 cr
 cA
-aV
+aA
 ab
 bu
 bw
@@ -1053,7 +1033,7 @@ cH
 (6,1,1) = {"
 ab
 ab
-ae
+aY
 am
 ar
 ay
@@ -1255,7 +1235,7 @@ be
 be
 ab
 ab
-bP
+aA
 bK
 ba
 ba
@@ -1269,7 +1249,7 @@ ba
 ba
 bQ
 ck
-aV
+aA
 ab
 bu
 bw
@@ -1410,10 +1390,10 @@ aa
 aa
 aa
 ab
-bP
+aA
 bh
 bm
-aV
+aA
 ab
 bI
 bO


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Extends the bridge of the shuttle by 1 tile. Adds 2 wall lockers with emergency oxygen.

Adds a medical records and AI restorer computer so each head's station has 2 consoles.

Recolours the bridge antechamber black.

Adds <STAND CLEAR> markings outside the entrence to the secure area.

Removes most of the floor markings, adds some back sparingly.

Adds windows to the external airlocks.

Adds operating equipment and a defibrillator to the ship medbay.

Adds a machine repair kit to the service bay.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
If the doctors forget or are unable to get their surgery equipment, there's not much they can do on the shuttle. Almost every purchasable shuttle has a proper operating table and surgery tools, and defibrillators are also fairly common.

This gives the doctors some more content and possibly allows some greatful players to survive to the end screen, total dopamine levels will increase.

Machine repair kit allows machines to get better treatment too.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<img width="576" height="960" alt="image" src="https://github.com/user-attachments/assets/f3f5bd9e-0d60-4ecf-9b83-c41b236a37d1" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Spawned in. Called the emergency shuttle. It worked.

Swapped the shuttle for another one and then swapped back, it worked too.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Default emergency shuttle bridge is 1 tile longer.
add: Adds surgery equipment and a defib to the default emergency shuttle.
add: Adds a machine repair kit to the emergency shuttle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
