### PR TITLE
Make legions run away from occupied mechs

### DIFF
--- a/code/modules/mob/living/basic/mining/hivelord_ai.dm
+++ b/code/modules/mob/living/basic/mining/hivelord_ai.dm
@@ -85,8 +85,6 @@
 	var/mob/living/target = controller.blackboard[target_key]
 	if(ismecha(target))
 		var/obj/mecha/mech = target
-		if(!mech.occupant)
-			return
 		target = mech.occupant
 	if(QDELETED(target) || target.faction_check_mob(controller.pawn))
 		return // Only flee if we have a hostile target


### PR DESCRIPTION
## What Does This PR Do
When checking if legion should run from target, if target is a mech, it'll check the occupant. Fixes #31075
## Why It's Good For The Game
No runtime, proper behaviour
## Testing
Spawned a ripley with me inside, spawned a legion, legion ran away when near my mech.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Legions will run away from occupied mechs.
/:cl: