### PR TITLE
Removes the Engine Bypass Pump From the Supermatter Engine Pipes

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -41406,9 +41406,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
 "deA" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/green{
-	dir = 1
-	},
 /obj/machinery/camera{
 	c_tag = "Supermatter Fore";
 	dir = 1;
@@ -41419,13 +41416,12 @@
 /obj/structure/sign/magboots{
 	pixel_y = -32
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 10
+	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "deB" = (
-/obj/machinery/atmospherics/binary/pump/on{
-	dir = 8;
-	name = "Gas to Filter"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -46527,7 +46523,7 @@
 /area/station/maintenance/apmaint)
 "egO" = (
 /obj/machinery/atmospherics/meter,
-/obj/machinery/atmospherics/pipe/simple/visible{
+/obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 9
 	},
 /turf/simulated/wall/r_wall,
@@ -60346,7 +60342,7 @@
 /area/station/hallway/primary/central/west)
 "kUR" = (
 /obj/machinery/atmospherics/meter,
-/obj/machinery/atmospherics/pipe/simple/visible{
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 5
 	},
 /turf/simulated/wall/r_wall,
@@ -74625,9 +74621,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "rPZ" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
-	},
 /obj/machinery/door_control{
 	id = "engsm";
 	name = "Radiation Shutters Control";
@@ -74635,6 +74628,9 @@
 	req_access = list(32)
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 6
+	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "rQp" = (

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -9687,10 +9687,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/binary/pump/on{
-	dir = 8;
-	name = "Gas to Filter"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -106732,9 +106728,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible/green,
 /obj/structure/sign/magboots{
 	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 9
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
@@ -110852,7 +110850,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /obj/machinery/door_control{
 	id = "engsm";
 	name = "Radiation Shutters Control";
@@ -110862,6 +110859,9 @@
 /obj/machinery/camera{
 	c_tag = "Supermatter South";
 	network = list("SS13","CE","engine")
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 5
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -7472,10 +7472,6 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/controlroom)
 "aFX" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8;
-	name = "Gas to Filter"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -7498,7 +7494,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 5
+	},
 /turf/simulated/floor/engine,
 /area/station/engineering/controlroom)
 "aFZ" = (
@@ -8487,7 +8485,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible/green,
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 9
+	},
 /turf/simulated/floor/engine,
 /area/station/engineering/controlroom)
 "aJv" = (

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -31995,15 +31995,15 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/chemistry)
 "gut" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 4
-	},
 /obj/machinery/atmospherics/meter,
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 9
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine)
@@ -47812,7 +47812,6 @@
 	pixel_x = -22;
 	req_access = list(10)
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -63716,9 +63715,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/binary/pump/on{
-	name = "Gas to Filter"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -68515,7 +68511,6 @@
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "nQI" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/structure/disaster_counter/supermatter{
 	pixel_x = -32
 	},
@@ -115475,9 +115470,6 @@
 /turf/simulated/floor/wood,
 /area/station/service/theatre)
 "xlH" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/green{
-	dir = 4
-	},
 /obj/machinery/atmospherics/meter,
 /obj/machinery/light{
 	dir = 8
@@ -115488,6 +115480,9 @@
 /obj/item/radio/intercom{
 	name = "west bump";
 	pixel_x = -28
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 10
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine)

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -5852,10 +5852,6 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
 "aPs" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 8;
-	initialize_directions = 11
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -5867,6 +5863,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 5
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
@@ -7018,9 +7017,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/public/locker)
 "aVs" = (
-/obj/machinery/atmospherics/binary/pump/on{
-	name = "Gas to Filter"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -77942,9 +77938,6 @@
 /turf/simulated/floor/plating,
 /area/station/security/permabrig)
 "urF" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/green{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Supermatter Port";
 	dir = 8;
@@ -77961,6 +77954,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 6
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the engine bypass pump from the supermatter engine piping.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This pump is never turned on. I have not seen it genuinely used for more than half a decade. If it is turned on it restricts how much gas the engine gets.

Removal of this pump creates a clear visual seperation between the hot and cold sides of the loop, making it more approachable to anyone that is unfamiliar with the supermatter engine.

The single use of this pump I can think of is pre-cooling freshly injected gas from atmos if a HE pipe wasn't attached to the injector if it's a highly excitable gas like CO2. You can make the effect on the engine less scary simply set the injector pump to a lower pressure instead. This actually gives you a reason to use a lower pressure than the max value, which is what is picked on almost every single occasion.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<img width="160" height="192" alt="image" src="https://github.com/user-attachments/assets/debe65e4-3cae-49ab-8477-a112533ed8cf" />
<img width="160" height="96" alt="image" src="https://github.com/user-attachments/assets/375d0f60-f0aa-44df-9ab3-4e7076ce66d0" />
<img width="160" height="96" alt="image" src="https://github.com/user-attachments/assets/ae04ef95-fb91-4751-bc6c-ba39bb9199b2" />
<img width="96" height="224" alt="image" src="https://github.com/user-attachments/assets/c7f8dd8f-0ab7-4477-8799-97123f6586e1" />
<img width="96" height="160" alt="image" src="https://github.com/user-attachments/assets/d066d49c-3e3c-420c-a4db-6b88ec0f9621" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Visual inspection.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
del: Removed the supermatter engine bypass pump.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
