### PR TITLE
Buff Atmos Firesuit

### DIFF
--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -51,6 +51,8 @@
 	desc = "An expensive firesuit that protects against even the most deadly of station fires. Designed to protect even if the wearer is set aflame."
 	icon_state = "firefighter_atmos"
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
+	w_class = WEIGHT_CLASS_NORMAL
+	slowdown = 0.75
 
 /*
  * Bomb protection


### PR DESCRIPTION
## What Does This PR Do
Shrinks the atmos firesuit from a bulky to a normal item and reduces its slowdown to be equial to normal MOD suits.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
## Why It's Good For The Game
The atmos firesuit never gets used because the MOD is almost strictly superior to it. Being able to keep it in your backpack changes that at least a little bit. The slowdown should keep atmos techs from being a bit silly and walking around in it constantly, but isn't as cripling any more.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
## Testing
Spawned both types of firesuits and tested their sizes and slowdown.
<!-- How did you test the PR, if at all? -->

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<img width="1361" height="124" alt="image" src="https://github.com/user-attachments/assets/d64df37a-f24c-42dd-8f9b-600be2cc2b95" />

  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Reduced size and slowdown of the atmos firesuit (not the emergency one found across the station).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
