### PR TITLE
Cache light colors in computers

### DIFF
--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -18,7 +18,7 @@
 	/// Are we forcing the icon to be represented in a no-power state?
 	var/force_no_power_icon_state = FALSE
 	/// Cached list of colors associated with overlays
-	var/list/cached_emmisive_color = list()
+	var/list/cached_emissive_color = list()
 
 /obj/machinery/computer/Initialize(mapload)
 	. = ..()
@@ -88,13 +88,13 @@
 		underlays += emissive_appearance(icon, "[icon_keyboard]_lightmask")
 
 	if(!(stat & BROKEN))
-		if(!cached_emmisive_color[overlay_state])
+		if(!cached_emissive_color[overlay_state])
 			// Get the average color of the computer screen so it can be used as a tinted glow
 			// Shamelessly stolen from /tg/'s /datum/component/customizable_reagent_holder.
 			var/icon/emissive_avg_screen_color = new(icon, overlay_state)
 			emissive_avg_screen_color.Scale(1, 1)
-			cached_emmisive_color[overlay_state] = copytext(emissive_avg_screen_color.GetPixel(1, 1), 1, 8) // remove opacity
-		set_light(light_range_on, light_power_on, cached_emmisive_color[overlay_state])
+			cached_emissive_color[overlay_state] = copytext(emissive_avg_screen_color.GetPixel(1, 1), 1, 8) // remove opacity
+		set_light(light_range_on, light_power_on, cached_emissive_color[overlay_state])
 
 /obj/machinery/computer/power_change()
 	. = ..() //we don't check parent return due to this also being contigent on the BROKEN stat flag


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it so computers keep a list of light colors for their various overlay states instead of constantly using `GetPixel()`. This has a greater impact on atmos computers due to `update_icon()` being called as part of their process.

## Why It's Good For The Game
`GetPixel()` is really expensive and it was getting called on every `process()` for atmos computers for what is essentially a fixed color per overlay.

## Images of changes
<img width="400" height="111" alt="Screenshot 2025-09-30 211939" src="https://github.com/user-attachments/assets/a98c5ec4-7f2c-40b2-b7a6-2fe88fb98009" />

## Testing
Booted an instance and looked at a computer and its cached list.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
