### PR TITLE
Fix DMI merge driver logging left/right is changed when opposite is true.

### DIFF
--- a/tools/dmi/merge_driver.py
+++ b/tools/dmi/merge_driver.py
@@ -110,11 +110,11 @@ def three_way_merge(base, left, right):
             final_states.append(state)
         elif left_equals:
             # changed only in right
-            print(f"    {state.name!r}: changed in left")
+            print(f"    {state.name!r}: changed in right")
             final_states.append(in_right)
         elif right_equals:
             # changed only in left
-            print(f"    {state.name!r}: changed in right")
+            print(f"    {state.name!r}: changed in left")
             final_states.append(in_left)
         elif states_equal(in_left, in_right):
             # changed in both, to the same thing


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fix DMI merge driver logging left/right is changed when opposite is true.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

It's easier to understand what changes are coming from where if the console messages are correct.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Changed, added, and deleted icons in the same file in separate branches, then merged them. The console messages are now correct with respect to what side changed an icon.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
