### PR TITLE
Removes an extra space in Tinea Luxor's description

### DIFF
--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -973,7 +973,7 @@
 /datum/reagent/consumable/tinlux
 	name = "Tinea Luxor"
 	id = "tinlux"
-	description = "A stimulating ichor which causes luminescent fungi to grow on the skin. "
+	description = "A stimulating ichor which causes luminescent fungi to grow on the skin."
 	color = "#b5a213"
 	var/light_activated = FALSE
 	taste_description = "tingling mushroom"


### PR DESCRIPTION
## What Does This PR Do
Removes an additional space from the end of Tinea Luxor's chemical description.
## Why It's Good For The Game
Sentences don't end with spaces after periods.
## Testing
Compiled. Inspected visually.
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
fix: Tinea Luxor's chemical description no longer has an extra space in it.
/:cl: