### PR TITLE
The Service Borg RSF Can Put Stuff in People's Hands

### DIFF
--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -102,7 +102,7 @@
 		playsound(loc, 'sound/machines/click.ogg', 10, TRUE)
 		return ITEM_INTERACT_COMPLETE
 
-	if(do_after_once(user, 1 SECONDS, target = target))
+	if(do_after_once(user, DEFAULT_ITEM_PUTON_DELAY, target = target))
 		var/mob/living/carbon/human/esteemed_individual = target
 		var/dispensed_item = new currently_dispensing(T)
 		if(esteemed_individual.put_in_hands(dispensed_item))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Allows the RSF to dispense items directly into people's hands. This requires a 2 second do_after (`DEFAULT_ITEM_PUTON_DELAY`).
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
I say! I do not care for picking things up from the floor, and I certainally cannot be bothered to hunch over a table to fetch what I crave either! I demand that this mechanical servitor place my cheese and caviar directly into my hands!

Minor fun interaction for the RSF.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Placed cheese and caviar into a skrell's hands.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: The RSF can dispense items into people's hands.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
