### PR TITLE
separate deer and nethermob behavior for return_home

### DIFF
--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/return_home.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/return_home.dm
@@ -1,0 +1,31 @@
+/datum/ai_behavior/return_home
+	required_distance = 0
+	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT | AI_BEHAVIOR_CAN_PLAN_DURING_EXECUTION
+	/// minimum time till next rest
+	var/minimum_time = 2 MINUTES
+	/// maximum time till next rest
+	var/maximum_time = 4 MINUTES
+
+/datum/ai_behavior/return_home/setup(datum/ai_controller/controller, target_key)
+	. = ..()
+	var/atom/target = controller.blackboard[target_key]
+	if(QDELETED(target))
+		return FALSE
+	var/list/possible_turfs = get_adjacent_open_turfs(target)
+	shuffle_inplace(possible_turfs)
+	for(var/turf/possible_turf as anything in possible_turfs)
+		if(!possible_turf.is_blocked_turf())
+			set_movement_target(controller, possible_turf)
+			return TRUE
+	return FALSE
+
+/datum/ai_behavior/return_home/perform(seconds_per_tick, datum/ai_controller/controller, target_key)
+	. = ..()
+	return AI_BEHAVIOR_DELAY | AI_BEHAVIOR_SUCCEEDED
+
+/datum/ai_behavior/return_home/incursion_portal
+	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT
+
+/datum/ai_behavior/return_home/incursion_portal/perform(seconds_per_tick, datum/ai_controller/controller, target_key)
+	. = ..()
+	return AI_BEHAVIOR_SUCCEEDED

--- a/code/modules/mob/living/basic/farm_animals/deer_ai.dm
+++ b/code/modules/mob/living/basic/farm_animals/deer_ai.dm
@@ -114,41 +114,14 @@
 		return SUBTREE_RETURN_FINISH_PLANNING
 	if(!controller.blackboard_key_exists(BB_DEER_TREEHOME) || controller.blackboard[BB_DEER_NEXT_REST_TIMER] > world.time)
 		return
-	controller.queue_behavior(/datum/ai_behavior/return_home, BB_DEER_TREEHOME)
+	controller.queue_behavior(/datum/ai_behavior/return_home/and_rest, BB_DEER_TREEHOME)
 
-/datum/ai_behavior/return_home
-	required_distance = 0
-	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT | AI_BEHAVIOR_CAN_PLAN_DURING_EXECUTION
-	/// minimum time till next rest
-	var/minimum_time = 2 MINUTES
-	/// maximum time till next rest
-	var/maximum_time = 4 MINUTES
-
-/datum/ai_behavior/return_home/setup(datum/ai_controller/controller, target_key)
+/datum/ai_behavior/return_home/and_rest/finish_action(datum/ai_controller/controller, succeeded, ...)
 	. = ..()
-	var/atom/target = controller.blackboard[target_key]
-	if(QDELETED(target))
-		return FALSE
-	var/list/possible_turfs = get_adjacent_open_turfs(target)
-	shuffle_inplace(possible_turfs)
-	for(var/turf/possible_turf as anything in possible_turfs)
-		if(!possible_turf.is_blocked_turf())
-			set_movement_target(controller, possible_turf)
-			return TRUE
-	return FALSE
 
-/datum/ai_behavior/return_home/perform(seconds_per_tick, datum/ai_controller/controller, target_key)
-	. = ..()
-	var/mob/living/living_pawn = controller.pawn
-	var/static/list/possible_emotes = list("rests its legs...", "yawns and naps...", "curls up and rests...")
-	living_pawn.custom_emote(EMOTE_VISIBLE, pick(possible_emotes))
-	controller.set_blackboard_key(BB_DEER_RESTING, world.time + 15 SECONDS)
-	controller.set_blackboard_key(BB_DEER_NEXT_REST_TIMER, world.time + rand(minimum_time, maximum_time))
-	return AI_BEHAVIOR_DELAY | AI_BEHAVIOR_SUCCEEDED
-
-/datum/ai_behavior/return_home/incursion_portal
-	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT
-
-/datum/ai_behavior/return_home/incursion_portal/perform(seconds_per_tick, datum/ai_controller/controller, target_key)
-	. = ..()
-	return AI_BEHAVIOR_SUCCEEDED
+	if(succeeded)
+		var/mob/living/living_pawn = controller.pawn
+		var/static/list/possible_emotes = list("rests its legs...", "yawns and naps...", "curls up and rests...")
+		living_pawn.custom_emote(EMOTE_VISIBLE, pick(possible_emotes))
+		controller.set_blackboard_key(BB_DEER_RESTING, world.time + 15 SECONDS)
+		controller.set_blackboard_key(BB_DEER_NEXT_REST_TIMER, world.time + rand(minimum_time, maximum_time))

--- a/paradise.dme
+++ b/paradise.dme
@@ -473,6 +473,7 @@
 #include "code\datums\ai\basic_mobs\basic_ai_behaviors\emote_with_target.dm"
 #include "code\datums\ai\basic_mobs\basic_ai_behaviors\interact_with_target.dm"
 #include "code\datums\ai\basic_mobs\basic_ai_behaviors\nearest_targeting.dm"
+#include "code\datums\ai\basic_mobs\basic_ai_behaviors\return_home.dm"
 #include "code\datums\ai\basic_mobs\basic_ai_behaviors\run_away_from_target.dm"
 #include "code\datums\ai\basic_mobs\basic_ai_behaviors\stop_and_stare.dm"
 #include "code\datums\ai\basic_mobs\basic_ai_behaviors\swirl_around.dm"


### PR DESCRIPTION
## What Does This PR Do
This PR splits out the behavior that deer use after returning home (resting emotes) from the behavior that demons use for returning to their home portal.
## Why It's Good For The Game
Demons shouldn't be getting sleepy
<img width="887" height="213" alt="2025_11_23__07_58_33__Events dashboard - Elastic" src="https://github.com/user-attachments/assets/814bcdc8-ebde-4149-b5c4-824de217e06c" />
## Testing
Ensured that the deer side of things worked properly and that they only emoted once they reached their destination. Didn't check the demon side but since /datum/ai_behavior/return_home/incursion_portal is basically a passthrough, I think it should be fine.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Incursion demons will no longer take naps when returning to defend their portals.
/:cl: