### PR TITLE
log mob types in sentience polls

### DIFF
--- a/code/controllers/subsystem/SSghost_spawns.dm
+++ b/code/controllers/subsystem/SSghost_spawns.dm
@@ -44,7 +44,11 @@ SUBSYSTEM_DEF(ghost_spawns)
   * * role_cleanname - The name override to display to clients
   */
 /datum/controller/subsystem/ghost_spawns/proc/poll_candidates(question = "Would you like to play a special role?", role, antag_age_check = FALSE, poll_time = 30 SECONDS, ignore_respawnability = FALSE, min_hours = 0, flash_window = TRUE, check_antaghud = TRUE, source, role_cleanname, reason, dont_play_notice_sound = FALSE)
-	log_debug("Polling candidates [role ? "for [role_cleanname || role]" : "\"[question]\""] for [poll_time / 10] seconds")
+	var/mob/mob_source = source
+	if(role == ROLE_SENTIENT && istype(mob_source))
+		log_debug("Polling candidates for sentient mob `[mob_source.type]` for [poll_time / 10] seconds")
+	else
+		log_debug("Polling candidates [role ? "for [role_cleanname || role]" : "\"[question]\""] for [poll_time / 10] seconds")
 
 	// Start firing
 	polls_active = TRUE


### PR DESCRIPTION
## What Does This PR Do
This PR adds the typepaths of sentience-offered mobs to debug logs. Just giving the situation its own log because I don't want to untangle the arguments or refactor any of this.
## Why It's Good For The Game
These logs are unhelpful
<img width="711" height="78" alt="image" src="https://github.com/user-attachments/assets/281fed71-3187-494f-b3e6-c3c38c4727e3" />
## Testing
<img width="794" height="37" alt="2025_10_21__23_08_52__Paradise Station 13" src="https://github.com/user-attachments/assets/a36b81ab-d22f-445f-b816-17bc1d51dd4d" />

## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC