### PR TITLE
fix mouse squeak

### DIFF
--- a/code/modules/mob/living/basic/friendly/mouse.dm
+++ b/code/modules/mob/living/basic/friendly/mouse.dm
@@ -41,7 +41,7 @@
 /mob/living/basic/mouse/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/wears_collar)
-	AddComponent(/datum/component/squeak, list(squeak_sound = 1), 100, extrarange = SHORT_RANGE_SOUND_EXTRARANGE) // as quiet as a mouse or whatever
+	AddComponent(/datum/component/squeak, list(src.squeak_sound = 1), 100, extrarange = SHORT_RANGE_SOUND_EXTRARANGE) // as quiet as a mouse or whatever
 	AddComponent(/datum/component/swarming, 16, 16) // max_x, max_y
 	if(!mouse_color)
 		mouse_color = pick("brown", "gray", "white")


### PR DESCRIPTION
## What Does This PR Do
This PR fixes mice not squeaking when stepped on. `squeak_sound` here was getting coerced into a string, probably.
## Why It's Good For The Game
Mice should squeak.
## Testing
Spawned mice, squeaked em
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Mice properly squeak when stepped over
/:cl: