### PR TITLE
Fixes the dumbest of dumb SQL issues

### DIFF
--- a/code/modules/client/preference/character.dm
+++ b/code/modules/client/preference/character.dm
@@ -141,20 +141,20 @@
 
 	// ALL OF THIS SHIT BECAUSE h_style CAN BE A STRING OR A DATUM
 	var/h_style_str = "Bald"
-	if (istype(h_style, /datum/sprite_accessory/hair))
+	if(istype(h_style, /datum/sprite_accessory/hair))
 		var/datum/sprite_accessory/hair/H = h_style
 		h_style_str = H.name
 
-	if (istext(h_style))
+	if(istext(h_style))
 		h_style_str = h_style
 
 	// Same with f_style
 	var/f_style_str = "Bald"
-	if (istype(f_style, /datum/sprite_accessory/facial_hair))
+	if(istype(f_style, /datum/sprite_accessory/facial_hair))
 		var/datum/sprite_accessory/facial_hair/F = f_style
 		f_style_str = F.name
 
-	if (istext(f_style))
+	if(istext(f_style))
 		f_style_str = f_style
 
 	while(firstquery.NextRow())


### PR DESCRIPTION
This PR made me crack open the bottle of au ultra premium 5 times distilled blue raspberry. I am fucking ***done***.

## What Does This PR Do
Fixes saving hairstyles after character randomisation that was bought to light by the rustlibs SQL PR. That PR did not introduce the "issue" per say, it bought it to light because old FFI calling made passing a datum to an FFI call just do `"[D:name]"` for the value. This worked for hair stuff but is an absolutely ABYSMAL scenario. WE NEED STRONG TYPING.

## Why It's Good For The Game
Errors bad

## Images of changes
NPFC

## Testing
Tried saving an IPC after swapping the head (failure mode to repro this), now saves.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
fix: Fixed a bug where characters wouldnt save in weird circumstances
/:cl:
