### PR TITLE
TGUI number input clamps values to match old behavior

### DIFF
--- a/code/modules/tgui/tgui_input/number_input.dm
+++ b/code/modules/tgui/tgui_input/number_input.dm
@@ -153,7 +153,7 @@
 		if("submit")
 			if(!isnum(params["entry"]))
 				CRASH("A non number was input into TGUI Input Number by [usr]")
-			var/choice = clamp(round_value ? params["entry"] : params["entry"], min_value, max_value)
+			var/choice = clamp(round_value ? round(params["entry"]) : params["entry"], min_value, max_value)
 			set_entry(choice)
 			closed = TRUE
 			SStgui.close_uis(src)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes TGUI number input clamp values based on its specified min and max values. The fallback/old behavior did that in the first place.

## Why It's Good For The Game
Non-TGUI input already does that, while TGUI input would just crash on purpose instead. It's like removing guard rails, which is nonsense and it's better to match the old behavior since it's already present.

## Images of changes
<img width="291" height="161" alt="Screenshot 2025-10-23 201835" src="https://github.com/user-attachments/assets/4d3b909d-13c4-49fe-82ce-0d1ce9a3f772" />
<img width="362" height="39" alt="Screenshot 2025-10-23 201935" src="https://github.com/user-attachments/assets/413f96c3-082a-47b4-acd0-e4f186da7f0e" />

## Testing
Fired an instance and inserted materials in a fabricator.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog
:cl:
tweak: TGUI number inputs properly limits submitted numbers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
