### PR TITLE
Fix alien cache site tiles becoming lava when destroyed

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/alien_cache_site.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/alien_cache_site.dmm
@@ -6,61 +6,61 @@
 /obj/item/clothing/under/rank/cargo/expedition/skirt,
 /obj/item/clothing/under/rank/cargo/expedition/skirt,
 /turf/simulated/floor/plating/abductor,
-/area/ruin/powered/alien_cache_site)
+/area/ruin/space/powered/alien_cache_site)
 "dV" = (
 /obj/structure/lightable/bonfire,
 /turf/simulated/floor/plating/abductor,
-/area/ruin/powered/alien_cache_site)
+/area/ruin/space/powered/alien_cache_site)
 "ec" = (
 /obj/machinery/hydroponics/soil,
 /turf/simulated/floor/plating/abductor,
-/area/ruin/powered/alien_cache_site)
+/area/ruin/space/powered/alien_cache_site)
 "en" = (
 /obj/structure/table/abductor,
 /obj/item/kitchen/knife,
 /turf/simulated/floor/plating/abductor,
-/area/ruin/powered/alien_cache_site)
+/area/ruin/space/powered/alien_cache_site)
 "et" = (
 /turf/simulated/floor/plating/abductor,
-/area/ruin/powered/alien_cache_site/cache_room)
+/area/ruin/space/powered/alien_cache_site/cache_room)
 "eF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/pickaxe,
 /obj/item/weldingtool/largetank,
 /turf/simulated/floor/plating/abductor,
-/area/ruin/powered/alien_cache_site)
+/area/ruin/space/powered/alien_cache_site)
 "fA" = (
 /obj/structure/fans/tiny/invisible,
 /obj/machinery/door/airlock/abductor/secure,
 /turf/simulated/floor/plating/abductor,
-/area/ruin/powered/alien_cache_site)
+/area/ruin/space/powered/alien_cache_site)
 "gf" = (
 /obj/effect/spawner/random/glowstick,
 /obj/structure/table/abductor,
 /obj/effect/spawner/random/engineering/tools,
 /turf/simulated/floor/plating/abductor,
-/area/ruin/powered/alien_cache_site)
+/area/ruin/space/powered/alien_cache_site)
 "hj" = (
 /obj/effect/spawner/random/snacks,
 /obj/effect/spawner/random/snacks,
 /obj/effect/spawner/random/snacks,
 /obj/structure/table/wood,
 /turf/simulated/floor/plating/abductor,
-/area/ruin/powered/alien_cache_site)
+/area/ruin/space/powered/alien_cache_site)
 "jZ" = (
 /obj/item/reagent_containers/glass/bottle/nutrient/empty,
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/plating/abductor,
-/area/ruin/powered/alien_cache_site)
+/area/ruin/space/powered/alien_cache_site)
 "kY" = (
 /obj/effect/simon_says,
 /turf/simulated/floor/plating/abductor,
-/area/ruin/powered/alien_cache_site)
+/area/ruin/space/powered/alien_cache_site)
 "ml" = (
 /obj/structure/table/abductor,
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/plating/abductor,
-/area/ruin/powered/alien_cache_site)
+/area/ruin/space/powered/alien_cache_site)
 "mQ" = (
 /turf/space,
 /area/space)
@@ -69,19 +69,19 @@
 /obj/effect/spawner/random/food_or_drink,
 /obj/structure/table/wood,
 /turf/simulated/floor/plating/abductor,
-/area/ruin/powered/alien_cache_site)
+/area/ruin/space/powered/alien_cache_site)
 "pX" = (
 /obj/item/assembly/igniter,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/abductor,
-/area/ruin/powered/alien_cache_site)
+/area/ruin/space/powered/alien_cache_site)
 "uD" = (
 /obj/structure/bed/abductor,
 /turf/simulated/floor/plating/abductor,
-/area/ruin/powered/alien_cache_site)
+/area/ruin/space/powered/alien_cache_site)
 "wy" = (
 /turf/simulated/floor/plating/abductor,
-/area/ruin/powered/alien_cache_site)
+/area/ruin/space/powered/alien_cache_site)
 "zB" = (
 /obj/structure/closet,
 /obj/item/clothing/under/rank/cargo/expedition,
@@ -95,49 +95,49 @@
 	tracking = 1
 	},
 /turf/simulated/floor/plating/abductor,
-/area/ruin/powered/alien_cache_site)
+/area/ruin/space/powered/alien_cache_site)
 "Bl" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating/abductor,
-/area/ruin/powered/alien_cache_site)
+/area/ruin/space/powered/alien_cache_site)
 "CK" = (
 /turf/simulated/wall/indestructible/abductor,
-/area/ruin/powered/alien_cache_site)
+/area/ruin/space/powered/alien_cache_site)
 "Do" = (
 /obj/machinery/shower/directional/east,
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor/plating/abductor,
-/area/ruin/powered/alien_cache_site)
+/area/ruin/space/powered/alien_cache_site)
 "Ey" = (
 /obj/machinery/alien_cache,
 /turf/simulated/floor/plating/abductor,
-/area/ruin/powered/alien_cache_site/cache_room)
+/area/ruin/space/powered/alien_cache_site/cache_room)
 "Ha" = (
 /turf/simulated/wall/indestructible/abductor,
-/area/ruin/powered/alien_cache_site/cache_room)
+/area/ruin/space/powered/alien_cache_site/cache_room)
 "JC" = (
 /obj/structure/curtain/open,
 /turf/simulated/floor/plating/abductor,
-/area/ruin/powered/alien_cache_site)
+/area/ruin/space/powered/alien_cache_site)
 "LK" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/wall/indestructible/abductor{
 	desc = "Effectively impervious to conventional methods of destruction. It looks like someone tried to break it, but failed"
 	},
-/area/ruin/powered/alien_cache_site)
+/area/ruin/space/powered/alien_cache_site)
 "TW" = (
 /turf/simulated/wall/mineral/wood,
-/area/ruin/powered/alien_cache_site)
+/area/ruin/space/powered/alien_cache_site)
 "Yg" = (
 /obj/machinery/door/airlock/abductor,
 /obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/plating/abductor,
-/area/ruin/powered/alien_cache_site)
+/area/ruin/space/powered/alien_cache_site)
 "YA" = (
 /obj/effect/spawner/random/engineering/toolbox,
 /obj/structure/table/abductor,
 /turf/simulated/floor/plating/abductor,
-/area/ruin/powered/alien_cache_site)
+/area/ruin/space/powered/alien_cache_site)
 
 (1,1,1) = {"
 mQ

--- a/code/game/area/areas/ruins/alien_cache_site_areas.dm
+++ b/code/game/area/areas/ruins/alien_cache_site_areas.dm
@@ -1,7 +1,7 @@
-/area/ruin/powered/alien_cache_site
+/area/ruin/space/powered/alien_cache_site
 	name = "Alien Cache Site"
 	report_alerts = FALSE
 	dynamic_lighting = FALSE
 
-/area/ruin/powered/alien_cache_site/cache_room
+/area/ruin/space/powered/alien_cache_site/cache_room
 	name = "Alien Cache Chamber"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes #30652 by changing the area to be a a space ruin subtype instead of a lavaland ruin subtype
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
less bug more good 
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
- disassembled a tile and it became space 
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixes alien cache tiles becoming lava instead of space when destroyed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
