### PR TITLE
remove permission check for wikilabel usage

### DIFF
--- a/.github/workflows/wiki_label.yml
+++ b/.github/workflows/wiki_label.yml
@@ -11,19 +11,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - name: Check commenter authorization
-        id: check-auth
-        run: |
-          IFS=',' read -ra WIKI_MANAGERS <<< "${{ vars.WIKI_MANAGERS }}"
-          COMMENTER_ID="${{ github.event.comment.user.id }}"
-          if [[ " ${WIKI_MANAGERS[@]} " =~ " ${COMMENTER_ID} " ]]; then
-            echo "authorized=true" >> $GITHUB_OUTPUT
-          else
-            echo "authorized=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Add thumbs up reaction and Wiki label
-        if: steps.check-auth.outputs.authorized == 'true'
         run: |
           # Add thumbs up reaction
           curl -X POST \
@@ -38,12 +26,3 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels" \
             -d '["Requires Wiki Update"]'
-
-      - name: Unauthorized user thumbs down reaction
-        if: steps.check-auth.outputs.authorized == 'false'
-        run: |
-          curl -X POST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
-            -d '{"content":"-1"}'


### PR DESCRIPTION
## What Does This PR Do
This PR removes the permission check for the wiki_label command, allowing any contributor to use it.
## Why It's Good For The Game
Makes it easier for wiki contributors to slam a tag on something without having to futz with permissions. We can vaporize anyone who abuses it or uses it when they shouldn't.
## Testing
Visual inspection.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC