### PR TITLE
Non Metal Kitchen Utensels are now Nonconductive

### DIFF
--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -16,9 +16,6 @@
 	icon = 'icons/obj/kitchen.dmi'
 	origin_tech = "materials=1"
 
-
-
-
 /*
  * Utensils
  */
@@ -72,6 +69,7 @@
 	name = "plastic fork"
 	desc = "Yay, no washing up to do."
 	icon_state = "pfork"
+	flags = NONE
 
 /obj/item/kitchen/utensil/spoon
 	name = "spoon"
@@ -84,6 +82,7 @@
 	desc = "It's a plastic spoon. How dull."
 	icon_state = "pspoon"
 	attack_verb = list("attacked", "poked")
+	flags = NONE
 
 /obj/item/kitchen/utensil/spork
 	name = "spork"
@@ -96,6 +95,7 @@
 	desc = "It's a plastic spork. It's the fork side of the spoon!"
 	icon_state = "pspork"
 	attack_verb = list("attacked", "sporked")
+	flags = NONE
 
 /*
  * Knives
@@ -136,6 +136,7 @@
 	desc = "The bluntest of blades."
 	icon_state = "pknife"
 	sharp = FALSE
+	flags = NONE
 
 /obj/item/kitchen/knife/ritual
 	name = "ritual knife"
@@ -149,6 +150,7 @@
 	desc = "A haphazard sharp object wrapped in cloth, just like great-great-great-great grandma used to make."
 	icon = 'icons/obj/weapons/melee.dmi'
 	icon_state = "glass_shiv"
+	flags = NONE
 
 /obj/item/kitchen/knife/shiv/carrot
 	name = "carrot shiv"
@@ -207,6 +209,7 @@
 	icon_state = "bone_dagger"
 	inhand_icon_state = "bone_dagger"
 	materials = list()
+	flags = NONE
 
 /obj/item/kitchen/knife/combat/cyborg
 	name = "cyborg knife"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the conductive flag from plastic utensels, bone knives, glass (and carrot) shivs.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
These objects should neither conduct electricity nor be attracted to magnets.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned these items and poked a cable. I was not shocked.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Non metal knives and utensels are no longer conductive or magnetic.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
