### PR TITLE
Adds a do_after when unbuckling people from wheelchairs

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -20,6 +20,7 @@
 /obj/structure/chair/wheelchair/user_unbuckle_mob(mob/living/buckled_mob, mob/user)
 	if(do_after(user, 2 SECONDS, target = buckled_mob))
 		return ..()
+
 /obj/structure/chair/wheelchair/post_buckle_mob(mob/living/M)
 	. = ..()
 	handle_layer()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Title, it now takes 2 seconds to unbuckle yourself or others from a wheelchair.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Being able to instantly cripple someone and steal their only reliable method of transportation (canes/crutches are very slow) is not fun.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Run the game. Nothing exploded. Unbuckling myself or others from a wheelchair took 2 seconds. Moving stopped the timer.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<img width="541" height="66" alt="image" src="https://github.com/user-attachments/assets/2022d70a-6840-4567-8b99-e788c3db8bbe" />

## Changelog

:cl:
tweak: Unbuckling from wheelchairs now takes 2 seconds to do
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
