### PR TITLE
allow for undershirts to be ckey-enabled

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -17,7 +17,7 @@
 	//underwear
 	init_sprite_accessory_subtypes(/datum/sprite_accessory/underwear, GLOB.underwear_list, GLOB.underwear_m, GLOB.underwear_f)
 	//undershirt
-	init_sprite_accessory_subtypes(/datum/sprite_accessory/undershirt, GLOB.undershirt_list, GLOB.undershirt_m, GLOB.undershirt_f)
+	init_sprite_accessory_subtypes(/datum/sprite_accessory/undershirt, GLOB.undershirt_list, GLOB.undershirt_m, GLOB.undershirt_f, GLOB.undershirt_full_list)
 	//socks
 	init_sprite_accessory_subtypes(/datum/sprite_accessory/socks, GLOB.socks_list, GLOB.socks_m, GLOB.socks_f)
 	//alt heads

--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -20,6 +20,7 @@ GLOBAL_LIST_EMPTY(underwear_f)	//stores only underwear name
 GLOBAL_LIST_EMPTY(undershirt_list) 	//stores /datum/sprite_accessory/undershirt indexed by name
 GLOBAL_LIST_EMPTY(undershirt_m)	 //stores only undershirt name
 GLOBAL_LIST_EMPTY(undershirt_f)	 //stores only undershirt name
+GLOBAL_LIST_EMPTY(undershirt_full_list)
 	//Socks
 GLOBAL_LIST_EMPTY(socks_list)		//stores /datum/sprite_accessory/socks indexed by name
 GLOBAL_LIST_EMPTY(socks_m)	 //stores only socks name

--- a/code/controllers/configuration/sections/custom_sprites_configuration.dm
+++ b/code/controllers/configuration/sections/custom_sprites_configuration.dm
@@ -10,6 +10,8 @@
 	var/list/pai_holoform_ckeys = list()
 	/// Assoc of ckeys that have custom pAI screens. Key: ckey | value: list of icon states
 	var/list/ipc_screen_map = list()
+	/// A list of ckeys to available undershirt fluff accessories
+	var/list/fluff_undershirts = list()
 
 /datum/configuration_section/custom_sprites_configuration/load_data(list/data)
 	// Use the load wrappers here. That way the default isnt made 'null' if you comment out the config line
@@ -17,6 +19,7 @@
 	CONFIG_LOAD_LIST(ai_core_ckeys, data["ai_core"])
 	CONFIG_LOAD_LIST(ai_hologram_ckeys, data["ai_hologram"])
 	CONFIG_LOAD_LIST(pai_holoform_ckeys, data["pai_holoform"])
+	CONFIG_LOAD_LIST(fluff_undershirts, data["fluff_undershirts"])
 
 	// Load the ipc screens
 	if(islist(data["ipc_screens"]))

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -377,7 +377,7 @@ GLOBAL_VAR_INIT(record_id_num, 1001)
 			underwear_standing.Blend(new /icon(u_icon, "uw_[U.icon_state]_s"), ICON_OVERLAY)
 
 	if(H.undershirt && H.dna.species.clothing_flags & HAS_UNDERSHIRT)
-		var/datum/sprite_accessory/undershirt/U2 = GLOB.undershirt_list[H.undershirt]
+		var/datum/sprite_accessory/undershirt/U2 = GLOB.undershirt_full_list[H.undershirt]
 		if(U2)
 			var/u2_icon = U2.sprite_sheets && (H.dna.species.sprite_sheet_name in U2.sprite_sheets) ? U2.sprite_sheets[H.dna.species.sprite_sheet_name] : U2.icon
 			underwear_standing.Blend(new /icon(u2_icon, "us_[U2.icon_state]_s"), ICON_OVERLAY)

--- a/code/game/objects/structures/dresser.dm
+++ b/code/game/objects/structures/dresser.dm
@@ -35,6 +35,10 @@
 					if(!(H.dna.species.name in S.species_allowed))
 						continue
 					valid_undershirts[undershirt] = GLOB.undershirt_list[undershirt]
+				for(var/config in GLOB.configuration.custom_sprites.fluff_undershirts)
+					if(user.ckey in config["ckeys"])
+						valid_undershirts[config["name"]] = GLOB.undershirt_full_list[config["name"]]
+				sortTim(valid_undershirts, GLOBAL_PROC_REF(cmp_text_asc))
 				var/new_undershirt = tgui_input_list(user, "Choose your undershirt:", "Changing", valid_undershirts)
 				if(new_undershirt)
 					H.undershirt = new_undershirt

--- a/code/modules/client/preference/character.dm
+++ b/code/modules/client/preference/character.dm
@@ -1017,7 +1017,7 @@
 
 	var/icon/undershirt_s = null
 	if(undershirt && (current_species.clothing_flags & HAS_UNDERSHIRT))
-		var/datum/sprite_accessory/undershirt/U2 = GLOB.undershirt_list[undershirt]
+		var/datum/sprite_accessory/undershirt/U2 = GLOB.undershirt_full_list[undershirt]
 		if(U2)
 			var/u2_icon = U2.sprite_sheets && (current_species.sprite_sheet_name in U2.sprite_sheets) ? U2.sprite_sheets[current_species.sprite_sheet_name] : U2.icon
 			undershirt_s = new/icon(u2_icon, "us_[U2.icon_state]_s", ICON_OVERLAY)

--- a/code/modules/client/preference/link_processing.dm
+++ b/code/modules/client/preference/link_processing.dm
@@ -613,6 +613,9 @@
 						if(active_character.body_type == FEMALE && SA.body_type == MALE)
 							continue
 						valid_undershirts[undershirt] = GLOB.undershirt_list[undershirt]
+					for(var/config in GLOB.configuration.custom_sprites.fluff_undershirts)
+						if(user.ckey in config["ckeys"])
+							valid_undershirts[config["name"]] = GLOB.undershirt_full_list[config["name"]]
 					sortTim(valid_undershirts, GLOBAL_PROC_REF(cmp_text_asc))
 					var/new_undershirt = tgui_input_list(user, "Choose your character's undershirt", "Character Preference", valid_undershirts)
 					ShowChoices(user)

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -257,7 +257,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 			underwear_standing.Blend(new /icon(u_icon, "uw_[U.icon_state]_s"), ICON_OVERLAY)
 
 	if(undershirt && dna.species.clothing_flags & HAS_UNDERSHIRT)
-		var/datum/sprite_accessory/undershirt/U2 = GLOB.undershirt_list[undershirt]
+		var/datum/sprite_accessory/undershirt/U2 = GLOB.undershirt_full_list[undershirt]
 		if(U2)
 			var/u2_icon = U2.sprite_sheets && (dna.species.sprite_sheet_name in U2.sprite_sheets) ? U2.sprite_sheets[dna.species.sprite_sheet_name] : U2.icon
 			underwear_standing.Blend(new /icon(u2_icon, "us_[U2.icon_state]_s"), ICON_OVERLAY)

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -163,6 +163,13 @@ ipc_screens = [
     "Icon State 2",
   ]},
 ]
+fluff_undershirts = [
+	{ name = "Shirt Name Here", ckeys = [
+		"ckeyhere1",
+		"ckeyhere2",
+	] },
+]
+
 
 ################################################################
 


### PR DESCRIPTION
## What Does This PR Do
This PR creates a configuration option for enabling specific undershirts by ckey. I went with the shirt -> list of ckeys structure versus the existing config item structures for fluff items to avoid constantly having to repeat the accessory name. In prod it will end up looking like:
```toml
fluff_undershirts = [
	{ name = "Great Synthwave Shirt", ckeys = [
		"ckeyname1",
		"ckeyname2",
		"ckeyname3",
	] },
]
```
## Why It's Good For The Game
PBTF 24's contributor reward was an undershirt, but undershirts aren't items, they're sprite accessories which are configured as part of player DNA appearance, meaning they cannot be enabled by adding to a player's gear loadout. Rather than deal with the nightmare of trying to move the shirt to the jumpsuit layer, I just made it so we can add participant ckeys to the config file.
## Images of changes
<img width="732" height="583" alt="2025_10_26__13_24_03__" src="https://github.com/user-attachments/assets/93c0a4b9-794d-4e63-8350-37f4d4a981d5" />

## Testing
Added my ckey to the config, ensured I could select the shirt from charprefs and a dresser drawer. Removed my ckey from the config and restarted, ensured I couldn't select the shirt.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC