### PR TITLE
Remaps That Bit of Maint in Cyberiad Between Arrivals and Disposals

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -29786,14 +29786,6 @@
 /obj/effect/mapping_helpers/turfs/rust/maybe,
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/port)
-"cjf" = (
-/obj/structure/table/glass,
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "cjg" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/generic,
@@ -50558,11 +50550,6 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/port/east)
-"gea" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "geb" = (
 /obj/item/radio/intercom{
 	name = "south bump";
@@ -57512,7 +57499,8 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
 "jDL" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -58321,7 +58309,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
 "jWV" = (
 /obj/machinery/light/small{
@@ -66136,7 +66124,8 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
 "nSQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
@@ -68062,11 +68051,6 @@
 "oJr" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/asmaint)
-"oJO" = (
-/obj/machinery/light/small,
-/obj/structure/closet/firecloset/full,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "oJX" = (
 /obj/structure/cable,
 /obj/effect/spawner/window/reinforced/polarized/grilled{
@@ -71774,7 +71758,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/barrier/temporary,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
 "qzV" = (
 /obj/structure/chair{
@@ -73550,6 +73534,13 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/toxins/launch)
+"rov" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/spawner/random/cobweb/left/frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "roQ" = (
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "atmos";
@@ -82079,6 +82070,11 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage)
+"vKe" = (
+/obj/structure/closet/firecloset/full,
+/obj/effect/spawner/random/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "vKr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -100991,10 +100987,10 @@ gbU
 cvp
 lRv
 lRv
-lRv
-lRv
+cvp
+cvp
 lGJ
-aaa
+cvp
 cyk
 cgQ
 cgQ
@@ -101244,14 +101240,14 @@ cjg
 bnw
 vwk
 gzN
+rov
 coL
-iez
-cjf
 kUo
 kJk
-oJO
+coL
+qov
 cvp
-lRv
+vKe
 cvp
 fJK
 rcY
@@ -101501,11 +101497,11 @@ bnK
 bII
 pcH
 nSG
-gea
+bGn
 swy
 swy
-gea
-gea
+bGn
+bGn
 swy
 qzE
 bGn


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Remaps the spot between disposals and arrivals on Cyberiad.

The right hand path is no longer blocked by 4 welded doors and 4 wooden barricades and also maybe some grilles too.

Instead the left hand path is blocked by a random type of tempoary obstacle (grille, barricade, etc), and the right hand path is maybe blocked by a grille sometimes.

The right hand area has been expanded to a small room. Some trash spawners, a toolbox spawner, a toy spawner, and some goon wine have been added along with a table and some benches, and a contraband poster spawner.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This part of maint is currently very awkward, and also very annoying due to the power wire going through the extremely blocked right path, which can be all chewed up by mice. This makes it more accessable for use, makes it less tedious to traverse, and also creates a usable room for anything between hangout, project spot, or evil lair.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<img width="352" height="384" alt="image" src="https://github.com/user-attachments/assets/1fb0121f-a487-41fc-a56c-fe6dc6466b6e" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Visual inspection.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Remapped the area of maint on box between arrivals and disposals.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
