### PR TITLE
Revenants can understand galactic common again

### DIFF
--- a/code/modules/mob/living/basic/hostile/revenant/revenant.dm
+++ b/code/modules/mob/living/basic/hostile/revenant/revenant.dm
@@ -157,6 +157,8 @@
 	giveSpells()
 	RegisterSignal(src, COMSIG_BODY_TRANSFER_TO, PROC_REF(make_revenant_antagonist))
 	AddComponent(/datum/component/event_tracker, EVENT_REVENTANT)
+	add_language("Galactic Common")
+	set_default_language(GLOB.all_languages["Galactic Common"])
 
 /mob/living/basic/revenant/event_cost()
 	if(is_station_level((get_turf(src)).z) && stat != DEAD)


### PR DESCRIPTION
## What Does This PR Do
Fixes revenants not understanding galactic common

## Why It's Good For The Game
They should be able to understand what crew are saying. they get a ability to talk to crew, yet cant understand them currently
this was a seemingly unintended side effect from #30661

## Testing
loaded up a test server, forced a mob to speak, could understand the mob speaking
double checked the force say thing isn't globally understandable on a live build 

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
fix: Fixed revenants not understanding galactic common
/:cl: