### PR TITLE
Slightly Remaps the Mining Shuttle

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
@@ -1341,6 +1341,7 @@
 /area/mine/outpost/hallway/west)
 "io" = (
 /obj/effect/baseturf_helper/lava_land,
+/obj/machinery/light/floor,
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/mining)
 "iq" = (
@@ -6572,7 +6573,10 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/item/radio/intercom{
+	name = "south bump";
+	pixel_y = -28
+	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/mining)
 "Mr" = (
@@ -6785,10 +6789,6 @@
 	c_tag = "Mining Outpost - Shuttle";
 	network = list("Mining Outpost");
 	dir = 1
-	},
-/obj/item/radio/intercom{
-	name = "south bump";
-	pixel_y = -28
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/mining)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Installs glass in the mining shuttle's airlock.

Installs a window on the other side of the airlock.

Moves the camera and intercom to the top of the cockpit so they're not sitting on windows.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
A much better view of space when in-flight, and a good view of lavaland when docked thanks to having 1x3 viewing ports on both sides of the shuttle.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<img width="160" height="224" alt="image" src="https://github.com/user-attachments/assets/161c5fb8-4559-4647-8bc1-14b0f2e51c4d" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Visual inspection.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: The mining shuttle now has glass in its airlock and a full 1x3 window on the other side.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
