### PR TITLE
Removes soul(less IPC revival)

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -242,6 +242,8 @@
 #define STATUS_EFFECT_UNBUCKLE /datum/status_effect/action_status_effect/unbuckle
 #define STATUS_EFFECT_EXIT_CRYOCELL /datum/status_effect/action_status_effect/exit_cryocell
 
+#define STATUS_EFFECT_REVIVE_NOTICE /datum/status_effect/revive_notice_delay
+
 //////////////////////////
 // Mind batter variants //
 //////////////////////////

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -412,3 +412,8 @@
 
 /datum/status_effect/action_status_effect/exit_cryocell
 	id = "exit_cryocell"
+
+/datum/status_effect/revive_notice_delay
+	id = "revive_notice_delay"
+	alert_type = null
+	duration = 15 SECONDS

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -109,8 +109,5 @@
 	/// Lazylist of sources to track what our alpha should be, alpha is set to the minimum. Use the `set_alpha_tracking` and `get_alpha` helpers.
 	var/list/alpha_sources
 
-	/// Used to prevent spam with IPC revival messages
-	COOLDOWN_DECLARE(ghost_notification)
-
 /mob/living/carbon/human/fake
 	flags = ABSTRACT

--- a/code/modules/mob/living/carbon/human/human_update_status.dm
+++ b/code/modules/mob/living/carbon/human/human_update_status.dm
@@ -9,17 +9,17 @@
 				if((health >= (HEALTH_THRESHOLD_DEAD + HEALTH_THRESHOLD_CRIT) * 0.5) && ipc_vital_organ_check() && !suiciding)
 					var/mob/dead/observer/ghost = get_ghost()
 					if(!client && !check_ghost_client() && !key)
-						if(COOLDOWN_FINISHED(src, ghost_notification))
+						if(!has_status_effect(STATUS_EFFECT_REVIVE_NOTICE))
 							visible_message("<span class='danger'>[src]'[p_s()] posibrain fails its power-on self-test. Any recovery from this state is unlikely.</span>")
-							COOLDOWN_START(src, ghost_notification, 15 SECONDS)
+							apply_status_effect(STATUS_EFFECT_REVIVE_NOTICE)
 						return
 
 					if(ghost)
-						if(COOLDOWN_FINISHED(src, ghost_notification))
+						if(!has_status_effect(STATUS_EFFECT_REVIVE_NOTICE))
 							to_chat(ghost, "<span class='ghostalert'>Your chassis has been repaired and repowered, re-enter if you want to continue playing!</span> (Verbs -> Ghost -> Re-enter corpse)")
 							SEND_SOUND(ghost, sound('sound/effects/genetics.ogg'))
 							visible_message("<span class='notice'>[src]'[p_s()] posibrain buffers...</span>")
-							COOLDOWN_START(src, ghost_notification, 15 SECONDS)
+							apply_status_effect(STATUS_EFFECT_REVIVE_NOTICE)
 						return
 
 					update_revive()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it so that, in order to actually become alive again, an IPC's player has to enter their body. This doesn't change anything about how they're actually revived - repairs can still be made to the chassis, it just isn't _alive_ until the soul enters the body.

Also gives more feedback to IPC revival; it'll give a notification on top of the "soul departed" examine text, if applicable, and a simple message if it's just waiting for the player to re-enter their body. IPCs also chime when they're reactivated (as an emote) to further signal they've been revived.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Currently, if you set DNR or disconnect or whatever as an IPC when dead, then get revived, your character remains as a soulless homunculus. This change brings IPCs more in line with how other species work revival-wise without actually changing anything about how they're revived (you don't need to defibrillate or whatever, the ghost just needs to enter the body and they'll pop up.)
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Beat an IPC to death, set up a medibeam on it, then aghosted and possessed the body. Waited a bit and got notified when I was revived, saw that the body stayed dead with some feedback, then entered the body and revived as expected.

Beat another IPC to death, tried to revive it without possessing it or anything, and got feedback for why it wasn't working.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<img width="597" height="82" alt="image" src="https://github.com/user-attachments/assets/b9fb7dee-9339-43af-bdd4-d4e28a028140" />
<img width="552" height="80" alt="image" src="https://github.com/user-attachments/assets/63903376-c9c1-4812-8273-27fc8196ec4d" />

  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: IPCs no longer come to life until their player enters their body; they can still be repaired as normal, though
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
