### PR TITLE
Fix cigarette_act trying to light a cigarette on non-mobs.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1043,7 +1043,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
   * * direct_attackby_item - Used if the cigarette item is clicked on directly with a lighter instead of a mob wearing a cigarette.
   */
 /obj/item/proc/cigarette_lighter_act(mob/living/user, mob/living/target, obj/item/direct_attackby_item)
-	if(!user || !target)
+	if(!user || !istype(target))
 		return null
 
 	var/obj/item/clothing/mask/cigarette/cig = direct_attackby_item ? direct_attackby_item : target.wear_mask


### PR DESCRIPTION
## What Does This PR Do
Changes `!target` to `!istype(target)`. It handles the null checks and prevents people from trying to light the protolathes cigarette.
## Why It's Good For The Game
Won't runtime.
## Testing
Lit a cigarette on a player. Tried lighting the cigarette of a protolathe.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: You'll no longer attempt to light a cigarette on furniture.
/:cl: