### PR TITLE
[TM ONLY] Disables seeing action buttons on observing [TM ONLY]

### DIFF
--- a/code/_onclick/hud/hud_datum.dm
+++ b/code/_onclick/hud/hud_datum.dm
@@ -246,7 +246,6 @@
 			show_hud(hud_version, M)
 	else if(viewmob.hud_used)
 		viewmob.hud_used.plane_masters_update()
-		viewmob.show_other_mob_action_buttons(mymob)
 	plane_masters_update()
 	return TRUE
 

--- a/code/modules/mob/dead/observer/observer_base.dm
+++ b/code/modules/mob/dead/observer/observer_base.dm
@@ -936,7 +936,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		bag.update_viewers(src)
 
 	if(!QDELETED(target) && istype(target))
-		hide_other_mob_action_buttons(target)
 		target.observers -= src
 
 /mob/dead/observer/proc/on_observer_orbit_end(mob/follower, atom)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Disables seeing action buttons when observing someone
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

This breaks spell cooldowns visually. We have one, and 2 with heretic on tm, common antags that rely on spells. Antagonists should be able to use their spells without them shittting the bed visually. Until we find out what part of the observing is breaking the spells, no action buttons shall be seen.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
spam observed vampire with recharging spells, could not see the spells, and the spells did not break

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
experiment: Someone merged a tm only pr. Laugh at them (in a nice way)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
