### PR TITLE
don't let slimes spawn abstract burgers

### DIFF
--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -150,6 +150,7 @@
 
 	var/list/blocked = list(
 		/obj/item/food,
+		/obj/item/food/burger, // abstract burger
 		/obj/item/food/sliced/bread,
 		/obj/item/food/sliceable,
 		/obj/item/food/sliceable/pizza,


### PR DESCRIPTION
## What Does This PR Do
This PR adds the burger basetype to the prohibited list of slime core food spawns.
## Why It's Good For The Game
Bugfix.
## Testing
Visual inspection.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: An invalid burger type was being spawned by slime cores. It has been removed.
/:cl: