### PR TITLE
Adds back the Bottler Unit Crate. Fixes Issue #30549

### DIFF
--- a/code/modules/supply/supply_packs/pack_organic.dm
+++ b/code/modules/supply/supply_packs/pack_organic.dm
@@ -449,7 +449,7 @@
 	containername = "beekeeper suits"
 
 /datum/supply_packs/organic/bottler
-	name = "Bottler Unit"
+	name = "Bottler Unit Crate"
 	contains = list(/obj/machinery/bottler)
 	cost = 150
 	containertype = /obj/structure/largecrate


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds back the Bottler Unit Crate, orderable from cargo for 150 credits. Fixes #30549
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Crates going missing in a refractor bad. 
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Server booted, crate ordered, crated opened, bottler was in front of me
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
fix: You can now order the Bottler Unit crate again from Cargo.
/:cl:
