### PR TITLE
Adds the Shaft Miner and Smith overalls to the loadout menu

### DIFF
--- a/code/modules/client/preference/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference/loadout/loadout_uniform.dm
@@ -520,7 +520,7 @@
 	display_name = "Overalls, smith"
 	path = /obj/item/clothing/under/rank/cargo/smith/overalls
 	allowed_roles = list("Quartermaster", "Smith")
-  
+
 /datum/gear/uniform/overalls/job/atmos
 	display_name = "Overalls, atmos"
 	path = /obj/item/clothing/under/rank/engineering/atmospheric_technician/overalls


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Adds the overalls for the Shaft Miner and the Smith to the loadout menu for parity with the other jobs that have them

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

They look good and it may have been an oversight that they weren't added alongside the rest, oops

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

<img width="697" height="451" alt="image" src="https://github.com/user-attachments/assets/46123db5-b04c-4494-ac9e-62bdab006e2a" />

<img width="143" height="158" alt="image" src="https://github.com/user-attachments/assets/61ddf5f4-2b88-40d5-b679-473af7988922" />

## Testing

<!-- How did you test the PR, if at all? -->

Ran debug, overalls were on the loadout menu, started the shift with overalls on.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Smith and Shaft Miner overalls can now be selected from the loadout screen
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
