### PR TITLE
Starline Fixes

### DIFF
--- a/code/game/objects/starline_phone.dm
+++ b/code/game/objects/starline_phone.dm
@@ -114,20 +114,20 @@
 		icon_state = "ringing"
 		sleep(ring_duration)
 		if(phone_state == RINGING) // in case its answered mid ring
-			icon_state = "answered"
+			icon_state = "base"
 		sleep(ring_rest_duration)
 
 /obj/machinery/phone/proc/start_call()
 	phone_state = ACTIVE_CALL
 	handheld.listening = TRUE
 	connected_line.handheld.listening = TRUE
-	connected_line.audible_message("<span class='information'>The receiver clicks as the other line picks up.</span>", hearing_distance = 1)
+	connected_line.audible_message("<span class='information'>The receiver clicks as the other line picks up.</span>", hearing_distance = 3)
 
 /obj/machinery/phone/proc/end_call()
 	handheld.listening = FALSE
 	phone_state = NO_CALLS
 	if(connected_line)
-		connected_line.audible_message("<span class='information'>The receiver clicks as the other line hangs up</span>", hearing_distance = 1)
+		connected_line.audible_message("<span class='information'>The receiver clicks as the other line hangs up</span>", hearing_distance = 3)
 		connected_line.connected_line = null
 		if(connected_line.phone_state == RINGING)
 			connected_line.phone_state = NO_CALLS


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Starline no longer gives the person picking up the "other line picks up" message

Phone icon no longer reverts after picking up

Increased the hearing distance so even if you're not standing directly next to the phone you can hear the receiver click

## Why It's Good For The Game

Fixes good

## Testing

made some calls

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed some starline bugs with icons and messages
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
