### PR TITLE
Adds some chemthrowers to the syndi space base

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
@@ -3155,6 +3155,23 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_space_base/main)
+"uh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/chemical_flamethrower/extended{
+	pixel_x = -28;
+	pixel_y = 2
+	},
+/obj/item/chemical_flamethrower/extended{
+	pixel_x = -26;
+	pixel_y = 5
+	},
+/obj/item/chemical_flamethrower/extended{
+	pixel_x = -24;
+	pixel_y = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered/syndicate_space_base/storage)
 "ui" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -6917,16 +6934,16 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/chemical_flamethrower{
-	pixel_x = 0;
-	pixel_y = -2
+	pixel_x = -2;
+	pixel_y = 6
 	},
 /obj/item/chemical_flamethrower{
-	pixel_x = 0;
-	pixel_y = 4
+	pixel_x = -1;
+	pixel_y = 9
 	},
 /obj/item/chemical_flamethrower{
-	pixel_x = 0;
-	pixel_y = 10
+	pixel_x = 1;
+	pixel_y = 12
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered/syndicate_space_base/storage)
@@ -11469,7 +11486,7 @@ xo
 xo
 xo
 US
-xo
+uh
 xo
 xo
 mQ


### PR DESCRIPTION

## What Does This PR Do
Lets ghosts mess with the chemthrowers that were added a while ago
Minor edits the storage area to get room for the throwers, removes two space cleaner sprays and a stack of plasma(theres plenty in other areas)

## Why It's Good For The Game
These things go rather unused mainly because people dont know they exist, and when people find them they cant really mess with them a whole lot

## Images of changes
<img width="387" height="638" alt="image" src="https://github.com/user-attachments/assets/d2cf7f51-a602-4a91-8453-d9d94ecdc0c1" />


## Testing
see above
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Slightly changed the storage room of the syndicate space base for the addition of some chemthrowers and canisters
/:cl:
