### PR TITLE
Reworks Shuttle 667

### DIFF
--- a/_maps/map_files/shuttles/emergency_narnar.dmm
+++ b/_maps/map_files/shuttles/emergency_narnar.dmm
@@ -483,7 +483,6 @@
 /turf/simulated/floor/engine/cult,
 /area/shuttle/escape)
 "GR" = (
-/obj/structure/grille,
 /obj/structure/window/full/reinforced{
 	color = "red"
 	},


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Expands and remaps Shuttle 667 (the Nar'sie cult shuttle).

The bridge has been expanded to include additional consoles, as found on other large shuttles such as the Chrenkov and Clockwork Shuttle.

Adds a fully functional medbay, decorative cult furnishings, cyborg chargers, a mech charger, and an EVA retrieval room.

Adds a fire axe cabinet.

All the furnature and walls are made out of stone, and won't drop runed metal when destroyed.

All the cult altars, forges, and pylons are non-functional, and exist purely for cosmetic purposes.

The Summoning Rune in the middle of the ship is non functional.

There is no electric lighting on this shuttle. Illumination is provided purely by the cosmetic cult structures, the cult constructs, and the pre-lit eternal candles dotted around the ship for ambiance.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
A superior cult shuttle to match what the Ratvar enjoyers get.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<img width="544" height="1088" alt="image" src="https://github.com/user-attachments/assets/74bb9c8c-aad6-4370-86d4-353828ef5334" />
<img width="748" height="1229" alt="image" src="https://github.com/user-attachments/assets/824e2abf-bba5-4273-ab20-ffc31c49a093" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Spawned the shuttle and called it.

Inspected the shuttle, everything was there as it should be.

Flew the shuttle back to CC.

The shuttle made it back. At no point did any part of the shuttle fall off, nor did the shuttle get trapped in hell forever.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Remapped Shuttle 667 (the narsie cult shuttle). It is now larger, more thematic, more poorly lit, and more has a medical bay with proper equipment.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
