### PR TITLE
Optimize the volcanoes

### DIFF
--- a/code/datums/weather/weather_types/lavaland_weather.dm
+++ b/code/datums/weather/weather_types/lavaland_weather.dm
@@ -160,6 +160,8 @@
 				valid_targets += T
 		if(isnull(valid_targets)) // prevents a runtime when coding without lavaland enabled. Or theres somehow ZERO turfs.
 			return
+		var/hits = 0
+		var/target
 		while(hits <= 150 && length(valid_targets)) //sling a bunch of rocks around the map
 			target = pick(valid_targets)
 			new /obj/effect/temp_visual/rock_target(target)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Tweaks how the volcano weather gets its list of turfs to affect on lavaland to improve performance. There is still an empty gap in tracy I have no idea what it is, but this is a start.

## Why It's Good For The Game
Cuts down getting turfs for volcanoes by about ~50%? Lavaland has a _lot_ of turfs, and `get_area_turfs()` is costly on top of that when volcanoes are more picky about what they affect.

## Images of changes
<img width="250" height="36" alt="Screenshot 2025-10-01 163950" src="https://github.com/user-attachments/assets/03d0a11f-c98c-4a63-a99c-568d0f005d54" />

## Testing
Running both old and new code in sequence, 100 times and measure how long it takes. Accumulated turfs were tracked to make sure behavior was otherwise identical.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
