### PR TITLE
add an argument that toggles spammability of use_tool()

### DIFF
--- a/code/game/objects/items/tools/tool_behaviour.dm
+++ b/code/game/objects/items/tools/tool_behaviour.dm
@@ -2,7 +2,7 @@
  * Called when a mob tries to use the item as a tool.
  * Handles most checks.
 */
-/obj/item/proc/use_tool(atom/target, mob/living/user, delay, amount=0, volume=0, datum/callback/extra_checks, spammable = TRUE)
+/obj/item/proc/use_tool(atom/target, mob/living/user, delay, amount=0, volume=0, datum/callback/extra_checks, do_after_once = FALSE)
 	// No delay means there is no start message, and no reason to call tool_start_check before use_tool.
 	// Run the start check here so we wouldn't have to call it manually.
 	target.add_fingerprint(user)
@@ -21,7 +21,7 @@
 			if(!do_mob(user, target, delay, extra_checks = list(tool_check)))
 				return
 
-		else if(spammable)
+		else if(!do_after_once)
 			if(!do_after(user, delay, target=target, extra_checks = list(tool_check)))
 				return
 		else

--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -187,7 +187,7 @@
 	cig.light(user, target)
 	return TRUE
 
-/obj/item/weldingtool/use_tool(atom/target, user, delay, amount, volume, datum/callback/extra_checks, spammable)
+/obj/item/weldingtool/use_tool(atom/target, user, delay, amount, volume, datum/callback/extra_checks, do_after_once)
 	target.add_overlay(GLOB.welding_sparks)
 	var/did_thing = ..()
 	if(did_thing)


### PR DESCRIPTION
## What Does This PR Do
You're able to set whether or not a use of the tool is spammable. By default, it follows the old behavior.
## Why It's Good For The Game
Sometimes you might not want for a tool to be spammable. This lets you cancel the attempt.
## Testing
Spammed tools. They were spammable.
Temporarily set a `use_act()` to not be spammable. I could not spam it.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC