### PR TITLE
move hydroponics to use Initialize()

### DIFF
--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -584,8 +584,8 @@
 	var/seeds_scanned = 0
 	var/seeds_needed = 5
 
-/obj/item/disk/plantgene/New()
-	..()
+/obj/item/disk/plantgene/Initialize(mapload)
+	. = ..()
 	update_icon(UPDATE_ICON_STATE)
 
 /obj/item/disk/plantgene/Destroy()

--- a/code/modules/hydroponics/grown/random_seeds.dm
+++ b/code/modules/hydroponics/grown/random_seeds.dm
@@ -12,9 +12,9 @@
 	icon_harvest = "xpod-harvest"
 	growthstages = 4
 
-/obj/item/seeds/random/New()
+/obj/item/seeds/random/Initialize(mapload)
+	. = ..()
 	randomize_stats()
-	..()
 	if(prob(60))
 		add_random_reagents()
 	if(prob(50))
@@ -24,7 +24,7 @@
 /obj/item/seeds/random/labelled
 	name = "pack of exotic strange seeds"
 
-/obj/item/seeds/random/labelled/New()
+/obj/item/seeds/random/labelled/Initialize(mapload)
 	. = ..()
 	add_random_traits(1, 2)
 	add_random_plant_type(100)
@@ -42,4 +42,3 @@
 	wine_power = rand(0.1,1.5)
 	if(prob(1))
 		wine_power = 2.0
-

--- a/code/modules/hydroponics/sample.dm
+++ b/code/modules/hydroponics/sample.dm
@@ -28,8 +28,8 @@ GLOBAL_LIST_INIT(chem_t4_reagents, list(
 	yield = -1
 	var/sample_color = "#FFFFFF"
 
-/obj/item/seeds/sample/New()
-	..()
+/obj/item/seeds/sample/Initialize(mapload)
+	. = ..()
 	if(sample_color)
 		var/image/I = image(icon, icon_state = "sample-filling")
 		I.color = sample_color

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -58,8 +58,8 @@
 		"weed rate" = TRUE,
 		"weed chance" = TRUE)
 
-/obj/item/seeds/New(loc, nogenes = 0)
-	..()
+/obj/item/seeds/Initialize(mapload, nogenes = FALSE)
+	. = ..()
 	pixel_x = rand(-6, 6)
 	pixel_y = rand(-6, 6)
 
@@ -618,8 +618,8 @@
 
 	var/datum/unsorted_seed/seed_data
 
-/obj/item/unsorted_seeds/New(obj/item/seeds/template, mutation_level, list/mutation_focus, seed_data_in = null)
-	..()
+/obj/item/unsorted_seeds/Initialize(mapload, obj/item/seeds/template, mutation_level, list/mutation_focus, seed_data_in = null)
+	. = ..()
 	template = template.Copy()
 	scatter_atom()
 	if(seed_data_in)


### PR DESCRIPTION
## What Does This PR Do
Another one to the `Initialize()` bin. Moves various hydroponics items to use `Initialize()` over `New()`
## Why It's Good For The Game
Codebase is migrating to Initialize
## Testing
Spawned a disk, spawned various seeds. They all spawned properly.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC