### PR TITLE
Caps the eshotgun damage multiplier from lens to 1.5x

### DIFF
--- a/code/modules/projectiles/guns/energy/energy.dm
+++ b/code/modules/projectiles/guns/energy/energy.dm
@@ -239,6 +239,7 @@
 	var/fail_tick = 0
 	ammo_x_offset = 1
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler/eshotgun, /obj/item/ammo_casing/energy/laser/eshotgun)
+	lens_damage_cap = 1.5 // Caps at 90 stamina damage, to prevent one shot stamina crits.
 	var/pump_time = 1 SECONDS
 	COOLDOWN_DECLARE(pump_cooldown)
 

--- a/code/modules/projectiles/guns/energy_guns.dm
+++ b/code/modules/projectiles/guns/energy_guns.dm
@@ -38,6 +38,8 @@
 	var/can_be_lensed = TRUE
 	/// Current lens
 	var/obj/item/smithed_item/lens/current_lens
+	/// The max damage multiplier a lens can apply to a energy gun. Use sparingly, primarly for stamina based weapons.
+	var/lens_damage_cap = 999
 
 /obj/item/gun/energy/examine(mob/user)
 	. = ..()

--- a/code/modules/smithing/smithed_items/lens.dm
+++ b/code/modules/smithing/smithed_items/lens.dm
@@ -45,7 +45,7 @@
 	for(var/obj/item/ammo_casing/energy/casing in attached_gun.ammo_type)
 		casing.delay = casing.delay / fire_rate_mult
 		casing.e_cost = casing.e_cost * power_mult
-		casing.lens_damage_multiplier = casing.lens_damage_multiplier * damage_mult
+		casing.lens_damage_multiplier = casing.lens_damage_multiplier * min(attached_gun.lens_damage_cap, damage_mult)
 		casing.lens_speed_multiplier = casing.lens_speed_multiplier / laser_speed_mult
 
 /obj/item/smithed_item/lens/on_detached()
@@ -56,7 +56,7 @@
 	for(var/obj/item/ammo_casing/energy/casing in attached_gun.ammo_type)
 		casing.delay = casing.delay * fire_rate_mult
 		casing.e_cost = casing.e_cost / power_mult
-		casing.lens_damage_multiplier = casing.lens_damage_multiplier / damage_mult
+		casing.lens_damage_multiplier = casing.lens_damage_multiplier / min(attached_gun.lens_damage_cap, damage_mult)
 		casing.lens_speed_multiplier = casing.lens_speed_multiplier * laser_speed_mult
 	attached_gun.current_lens = null
 	attached_gun = null


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Caps the eshotgun damage multiplier from lens to 1.5
Allows any gun to be capped, should be used sparingly.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

We do not need energy shotguns being able to one tap stamina crit from 2 tiles away. We try to keep instant stuns rare, tied to anomaly or admin or rare mainly one use items. Being able to make 3 lenses for 3 eshotguns without using rnd, that can act as close range tasers, is not the best.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Fired eshotgun: 60 damage.
Fired eshotgun with admin lens: 90 damage, 1.5x.
Fired eshotgun after removing lens: 60 damage.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

See silverplate's comment in 2 minutes.

## Changelog

:cl:
tweak: Caps the eshotgun damage multiplier from lens to 1.5x
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
