### PR TITLE
bump spacemandmm to 1.11 and avulto to 0.1.22

### DIFF
--- a/_build_dependencies.sh
+++ b/_build_dependencies.sh
@@ -1,6 +1,6 @@
 # This file has all the information on what versions of libraries are thrown into the code
 # For dreamchecker
-export SPACEMANDMM_TAG=suite-1.10
+export SPACEMANDMM_TAG=suite-1.11
 # For TGUI
 export NODE_VERSION=20
 # Stable Byond Major

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -8,4 +8,4 @@ PyYaml==6.0.2 # maplint also
 beautifulsoup4==4.13.4
 
 # various CI checks
-avulto==0.1.17
+avulto==0.1.22


### PR DESCRIPTION
## What Does This PR Do
Bumps spacemandmm to 1.11
Bumps avulto to 0.1.22
## Why It's Good For The Game
The future is now. Plus new syntax and stuff!
## Testing
It compiled. SpacemanDMM didnt complain about new syntax, avulto got updated and showed up as 0.1.22.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC