### PR TITLE
More SRM fixes

### DIFF
--- a/code/game/machinery/machine_frame.dm
+++ b/code/game/machinery/machine_frame.dm
@@ -1035,7 +1035,7 @@ to destroy them and players will be able to make replacements.
 /obj/item/circuitboard/salvage_redemption
 	board_name = "Salvage Redemption"
 	icon_state = "supply"
-	build_path = /obj/item/circuitboard/salvage_redemption
+	build_path = /obj/machinery/salvage_redemption
 	board_type = "machine"
 	origin_tech = "programming=1;engineering=2"
 	req_components = list(

--- a/code/modules/mining/salvage_redemption.dm
+++ b/code/modules/mining/salvage_redemption.dm
@@ -86,7 +86,7 @@
 
 	if(istype(used, /obj/item/storage/bag/expedition))
 		var/obj/item/storage/bag/expedition/bag = used
-		if(!bag.contents)
+		if(!length(bag.contents))
 			to_chat(user, "<span class='warning'>You have no salvage to redeem.</span>");
 			return ITEM_INTERACT_COMPLETE
 		for(var/obj/item/salvage/loot in bag.contents)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes an issue where using a treasure satchel on a salvage redemption machine prints an empty credit ticket.

Fixes #30520

## Why It's Good For The Game

Bugs bad

## Testing

Compiled.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed the construction of the SRM
fix: Fixed empty treasure bags giving worthless credit slips
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
