### PR TITLE
Staff of storms works on basic mobs, buff for new movement / storms

### DIFF
--- a/code/modules/mining/lavaland/loot/legion_loot.dm
+++ b/code/modules/mining/lavaland/loot/legion_loot.dm
@@ -116,16 +116,13 @@
 		to_chat(user, "<span class='warning'>You don't want to hurt anyone!</span>")
 		return
 	var/power_boosted = FALSE
-	for(var/V in SSweather.processing)
-		var/datum/weather/W = V
-		if((target_turf.z in W.impacted_z_levels) && is_type_in_list(target_area, W.area_types))
-			power_boosted = TRUE
-			break
+	if(iswizard(user) || is_mining_level(user.z) || istype(get_area(user), /area/ruin/space/bubblegum_arena))
+		power_boosted = TRUE
 	playsound(src, 'sound/magic/lightningshock.ogg', 10, TRUE, extrarange = SILENCED_SOUND_EXTRARANGE, falloff_distance = 0)
 	targeted_turfs += target_turf
 	to_chat(user, "<span class='warning'>You aim at [target_turf]!</span>")
 	new /obj/effect/temp_visual/thunderbolt_targeting(target_turf)
-	addtimer(CALLBACK(src, PROC_REF(throw_thunderbolt), target_turf, power_boosted, user), 1.5 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(throw_thunderbolt), target_turf, power_boosted, user), 1 SECONDS)
 	thunder_charges--
 	addtimer(CALLBACK(src, PROC_REF(recharge)), thunder_charge_time)
 
@@ -147,7 +144,7 @@
 		new /obj/effect/temp_visual/electricity(T)
 		for(var/mob/living/hit_mob in T)
 			to_chat(hit_mob, "<span class='userdanger'>You've been struck by lightning!</span>")
-			hit_mob.electrocute_act(15 * (isanimal(hit_mob) ? 3 : 1) * (T == target ? 2 : 1) * (boosted ? 2 : 1), src, flags = SHOCK_TESLA|SHOCK_NOSTUN)
+			hit_mob.electrocute_act(15 * (isanimal_or_basicmob(hit_mob) ? 3 : 1) * (T == target ? 2 : 1) * (boosted ? 2 : 1), src, flags = SHOCK_TESLA|SHOCK_NOSTUN)
 			if(ishostile(hit_mob))
 				var/mob/living/simple_animal/hostile/H = hit_mob //mobs find and damage you...
 				if(H.stat == CONSCIOUS && !H.target && H.AIStatus != AI_OFF && !H.client)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Staff of storms gets it's 3x damage on basic mobs.
It strikes in 1 seconds instead of 1.5, to help make aiming on the faster basic mobs easier.
It is now always boosted on lavaland, or when a wizard has it, instead of only during storms, as new storms are not exactly viable to fight in most of the time.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It''s a late game drop that could use some love. Think of it as a much better resonator.
Direct hits to fauna on lavaland will deal 270 damage. Indirect hits will be closer to 120. Damage to humans or cyborgs will be less. Station effectivness will remain the same, and barely hurt humans.
Like all lavaland staffs, gets boosted to full when a wizard uses it now.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Cast lighting on watchers / goliaths / legions

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Staff of storms gets the damage multipliers on basic mobs.
tweak: Staff of storms is now always boosted on lavaland, or when a wizard has it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
