### PR TITLE
Fix wrong silicon flash overlay

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/maint_drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/maint_drone.dm
@@ -396,7 +396,7 @@
 	..()
 	update_headlamp(TRUE, 0, FALSE)
 
-/mob/living/silicon/robot/drone/flash_eyes(intensity = 1, override_blindness_check = FALSE, affect_silicon = FALSE, visual = FALSE)
+/mob/living/silicon/robot/drone/flash_eyes(intensity = 1, override_blindness_check = FALSE, affect_silicon = FALSE, visual = FALSE, laser_pointer = FALSE, type = /atom/movable/screen/fullscreen/stretch/flash/noise)
 	if(affect_silicon)
 		return ..()
 

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -55,7 +55,7 @@
 				sleep(3)
 				step_away(src, user, 15)
 
-/mob/living/silicon/robot/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /atom/movable/screen/fullscreen/stretch/flash/noise)
+/mob/living/silicon/robot/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, laser_pointer = FALSE, type = /atom/movable/screen/fullscreen/stretch/flash/noise)
 	if(!affect_silicon || !can_be_flashed())
 		return
 	Confused(intensity * 4 SECONDS)

--- a/code/modules/mob/living/silicon/silicon_mob.dm
+++ b/code/modules/mob/living/silicon/silicon_mob.dm
@@ -463,7 +463,7 @@
 /mob/living/silicon/get_access()
 	return IGNORE_ACCESS //silicons always have access
 
-/mob/living/silicon/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /atom/movable/screen/fullscreen/stretch/flash/noise)
+/mob/living/silicon/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, laser_pointer = FALSE, type = /atom/movable/screen/fullscreen/stretch/flash/noise)
 	if(affect_silicon)
 		return ..()
 


### PR DESCRIPTION
## What Does This PR Do
Fixes the positional arguments for the silicon `flash_eyes` procs. Their default flash overlay was supposed to be a noisy variant, rather than pure white. Due to a missing argument, the type was passed on as the laser_pointer arg.
## Why It's Good For The Game
Flavorful borgs
## Images of changes

https://github.com/user-attachments/assets/fecfd5d3-d26f-4828-bb2a-954e0b88db6c

## Testing
Flashed a cyborg and a maint drone.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Silicons will get the correct flash overlay.
/:cl: