### PR TITLE
Adds ragin' mages to the gamemode rotation.

### DIFF
--- a/code/game/gamemodes/wizard/raginmages.dm
+++ b/code/game/gamemodes/wizard/raginmages.dm
@@ -2,6 +2,7 @@
 	name = "ragin' mages"
 	config_tag = "raginmages"
 	but_wait_theres_more = TRUE
+	required_players = 30 //Same as nukies
 	var/max_mages = 0
 	var/making_mage = FALSE
 	var/mages_made = 1
@@ -15,6 +16,10 @@
 /datum/game_mode/wizard/raginmages/announce()
 	to_chat(world, "<B>The current game mode is - Ragin' Mages!</B>")
 	to_chat(world, "<B>The <font color='red'>Space Wizard Federation</font> is pissed, crew must help defeat all the Space Wizards invading the station!</B>")
+
+/datum/game_mode/wizard/raginmages/post_setup()
+	..()
+	addtimer(CALLBACK(src, PROC_REF(announce_wizards)), rand(1 MINUTES, 2 MINUTES))
 
 /datum/game_mode/wizard/raginmages/check_finished()
 	var/wizards_alive = 0
@@ -152,3 +157,11 @@
 		magic.build_inventory(magic.products, magic.product_records)
 
 	have_we_populated_magivends = TRUE
+
+#define RAGIN_ANNOUNCEMENT_MESSAGE "Don't fuck with the Space Wizard Federation! ROLL INITIATIVE!"
+
+/datum/game_mode/wizard/raginmages/proc/announce_wizards()
+	GLOB.major_announcement.Announce(RAGIN_ANNOUNCEMENT_MESSAGE, "Declaration of War", 'sound/items/airhorn.ogg')
+	addtimer(CALLBACK(SSsecurity_level, TYPE_PROC_REF(/datum/controller/subsystem/security_level, set_level), SEC_LEVEL_GAMMA), 30 SECONDS)
+
+#undef RAGIN_ANNOUNCEMENT_MESSAGE

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -253,14 +253,14 @@ gamemode_probabilities = [
 	{ gamemode = "extend-a-traitormongous", probability = 0 }, # Autotraitor
 	{ gamemode = "extended", probability = 0 },
 	{ gamemode = "nuclear", probability = 2 },
-	{ gamemode = "raginmages", probability = 0 },
+	{ gamemode = "raginmages", probability = 1 },
 	{ gamemode = "revolution", probability = 0 },
 	{ gamemode = "traitor", probability = 0 },
 	{ gamemode = "traitorchan", probability = 0 },
 	{ gamemode = "traitorvamp", probability = 0 },
 	{ gamemode = "vampchan", probability = 0 },
 	{ gamemode = "vampire", probability = 0 },
-	{ gamemode = "wizard", probability = 2 },
+	{ gamemode = "wizard", probability = 1 },
 	{ gamemode = "trifecta", probability = 0 },
 	{ gamemode = "dynamic", probability = 22 },
 ]


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Adds ragin' mages back into the rotation, with a weight of 1. Reduces normal wizard's weight from 2 to 1 to compensate. Adds an automatic war-dec type announcement to let crew know what's coming.
## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Wizard is notorious for being a mode that just lets one player go crazy, adding ragin' mages back into rotation at higher populations gives more players the opportunity to roll wizard. It doesn't feel as horrible to get gibbed when you know you have the chance to gib other people afterwards.

I'm keeping normal wizard as a possibility due to the two gamemodes having their own pros and cons. Notably that many spells/summons are disabled on ragin, and it would be a shame to completely remove those options since they do offer a more unique wizard round.
## Testing

<!-- How did you test the PR, if at all? -->
Forced ragin, waited until there was an announcement and a gamma alert.
## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<img width="496" height="110" alt="image" src="https://github.com/user-attachments/assets/cc08f769-b420-4dc8-9df9-64e34d6f9899" />
<img width="470" height="143" alt="image" src="https://github.com/user-attachments/assets/101154ab-c8f9-43aa-a2cb-fb283f1f480d" />

  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Ragin mages back into the gamemode rotation
tweak: The SWF now announces themselves to the crew on ragin mages rounds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
