### PR TITLE
Fixes a runtime with cooling plastic

### DIFF
--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -870,9 +870,9 @@
 	var/sheets = floor(original_volume / 5)
 	new /obj/item/stack/sheet/plastic(get_turf(holder.my_atom), sheets)
 
+	holder.my_atom.visible_message("<span class='notice'>The molten plastic solidifies.</span>")
 	holder.del_reagent(id)
 	holder.add_reagent("plastic_dust", original_volume - sheets * 5, reagtemp = T0C + 119)
-	holder.my_atom.visible_message("<span class='notice'>The molten plastic solidifies.</span>")
 
 /datum/reagent/plastic_dust
 	name = "Plastic Dust"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Title
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Resolves #30740 
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Cooled molten plastic, didn't runtime
<!-- How did you test the PR, if at all? -->

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Molten plastic no longer runtimes when cooling down
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
