### PR TITLE
Hides off-station power monitors from the power-on app

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -305,13 +305,13 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/computer/monitor,
 /obj/machinery/door_control{
 	pixel_y = 25;
 	id = "DS_Rad";
 	name = "Generator Storage"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/monitor/secret,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "browncorner"

--- a/_maps/map_files/RandomRuins/SpaceRuins/dj.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/dj.dmm
@@ -156,13 +156,13 @@
 /turf/template_noop,
 /area/ruin/space/djstation/solars)
 "aC" = (
-/obj/machinery/computer/monitor,
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/computer/monitor/secret,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow";
 	dir = 1

--- a/_maps/map_files/RandomRuins/SpaceRuins/telecomns_returns.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/telecomns_returns.dmm
@@ -1732,9 +1732,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/computer/monitor{
-	name = "Telecoms Power Monitoring";
-	dir = 1
+/obj/machinery/computer/monitor/secret{
+	dir = 1;
+	name = "Telecoms Power Monitoring"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bot"

--- a/_maps/map_files/RandomRuins/SpaceRuins/turretedoutpost.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/turretedoutpost.dmm
@@ -549,10 +549,10 @@
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/turreted_outpost)
 "SV" = (
-/obj/machinery/computer/monitor,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/computer/monitor/secret,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/turreted_outpost)
 "Tv" = (


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Replaces all the power monitors in all ruins with the `secret` subtype that hides it from the power-ON PDA app.

Fixes #30530.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The secret power monitor subtype was made for exactly this reason.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned all the ruins with power monitors. Could not see them in my PDA.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Off-station power monitors can no longer be seen by engineer PDAs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
