### PR TITLE
Vampire lair hotfix

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -32,7 +32,7 @@
 
 /obj/structure/closet/coffin/vampire/Initialize(mapload, mob/user)
 	. = ..()
-	name = "\proper the coffin of [user]"
+	name = "\proper the coffin of [user.mind.name]"
 	desc += "<br>This coffin's owner may not actually have been dear to anyone, or even departed quite yet.<br>\
 		<span class='warning'>It appears impervious to everything but lasers and fire! Especially fire!</span>"
 	vampire = user

--- a/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
@@ -252,7 +252,8 @@
 	qdel(C)
 	var/datum/antagonist/vampire/V = user.mind.has_antag_datum(/datum/antagonist/vampire)
 	V.has_lair = TRUE
-	user.mind.RemoveSpell(src)
+	V.upgrade_tiers -= type
+	V.remove_ability(src)
 
 /obj/effect/lair_rune
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes (?) the vampire lair.
Makes it follow the identical logic that the spell used for specialisation picking follows so it is properly removed from the list of spells.
Makes the coffin use your actual name rather than the ID one.

This does _not_ fix the issue of TP-made vampires sometimes causing a similar server crash. I have only managed to replicate that issue with one of the randomly picked objectives. Removing it from the pool has led to successful creation of a vampire every single time.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It should prevent duping of abilities and crashing the server. Maybe.
I think I have managed to replicate the bug once as my server exploded on a bite at one point. Unfortunately, it exploded so hard it couldn't even throw any runtimes at me.
This should address some of the runtimes I have seen from the prod.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I have spawned in, made myself a vampire, feeding on humans with dummy ckeys I have picked specialisation, made a lair and continued to eat humans until full power. Failed to replicate the crash on bite.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Vampire lair should no longer dupe your abilities and potentially break the server
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
