### PR TITLE
Fix RPD interactions with storage and UI elements

### DIFF
--- a/code/game/objects/items/rpd.dm
+++ b/code/game/objects/items/rpd.dm
@@ -315,11 +315,11 @@
 			else
 				return //Either nothing was selected, or an invalid mode was selected
 		to_chat(user, "<span class='notice'>You set [src]'s mode.</span>")
-	
+
 /obj/item/rpd/ranged_interact_with_atom(atom/target, mob/living/user, list/modifiers)
 	if(!ranged)
 		return NONE
-	
+
 	if(handle_atom_interaction(target, user, ranged))
 		return ITEM_INTERACT_COMPLETE
 
@@ -332,10 +332,7 @@
 	return NONE
 
 /obj/item/rpd/proc/handle_atom_interaction(atom/target, mob/living/user, ranged)
-	if(isstorage(target))
-		var/obj/item/storage/S = target
-		if(!S.can_be_inserted(src, stop_messages = TRUE))
-			return ITEM_INTERACT_COMPLETE
+	if(isstorage(target) || ismodcontrol(target))
 		return NONE
 
 	if(world.time < lastused + spawndelay)
@@ -350,6 +347,9 @@
 		return ITEM_INTERACT_COMPLETE
 
 	if(target != T)
+		if(target.loc != T) // Avoids placing pipes when clicking onto something that's inside something. Like clicking on your PDA on UI.
+			return ITEM_INTERACT_COMPLETE
+
 		// We only check the rpd_act of the target if it isn't the turf, because otherwise
 		// (A) blocked turfs can be acted on, and (B) unblocked turfs get acted on twice.
 		if(target.rpd_act(user, src))


### PR DESCRIPTION
## What Does This PR Do
RPD will now continue the attack chain on mod control units and backpacks, allowing inventory interaction and feedback to work normally.
When placing a pipe, the RPD will now check if the targets location is the same as the turf, fixing placing pipes under you if you click on an inventory element like the PDA.
Fixes #30628
Fixes #27032
Fixes #30318
## Why It's Good For The Game
Works better.
## Testing
Placed an RPD in a backpack and modsuit, tried placing an RPD in a full backpack and modsuit, placed a pipe on turf, placed a pipe when clicking on an object on the turf, tried placing a pipe by clicking on my PDA.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: RPD won't place pipes when clicking on a mod control unit.
fix: RPD won't place pipes when clicking on an UI element.
/:cl: