### PR TITLE
Adds Windows to the Mining and Cargo Dock External Airlocks + Lock Helpers, Monitors, and Walls.

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -26064,7 +26064,7 @@
 /turf/simulated/floor/wood,
 /area/station/command/office/blueshield)
 "bTq" = (
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -32626,12 +32626,12 @@
 /area/station/medical/patients_rooms_secondary)
 "cuD" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/external{
-	id_tag = "supply_home";
-	locked = 1;
-	name = "Cargo Docking Hatch"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/supply_shuttle,
+/obj/machinery/door/airlock/external/glass{
+	name = "Cargo Docking Hatch";
+	id_tag = "supply_home"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/supply/storage)
 "cuE" = (
@@ -45298,6 +45298,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
+"dGp" = (
+/obj/machinery/status_display/supply_display,
+/turf/simulated/wall,
+/area/station/supply/storage)
 "dGO" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
@@ -57236,12 +57240,12 @@
 /area/station/command/bridge)
 "jvE" = (
 /obj/structure/fans/tiny,
-/obj/machinery/door/airlock/external{
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/machinery/door/airlock/external/glass{
 	id_tag = "mining_home";
-	locked = 1;
 	name = "Mining Dock Airlock"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/supply/miningdock)
 "jvM" = (
@@ -63751,12 +63755,12 @@
 /turf/simulated/floor/wood,
 /area/station/command/office/hop)
 "mDy" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "supply_home";
-	locked = 1;
-	name = "Cargo Docking Hatch"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/supply_shuttle,
+/obj/machinery/door/airlock/external/glass{
+	name = "Cargo Docking Hatch";
+	id_tag = "supply_home"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/supply/storage)
 "mDF" = (
@@ -66025,6 +66029,10 @@
 "nOo" = (
 /turf/simulated/floor/plasteel,
 /area/station/science/hallway)
+"nOv" = (
+/obj/structure/sign/vacuum/external,
+/turf/simulated/wall,
+/area/station/supply/storage)
 "nOx" = (
 /obj/structure/grille,
 /obj/structure/barricade/wooden,
@@ -86582,7 +86590,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_port)
 "xSH" = (
-/obj/machinery/light/small,
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/station/supply/storage)
 "xSM" = (
@@ -105185,7 +105193,7 @@ aaa
 wNM
 bRI
 mDy
-wNM
+nOv
 mDy
 bUg
 wNM
@@ -105442,7 +105450,7 @@ aaa
 hMm
 bRK
 xSH
-bxb
+dGp
 bTq
 bYw
 hMm
@@ -105699,7 +105707,7 @@ hMm
 hMm
 bRI
 cuD
-hMm
+bxb
 cuD
 bUg
 hMm
@@ -108536,11 +108544,11 @@ fPF
 yfi
 aaa
 aaa
-wPp
+cam
 wPp
 jvE
 wPp
-wPp
+cam
 aaa
 aab
 gzN

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -1656,7 +1656,7 @@
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/pod_4)
 "alC" = (
-/obj/machinery/light/small,
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/station/supply/storage)
 "alD" = (
@@ -1905,7 +1905,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/permabrig)
 "aoo" = (
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -88385,6 +88385,10 @@
 	},
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/command/starboard)
+"smW" = (
+/obj/structure/sign/vacuum/external,
+/turf/simulated/wall,
+/area/station/supply/storage)
 "smX" = (
 /obj/structure/chair/stool/bar{
 	dir = 4
@@ -111081,6 +111085,10 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/service/aft_starboard)
+"xgw" = (
+/obj/machinery/status_display/supply_display,
+/turf/simulated/wall,
+/area/station/supply/storage)
 "xgA" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -167364,7 +167372,7 @@ rNK
 qhA
 dwI
 mSv
-qhA
+smW
 mSv
 vKh
 qhA
@@ -167621,7 +167629,7 @@ rNK
 jkL
 cag
 alC
-nLP
+xgw
 aoo
 lUt
 jkL
@@ -167878,7 +167886,7 @@ jkL
 jkL
 dwI
 qYk
-jkL
+nLP
 qYk
 vKh
 jkL

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -61830,13 +61830,13 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/equipmentstorage)
 "jsk" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "supply_home";
-	locked = 1;
-	name = "Cargo Docking Hatch"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/supply/supply_shuttle,
+/obj/machinery/door/airlock/external/glass{
+	name = "Cargo Docking Hatch";
+	id_tag = "supply_home"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/supply/storage)
 "jtb" = (
@@ -67097,10 +67097,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
-"lLU" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/turf/simulated/floor/plating,
-/area/station/supply/qm)
 "lLV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -143725,7 +143721,7 @@ mKm
 mKm
 aGP
 jsk
-mKm
+ayD
 jsk
 aIk
 mKm
@@ -143997,11 +143993,11 @@ aSb
 aSb
 aSb
 aSb
-lLU
+aSb
 vuu
 tsL
 vuu
-vuu
+bbe
 bbe
 eNt
 eNt
@@ -144239,7 +144235,7 @@ aaa
 mKm
 aGP
 jsk
-mKm
+ayD
 jsk
 aIk
 mKm

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -5311,7 +5311,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dorms/starboard)
 "bff" = (
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -28017,12 +28017,12 @@
 /area/station/security/prison/cell_block)
 "fFb" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/external{
-	id_tag = "supply_home";
-	locked = 1;
-	name = "Cargo Docking Hatch"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/supply_shuttle,
+/obj/machinery/door/airlock/external/glass{
+	name = "Cargo Docking Hatch";
+	id_tag = "supply_home"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/supply/storage)
 "fFi" = (
@@ -40739,13 +40739,13 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "ijM" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "mining_home";
-	locked = 1;
-	name = "Mining Dock Airlock"
-	},
 /obj/structure/fans/tiny,
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "mining_home";
+	name = "Mining Dock Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/supply/miningdock)
 "ijS" = (
@@ -62580,12 +62580,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/science/storage)
 "mLi" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "supply_home";
-	locked = 1;
-	name = "Cargo Docking Hatch"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/supply_shuttle,
+/obj/machinery/door/airlock/external/glass{
+	name = "Cargo Docking Hatch";
+	id_tag = "supply_home"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/supply/storage)
 "mLj" = (
@@ -68806,6 +68806,10 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/hallway/primary/central/west)
+"nUk" = (
+/obj/machinery/status_display/supply_display,
+/turf/simulated/wall,
+/area/station/supply/storage)
 "nUr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/turf_decal/tiles/department/virology,
@@ -90273,9 +90277,7 @@
 /area/station/maintenance/solar_maintenance/fore_starboard)
 "sgs" = (
 /obj/structure/sign/vacuum/external,
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/effect/spawner/random/blood/maybe,
-/turf/simulated/floor/plating,
+/turf/simulated/wall,
 /area/station/supply/storage)
 "sgG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -117935,7 +117937,7 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/security/fore)
 "xLI" = (
-/obj/machinery/light/small,
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/station/supply/storage)
 "xLK" = (
@@ -136469,7 +136471,7 @@ jnP
 lQZ
 her
 xLI
-mQe
+nUk
 bff
 fQE
 lQZ
@@ -136726,7 +136728,7 @@ lQZ
 lQZ
 afC
 fFb
-lQZ
+mQe
 fFb
 wom
 lQZ

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -40462,12 +40462,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "gRp" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "supply_home";
-	locked = 1;
-	name = "Cargo Docking Hatch"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/supply_shuttle,
+/obj/machinery/door/airlock/external/glass{
+	name = "Cargo Docking Hatch";
+	id_tag = "supply_home"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/supply/storage)
 "gRq" = (
@@ -41920,14 +41920,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/theatre)
 "huj" = (
-/obj/structure/lattice,
-/obj/machinery/door/airlock/external{
-	id_tag = "mining_home";
-	locked = 1;
-	name = "Mining Dock Airlock"
-	},
 /obj/structure/fans/tiny,
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "mining_home";
+	name = "Mining Dock Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plasteel/dark,
 /area/station/supply/miningdock)
 "hun" = (
@@ -46372,9 +46371,6 @@
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/turf_decal/tiles/department/cargo/side{
 	dir = 1
 	},
@@ -46455,7 +46451,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
 "jad" = (
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -67762,6 +67758,10 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
+"qHd" = (
+/obj/machinery/status_display/supply_display,
+/turf/simulated/wall,
+/area/station/supply/storage)
 "qHe" = (
 /obj/item/shard,
 /obj/item/shard,
@@ -69842,12 +69842,12 @@
 /area/station/command/office/captain/bedroom)
 "rul" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/external{
-	id_tag = "supply_home";
-	locked = 1;
-	name = "Cargo Docking Hatch"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/supply_shuttle,
+/obj/machinery/door/airlock/external/glass{
+	name = "Cargo Docking Hatch";
+	id_tag = "supply_home"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/supply/storage)
 "ruo" = (
@@ -76499,7 +76499,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
 "tUP" = (
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -104622,7 +104622,7 @@ aaa
 aaa
 aaa
 aZt
-aZt
+qHd
 aZt
 iYr
 lpq


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The mining dock and cargo dock external airlocks are all their glass variants so they can be seen through.

All cargo bays now have a cargo shuttle display at the cargo airlock.

All cargo bay airlocks now use light tubes to ensure the area is well-lit.

Replaces a few windows with walls.

Removes a lattice on top of plating under the mining dock airlock of Meta that somehow escaped the linters.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Door windows give a better view into space, I want to see space. There's windows on either side of the door so a black line of non-visibility is annoying.

Cargo display gives better info about cargo doicking time.

Oddly placed windows are now walls, looks better.

Mappers should see at a glance that doors are pre-locked without needing to see the var edits on the doors.

Hidden lattice over plating is bad.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Box:
<img width="160" height="160" alt="image" src="https://github.com/user-attachments/assets/c811c1ae-4ad7-4dc3-8d9c-bb240d7c1f7f" />
<img width="96" height="224" alt="image" src="https://github.com/user-attachments/assets/42378667-c34d-4f59-ab7b-13cca38c418c" />
Delta:
<img width="160" height="160" alt="image" src="https://github.com/user-attachments/assets/259d31c3-0dad-405a-a904-86ef7d4558fe" />
<img width="96" height="160" alt="image" src="https://github.com/user-attachments/assets/8bda27a0-4900-4d85-8c39-2b593bcebe03" />
Emerald:
<img width="160" height="160" alt="image" src="https://github.com/user-attachments/assets/abc24e06-5506-414d-ada6-375389fe9243" />
<img width="96" height="96" alt="image" src="https://github.com/user-attachments/assets/af961b14-a8c8-4f12-9b04-4ec30077539a" />
Meta:
<img width="160" height="160" alt="image" src="https://github.com/user-attachments/assets/0745d119-b538-4eb5-ab52-14a29199e1e0" />
<img width="96" height="96" alt="image" src="https://github.com/user-attachments/assets/858792a8-d0ec-473b-a1da-0b3bcab372dd" />
Cere:
<img width="160" height="160" alt="image" src="https://github.com/user-attachments/assets/8dde1839-76b1-4de0-925d-916553488203" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Visual inspection.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: The cargo and mining docks of all stations have windowed airlocks.
tweak: The cargo docks of all stations have a cargo display and light tubes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
