### PR TITLE
fix hijack showing as traitor on antaghud

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -114,7 +114,7 @@ RESTRICT_TYPE(/datum/antagonist/traitor)
 	var/is_contractor = LAZYACCESS(GLOB.contractors, owner)
 	if(locate(/datum/objective/hijack) in owner.get_all_objectives())
 		antag_hud_name = is_contractor ? "hudhijackcontractor" : "hudhijack"
-	if(locate(/datum/objective/nuke) in owner.get_all_objectives())
+	else if(locate(/datum/objective/nuke) in owner.get_all_objectives())
 		antag_hud_name = is_contractor ? "hudnukecontractor" : "hudnuke"
 	else
 		antag_hud_name = is_contractor ? "hudcontractor" : "hudsyndicate"


### PR DESCRIPTION
## What Does This PR Do
there was a skipped else if, causing it to hit the else block, resetting the icon to the normal traitor icon. Fixes #31092
## Why It's Good For The Game
Hijackers now show properly on antaghud
## Images of changes

<img width="99" height="98" alt="image" src="https://github.com/user-attachments/assets/4423ba96-8ad4-467d-89b6-5c497a3adaf4" />

## Testing
Forced my character to hijack. Icon showed.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Antaghud shows the right icon for hijack.
/:cl: