### PR TITLE
fix references to rustlibs in mapmanip.ps1

### DIFF
--- a/tools/rustlibs_tools/mapmanip.ps1
+++ b/tools/rustlibs_tools/mapmanip.ps1
@@ -12,14 +12,14 @@ echo "Should launch the actual server to get stacktraces and the like."
 echo "*****"
 
 # find path to rustlibs.dll
-if (Test-Path "./rust/target/i686-pc-windows-msvc/release/rustlibs_515.dll") {
-	$BapiPath = "./rust/target/i686-pc-windows-msvc/release/rustlibs_515.dll"
+if (Test-Path "./rust/target/i686-pc-windows-msvc/release/rustlibs.dll") {
+	$BapiPath = "./rust/target/i686-pc-windows-msvc/release/rustlibs.dll"
 }
-elseif (Test-Path "./rust/target/i686-pc-windows-msvc/debug/rustlibs_515.dll") {
-	$BapiPath = "./rust/target/i686-pc-windows-msvc/debug/rustlibs_515.dll"
+elseif (Test-Path "./rust/target/i686-pc-windows-msvc/debug/rustlibs.dll") {
+	$BapiPath = "./rust/target/i686-pc-windows-msvc/debug/rustlibs.dll"
 }
-elseif (Test-Path "./rustlibs_515.dll") {
-	$BapiPath = "./rustlibs_515.dll"
+elseif (Test-Path "./rustlibs.dll") {
+	$BapiPath = "./rustlibs.dll"
 }
 else {
 	echo "Cannot find rustlibs."


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the locations of rustlibs in the mapmanip FFI test script (used for testing mapmanip outside of the game).
## Why It's Good For The Game
Tools should work.
## Testing
Ran `.\tools\rustlibs_tools\mapmanip.ps1`, ensured that all mapmanipout.dmm files were created.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC