### PR TITLE
IPC arm implant no longer overridden by cybernetic revolution

### DIFF
--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -224,20 +224,27 @@
 	// Prevent replacing existing arm implants (protect IPC arm implant)
 	if(istype(cybernetic, /obj/item/organ/internal/cyberimp/arm))
 		var/obj/item/organ/internal/cyberimp/arm/arm_implant = cybernetic
+
+		var/obj/item/organ/external/left_arm = spawned.get_organ("l_arm")
+		var/obj/item/organ/external/right_arm = spawned.get_organ("r_arm")
+
 		var/obj/item/organ/internal/left_arm_implant = spawned.get_organ_slot("l_arm_device")
 		var/obj/item/organ/internal/right_arm_implant = spawned.get_organ_slot("r_arm_device")
 
-		// Try left arm first, then right arm, then replace left arm if both occupied
-		if(!left_arm_implant)
+		// Try left arm first, then right arm, then replace left arm if both occupied, then just give up.
+		if(left_arm && !left_arm_implant)
 			arm_implant.slot = "l_arm_device"
 			arm_implant.parent_organ = "l_arm"
-		else if(!right_arm_implant)
+		else if(right_arm && !right_arm_implant)
 			arm_implant.slot = "r_arm_device"
 			arm_implant.parent_organ = "r_arm"
-		else
+		else if(left_arm)
 			left_arm_implant.remove(spawned)
 			qdel(left_arm_implant)
 			arm_implant.slot = "l_arm_device"
 			arm_implant.parent_organ = "l_arm"
+		else
+			qdel(arm_implant)
+			return
 
 	INVOKE_ASYNC(cybernetic, TYPE_PROC_REF(/obj/item/organ/internal, insert), spawned, TRUE)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Fixes https://github.com/ParadiseSS13/Paradise/issues/30593

Adds fallback logic for cybernetic revolution to keep IPCs from losing their arm chargers

Priority is:
- Left arm
- Right arm if left arm occupied
- Delete and replace left arm implant if both occupied

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

IPCs shouldn't lose their arm implant because of cybernetic revolution

## Testing

<!-- How did you test the PR, if at all? -->

Spawned in as Blueshield IPC on cybernetic revolution, looked to make sure I had a left and right arm implant

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: IPCs keep their chargers on cybernetic revolution
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
