### PR TITLE
Make chem dispensers appear off when they have no power.

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -132,6 +132,11 @@
 		return
 	icon_state = "[initial(icon_state)][beaker ? "_working" : ""]"
 
+/obj/machinery/chem_dispenser/power_change()
+	if(!..())
+		return
+	update_icon()
+
 /obj/machinery/chem_dispenser/ex_act(severity)
 	if(severity < EXPLODE_LIGHT)
 		if(beaker)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes chem dispensers appearing on when they're actually off.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

It's confusing when your machine looks like it has power but it doesn't work.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<img width="638" height="348" alt="2025-10-15 17_42_22-Paradise Station 13" src="https://github.com/user-attachments/assets/da278820-3b13-419f-8825-0bfd8d5fcb29" />
<img width="657" height="345" alt="2025-10-15 17_42_44-Paradise Station 13" src="https://github.com/user-attachments/assets/c3e42072-4cd1-4402-bf71-977a171895d9" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

Compiled, hosted, turned APC power on and off both with and without a beaker in the dispenser.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed chem dispensers appearing to be on when they have no power.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
