### PR TITLE
Fix bloody writing letting you write with 0 characters

### DIFF
--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1394,6 +1394,8 @@
 		return
 	if(bloody_hands <= 1)
 		remove_verb(src, /mob/living/carbon/human/proc/bloody_doodle)
+		to_chat(src, "<span class='warning'>Your hands aren't bloody enough!</span>")
+		return
 
 	if(gloves)
 		to_chat(src, "<span class='warning'>[gloves] are preventing you from writing anything down!</span>")


### PR DESCRIPTION
## What Does This PR Do
If your bloody_hands stacks are equal or less than 1, the bloody writing verb will be removed. However, since it doesn't return there, it'll continue and it'll prompt you to write something that's less than 0 characters.
## Why It's Good For The Game
You're no longer falsely prompted to write.
## Testing
Bloodied my hands and wrote stuff when my bloody_hands level was >=2. Tried writing with a bloody_hands level of 1, and chat said my hands arent bloody enough and stopped.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Bloody writing will no longer prompt you to write with 0 characters.
/:cl: