### PR TITLE
Adds Artistic Toolboxes to the Toolbox Spawner

### DIFF
--- a/code/game/objects/effects/spawners/random/engineering_spawners.dm
+++ b/code/game/objects/effects/spawners/random/engineering_spawners.dm
@@ -61,5 +61,6 @@
 	loot = list(
 		/obj/item/storage/toolbox/mechanical,
 		/obj/item/storage/toolbox/electrical,
-		/obj/item/storage/toolbox/emergency
+		/obj/item/storage/toolbox/emergency,
+		/obj/item/storage/toolbox/artistic,
 	)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Toolbox spawners have a chance to spawn artistic toolboxes (**this is not His Grace**).

Artistic toolboxes are bigger than normal toolboxes and are pre-loaded with cable coils, crayons, and a crowbar.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
A bit more variance in maint loot. The toolbox currently can only be found in a single cargo crate with nothing else of note inside.

It also gives a tiny amount of plausable deniability to anyone that happens to be holding the actual His Grace (we also play around with doing that with the wind-up toolbox).
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Placed down a ton of toolbox spawners.
Some of them spawned artistic toolboxes.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Toolbox spawners can spawn Artistic Toolboxes (NOT HIS GRACE!).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
