### PR TITLE
[TM Only] Temporarily removes disky

### DIFF
--- a/code/modules/mob/living/living_update_status.dm
+++ b/code/modules/mob/living/living_update_status.dm
@@ -1,11 +1,11 @@
 /mob/living/update_blind_effects(sleeping = FALSE, force_clear_sleeping = FALSE)
 	if(force_clear_sleeping) //We force it on waking up, as if you are blind from other methods it will refuse to clear it.
 		clear_fullscreen("sleepblind")
-		clear_fullscreen("disky")
+//		clear_fullscreen("disky")
 	if(!has_vision(information_only=TRUE))
 		if(sleeping)
 			overlay_fullscreen("sleepblind", /atom/movable/screen/fullscreen/center/blind/sleeping, animated = 2 SECONDS)
-			overlay_fullscreen("disky", /atom/movable/screen/fullscreen/center/blind/disky, animated = 7 SECONDS)
+//			overlay_fullscreen("disky", /atom/movable/screen/fullscreen/center/blind/disky, animated = 7 SECONDS)
 			throw_alert("blind", /atom/movable/screen/alert/blind)
 			return TRUE
 		overlay_fullscreen("blind", /atom/movable/screen/fullscreen/stretch/blind)
@@ -14,7 +14,7 @@
 	else
 		clear_fullscreen("blind")
 		clear_fullscreen("sleepblind")
-		clear_fullscreen("disky")
+//		clear_fullscreen("disky")
 		clear_alert("blind")
 		return FALSE
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Temporarily removes disky to see if it's the cause of the crashes
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Testing
went into cryotube, did not see disky
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
