### PR TITLE
Tweaks mob mech damage, makes basic mobs handle mechs consistently.

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -624,22 +624,21 @@
 	if(!attacker.melee_damage_upper && !attacker.obj_damage)
 		attacker.custom_emote(EMOTE_VISIBLE, "[attacker.friendly_verb_continuous] [src].")
 		return FALSE
-	else
-		var/play_soundeffect = TRUE
-		var/animal_damage = rand(attacker.melee_damage_lower, attacker.melee_damage_upper)
-		if(attacker.obj_damage)
-			animal_damage = min(animal_damage * 2, attacker.obj_damage * 2)
-		animal_damage = max(animal_damage, min(10 * attacker.environment_smash, 40))
-		if(animal_damage)
-			add_attack_logs(attacker, OCCUPANT_LOGGING, "Basic mob attacked mech [src]")
-		if(attacker.environment_smash)
-			play_soundeffect = FALSE
-			playsound(src, 'sound/effects/bang.ogg', 50, TRUE)
-		attack_generic(attacker, animal_damage, attacker.melee_damage_type, MELEE, play_soundeffect)
-		if(!attacker.client)
-			var/melee_attack_cooldown = rand(attacker.melee_attack_cooldown_min, attacker.melee_attack_cooldown_max)
-			attacker.changeNext_move(melee_attack_cooldown)
-		return TRUE
+	var/play_soundeffect = TRUE
+	var/animal_damage = rand(attacker.melee_damage_lower, attacker.melee_damage_upper)
+	if(attacker.obj_damage)
+		animal_damage = min(animal_damage * 2, attacker.obj_damage * 2)
+	animal_damage = max(animal_damage, min(10 * attacker.environment_smash, 40))
+	if(animal_damage)
+		add_attack_logs(attacker, OCCUPANT_LOGGING, "Basic mob attacked mech [src]")
+	if(attacker.environment_smash)
+		play_soundeffect = FALSE
+		playsound(src, 'sound/effects/bang.ogg', 50, TRUE)
+	attack_generic(attacker, animal_damage, attacker.melee_damage_type, MELEE, play_soundeffect)
+	if(!attacker.client)
+		var/melee_attack_cooldown = rand(attacker.melee_attack_cooldown_min, attacker.melee_attack_cooldown_max)
+		attacker.changeNext_move(melee_attack_cooldown)
+	return TRUE
 
 /obj/mecha/hulk_damage()
 	return 15


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Does the following:
- Mech damage from mobs is adjusted to prevent mobs from doing wildly more damage than appropriate.
- Basic mob attacks now have a dedicated handler on mechs
- Basic mobs now attack mechs at the same rate they attack mobs.

## Why It's Good For The Game

Mobs should be consistent - a blob spore that deals all of 4 damage shouldn't deal 20 to a mech. Likewise, basic mobs should behave consistently instead of having a faster attack speed against mechs.

## Testing

Hopped in a durand. Let a hellhound bash it up.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Made mob mech damage more consistent and less likely to be wildly overinflated
fix: Added basic mob attack handler to mechs, fixing an issue with them attacking mechs too quickly/
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
