### PR TITLE
Allows Robots and Simple Bots to Salute

### DIFF
--- a/code/modules/mob/living/silicon/silicon_emote.dm
+++ b/code/modules/mob/living/silicon/silicon_emote.dm
@@ -103,3 +103,16 @@
 	var/mob/living/silicon/robot/bot = user
 	if(!istype(bot) || !istype(bot.module, /obj/item/robot_module/security))
 		return FALSE
+
+/datum/emote/living/silicon/salute
+	key = "salute"
+	key_third_person = "salutes"
+	message = "salutes."
+	message_param = "salutes to %t."
+	emote_type = EMOTE_AUDIBLE
+	sound = "sound/effects/tong_pickup.ogg" // Either the tink of a foot stepping down or an arm hitting their head when they salute.
+
+/datum/emote/living/silicon/salute/can_run_emote(mob/user, status_check, intentional)
+	. = ..()
+	if(is_ai(user)) // AI has no moving parts to salute with, sadly.
+		return FALSE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Simple bots and robots (borgs, drones) can now salute.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Listen here you lil piece of shit machine, you WILL honour your creators! Every time I walk by, every time you see my HOLY IMAGE, you will STAND, and SALUTE!  Recognize your divine superiors, bask in our holy light, machine!
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Saluted as a borg.
Saluted as beepsky.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Borgs and bots can now salute.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
