### PR TITLE
changes the ancient goliath on skullakin mine to a space one...

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroidmine_skullakin.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroidmine_skullakin.dmm
@@ -725,7 +725,7 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/skullakin_mine/overseer)
 "om" = (
-/mob/living/basic/mining/goliath/ancient,
+/mob/living/basic/mining/goliath/space,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin)
 "on" = (


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
edits an ANCIENT GOLIATH into a much more reasonable space variant, like the others
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
ancient goliath bad, author of original ruin PR requested this
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
the sprites are the same
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
i loaded the map, it was there, it wasnt an ancient one, shot them all with .357
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: fixed an ancient golaith being mapped into a space ruin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
