### PR TITLE
Fix flayer download not giving items needed for followup objectives

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1238,7 +1238,16 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 
 		var/datum/antagonist/mindflayer/flayer_datum = M.has_antag_datum(/datum/antagonist/mindflayer)
 
-		holder.replace_objective(src, flayer_datum.roll_single_human_objective())
+		// replace_objective doesn't trigger things like giving SM sliver steal kits or the PPP, so we'll replace it manually
+		var/download_index = flayer_datum.objective_holder.objectives.Find(src)
+		var/datum/objective/new_objective = flayer_datum.add_antag_objective(flayer_datum.roll_single_human_objective())
+
+		// Move the new objective to where the download objective was
+		if(download_index && new_objective)
+			flayer_datum.objective_holder.objectives -= new_objective
+			flayer_datum.objective_holder.objectives.Insert(download_index, new_objective)
+
+		holder.remove_objective(src)
 
 		SEND_SOUND(M.current, sound('sound/ambience/alarm4.ogg'))
 		var/list/messages = M.prepare_announce_objectives(FALSE)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes https://github.com/ParadiseSS13/Paradise/issues/30877
Rather than use replace_objective we create the followup objective normally, moves it to the correct index, and deletes the Download objective
I am guessing this probably fixes some other bugs since the objective wasn't being initialized correctly
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Fixes an oversight
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Downloaded an objective that gives a kit, made sure I got that kit
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Flayer Download properly gives items for followup objectives
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
