### PR TITLE
Remaps Meta Xenobiology

### DIFF
--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -13808,9 +13808,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/ai_monitored/storage/eva)
 "byZ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the special containment chamber.";
 	layer = 4;
@@ -33738,9 +33735,6 @@
 /area/station/maintenance/port)
 "eyN" = (
 /obj/machinery/atmospherics/unary/portables_connector,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/turf_decal/box,
 /obj/structure/sign/electricshock{
 	pixel_y = 32
@@ -39870,10 +39864,6 @@
 "gGV" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/classic/normal{
-	name = "Maximum Security Test Chamber";
-	dir = 8
-	},
 /obj/effect/mapping_helpers/airlock/windoor/access/all/science/xenobio{
 	dir = 8
 	},
@@ -39882,6 +39872,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/door/window/reinforced/normal{
+	name = "Maximum Security Test Chamber";
+	dir = 8
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/xenobiology)
@@ -41320,12 +41314,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/robotics)
-"hfR" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/science/xenobiology)
 "hfX" = (
 /obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plating,
@@ -46786,7 +46774,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/light,
 /obj/effect/turf_decal/box,
 /obj/structure/sign/electricshock{
 	pixel_y = -32
@@ -61906,6 +61893,13 @@
 /obj/structure/closet/wardrobe/black,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/arrival/station)
+"otK" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/xenobiology)
 "otS" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -62082,6 +62076,16 @@
 "oxF" = (
 /turf/simulated/wall/r_wall,
 /area/station/public/construction)
+"oxI" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	name = "north bump";
+	pixel_y = 30
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/xenobiology)
 "oxT" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock,
@@ -136098,11 +136102,11 @@ eUC
 mdi
 ivR
 mdi
-jFi
+hEv
 rZt
 fhR
 nQM
-jFi
+hEv
 mdi
 cIP
 mdi
@@ -136355,11 +136359,11 @@ eUC
 mdi
 gxC
 mdi
-hEv
-rZt
+cZr
+oxI
 gSu
-nQM
-hEv
+otK
+cZr
 mdi
 gxC
 mdi
@@ -136613,7 +136617,7 @@ eUC
 eUC
 eUC
 ncp
-hfR
+kHi
 gSu
 byZ
 cZr


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Replaces the 1 wide glass hallway with a full sized hallway/breakroom area. This hallway now also connects to scimaint.
- Remaps the xenobio containment cells to use full-tile windows. Properly extended the containment blast doors so they actually do something (they previously covered one tile per cell - and it was less effort to just break the directional windows instead of the windoors anyway.
- Added cameras to the containment cells.
- Fixed the electrified grilles of the max security containment cell not working due to not incorporating a green heavy duty wire.
- Connected xenobiology's atmos to the station atmos (as on other stations).
- Due to changes in the geometry of xenobiology, rearranged the meteor grilles.
- Due to a change in the location of xenobiology, adds a reinforced meteor screen to protect the atmospherics primary air tank, as xenobiology was previously blocking that lane of approach. A second was added on the other side of xenobio for symmetry.
- Fixed all wallbump conflicts in xenobio.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
- More up to date xenobiology is good.
- The cells are no longer way flimsier than other stations'.
- The 1 wide glass hallway of dying to 43 million space carp is no more.
- Another way to slip into maintenance, less bottlenecking is good.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<img width="1856" height="1088" alt="image" src="https://github.com/user-attachments/assets/8c57ea84-b8fd-4dc1-b80c-3a7528759c94" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Checked all the blast doors worked.
Checked the fire doors.
Checked I could reach all the work stations.
Made sure everything was lit.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Remapped meta station xenobiology.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
