### PR TITLE
Fixed the integrated toolbelt not having a action button sprite

### DIFF
--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -250,7 +250,7 @@
 
 /datum/action/item_action/organ_action/toggle/utility_belt
 	button_icon = 'icons/obj/clothing/belts.dmi'
-	button_icon_state = "utilitybelt"
+	button_icon_state = "utility"
 
 /obj/item/organ/internal/cyberimp/arm/toolset
 	name = "integrated toolset implant"


### PR DESCRIPTION
## What Does This PR Do
fixes a icon state being out of date

## Why It's Good For The Game
fixes #30852 and also fixes #30684
## Testing
compiled, checked
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
fix: Fixed the integrated toolbelt not having a action button sprite
/:cl: