### PR TITLE
sets rubberducky throwforce to 0

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -503,6 +503,7 @@ MAPPING_DIRECTIONAL_HELPERS_CUSTOM(/obj/machinery/shower, 16, -5, 0, 0)
 	inhand_icon_state = "rubberducky"
 	honk_sounds = list('sound/items/squeaktoy.ogg')
 	attack_verb = list("quacked", "squeaked")
+	throwforce = 0
 
 /obj/item/bikehorn/rubberducky/captainducky
 	name = "captain rubber ducky"


### PR DESCRIPTION
## What Does This PR Do
Makes it so you don't get hurt when someone throws a rubber ducky at you.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
## Why It's Good For The Game
It is counterintuitive that something as soft and light as a rubber ducky would injure someone when thrown at them. This leads to players accidentally injuring other characters when just trying to be harmlessly silly, breaking immersion and creating confusion.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
## Testing
Threw rubber ducky and captain ducky at human. No damage on health scan. Hit human with duckies. No damage. Hit human with bike horn. No damage. Threw bike horn at human. 3 damage caused. (The latter two are untouched existing behaviour.)
<!-- How did you test the PR, if at all? -->
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Rubber duckies are now made out of softer rubber and no longer hurt when thrown at people.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
