### PR TITLE
clean up logs for mob spawns

### DIFF
--- a/code/modules/awaymissions/mob_spawn.dm
+++ b/code/modules/awaymissions/mob_spawn.dm
@@ -147,7 +147,8 @@
 	return FALSE
 
 /obj/effect/mob_spawn/proc/create(ckey, flavour = TRUE, name, mob/user = usr)
-	log_game("[ckey] became [mob_name]")
+	if(ckey) // we don't care about corpse spawners etc
+		log_game("[ckey] became [mob_name]")
 	var/mob/living/M = new mob_type(get_turf(src)) //living mobs only
 	if(mob_name)
 		M.rename_character(M.real_name, mob_name)


### PR DESCRIPTION
## What Does This PR Do
This PR removes a log for mob spawners when no ckey is associated with the action (e.g. corpse spawners).
## Why It's Good For The Game
This crap is useless
<img width="885" height="270" alt="2025_09_21__12_06_37__" src="https://github.com/user-attachments/assets/ab852259-daf7-4af1-9186-fce4eb8c618c" />

## Testing
Visual inspection.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC