### PR TITLE
Fix being able to generate requisition forms without an order

### DIFF
--- a/code/modules/supply/supply_console.dm
+++ b/code/modules/supply/supply_console.dm
@@ -301,6 +301,10 @@
 
 			//===orderee account information===
 			var/datum/money_account/selected_account = locateUID(params["account"])
+			if(!selected_account)
+				playsound(loc, 'sound/machines/buzz-sigh.ogg', 15, FALSE)
+				to_chat(user, "<span class='warning'>You must select an account to pay for the order.</span>")
+				return
 			var/successes = 0
 			for(var/i in 1 to amount)
 				var/datum/supply_order/order = SSeconomy.generate_supply_order(params["crate"], idname, idrank, reason)


### PR DESCRIPTION
## What Does This PR Do
When you didn't have an account selected and ordered a crate, the console would print a requisition form but not place an order. This fixes it by not placing an order, buzzing and sending an error message to the player.
## Why It's Good For The Game
Less bug better.
## Testing
Placed an order without account selected. Got error message, it buzzed and no order was placed.
Placed three orders with departmental accounts. Accepted one, denied one and left the third unaccepted. Called the shuttle. Only one crate arrived.
## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Requisition consoles no longer print fake forms when you try to place an order without selecting an account.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
