### PR TITLE
Reverts the HP of grilles back to their pre-buff state, but makes meteors take more damage from them

### DIFF
--- a/code/game/objects/effects/meteors.dm
+++ b/code/game/objects/effects/meteors.dm
@@ -157,7 +157,7 @@ GLOBAL_LIST_INIT(meteors_gore, list(/obj/effect/meteor/meaty = 5, /obj/effect/me
 	var/damage_cap = wall.damage_cap
 	if(wall.rotting)
 		damage_cap /= 10
-	var/damage_needed = (damage_cap - wall.damage) * OBJ_INTEGRITY_TO_WALL_DAMAGE 
+	var/damage_needed = (damage_cap - wall.damage) * OBJ_INTEGRITY_TO_WALL_DAMAGE
 	if(damage_needed <= 0)
 		wall.dismantle_wall()
 	else if(damage_needed < obj_integrity)
@@ -199,6 +199,9 @@ GLOBAL_LIST_INIT(meteors_gore, list(/obj/effect/meteor/meaty = 5, /obj/effect/me
 		. = TRUE // Hit an object.
 
 		var/damage_needed = obstacle.calculate_oneshot_damage(BRUTE, MELEE)
+		if(istype(obstacle, /obj/structure/grille))
+			damage_needed *= 6
+
 		if(obj_integrity > damage_needed)
 			obj_integrity -= damage_needed
 			obstacle.obj_break(MELEE)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -10,8 +10,8 @@
 	layer = BELOW_OBJ_LAYER
 	level = 3
 	armor = list(MELEE = 50, BULLET = 70, LASER = 70, ENERGY = 100, BOMB = 10, RAD = 100, FIRE = 0, ACID = 0)
-	max_integrity = 150
-	integrity_failure = 50
+	max_integrity = 50
+	integrity_failure = 20
 	cares_about_temperature = TRUE
 	rad_insulation_beta = RAD_BETA_BLOCKER
 	var/rods_type = /obj/item/stack/rods


### PR DESCRIPTION
## What Does This PR Do
Reverts the HP of grilles back to 50, multiplies the damage taken by meteors from grilles by 6, so theres functionally no change on that front. Just players/mobs breaking grills

## Why It's Good For The Game
pr #29797 increased the hp of grilles be *alot* kinda way too much, it makes busting them down incredibly hard, and theres some cheesey things you can do with them,

The dev team has been in talks about lowering the hp but no one has actually made a pr about it, so this is it.

## Testing
Spawned a grille, spawned a  meteor, possessed the meteor, rammed it into some things, checked damage values with current live build, all consistant

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<img width="600" height="200" alt="image" src="https://github.com/user-attachments/assets/6aee8892-5e11-4991-aff8-315d646e232a" />



## Changelog
:cl:
Tweak: Reverts the damage buff grilles got.
Tweak: Multiplies the damage taken by meteors hitting grilles by six, nullifying the change for meteors. 
/:cl:
