### PR TITLE
Fix variety reagent secondary goal to tally smaller quantities until filled.

### DIFF
--- a/code/modules/station_goals/secondary/variety_reagent.dm
+++ b/code/modules/station_goals/secondary/variety_reagent.dm
@@ -117,9 +117,9 @@
 		return
 	var/single_reagent
 	var/reagents_tally = 0
-	for (single_reagent in reagents_sent)
+	for(single_reagent in reagents_sent)
 		reagents_tally += (reagents_sent[single_reagent] >= amount_per ? 1 : 0)
-	if (reagents_tally < needed)
+	if(reagents_tally < needed)
 		return
 
 	three_way_reward(manifest, department, department_account, reward, "Secondary goal complete: [needed] different [generic_name_plural].")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Changes the way the variety reagent goals count the reagents they receive. Instead of requiring the full amount in one container (pill, liquid bottle, patch), it keeps a running tally of how much of each reagent one has sent in, and marks the goal as complete when ten of them reach 50 units.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

The console says that you can send the medicine in as pills, patches, or whatever form you please, so it's very frustrating to players if it doesn't actually work that way.
Fixes #30562

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

Compiled, hosted, and did several rounds of variety medicine goals. The first time I sent medicines in multiple shipments, spreading each reagent across multiple pills. The second time I sent the entire goal in one shipment, with a mixed-reagent pill and a bit of amount overflow to test how it would handle that. The third time I sent 250u of silver sulfadiazine to test whether the excessive reagent messages still work.

I would like additional testing, maybe a test merge for a little while, to make sure everything is running smoothly. I'm not used to this system and I can't tell if I've overlooked something.

Log of shipments from cargo console is below.
<details><summary>Details</summary>
<p>

```
Central Command Cargo Message Log
---12:00:03---

Remember to stamp and send back the supply manifests.
---05:04:17---

Medical Account Notice: Received 5u of Atropine.
Medical Account Notice: Received 5u of Atropine.
Medical Account Notice: Received 5u of Atropine.
Medical Account Notice: Received 5u of Atropine.
Medical Account Notice: Received 5u of Atropine.
Medical Account Notice: Received 5u of Salicylic Acid.
Medical Account Notice: Received 5u of Salicylic Acid.
Medical Account Notice: Received 5u of Salicylic Acid.
Medical Account Notice: Received 5u of Salicylic Acid.
Medical Account Notice: Received 5u of Salicylic Acid.
Medical Account Notice: Received 10u of Epinephrine.
Medical Account Notice: Received 10u of Epinephrine.
Medical Account Notice: Received 10u of Epinephrine.
Medical Account Notice: Received 10u of Mutadone.
Medical Account Notice: Received 10u of Mutadone.
Medical Account Notice: Received 10u of Mutadone.
Medical Account Notice: Received 10u of Haloperidol.
Medical Account Notice: Received 10u of Haloperidol.
Medical Account Notice: Received 10u of Haloperidol.
Medical Account Notice: Received 10u of Haloperidol.
Medical Account Notice: Received 10u of Diphenhydramine.
Medical Account Notice: Received 10u of Diphenhydramine.
Medical Account Notice: Received 10u of Ephedrine.
Medical Account Notice: Received 10u of Ephedrine.
Medical Account Notice: Received 10u of Teporone.
Medical Account Notice: Received 10u of Teporone.
Medical Account Notice: Received 10u of Ether.
Medical Account Notice: Received 10u of Potassium Iodide.
Supply Account +15: Returned 1 crate(s).
---05:17:45---

Medical Account Notice: Received 5u of Atropine.
Medical Account Notice: Received 5u of Atropine.
Medical Account Notice: Received 5u of Atropine.
Medical Account Notice: Received 5u of Atropine.
Medical Account Notice: Received 5u of Atropine.
Medical Account Notice: Received 5u of Salicylic Acid.
Medical Account Notice: Received 5u of Salicylic Acid.
Medical Account Notice: Received 5u of Salicylic Acid.
Medical Account Notice: Received 5u of Salicylic Acid.
Medical Account Notice: Received 5u of Salicylic Acid.
Medical Account Notice: Received 10u of Ether.
Medical Account Notice: Received 10u of Ether.
Medical Account Notice: Received 10u of Ether.
Medical Account Notice: Received 10u of Ether.
Medical Account Notice: Received 10u of Potassium Iodide.
Medical Account Notice: Received 10u of Potassium Iodide.
Medical Account Notice: Received 10u of Potassium Iodide.
Medical Account Notice: Received 10u of Potassium Iodide.
Medical Account Notice: Received 10u of Teporone.
Medical Account Notice: Received 10u of Teporone.
Medical Account Notice: Received 10u of Teporone.
Medical Account Notice: Received 10u of Ephedrine.
Medical Account Notice: Received 10u of Ephedrine.
Medical Account Notice: Received 10u of Ephedrine.
Medical Account Notice: Received 10u of Diphenhydramine.
Medical Account Notice: Received 10u of Diphenhydramine.
Medical Account Notice: Received 10u of Diphenhydramine.
Medical Account Notice: Received 10u of Mutadone.
Medical Account Notice: Received 10u of Mutadone.
Medical Account Notice: Received 10u of Epinephrine.
Medical Account Notice: Received 10u of Epinephrine.
Supply Account +15: Returned 1 crate(s).
---05:23:12---

Medical Account Notice: Received 10u of Haloperidol.
Supply Account +15: Returned 1 crate(s).
Supply Account +100: Secondary goal complete: 10 different medicines.
Medical Account +100: Secondary goal complete: 10 different medicines.
Malik Zalack +100: Secondary goal complete: 10 different medicines.
---05:30:51---

Medical Account Notice: That Potassium Iodide seems to be mixed with something else. Send it by itself, please.
Medical Account Notice: Received 10u of Teporone.
Medical Account Notice: Received 10u of Silver Sulfadiazine.
Medical Account Notice: Received 10u of Silver Sulfadiazine.
Medical Account Notice: Received 10u of Silver Sulfadiazine.
Medical Account Notice: Received 10u of Silver Sulfadiazine.
Medical Account Notice: Received 10u of Silver Sulfadiazine.
Medical Account Notice: Received 10u of Styptic Powder.
Medical Account Notice: Received 10u of Styptic Powder.
Medical Account Notice: Received 10u of Styptic Powder.
Medical Account Notice: Received 10u of Styptic Powder.
Medical Account Notice: Received 10u of Styptic Powder.
Medical Account Notice: Received 50u of Mannitol.
Medical Account Notice: Received 50u of Potassium Iodide.
Medical Account Notice: Received 50u of Teporone.
Medical Account Notice: Received 50u of Diphenhydramine.
Medical Account Notice: Received 50u of Ephedrine.
Medical Account Notice: Received 50u of Haloperidol.
Medical Account Notice: Received 50u of Ether.
Medical Account Notice: Received 50u of Salicylic Acid.
Supply Account +15: Returned 1 crate(s).
Supply Account +100: Secondary goal complete: 10 different medicines.
Medical Account +100: Secondary goal complete: 10 different medicines.
Malik Zalack +100: Secondary goal complete: 10 different medicines.
---05:38:37---

Medical Account Notice: Received 20u of Silver Sulfadiazine.
Medical Account Notice: Received 20u of Silver Sulfadiazine.
Medical Account Notice: Received 20u of Silver Sulfadiazine.
Medical Account Notice: You already sent us enough Silver Sulfadiazine.
Medical Account Notice: You already sent us enough Silver Sulfadiazine.
Medical Account Notice: You already sent us enough Silver Sulfadiazine.
Medical Account Notice: You already sent us enough Silver Sulfadiazine.
Medical Account Notice: You already sent us enough Silver Sulfadiazine.
Medical Account Notice: You already sent us enough Silver Sulfadiazine.
Medical Account Notice: You already sent us enough Silver Sulfadiazine.
Medical Account Notice: You already sent us enough Silver Sulfadiazine.
Medical Account Notice: You already sent us enough Silver Sulfadiazine.
Medical Account Notice: You already sent us enough Silver Sulfadiazine.
Medical Account Notice: You already sent us enough Silver Sulfadiazine.
Medical Account Notice: You already sent us enough Silver Sulfadiazine.
Supply Account +15: Returned 1 crate(s).

``` 
</p>
</details> 

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed secondary goals that ask for a variety of medicines/chemicals/drinks: they now accept and keep a running tally of smaller quantities submitted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
