### PR TITLE
fix dock markers not appearing

### DIFF
--- a/code/modules/mining/equipment/marker_beacons.dm
+++ b/code/modules/mining/equipment/marker_beacons.dm
@@ -159,6 +159,9 @@ GLOBAL_LIST_INIT(marker_beacon_colors, list(
 	. = ..()
 	RegisterSignal(src, COMSIG_ATTACK_BY, TYPE_PROC_REF(/datum, signal_cancel_attack_by))
 
+/obj/structure/marker_beacon/dock_marker/update_icon_state()
+	set_light(light_range, light_power, LIGHT_COLOR_BLUE)
+
 /obj/structure/marker_beacon/dock_marker/attack_hand()
 	return
 


### PR DESCRIPTION
## What Does This PR Do
This PR fixes dock markers not appearing. Some code was apparently fatfinger deleted in #30365. 
## Why It's Good For The Game
Bugfix.
## Images of changes
<img width="953" height="966" alt="2025_11_04__00_53_54__Paradise Station 13" src="https://github.com/user-attachments/assets/18ff25f7-a0d2-458a-88cb-ed769edc4742" />

## Testing
Started server, ensured dock markers were visible.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Dock markers should now be visible again.
/:cl: