### PR TITLE
Enables temporary reminder to view the new rules

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -445,7 +445,9 @@
 
 	Master.UpdateTickRate()
 	INVOKE_ASYNC(src, TYPE_PROC_REF(/client, nag_516))
-	INVOKE_ASYNC(src, TYPE_PROC-REF(/client, nag_new_rules))
+
+	//TODO: Comment out after awhile, save for future use.
+	INVOKE_ASYNC(src, TYPE_PROC_REF(/client, nag_new_rules))
 
 	// Tell clients about active testmerges
 	if(world.TgsAvailable() && length(GLOB.revision_info.testmerges))
@@ -1342,9 +1344,9 @@
 
 	src << link("https://secure.byond.com/download/")
 
-// Comment out after awhile, keep in case of future needs.
+// TODO: Comment out after awhile, keep in case of future needs.
 /client/proc/nag_new_rules()
-	var/choice = tgui_alert(src, "IMPORTANT: We have updated and reworked our rules! If you haven't, please review them before joining the round. Thank you.", list("Okay", "View Rules")
+	var/choice = tgui_alert(src, "IMPORTANT: We have updated and reworked our rules! If you haven't, please review them before joining the round. Thank you.", "New Rule Alert", list("Okay", "View Rules"))
 	if(choice == "Okay")
 		return
 


### PR DESCRIPTION
## What Does This PR Do
Add and enables a temporary new rules reminder to remind players to review the new rules.
## Why It's Good For The Game
Important for game play.
## Images of changes
<img width="414" height="482" alt="image" src="https://github.com/user-attachments/assets/81295fcb-cb17-435a-9d7c-6ec09208a0c7" />

## Testing
Started up a test instance.
Tried both buttons to see if they functioned properly.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC