### PR TITLE
[s] fix telekinetics teleporting you to weight machines

### DIFF
--- a/code/modules/ruins/objects_and_mobs/gym.dm
+++ b/code/modules/ruins/objects_and_mobs/gym.dm
@@ -47,6 +47,9 @@
 /obj/structure/weightmachine/proc/AnimateMachine(mob/living/user)
 	return
 
+/obj/structure/weightmachine/attack_tk(mob/user)
+	return
+
 /obj/structure/weightmachine/attack_hand(mob/living/user)
 	. = ..()
 	if(.)


### PR DESCRIPTION
## What Does This PR Do
it fixes something
## Why It's Good For The Game
it was broken
## Testing
i tried to do it
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: you can no longer teleport to weight machines with telekinetics.
/:cl: