### PR TITLE
Fix windoor autoclosing when valid mobs stand among dead mobs.

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -89,7 +89,7 @@
 
 /// Check whether or not this door can close, based on whether or not someone's standing in front of it holding it open
 /obj/machinery/door/window/proc/check_close()
-	for(var/mob/living/blocker in get_turf(get_step(src, dir)))
+	for(var/mob/living/blocker in get_step(src, dir))
 		if(blocker && !blocker.stat && allowed(blocker))
 			return delay_close()
 	for(var/mob/living/blocker in get_turf(src))
@@ -100,7 +100,6 @@
 
 /obj/machinery/door/window/proc/delay_close()
 	addtimer(CALLBACK(src, PROC_REF(check_close)), check_access(null) ? 5 SECONDS : 2 SECONDS)
-	return
 
 /obj/machinery/door/window/Bumped(atom/movable/AM)
 	if(operating || !density)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Changes windoor's autoclose function to check every mob on a tile instead of just one, so that the door is held open if there is any valid mob standing next to it. Previously, it would pick one mob on the tile, and if that mob were dead, it would close the door even if someone alive with valid access was standing right there.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Fixes #20080

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted, held a windoor open from both sides. Put a dead mob on the same side and opposite side and again held the windoor open from both sides. Confirmed also that the windoor closed when I stepped away from it.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed windoors autoclosing when next to dead creatures even if live creatures try to hold the door open.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
