### PR TITLE
Screwing a Grinder Deteches its Beaker

### DIFF
--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -145,10 +145,11 @@
 
 /obj/machinery/reagentgrinder/screwdriver_act(mob/user, obj/item/I)
 	. = TRUE
-	if(!anchored || beaker)
+	if(!anchored)
 		return
 	if(!I.tool_use_check(user, 0))
 		return
+	detach(user)
 	default_deconstruction_screwdriver(user, "juicer_open", "juicer0", I)
 
 /obj/machinery/reagentgrinder/wrench_act(mob/user, obj/item/I)
@@ -328,9 +329,9 @@
 			juice()
 
 /obj/machinery/reagentgrinder/proc/detach(mob/user)
-	if(HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
-		return
 	if(!beaker)
+		return
+	if(HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 		return
 	beaker.forceMove(loc)
 	beaker = null


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Instead of doing nothing, screwdrivering a grinder with a beaker inside will automatically detach the beaker.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
QOL update.

Biogenerators and chemistry machines already do this.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Used screwdriver on a beaker'd grinder. Beaker fell out.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Beakers automatically come out of reagent grinders when a screwdriver is used on them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
