### PR TITLE
Deathgasp now makes you collapse

### DIFF
--- a/code/modules/mob/living/living_emote.dm
+++ b/code/modules/mob/living/living_emote.dm
@@ -49,7 +49,10 @@
 	. = ..()
 	if(. && isliving(user))
 		var/mob/living/L = user
-		L.KnockDown(10 SECONDS)
+		if(intentional)
+			L.KnockDown(4 SECONDS)
+		else
+			L.KnockDown(10 SECONDS)
 
 /datum/emote/living/dance
 	key = "dance"
@@ -82,7 +85,7 @@
 	. = ..()
 	if(. && isliving(user))
 		var/mob/living/L = user
-		L.KnockDown(10 SECONDS)
+		L.KnockDown(4 SECONDS)
 
 /datum/emote/living/deathgasp/should_play_sound(mob/user, intentional)
 	. = ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Title. You now collapse when you `*deathgasp`, to help sell the illusion of faux-death. (Also, `*collapse`, when intentional, only lasts 4 seconds.)
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
If you "seize up and fall limp," you probably don't stay standing. These changes make the `*deathgasp` emote more like, well, dying, and not just "John Tider didn't get his insuls."
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in, used `*deathgasp`, dropped to the floor.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<img width="1067" height="136" alt="image" src="https://github.com/user-attachments/assets/4a325203-8919-4a24-97b9-9fc1ea334cf6" />

## Changelog

:cl:
tweak: *deathgasp is now more convincing
tweak: *collapse, when intentional, doesn't last as long
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
