### PR TITLE
Fix the Captain's saber being invisible and undrawable in the eyes of others.

### DIFF
--- a/code/game/objects/items/weapons/melee/melee.dm
+++ b/code/game/objects/items/weapons/melee/melee.dm
@@ -9,6 +9,7 @@
 	name = "captain's saber"
 	desc = "An elegant weapon, for a more civilized age."
 	icon_state = "saber"
+	inhand_icon_state = "rapier"
 	flags = CONDUCT
 	force = 15
 	throwforce = 10

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -799,6 +799,9 @@
 		icon_state = "[base_icon_state]-sword"
 	else
 		icon_state = base_icon_state
+	if(isliving(loc))
+		var/mob/living/L = loc
+		L.update_inv_belt()
 
 /obj/item/storage/belt/sheath/saber
 	name = "saber sheath"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Restores the function that updated the mob icon when someone draws an item from their saber or puts one in. It also restores the inhand icon state for the Captain's saber, if I have found the correct sprite. I don't know if I have because I have never used this item myself. Someone who knows better than me: please confirm.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Fixes #30733

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<img width="82" height="95" alt="2025-10-22 00_36_24-Paradise Station 13" src="https://github.com/user-attachments/assets/63c7b96a-a5c5-41da-817a-97da15f5ce14" />
<img width="83" height="87" alt="2025-10-22 00_36_29-Paradise Station 13" src="https://github.com/user-attachments/assets/e6f81de2-a285-4ecb-9522-47598c4d121c" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

Compiled, hosted, spawned as captain, spawned in saber sheath, wore and drew from it. Took pictures.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed invisible, undrawable Captain's sword as far as observers are concerned.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
