### PR TITLE
Tweaks beams doing whatever they want until redrawn

### DIFF
--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -43,7 +43,8 @@
 	max_distance = INFINITY,
 	beam_type = /obj/effect/ebeam,
 	beam_color,
-	use_get_turf = FALSE
+	use_get_turf = FALSE,
+	clip_distance
 )
 	src.origin = origin
 	src.target = target
@@ -53,6 +54,7 @@
 	src.beam_type = beam_type
 	src.beam_color = beam_color
 	src.use_get_turf = use_get_turf
+	src.clip_distance = clip_distance
 	if(time < INFINITY)
 		QDEL_IN(src, time)
 
@@ -138,7 +140,7 @@
 	if(distance / 32 > max_distance)
 		qdel(src)
 		return
-		
+
 	var/length = min(distance, clip_distance * 32)
 
 	for(N in 0 to length-1 step 32) // -1 as we want < not <=, but we want the speed of X in Y to Z and step X

--- a/code/modules/projectiles/guns/medbeam.dm
+++ b/code/modules/projectiles/guns/medbeam.dm
@@ -53,7 +53,7 @@
 
 	current_target = target
 	active = TRUE
-	var/datum/beam/current_beam = user.Beam(current_target, "medbeam", time = 10 MINUTES, beam_type = /obj/effect/ebeam/medical)
+	var/datum/beam/current_beam = user.Beam(current_target, "medbeam", time = 10 MINUTES, beam_type = /obj/effect/ebeam/medical, maxdistance = max_range)
 	beam_UID = current_beam.UID()
 
 	SSblackbox.record_feedback("tally", "gun_fired", 1, type)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Qdels beams that go too far on initial draw instead of checking it on the redraw which can occur up to 2s later
Adds a new argument, clip_distance; beams that have a target past the clip_distance will truncate the beam instead of outright qdeling it, useful for temporary effects that dont care about the mechanical 'touching' of the beam with the target
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
spooking people by firing beams at them through cameras is immersion breaking, firing short range beam effects is cool and useful
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
medbeam with tweaked clip_distance
<img width="537" height="333" alt="image" src="https://github.com/user-attachments/assets/99f1df48-4a37-4c18-9481-3d7bca784ca4" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
shot a beam gun far away, it didnt shoot, tweaked the clip distance to be less than the max distance, it clipped off the beam but didnt qdel it, good
<!-- How did you test the PR, if at all? -->

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Clips beam drawing and checks for max distance on draw
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
