### PR TITLE
Removes Swarming component from Space Carp

### DIFF
--- a/code/modules/mob/living/basic/hostile/carp.dm
+++ b/code/modules/mob/living/basic/hostile/carp.dm
@@ -38,7 +38,6 @@
 	faction = list("carp", "mining")
 	pressure_resistance = 200
 	gold_core_spawnable = HOSTILE_SPAWN
-	density = FALSE
 
 	initial_traits = list(TRAIT_FLYING, TRAIT_SHOCKIMMUNE)
 
@@ -68,7 +67,6 @@
 /mob/living/basic/carp/Initialize(mapload)
 	. = ..()
 	carp_randomify(rarechance)
-	AddComponent(/datum/component/swarming)
 	AddComponent(/datum/component/aggro_emote, emote_list = list("gnashes"))
 
 /mob/living/basic/carp/proc/carp_randomify(rarechance)
@@ -107,16 +105,6 @@
 		return
 
 	. += mutable_appearance(icon, "base_[stat == DEAD ? "dead_" : ""]mouth", appearance_flags = RESET_COLOR)
-
-// We do not want mobs moving through space carp, we as such we block it if the mob is not dense
-/mob/living/basic/carp/CanPass(atom/movable/mover, border_dir)
-	if(isliving(mover) && !istype(mover, /mob/living/basic/carp) && mover.density == TRUE && stat != DEAD)
-		return FALSE
-	return ..()
-
-// Since it's not dense we let it always hit
-/mob/living/basic/carp/projectile_hit_check(obj/item/projectile/P)
-	return stat == DEAD
 
 /mob/living/basic/carp/holocarp
 	icon_state = "holocarp"


### PR DESCRIPTION
## What Does This PR Do

This PR removes the swarming component from space carp and ensures they are dense.

## Why It's Good For The Game

Its been shown to me time and time again that with improvements to carp AI, that this feature is no longer needed to make carp a threat. Carp in their current state are just not fun.

## Testing

Loaded in, spawned a bunch of carp, got beaten to death, carp didn't swarm.

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<img width="724" height="88" alt="image" src="https://github.com/user-attachments/assets/243d2a66-7524-4948-ad0e-6ffd1cc6b40d" />
<img width="1089" height="134" alt="image" src="https://github.com/user-attachments/assets/9a277b3c-ae77-42e8-9a90-261fd6f5d2a4" />
<img width="1054" height="165" alt="image" src="https://github.com/user-attachments/assets/c02d4432-a4de-4b12-9bae-cdd3a353ebf7" />


## Changelog

:cl:
del: Removed swarming component from space carp mobs.
tweak: Space carp mobs are now dense.
/:cl:
