### PR TITLE
Fix hydroponics initialization destroying lavaland

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -38,8 +38,8 @@
 	QDEL_NULL(myseed)
 	return ..()
 
-/obj/structure/glowshroom/New(loc, obj/item/seeds/newseed, mutate_stats)
-	..()
+/obj/structure/glowshroom/Initialize(mapload, loc, obj/item/seeds/newseed, mutate_stats)
+	. = ..()
 	if(newseed)
 		myseed = newseed.Copy()
 		myseed.forceMove(src)


### PR DESCRIPTION
## What Does This PR Do
Let's #30691 be closed.

Moves glowshroom structures to Initialize. This way, they won't fucking scream and screech on mapload and end their lives cause they tried to access genes before they were created.
## Why It's Good For The Game
Hydroponics will no longer destroy lavaland.
## Testing
Loaded the game with space, lavaland, ruins and a station enabled, several times.
Loaded test_tiny with every single glowshroom structure.
Placed a glowshroom of each type several times.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC