### PR TITLE
add expandable extra_checks to do_after_once

### DIFF
--- a/code/__HELPERS/mob_helpers.dm
+++ b/code/__HELPERS/mob_helpers.dm
@@ -485,7 +485,7 @@
 
 #define DOAFTERONCE_MAGIC "Magic~~"
 GLOBAL_LIST_EMPTY(do_after_once_tracker)
-/proc/do_after_once(mob/user, delay, needhand = 1, atom/target = null, progress = 1, allow_moving, must_be_held, attempt_cancel_message = "Attempt cancelled.", special_identifier, hidden = FALSE, interaction_key = null)
+/proc/do_after_once(mob/user, delay, needhand = 1, atom/target = null, progress = 1, allow_moving, must_be_held, attempt_cancel_message = "Attempt cancelled.", special_identifier, hidden = FALSE, interaction_key = null, list/extra_checks = list())
 	if(!user || !target)
 		return
 
@@ -494,8 +494,10 @@ GLOBAL_LIST_EMPTY(do_after_once_tracker)
 		GLOB.do_after_once_tracker[cache_key] = DOAFTERONCE_MAGIC
 		to_chat(user, "<span class='warning'>[attempt_cancel_message]</span>")
 		return FALSE
+
+	extra_checks += CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(do_after_once_checks), cache_key, hidden)
 	GLOB.do_after_once_tracker[cache_key] = TRUE
-	. = do_after(user, delay, needhand, target, progress, allow_moving, must_be_held, extra_checks = list(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(do_after_once_checks), cache_key, hidden)), interaction_key = interaction_key)
+	. = do_after(user, delay, needhand, target, progress, allow_moving, must_be_held, extra_checks, interaction_key = interaction_key)
 	GLOB.do_after_once_tracker[cache_key] = FALSE
 
 // Please don't use this unless you absolutely need to. Just have a direct call to do_after_once whenever possible.


### PR DESCRIPTION
## What Does This PR Do
Let's you expand the callback checks in `do_after_once`.
## Why It's Good For The Game
the base `do_after` can do it, why can't the `_once` version do it? It could be handy if you want to interrupt something for a specific reason.
## Images of changes

https://github.com/user-attachments/assets/9d2c3ed4-b458-4d12-a07d-c5c8d2db0ee7

## Testing
Video relevant.
It adds an argument at the tail end. The default `do_after_once` callback checks are appended to the list by default.
Picked up an item, and the callback for `get_active_hand` returned something. The do_after was interrupted. Also tested with the standard `do_after_once` interrupts and it worked fine. Existing `do_after_onces` shouldn't be affected, as this argument is at the tail end.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC