### PR TITLE
Proof of concept/proposal: Add offset capability for monitor headwear, demonstrated by berets

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -8,7 +8,10 @@
 	permeability_coefficient = 0.8
 	/// Only these species can wear this kit.
 	var/list/species_restricted
-	var/icon_monitor = null //If set to a sprite path, replaces the sprite for monitor heads
+	//If set to a sprite path, replaces the sprite for monitor heads
+	var/icon_monitor = null
+	//If set, adjusts the sprite's y offset on monitor heads.
+	var/monitor_offset_y = 0
 	/// Can the wearer see reagents inside transparent containers while it's equipped?
 	var/scan_reagents = FALSE
 	/// Can the wearer see reagents inside any container and identify blood types while it's equipped?

--- a/code/modules/clothing/head/beret.dm
+++ b/code/modules/clothing/head/beret.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/clothing/head/beret.dmi'
 	icon_state = "beret"
 	worn_icon = 'icons/mob/clothing/head/beret.dmi'
+	monitor_offset_y = 1
 	dog_fashion = /datum/dog_fashion/head/beret
 	sprite_sheets = list(
 		"Kidan" = 'icons/mob/clothing/species/kidan/head/beret.dmi',

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -34,6 +34,7 @@
 	name = "magical beret"
 	desc = "A magical red beret."
 	icon_state = "wizhatmime"
+	monitor_offset_y = 1
 	dog_fashion = null
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/clothing/species/vox/head.dmi',

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -811,6 +811,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		var/worn_icon = (head_clothes && robohead && robohead.is_monitor ? head_clothes.icon_monitor : FALSE) || listgetindex(head.sprite_sheets, dna.species.sprite_sheet_name) || head.worn_icon || 'icons/mob/clothing/head.dmi'
 		var/worn_icon_state = head.worn_icon_state || head.icon_state
 		var/mutable_appearance/standing = mutable_appearance(worn_icon, worn_icon_state, layer = -HEAD_LAYER, alpha = head.alpha, color = head.color)
+		standing.pixel_y = head_clothes && robohead && robohead.is_monitor ? head_clothes.monitor_offset_y : 0
 
 		if(istype(head, /obj/item/clothing/head/helmet/space/plasmaman))
 			var/obj/item/clothing/head/helmet/space/plasmaman/P = head


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Adds a variable and logic to offset the `pixel_y` of hats on monitor heads.

## Why It's Good For The Game

Makes some hats fit without the need for extra sprite files and time spent spriting.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

New beret height (with human to demonstrate the height only changes on monitor heads)
<img width="518" height="456" alt="2025-09-26 15_19_04-Paradise Station 13" src="https://github.com/user-attachments/assets/494b665c-803e-4b15-a6dd-db7cf1289a4e" />

Small slice from master, for comparison:
<img width="138" height="140" alt="2025-09-26 15_23_36-Paradise Station 13" src="https://github.com/user-attachments/assets/056e029c-462f-4cc6-bf1a-8b73fe2e2e67" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

Compiled, hosted, dressed IPCs in every beret affected.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Tweaked beret fit on IPCs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
