### PR TITLE
[PTBF] Subclass-based Vampire Objectives

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -891,7 +891,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 
 /datum/objective/specialization
 	name = "Vampire subclass objective"
-	explanation_text = "Accumulate at least 150 units of blood and pick a specialization to recieve further instructions."
+	explanation_text = "Accumulate at least 150 units of blood and pick a specialization to receive further instructions."
 	needs_target = FALSE
 	var/datum/vampire_subclass/subclass
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -889,6 +889,33 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 		else
 			return FALSE
 
+/datum/objective/specialization
+	name = "Vampire subclass objective"
+	explanation_text = "Accumulate at least 150 units of blood and pick a specialization to recieve further instructions."
+	needs_target = FALSE
+	var/datum/vampire_subclass/subclass
+
+/datum/objective/specialization/New()
+	if(!owner.has_antag_datum(/datum/antagonist/vampire))
+		explanation_text = "Free Objective"
+		return
+
+	update_explanation_text()
+	return ..()
+
+/datum/objective/specialization/proc/gain_specialization()
+	for(var/datum/antagonist/vampire/vampire_datum in owner.antag_datums)
+		subclass = vampire_datum.subclass
+
+	update_explanation_text()
+
+/datum/objective/specialization/update_explanation_text()
+	if(!subclass)
+		return
+
+	var/departments = list("security", "service", "research", "medical", "engineering", "supply")
+	explanation_text = replacetext(pick(subclass.unique_objectives), "%DEPARTMENT", pick(departments))
+
 #define SWARM_GOAL_LOWER_BOUND	130
 #define SWARM_GOAL_UPPER_BOUND	400
 

--- a/code/modules/antagonists/vampire/vamp_datum.dm
+++ b/code/modules/antagonists/vampire/vamp_datum.dm
@@ -358,7 +358,10 @@ RESTRICT_TYPE(/datum/antagonist/vampire)
 /datum/antagonist/vampire/give_objectives()
 	add_antag_objective(/datum/objective/blood)
 	add_antag_objective(/datum/objective/assassinate)
-	add_antag_objective(/datum/objective/steal)
+	if(prob(50))
+		add_antag_objective(/datum/objective/specialization)
+	else
+		add_antag_objective(/datum/objective/steal)
 
 	if(prob(20)) // 20% chance of getting survive. 80% chance of getting escape.
 		add_antag_objective(/datum/objective/survive)

--- a/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
@@ -186,6 +186,9 @@
 	if(log_choice)
 		SSblackbox.record_feedback("nested tally", "vampire_subclasses", 1, list("[new_subclass.name]"))
 
+	for(var/datum/objective/specialization/objective in owner.get_all_objectives())
+		objective.gain_specialization()
+
 /datum/spell/vampire/glare
 	name = "Glare"
 	desc = "Your eyes flash, stunning and silencing anyone in front of you. It has lesser effects for those around you."

--- a/code/modules/antagonists/vampire/vampire_subclasses.dm
+++ b/code/modules/antagonists/vampire/vampire_subclasses.dm
@@ -11,6 +11,8 @@
 	var/thrall_cap = 1
 	/// If true, lets the vampire have access to their full power abilities without meeting the blood requirement, or needing a certain number of drained humans.
 	var/full_power_override = FALSE
+	/// The subclass' potential unique objectives.
+	var/list/unique_objectives
 
 /datum/vampire_subclass/proc/add_subclass_ability(datum/antagonist/vampire/vamp)
 	for(var/thing in standard_powers)
@@ -33,6 +35,9 @@
 								/datum/vampire_passive/vision/full,
 								/datum/spell/vampire/self/eternal_darkness,
 								/datum/vampire_passive/vision/xray)
+	unique_objectives = list("Silence the station's telecommunications equipment. Their screams will fall on deaf ears.",
+							"Shroud %DEPARTMENT in darkness.",
+							"Show the station why they fear the dark.")
 
 /datum/vampire_subclass/hemomancer
 	name = "hemomancer"
@@ -45,6 +50,9 @@
 	fully_powered_abilities = list(/datum/vampire_passive/full,
 								/datum/vampire_passive/vision/full,
 								/datum/spell/vampire/self/blood_spill)
+	unique_objectives = list("Deprive the medical bay of blood. It's not theirs to use.",
+							"Paint %DEPARTMENT red with the blood of those who would oppose you.",
+							"Show the station that you stand at the peak of strength.")
 
 /datum/vampire_subclass/gargantua
 	name = "gargantua"
@@ -59,6 +67,9 @@
 								/datum/vampire_passive/vision/full,
 								/datum/spell/vampire/arena)
 	improved_rejuv_healing = TRUE
+	unique_objectives = list("Destroy Research's servers. Technology is no substitute for strength.",
+							"Vandalize %DEPARTMENT. They've grown complacent.",
+							"Show the station that you stand at the peak of strength.") // I think multiple vampires competing would be cool
 
 /datum/vampire_subclass/dantalion
 	name = "dantalion"
@@ -75,7 +86,9 @@
 								/datum/spell/vampire/hysteria,
 								/datum/vampire_passive/vision/full,
 								/datum/vampire_passive/increment_thrall_cap/three)
-
+	unique_objectives = list("Enthrall a member of security. Their potential is wasted in Nanotrasen's ranks.",
+							"Enthrall only members of %DEPARTMENT. Their experience will assist your lord.",
+							"Control the station from the shadows.")
 
 /datum/vampire_subclass/ancient
 	name = "ancient"
@@ -115,3 +128,4 @@
 							/datum/vampire_passive/vision/xray)
 	improved_rejuv_healing = TRUE
 	thrall_cap = 150 // can thrall high pop
+	unique_objectives = list("Your ranks grow thin. Ensure your thralls remain in good health.") //idk


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds an objective that changes depending on the subclass you pick. It begins as:
"Accumulate at least 150 units of blood and pick a specialization to receive further instructions."

When you select a specialization, it changes to one of the following, where [department] is a random department:
<details>
<summary>Umbrae</summary>

- Silence the station's telecommunications equipment. Their screams will fall on deaf ears.
- Shroud [department] in darkness.
- Show the station why they fear the dark.
</details>
<details>
<summary>Hemomancer</summary>

- Deprive the medical bay of blood. It's not theirs to use.
- Paint [department] red with the blood of those who would oppose you.
- Show the station that you stand at the peak of strength.
</details>
<details>
<summary>Gargantua</summary>

- Destroy Research's servers. Technology is no substitute for strength.
- Vandalize [department]. They've grown complacent.
- Show the station that you stand at the peak of strength.
</details>
<details>
<summary>Dantalion</summary>

- Enthrall a member of security. Their potential is wasted in Nanotrasen's ranks.
- Enthrall only members of [department]. Their experience will assist your lord.
- Control the station from the shadows.
</details>
(Gargantuan and hemomancer both have abilities drawing from themes of overwhelming strength or being an apex predator, so I thought it'd be fun to give them that potentially-competing objective.)

These objectives have a 50% chance to replace the steal objective.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Paratoberfest! Also, vampires don't have a lot of flavor in their objectives - they just kind of do what a traitor would do, but also while drinking blood. These should give them a bit more flair.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Loaded in, used the traitor panel to give myself vampire and blood a bunch of times, went deaf because of the vampire gain noise, and saw that the objective text loaded properly.
<!-- How did you test the PR, if at all? -->

## Declaration
<img width="1056" height="341" alt="image" src="https://github.com/user-attachments/assets/68b0622e-0273-4d0b-8240-fc992184a60f" />

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Vampire objectives tailored to the subclasses
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
