### PR TITLE
fix overlay stacking on action HUD icons

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -27,6 +27,8 @@
 	var/shown_to_observers = FALSE
 	/// Whether or not this button is locked, preventing it from being dragged.
 	var/locked = TRUE
+	/// Overlay for displaying the availability of the button
+	var/image/unavailable_image
 
 /atom/movable/screen/movable/action_button/Destroy()
 	. = ..()

--- a/code/datums/actions/action.dm
+++ b/code/datums/actions/action.dm
@@ -30,8 +30,6 @@
 	var/show_to_observers = TRUE
 	/// Toggles whether this action is usable or not
 	var/action_disabled = FALSE
-	/// The appearance used as an overlay for when the action is unavailable
-	var/mutable_appearance/unavailable_effect
 	/// If False, the owner of this action does not get a hud and cannot activate it on their own
 	var/owner_has_control = TRUE
 
@@ -194,7 +192,7 @@
  * force - whether an update is forced regardless of existing status
  */
 /datum/action/proc/update_button_status(atom/movable/screen/movable/action_button/button, force = FALSE)
-	button.overlays -= unavailable_effect
+	button.cut_overlay(button.unavailable_image)
 	button.maptext = ""
 	if(IsAvailable(show_message = FALSE))
 		button.color = rgb(255, 255, 255, 255)
@@ -268,13 +266,18 @@
 			return
 
 /datum/action/proc/apply_unavailable_effect(atom/movable/screen/movable/action_button/button)
-	if(isnull(unavailable_effect))
-		unavailable_effect = mutable_appearance('icons/mob/screen_white.dmi', icon_state = "template")
-		unavailable_effect.alpha = 200
-		unavailable_effect.appearance_flags = RESET_COLOR | RESET_ALPHA
-		unavailable_effect.color = "#000000"
-		unavailable_effect.plane = FLOAT_PLANE + 1
-	button.overlays |= unavailable_effect
+	if(isnull(button.unavailable_image))
+		var/mutable_appearance/ma = mutable_appearance(
+			icon = 'icons/mob/screen_white.dmi',
+			icon_state = "template",
+			plane = FLOAT_PLANE + 1,
+			alpha = 200,
+			appearance_flags = RESET_COLOR | RESET_ALPHA,
+			color = "#000000",
+		)
+		button.unavailable_image = new
+		button.unavailable_image.appearance = ma
+	button.add_overlay(button.unavailable_image)
 
 /**
  * Applies any overlays to our button

--- a/code/datums/actions/spell_action.dm
+++ b/code/datums/actions/spell_action.dm
@@ -48,21 +48,27 @@
 	return FALSE
 
 /datum/action/spell_action/apply_unavailable_effect(atom/movable/screen/movable/action_button/button)
-	var/datum/spell/S = target
-	if(!istype(S))
-		return ..()
+	var/datum/spell/spell = target
+	if(!istype(spell))
+		return
 
-	unavailable_effect = mutable_appearance('icons/mob/screen_white.dmi', icon_state = "template")
-	unavailable_effect.appearance_flags = RESET_COLOR | RESET_ALPHA
-	unavailable_effect.color = "#000000"
-	unavailable_effect.plane = FLOAT_PLANE + 1
-	unavailable_effect.alpha = S.cooldown_handler.get_cooldown_alpha()
+	var/text = spell.cooldown_handler.cooldown_info()
 
-	// Make a holder for the charge text
+	button.cut_overlay(button.unavailable_image)
+	var/mutable_appearance/ma = mutable_appearance(
+		icon = 'icons/mob/screen_white.dmi',
+		icon_state = "template",
+		plane = FLOAT_PLANE + 1,
+		alpha = spell.cooldown_handler.get_cooldown_alpha(),
+		appearance_flags = RESET_COLOR | RESET_ALPHA,
+		color = "#000000"
+	)
+	button.unavailable_image = new
+	button.unavailable_image.appearance = ma
+
+	// Make a holder for the charge text, and yes this needs to be a separate overlay on our overlay
 	var/image/count_down_holder = mutable_appearance('icons/effects/effects.dmi', icon_state = "nothing", appearance_flags = RESET_COLOR | RESET_ALPHA)
-	var/text = S.cooldown_handler.cooldown_info()
-	count_down_holder.maptext_y = 4
+	count_down_holder.maptext_y = 4 // bump up off the bottom border
 	count_down_holder.maptext = "<div style=\"font-size:6pt;color:[recharge_text_color];font:'Small Fonts';text-align:center;\" valign=\"bottom\">[text]</div>"
-	unavailable_effect.add_overlay(count_down_holder)
-
-	button.overlays |= unavailable_effect
+	button.unavailable_image.overlays += count_down_holder
+	button.add_overlay(button.unavailable_image)


### PR DESCRIPTION
## What Does This PR Do
This PR improves how action buttons display their cooldown effect and text. Might fix #30360 but not certain, will require TMing.
## Why It's Good For The Game
Bugfix
## Testing
<img width="2161" height="800" alt="2025_11_24__12_06_02__Paradise Station 13" src="https://github.com/user-attachments/assets/ab099a9a-873f-42c4-a382-26633e2d1674" />

Can see here that the appearance of the glare button is the same for the vamp player and the observer.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
fix: Action buttons with cooldowns should appear properly to observers.
/:cl: