### PR TITLE
Silicons' decompiler now makes noise when it recycles a small mob.

### DIFF
--- a/code/modules/mob/living/basic/friendly/lizard.dm
+++ b/code/modules/mob/living/basic/friendly/lizard.dm
@@ -92,6 +92,7 @@
 		C.stored_comms["metal"] += 2 // having more metal than glass because blood has iron in it
 		C.stored_comms["glass"] += 1
 		qdel(src)
+		playsound(src, 'sound/misc/demon_consume.ogg', 10, TRUE, SOUND_RANGE_SET(4))
 		return TRUE
 	return ..()
 

--- a/code/modules/mob/living/basic/friendly/mouse.dm
+++ b/code/modules/mob/living/basic/friendly/mouse.dm
@@ -267,6 +267,7 @@
 		new/obj/effect/decal/cleanable/blood/splatter(get_turf(src))
 		C.stored_comms["metal"] += 2
 		C.stored_comms["glass"] += 1
+		playsound(src, 'sound/misc/demon_consume.ogg', 10, TRUE, SOUND_RANGE_SET(4))
 		qdel(src)
 		return TRUE
 	return ..()

--- a/code/modules/mob/living/basic/hostile/spiderlings.dm
+++ b/code/modules/mob/living/basic/hostile/spiderlings.dm
@@ -87,6 +87,7 @@
 	"<span class='warning'>It's a bit of a struggle, but you manage to suck [src] into your decompiler. It makes a series of visceral crunching noises.</span>")
 	C.stored_comms["metal"] += 2
 	C.stored_comms["glass"] += 1
+	playsound(src, 'sound/misc/demon_consume.ogg', 10, TRUE, SOUND_RANGE_SET(4))
 	qdel(src)
 	return TRUE
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Adds a quiet version of the demon eating sounds when a silicon decompiles a mouse, lizard, or spiderling.
## Why It's Good For The Game
The text says it makes a visceral crunching sound, we have the technology to make that reality.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

<!-- How did you test the PR, if at all? -->
Eated each of the eatable mobs, they were cronchy
## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Silicons decompiling small mobs makes a noise now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
