### PR TITLE
Renames the swarmprod item to "swarmprod"

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -383,7 +383,7 @@
 	return FALSE
 
 /obj/item/melee/baton/flayerprod
-	name = "stunprod"
+	name = "swarmprod"
 	desc = "A mechanical mass which you can use to incapacitate someone with."
 	icon_state = "swarmprod"
 	base_icon = "swarmprod"


### PR DESCRIPTION
## What Does This PR Do
Title. Renames the swarmprod item from "stunprod" to "swarmprod".
## Why It's Good For The Game
Items should be named what their name is.
## Testing
Inspected visually.
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog
:cl:
tweak: The swarmprod item is now named "swarmprod" instead of "stunprod".
/:cl: