### PR TITLE
Moves some notes in MB19 to be lore consoles

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/moonoutpost19.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/moonoutpost19.dmm
@@ -1666,13 +1666,12 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/moonbase19)
 "fx" = (
-/obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/turf_decal/delivery/hollow,
-/obj/item/paper/fluff/ruins/moonoutpost19/log1,
+/obj/machinery/computer/loreconsole/moonoutpost19/log1,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -2213,9 +2212,9 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/computer/nonfunctional,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2,
+/obj/machinery/computer/loreconsole/moonoutpost19/lobby,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "dark"
@@ -2500,7 +2499,6 @@
 /obj/machinery/door/window/reinforced/normal{
 	dir = 4
 	},
-/obj/item/paper/fluff/ruins/moonoutpost19/lobby,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "dark"
@@ -7432,8 +7430,9 @@
 	},
 /area/ruin/space/moonbase19)
 "Cm" = (
-/obj/structure/table/glass/reinforced/plastitanium,
-/obj/item/paper/fluff/ruins/moonoutpost19/boreraccountant,
+/obj/machinery/computer/loreconsole/moonoutpost19/rdnote{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -7891,7 +7890,6 @@
 "Eo" = (
 /obj/structure/filingcabinet,
 /obj/structure/sign/poster/official/fruit_bowl/directional/north,
-/obj/item/paper/fluff/ruins/moonoutpost19/rdnote,
 /turf/simulated/floor/carpet/royalblue,
 /area/ruin/space/moonbase19)
 "Ep" = (
@@ -9463,12 +9461,13 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/space/moonbase19)
 "LK" = (
-/obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery/hollow,
-/obj/item/paper/fluff/ruins/moonoutpost19/log2,
+/obj/machinery/computer/loreconsole/moonoutpost19/log2{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "cafeteria"

--- a/code/modules/awaymissions/mission_code/ruins/moonoutpost19.dm
+++ b/code/modules/awaymissions/mission_code/ruins/moonoutpost19.dm
@@ -1,9 +1,5 @@
 //papers for moonoutpost19.dmm
 
-/obj/item/paper/fluff/ruins/moonoutpost19/lobby
-	name = "a note to Joe"
-	info = "<br>Hey Joe, since you keep forgetting here's the list of lockdown areas and the locations of control buttons. Thank me later.<br><br><b>(Lobby)</b><br><br>- Research Division lockdown<br>- Medical Ward lockdown<br>- Cargo Bay gates<br><br><b>(Cargo Bay)</b><br><br>- Exterior hangar gate<br>- Cargo bay gates<br><br><b>(Senior Researcher's Office)</b><br><br>- Specimen Containment Zone lockdown<br><br>Note: keep in mind, in case of power outages these buttons won't be functional. In this case you'll find a few generators in engineering wing, set them up properly then report to technicians ASAP."
-
 /obj/item/paper/fluff/ruins/moonoutpost19/entrance
 	name = "hastily written note"
 	info = "A warning to whose reading this, things here went really wrong. Way too damn wrong. Turn back while you can, there's nothing left for anyone. Not anymore."
@@ -16,22 +12,63 @@
 	name = "emergency procedures"
 	info = "(most of the parts are unreadable due to stains on the paper, the only words you can make out is...)<br><br> ...in case of power outages, use the provided portable generators. It is recommended setting up two of them at once rather than working with one generator on high power levels. It is also recommended using the pre-marked spots for generator setup. If you are uncertain where it is, use a t-ray scanner to check the floors. Provided plasma sheets will suffice until maintai..."
 
-/obj/item/paper/fluff/ruins/moonoutpost19/rdnote
-	name = "Personal Log"
-	info = "I am telling you, we're wasting our resources here with unnecessary things while we have means to make absolute difference. I have discussed this matter with Operations Officer, tomorrow we'll be expecting a shipment of three alien specimen eggs. They expect us to do something 'useful' about them, heh. I have made it this far, i sure can climb this ladder even further."
-
-/obj/item/paper/fluff/ruins/moonoutpost19/boreraccountant
-	name = "confusing note"
-	info = "I had a weird dream recently about something small catching me off-guard, from under my desk where they've hidden. <br><br>And now something in my mind whispers to me about 'tax norms', how it is implemented and various terms i have never heard before. <br><br> A note to self: don't push yourself too hard over small handicaps. It obviously makes you go insane, in a scary way too... And ask your therapist for extra session regarding to this matter."
-
-/obj/item/paper/fluff/ruins/moonoutpost19/log1
-	name = "Chamber #1 Log"
-	info = "<hr><b>Data Log #82<br><br> Subject: Yes<br><br> Details:</b><br><br> I fricking hate our so called 'Senior Researcher' Mr. Wood. Someone has to show him how we handle the pricks whose nose in the air in this line of business.<br><br> Therefore i have developed a gas cannon. What this device does is simply compressing air and releasing it in a specific direction -in this case it would be the airlock of this very chamber- at a funny velocity. He checks the containment chambers daily, all i have to do is keep this beauty locked and loaded until he opens the airlock. After all the only difference between messing around and science is writing it down. I bet you won't be so senior about this."
-
-/obj/item/paper/fluff/ruins/moonoutpost19/log2
-	name = "Chamber #2 Log"
-	info = "<hr><b>Data Log #74<br><br> Subject: Bizarre Bread<br><br> Details:</b><br><br> So, a few weeks ago our custodian Bob noticed loaf of breads appearing around the outpost. At first we didn't believe him of course, there is no reasonable way to put this situation in this colorful existence... Until i get the honor to actually witnessing it. Someone or something was teleporting bread directly to this location.<br><br> Despite my best efforts to isolate the outpost from this specific bluespace frequency the results have met with failure. This was silly and i couldn't be arsed so i told Bob to do his damn job. A few days later something extraordinary happened, the object has shown the sign of a sort of decay process which resembles a mutation. An object was experiencing mutation as if it was a living organism!<br><br> Investigations are still in progress, we'll be keeping all specimens locked in this chamber."
-
 /obj/item/paper/fluff/ruins/moonoutpost19/truth
 	name = "unsent note"
 	info = "As you have ordered, i managed to insert the device in one of the containment shield generators and cut one or two wires feeding the emergency systems. Remote signal is clear and in range, waiting for next step... <br><br>This will cost many lives but whatever make you guys satisfied and lessens my debt."
+
+
+// MARK: LORE CONSOLES
+
+/obj/machinery/computer/loreconsole/moonoutpost19/lobby
+	entries = list(
+		new/datum/lore_console_entry(
+			"Reminder to Joe",
+			{"Hey Joe, since you keep forgetting here's the list of lockdown areas and the locations of control buttons. Thank me later.
+			<br><br><b>(Lobby)</b><br><br>- Research Division lockdown<br>- Medical Ward lockdown
+			<br><br><b>(Cargo Bay)</b><br><br>- Exterior hangar gate<br>- Cargo bay gates
+			<br><br><b>(Senior Researcher's Office)</b><br><br>- Specimen Containment Zone lockdown<br>
+			<br>Note: keep in mind, in case of power outages these buttons won't be functional. In this case you'll find a few generators in engineering wing, set them up properly then report to technicians ASAP."},))
+
+
+/obj/machinery/computer/loreconsole/moonoutpost19/rdnote
+	entries = list(
+		new/datum/lore_console_entry(
+			"Personal Log",
+			{"<br><br><b>Entry #1</b><br>
+			We're wasting our time and resources here with these unnecessary things. We have means to make an ACTUAL difference.
+			I have expressed these feelings with the Operations Officer, so tomorrow we'll be expecting a shipment of three alien specimen eggs.
+			They expect us to do something 'useful' with them, i don't expect we're going to do much with the resources on hand though.
+			Whatever, i've made it this far already, i'm climbing this ladder even further, then we can start making a real difference.
+			<br><br><b>Entry #2</b><br>
+			I had a weird dream recently about something small catching me off-guard, from under my desk where they've hidden.
+			And now something in my mind whispers to me about 'tax norms', how it is implemented and various terms i have never heard before.
+			A note to self: don't push yourself too hard over small handicaps. It obviously makes you go insane, in a scary way too... And ask your therapist for extra session regarding to this matter."}))
+
+/obj/machinery/computer/loreconsole/moonoutpost19/log1
+	entries = list(
+		new/datum/lore_console_entry(
+			"Chamber #1 Log",
+			{"<hr><b>Data Log #82<br><br>
+			Subject: Yes<br><br>
+			Details:</b><br><br>
+			I fricking hate our so called 'Senior Researcher' Mr. Wood.
+			Someone has to show him how we handle the pricks whose nose in the air in this line of business.<br><br>
+			Therefore i have developed a gas cannon. What this device does is simply compressing air and releasing it in a specific direction -in this case it would be the airlock of this very chamber- at a funny velocity.
+			He checks the containment chambers daily, all i have to do is keep this beauty locked and loaded until he opens the airlock.
+			After all the only difference between messing around and science is writing it down. I bet you won't be so senior about this."}))
+
+/obj/machinery/computer/loreconsole/moonoutpost19/log2
+	entries = list(
+		new/datum/lore_console_entry(
+			"Chamber #2 Log",
+			{"<hr><b>Data Log #74<br><br>
+			Subject: Bizarre Bread<br><br>
+			Details:</b><br><br>
+			So, a few weeks ago our custodian, Bob noticed loaf of breads appearing around the outpost.
+			At first we didn't believe him of course, there is no reasonable way to put this situation in this colorful existence...
+			Until i get the honor to actually witnessing it. Someone or something was teleporting bread directly to this location.<br><br>
+			Despite my best efforts to isolate the outpost from this specific bluespace frequency the results have met with failure.
+			This was silly and i couldn't be arsed so i told Bob to do his damn job.
+			A few days later something extraordinary happened, the object has shown the sign of a sort of decay process which resembles a mutation.
+			An object was experiencing mutation as if it was a living organism!<br><br>
+			Investigations are still in progress, we'll be keeping all specimens secured in this chamber."}))

--- a/code/modules/awaymissions/mission_code/ruins/moonoutpost19.dm
+++ b/code/modules/awaymissions/mission_code/ruins/moonoutpost19.dm
@@ -24,51 +24,68 @@
 		new/datum/lore_console_entry(
 			"Reminder to Joe",
 			{"Hey Joe, since you keep forgetting here's the list of lockdown areas and the locations of control buttons. Thank me later.
-			<br><br><b>(Lobby)</b><br><br>- Research Division lockdown<br>- Medical Ward lockdown
-			<br><br><b>(Cargo Bay)</b><br><br>- Exterior hangar gate<br>- Cargo bay gates
-			<br><br><b>(Senior Researcher's Office)</b><br><br>- Specimen Containment Zone lockdown<br>
-			<br>Note: keep in mind, in case of power outages these buttons won't be functional. In this case you'll find a few generators in engineering wing, set them up properly then report to technicians ASAP."},))
+### Lobby
+- Research Division lockdown
+- Medical Ward lockdown
 
+### Cargo Bay
+- Exterior hangar gate
+- Cargo bay gates
+
+### Senior Researcher's Office
+- Specimen Containment Zone lockdown
+
+Note: keep in mind, in case of power outages these buttons won't be functional.
+In this case you'll find a few generators in engineering wing, set them up properly then report to technicians ASAP."}))
 
 /obj/machinery/computer/loreconsole/moonoutpost19/rdnote
 	entries = list(
 		new/datum/lore_console_entry(
-			"Personal Log",
-			{"<br><br><b>Entry #1</b><br>
-			We're wasting our time and resources here with these unnecessary things. We have means to make an ACTUAL difference.
-			I have expressed these feelings with the Operations Officer, so tomorrow we'll be expecting a shipment of three alien specimen eggs.
-			They expect us to do something 'useful' with them, i don't expect we're going to do much with the resources on hand though.
-			Whatever, i've made it this far already, i'm climbing this ladder even further, then we can start making a real difference.
-			<br><br><b>Entry #2</b><br>
-			I had a weird dream recently about something small catching me off-guard, from under my desk where they've hidden.
-			And now something in my mind whispers to me about 'tax norms', how it is implemented and various terms i have never heard before.
-			A note to self: don't push yourself too hard over small handicaps. It obviously makes you go insane, in a scary way too... And ask your therapist for extra session regarding to this matter."}))
+			"Entry #1",
+			{"We're wasting our time and resources here with these unnecessary things. We have means to make an ACTUAL difference.
+
+I have expressed these feelings with the Operations Officer, so tomorrow we'll be expecting a shipment of three alien specimen eggs.
+They expect us to do something 'useful' with them, i don't expect we're going to do much with the resources on hand though.
+
+Whatever, i've made it this far already, i'm climbing this ladder even further, then we can start making a real difference."}),
+		new/datum/lore_console_entry(
+			"Entry #2",
+			{"I had a weird dream recently about something small catching me off-guard, from under my desk where they've hidden.
+And now something in my mind whispers to me about 'tax norms', how it is implemented and various terms i have never heard before.
+
+A note to self: don't push yourself too hard over small handicaps. It obviously makes you go insane, in a scary way too... And ask your therapist for extra session regarding to this matter."}))
 
 /obj/machinery/computer/loreconsole/moonoutpost19/log1
 	entries = list(
 		new/datum/lore_console_entry(
-			"Chamber #1 Log",
-			{"<hr><b>Data Log #82<br><br>
-			Subject: Yes<br><br>
-			Details:</b><br><br>
-			I fricking hate our so called 'Senior Researcher' Mr. Wood.
-			Someone has to show him how we handle the pricks whose nose in the air in this line of business.<br><br>
-			Therefore i have developed a gas cannon. What this device does is simply compressing air and releasing it in a specific direction -in this case it would be the airlock of this very chamber- at a funny velocity.
-			He checks the containment chambers daily, all i have to do is keep this beauty locked and loaded until he opens the airlock.
-			After all the only difference between messing around and science is writing it down. I bet you won't be so senior about this."}))
+			"Data Log #82",
+			{"**Subject:** Yes
+**Details:**
+I fricking hate our so called 'Senior Researcher' Mr. Wood.
+Someone has to show him how we handle the pricks whose nose in the air in this line of business.
+
+Therefore I have developed a gas cannon. What this device does is simply compressing air and releasing it in a specific direction---in this case it would be the airlock
+of this very chamber---at a funny velocity.
+
+He checks the containment chambers daily, all i have to do is keep this beauty locked and loaded until he opens the airlock.
+After all the only difference between messing around and science is writing it down.
+
+I bet you won't be so senior about this."}))
 
 /obj/machinery/computer/loreconsole/moonoutpost19/log2
 	entries = list(
 		new/datum/lore_console_entry(
-			"Chamber #2 Log",
-			{"<hr><b>Data Log #74<br><br>
-			Subject: Bizarre Bread<br><br>
-			Details:</b><br><br>
-			So, a few weeks ago our custodian, Bob noticed loaf of breads appearing around the outpost.
-			At first we didn't believe him of course, there is no reasonable way to put this situation in this colorful existence...
-			Until i get the honor to actually witnessing it. Someone or something was teleporting bread directly to this location.<br><br>
-			Despite my best efforts to isolate the outpost from this specific bluespace frequency the results have met with failure.
-			This was silly and i couldn't be arsed so i told Bob to do his damn job.
-			A few days later something extraordinary happened, the object has shown the sign of a sort of decay process which resembles a mutation.
-			An object was experiencing mutation as if it was a living organism!<br><br>
-			Investigations are still in progress, we'll be keeping all specimens secured in this chamber."}))
+			"Data Log #74",
+			{"**Subject:** Bizarre Bread
+**Details:**
+So, a few weeks ago our custodian, Bob noticed loaf of breads appearing around the outpost.
+
+At first we didn't believe him of course, there is no reasonable way to put this situation in this colorful existence...
+until I got the honor to actually witnessing it. Someone or something was teleporting bread directly to this location.
+
+Despite my best efforts to isolate the outpost from this specific bluespace frequency the results have met with failure.
+This was silly and i couldn't be arsed so i told Bob to do his damn job.
+
+A few days later something extraordinary happened, the object has shown the sign of a sort of decay process which resembles a mutation. An object was experiencing mutation as if it was a living organism!
+
+Investigations are still in progress, we'll be keeping all specimens secured in this chamber."}))


### PR DESCRIPTION
## What Does This PR Do
Turns some notes into lore consoles on MB19
also slightly changed the wording on some things, as they were a little wonky

## Why It's Good For The Game
Small papers usually go unnoticed, or get blown away, or are a little too well hidden. 
and using lore consoles is neato :)

## Images of changes
<img width="381" height="566" alt="HIQqehG5Ok" src="https://github.com/user-attachments/assets/06783852-3088-49a8-add1-8269c2e792b9" />
<img width="524" height="387" alt="q6Gh7mB3aG" src="https://github.com/user-attachments/assets/5bc40d70-73ca-4017-a648-230853c45756" />
<img width="485" height="425" alt="Yf0a2RFXzb" src="https://github.com/user-attachments/assets/fff21b11-d19a-4a7e-bc59-89e5d9b71558" />


## Testing
made sure all the formatting was fine
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog

:cl:
tweak: Tweaked a few lore tidbits in moonbase 19
tweak: Swapped the paper lore dumps for lore consoles
/:cl: