### PR TITLE
Fixes new PKA guns having no inhand sprite

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -186,6 +186,7 @@
 	desc = "A heavy-duty proto-kinetic accelerator that uses highly overclocked coils to fire a kinetic projectile at staggering speeds."
 	icon_state = "kineticrailgun"
 	base_icon_state = "kineticrailgun"
+	inhand_icon_state = "kineticgun"
 	w_class = WEIGHT_CLASS_HUGE
 	overheat_time = 3 SECONDS
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic/railgun)
@@ -213,6 +214,7 @@
 	desc = "A proto-kinetic accelerator boasting deeper capacitors for prolonged firing solutions."
 	icon_state = "kineticrepeater"
 	base_icon_state = "kineticrepeater"
+	inhand_icon_state = "kineticgun"
 	overheat_time = 2 SECONDS
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic/repeater)
 	max_mod_capacity = 75
@@ -229,6 +231,7 @@
 	desc = "A sleek proto-kinetic accelerator with an integrated scattering system, allowing for multiple kinetic blasts to be released simultaneously."
 	icon_state = "kineticshotgun"
 	base_icon_state = "kineticshotgun"
+	inhand_icon_state = "kineticgun"
 	overheat_time = 2 SECONDS
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic/shotgun)
 	weapon_weight = WEAPON_HEAVY
@@ -247,6 +250,7 @@
 	desc = "A short-range portable cannon that fires a kinetic slug into the ground, allowing it to split and strike in all directions."
 	icon_state = "kineticshockwave"
 	base_icon_state = "kineticshockwave"
+	inhand_icon_state = "kineticgun"
 	overheat_time = 2 SECONDS
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic/shockwave)
 	max_mod_capacity = 75


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes PKA guns not having an inhand sprite. They use the regular PKA inhand sprite.

## Why It's Good For The Game

Guns should have sprites.

## Testing

Held a PKA accellerator and PKA shotgun. Fired a few rounds.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed PKA weapons not having inhand sprites.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
