### PR TITLE
Fix mech crusher and mining bombs not working on basic mobs

### DIFF
--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -501,7 +501,10 @@
 	chassis.occupant.changeNext_click(equip_cooldown)
 	var/proximate = chassis.Adjacent(target)
 	if(proximate)
-		target.attackby__legacy__attackchain(internal_crusher, chassis.occupant)
+		if(target.new_attack_chain)
+			target.attack_by(internal_crusher, chassis.occupant)
+		else
+			target.attackby__legacy__attackchain(internal_crusher, chassis.occupant)
 	internal_crusher.afterattack__legacy__attackchain(target, chassis.occupant, proximate, null)
 
 #undef MECH_RCD_MODE_DECONSTRUCT

--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -557,7 +557,7 @@
 			var/turf/simulated/mineral/mineral_turf = T
 			mineral_turf.gets_drilled(firer)
 	for(var/mob/living/mob in range(power, src))
-		mob.apply_damage(damage * (ishostile(mob) ? fauna_boost : 1), BRUTE, spread_damage = TRUE)
+		mob.apply_damage(damage * ((ishostile(mob) || istype(mob, /mob/living/basic/mining)) ? fauna_boost : 1), BRUTE, spread_damage = TRUE)
 		if(!ishostile(mob) || !firer || mob.stat != CONSCIOUS)
 			continue
 		var/mob/living/simple_animal/hostile/hostile_mob = mob


### PR DESCRIPTION
## What Does This PR Do
Adds basic mining mobs to the mining grenade launcher checks for damage multiplication. Fixes #31056
Adds an attack chain check on the mech crusher, letting it deal damage to migrated things. Fixes #31055
## Why It's Good For The Game
Functional items.
## Testing
Launched grenade at legion, damage dealt was multiplied x4, like before.
Beat a legion with a mech crusher, legion took damage.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Mining grenades now deal the same damage to mining mobs as before.
fix: Kinetic crusher can attack things on the new attack chain.
/:cl: