### PR TITLE
remove pressure sight from engine goggle description

### DIFF
--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -8,7 +8,7 @@
 
 /obj/item/clothing/glasses/meson/engine
 	name = "engineering scanner goggles"
-	desc = "Goggles used by engineers. The Meson Scanner mode lets you see basic structural and terrain layouts through walls, the T-ray Scanner mode lets you see underfloor objects such as cables and pipes, the Radiation Scanner mode lets you see objects contaminated by radiation, and the Pressure Scanner mode lets you visualize air pressure."
+	desc = "Goggles used by engineers. The Meson Scanner mode lets you see basic structural and terrain layouts through walls, the T-ray Scanner mode lets you see underfloor objects such as cables and pipes, and the Radiation Scanner mode lets you see objects contaminated by radiation."
 	icon_state = "trayson-meson"
 	inhand_icon_state = null
 	actions_types = list(/datum/action/item_action/toggle_mode)


### PR DESCRIPTION
## What Does This PR Do
Removes mention of pressure sight from engineering goggles desc. Fixes #30529
## Why It's Good For The Game
there's no pressure sight in engineering goggles
## Testing
Examined it.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Engineering goggles no longer claim to have a pressure mode.
/:cl: