### PR TITLE
add more space loot pool spawners around

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroid1.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroid1.dmm
@@ -217,7 +217,7 @@ V
 V
 V
 V
-b
+l
 b
 V
 V

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroid3.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroid3.dmm
@@ -194,7 +194,7 @@ a
 a
 a
 b
-b
+r
 c
 d
 c

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroid4.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroid4.dmm
@@ -57,6 +57,10 @@
 "Q" = (
 /turf/simulated/mineral/random/low_chance/space,
 /area/ruin/space/unpowered)
+"Z" = (
+/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/turf/simulated/floor/plating/asteroid/airless,
+/area/ruin/space/unpowered)
 
 (1,1,1) = {"
 a
@@ -130,7 +134,7 @@ b
 c
 Q
 b
-d
+Z
 d
 d
 a

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroid5.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroid5.dmm
@@ -670,7 +670,7 @@ a
 b
 b
 b
-d
+o
 d
 d
 a
@@ -1527,7 +1527,7 @@ d
 b
 b
 b
-d
+o
 d
 Y
 d

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroidmining3.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroidmining3.dmm
@@ -5,6 +5,10 @@
 "d" = (
 /turf/simulated/mineral/random/low_chance/space,
 /area/ruin/space/unpowered)
+"f" = (
+/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/turf/simulated/floor/plating/asteroid/airless,
+/area/ruin/space/unpowered)
 "h" = (
 /turf/simulated/mineral/random/high_chance/space,
 /area/ruin/space/unpowered)
@@ -24,6 +28,10 @@
 /area/ruin/space/unpowered)
 "y" = (
 /turf/simulated/floor/plating/asteroid/airless,
+/area/ruin/space/unpowered)
+"A" = (
+/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/turf/simulated/floor/plating/asteroid,
 /area/ruin/space/unpowered)
 "E" = (
 /obj/structure/spawner/mining/basilisk/space,
@@ -476,7 +484,7 @@ n
 n
 L
 V
-V
+A
 V
 V
 L
@@ -782,7 +790,7 @@ y
 y
 y
 y
-y
+f
 y
 y
 y
@@ -1396,7 +1404,7 @@ h
 d
 d
 L
-y
+f
 y
 L
 n

--- a/_maps/map_files/RandomRuins/SpaceRuins/debris2.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/debris2.dmm
@@ -134,6 +134,10 @@
 /obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
 /turf/simulated/floor/plasteel/airless,
 /area/ruin/unpowered)
+"Ou" = (
+/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/turf/simulated/floor/plating/airless,
+/area/ruin/unpowered)
 
 (1,1,1) = {"
 aa
@@ -302,7 +306,7 @@ aC
 aa
 aV
 aa
-ab
+Ou
 aa
 aa
 aa
@@ -383,7 +387,7 @@ aC
 aa
 aT
 aa
-ab
+Ou
 aN
 as
 aa

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict5.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict5.dmm
@@ -24,6 +24,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/unpowered)
+"dm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/turf/simulated/floor/plasteel,
+/area/ruin/space/unpowered)
 "dz" = (
 /obj/structure/closet/crate,
 /obj/item/storage/bag/ore,
@@ -1644,7 +1650,7 @@ sd
 xQ
 Zv
 rc
-vE
+dm
 Se
 Qx
 Dt

--- a/_maps/map_files/RandomRuins/SpaceRuins/emptyshell.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/emptyshell.dmm
@@ -170,7 +170,7 @@ a
 c
 c
 c
-d
+t
 d
 d
 d
@@ -233,7 +233,7 @@ d
 d
 p
 d
-d
+t
 c
 c
 a

--- a/_maps/map_files/RandomRuins/SpaceRuins/moonoutpost19.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/moonoutpost19.dmm
@@ -2718,6 +2718,7 @@
 "iB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
+/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
 /turf/simulated/floor/plasteel{
 	icon_state = "black";
 	dir = 1
@@ -8031,6 +8032,7 @@
 "ET" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/table,
+/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "escape"
@@ -10554,6 +10556,7 @@
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
+/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "caution"

--- a/_maps/map_files/RandomRuins/SpaceRuins/submaps/sieged_lab_submaps.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/submaps/sieged_lab_submaps.dmm
@@ -299,6 +299,12 @@
 /obj/effect/mapping_helpers/turfs/burn,
 /turf/simulated/floor/plating,
 /area/template_noop)
+"if" = (
+/obj/effect/mapping_helpers/turfs/burn,
+/obj/effect/decal/cleanable/blood/tracks/mapped,
+/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/turf/simulated/floor/plating,
+/area/template_noop)
 "ig" = (
 /obj/item/flashlight/flare/used,
 /turf/simulated/floor/plating/asteroid,
@@ -314,7 +320,14 @@
 /obj/effect/decal/cleanable/glass,
 /obj/effect/mapping_helpers/turfs/burn,
 /obj/machinery/alarm/directional/east,
+/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
 /turf/simulated/floor/plating,
+/area/template_noop)
+"ir" = (
+/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/template_noop)
 "iv" = (
 /obj/machinery/economy/vending/wallmed/directional/north,
@@ -842,6 +855,7 @@
 /area/template_noop)
 "so" = (
 /obj/effect/spawner/random/dirt/maybe,
+/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "green"
@@ -957,6 +971,7 @@
 /area/template_noop)
 "uu" = (
 /obj/structure/closet/cabinet,
+/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
 /turf/simulated/floor/wood,
 /area/template_noop)
 "uw" = (
@@ -1287,6 +1302,10 @@
 /area/template_noop)
 "BF" = (
 /obj/effect/decal/cleanable/generic,
+/turf/template_noop,
+/area/template_noop)
+"BJ" = (
+/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
 /turf/template_noop,
 /area/template_noop)
 "BM" = (
@@ -1720,6 +1739,11 @@
 /obj/effect/spawner/random/barrier/temporary,
 /turf/simulated/floor/plating,
 /area/template_noop)
+"Kw" = (
+/obj/effect/mapping_helpers/turfs/burn,
+/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/turf/simulated/floor/plating,
+/area/template_noop)
 "Kz" = (
 /obj/effect/spawner/random/storage,
 /obj/effect/spawner/random/engineering/materials,
@@ -2016,6 +2040,11 @@
 "RP" = (
 /obj/effect/spawner/random/dirt/frequent,
 /turf/template_noop,
+/area/template_noop)
+"Sl" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/turf/simulated/floor/wood,
 /area/template_noop)
 "Sm" = (
 /obj/effect/mapping_helpers/turfs/burn,
@@ -2806,7 +2835,7 @@ yb
 nK
 nK
 VI
-nK
+BJ
 nK
 nK
 ts
@@ -3234,7 +3263,7 @@ nK
 nK
 nK
 zz
-lm
+Kw
 WK
 fO
 SJ
@@ -3564,7 +3593,7 @@ nK
 nb
 VX
 ty
-ty
+if
 Zm
 gj
 ZI
@@ -4169,7 +4198,7 @@ nK
 (29,1,1) = {"
 nK
 nK
-pG
+Sl
 pG
 mt
 nK
@@ -5239,7 +5268,7 @@ nK
 nK
 Ba
 Af
-Af
+ir
 nK
 nK
 nK

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndiecakesfactory.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndiecakesfactory.dmm
@@ -239,6 +239,12 @@
 	icon_state = "cafeteria"
 	},
 /area/ruin/space/syndicakefactory)
+"ip" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced,
+/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/turf/simulated/floor/engine,
+/area/ruin/space/syndicakefactory)
 "iq" = (
 /obj/item/flag/syndi{
 	anchored = 1
@@ -1195,9 +1201,8 @@
 	},
 /area/ruin/space/syndicakefactory)
 "VI" = (
-/obj/item/food/meat/corgi{
-	pixel_y = 6
-	},
+/obj/structure/table/glass/reinforced/plastitanium,
+/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -2035,7 +2040,7 @@ Ga
 TG
 iL
 sh
-Ii
+ip
 xO
 yU
 wV

--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp_tele.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp_tele.dmm
@@ -15,6 +15,7 @@
 /area/ruin/space/derelict/teleporter)
 "dj" = (
 /obj/effect/mapping_helpers/turfs/damage,
+/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "ds" = (


### PR DESCRIPTION
## What Does This PR Do
This PR adds space loot pool spawners to a couple more places in space ruins.
## Why It's Good For The Game
Now that I have access to game logs in kibana I can see many rounds where hundreds of spawner points are left on the table because the pool runs out of spawners, even if there are four space sectors generated (e.g. round 46174, 46167 which had 700 points (!) remaining). This should help keep that number a bit lower. The budget was agreed upon by balance team at the time and if we have rounds where over 40% of the spawn budget isn't being used, that's not fair to explorers.
## Images of changes
See MDB.
## Testing
Visual inspection.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: Several more spawn points for space loot have been placed through the ruins, to ensure explorers have a better chance of all the points in the spawn pool being used for loot.
/:cl: