### PR TITLE
Fixes portable seed extractor bit runtime

### DIFF
--- a/code/game/objects/items/storage/storage_base.dm
+++ b/code/game/objects/items/storage/storage_base.dm
@@ -187,7 +187,7 @@
 /obj/item/storage/AltClick(mob/user)
 	if(ishuman(user) && Adjacent(user) && !user.incapacitated(FALSE, TRUE))
 		if(attached_bits.len > 0)
-			..()
+			return ..()
 		open(user)
 		add_fingerprint(user)
 	else if(isobserver(user))
@@ -228,7 +228,8 @@
 		user.s_active.hide_from(user) // If there's already an interface open, close it.
 	user.client.screen |= boxes
 	user.client.screen |= closer
-	user.client.screen |= contents
+	var/list/contents_to_show = contents - attached_bits
+	user.client.screen |= contents_to_show
 	user.s_active = src
 	LAZYDISTINCTADD(mobs_viewing, user)
 
@@ -241,7 +242,8 @@
 		return
 	user.client.screen -= boxes
 	user.client.screen -= closer
-	user.client.screen -= contents
+	var/list/contents_to_show = contents - attached_bits
+	user.client.screen -= contents_to_show
 	if(user.s_active == src)
 		user.s_active = null
 
@@ -633,7 +635,7 @@
 	var/turf/T = get_turf(src)
 	hide_from(user)
 	for(var/obj/item/I in contents)
-		if(I & attached_bits)
+		if(I in attached_bits)
 			continue
 		remove_from_storage(I, T)
 		I.scatter_atom()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes #30595

Also fixes bits showing up in the bag's contents.

## Why It's Good For The Game

Runtimes bad.

## Testing

Spawned as a botanist. Used bag with and without bits. Did not encounter runtime.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed bits showing up in portable seed extractor contents, fixed dropping items with a portable seed extractor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
