### PR TITLE
Gives Jobs Their Pocket Bags

### DIFF
--- a/code/game/jobs/job/engineering_jobs.dm
+++ b/code/game/jobs/job/engineering_jobs.dm
@@ -50,6 +50,7 @@
 	l_ear = /obj/item/radio/headset/heads/ce
 	id = /obj/item/card/id/ce
 	l_pocket = /obj/item/t_scanner
+	r_pocket = /obj/item/storage/bag/construction
 	pda = /obj/item/pda/heads/ce
 	backpack_contents = list(
 		/obj/item/melee/classic_baton/telescopic = 1
@@ -101,6 +102,7 @@
 	l_ear = /obj/item/radio/headset/headset_eng
 	id = /obj/item/card/id/engineering
 	l_pocket = /obj/item/t_scanner
+	r_pocket = /obj/item/storage/bag/construction
 	pda = /obj/item/pda/engineering
 
 	backpack = /obj/item/storage/backpack/industrial
@@ -142,6 +144,7 @@
 	jobtype = /datum/job/atmos
 
 	uniform = /obj/item/clothing/under/rank/engineering/atmospheric_technician
+	r_pocket = /obj/item/storage/bag/construction
 	belt = /obj/item/storage/belt/utility/atmostech
 	shoes = /obj/item/clothing/shoes/workboots
 	l_ear = /obj/item/radio/headset/headset_eng

--- a/code/game/jobs/job/medical_jobs.dm
+++ b/code/game/jobs/job/medical_jobs.dm
@@ -198,6 +198,7 @@
 	jobtype = /datum/job/chemist
 
 	uniform = /obj/item/clothing/under/rank/medical/chemist
+	r_pocket = /obj/item/storage/bag/chemistry
 	suit = /obj/item/clothing/suit/storage/labcoat/chemist
 	shoes = /obj/item/clothing/shoes/white
 	l_ear = /obj/item/radio/headset/headset_med
@@ -244,6 +245,7 @@
 	jobtype = /datum/job/virologist
 
 	uniform = /obj/item/clothing/under/rank/medical/virologist
+	r_pocket = /obj/item/storage/bag/bio
 	suit = /obj/item/clothing/suit/storage/labcoat/virologist
 	shoes = /obj/item/clothing/shoes/white
 	mask = /obj/item/clothing/mask/surgical

--- a/code/game/jobs/job/science_jobs.dm
+++ b/code/game/jobs/job/science_jobs.dm
@@ -154,6 +154,7 @@
 	jobtype = /datum/job/xenobiologist
 
 	uniform = /obj/item/clothing/under/rank/rnd/scientist
+	r_pocket = /obj/item/storage/bag/bio
 	suit = /obj/item/clothing/suit/storage/labcoat/science
 	shoes = /obj/item/clothing/shoes/white
 	gloves = /obj/item/clothing/gloves/color/latex/nitrile

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -87,6 +87,7 @@
 
 	uniform = /obj/item/clothing/under/rank/cargo/tech
 	l_pocket = /obj/item/mail_scanner
+	r_pocket = /obj/item/storage/bag/mail
 	l_ear = /obj/item/radio/headset/headset_cargo
 	id = /obj/item/card/id/supply
 	pda = /obj/item/pda/cargo
@@ -125,6 +126,7 @@
 
 	gloves = /obj/item/clothing/gloves/smithing
 	uniform = /obj/item/clothing/under/rank/cargo/smith
+	r_pocket = /obj/item/storage/bag/smith
 	l_ear = /obj/item/radio/headset/headset_cargo
 	shoes = /obj/item/clothing/shoes/workboots/smithing
 	id = /obj/item/card/id/smith
@@ -246,6 +248,8 @@
 	l_ear = /obj/item/radio/headset/headset_cargo/expedition
 	head = /obj/item/clothing/head/soft/expedition
 	uniform = /obj/item/clothing/under/rank/cargo/expedition
+	l_pocket = /obj/item/storage/bag/expedition
+	r_pocket = /obj/item/storage/bag/ore
 	gloves = /obj/item/clothing/gloves/color/black
 	shoes = /obj/item/clothing/shoes/jackboots
 	belt = /obj/item/storage/belt/utility/expedition
@@ -372,6 +376,7 @@
 	gloves = /obj/item/clothing/gloves/botanic_leather
 	l_ear = /obj/item/radio/headset/headset_service
 	l_pocket = /obj/item/storage/bag/plants/portaseeder
+	r_pocket = /obj/item/storage/bag/plants
 	pda = /obj/item/pda/botanist
 	id = /obj/item/card/id/botanist
 	backpack = /obj/item/storage/backpack/botany


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
All engineers now spawn with a construction bag.
Cargo techs now spawn with a mail bag.
Smiths now spawn with a smith bag.
Explorers now spawn with a salvage bag and an ore bag.
Botanists now spawn with a plant bag.
Chemists now spawn with a chem bag.
Virologists and Xenobiologists now spawn with a bio bag.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Quality of life update.

Miners currently are unique in that they spawn with a mining satchel already on them. Expanding this to other roles has two important effects:

1. For very limited quantity bags, such as the smith or chemistry bags, if someone goes to cryo with their job bag on their person, new arrivals that fill in won't be cheated out of what can be a quite important piece of equipment for doing their job (esp. true in the case of the chem bag).
2. New players can be given the spare locker bag whilst a person that spawned as the job is able to also be equipped, making them better equipped for teaching the new player as they won't have to juggle the bag around.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned as each of the affected jobs, saw that I had the desired bag.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: All engineers now spawn with a construction bag.
add: Cargo techs now spawn with a mail bag.
add: Smiths now spawn with a smith bag.
add: Explorers now spawn with a salvage bag and an ore bag.
add: Botanists now spawn with a plant bag.
add: Chemists now spawn with a chem bag.
add: Virologists and Xenobiologists now spawn with a bio bag.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
