### PR TITLE
make chicken noodle soup require chicken

### DIFF
--- a/code/modules/cooking/recipes/stove_recipes.dm
+++ b/code/modules/cooking/recipes/stove_recipes.dm
@@ -51,7 +51,7 @@
 	product_type = /obj/item/food/soup/chicken_noodle_soup
 	catalog_category = COOKBOOK_CATEGORY_SOUPS
 	steps = list(
-		PCWJ_ADD_MEATHUNK(),
+		PCWJ_ADD_ITEM(/obj/item/food/meat/chicken),
 		PCWJ_ADD_ITEM(/obj/item/food/boiledspaghetti),
 		PCWJ_ADD_PRODUCE(/obj/item/food/grown/carrot),
 		PCWJ_ADD_REAGENT("water", 10),


### PR DESCRIPTION
## What Does This PR Do
This PR changes the chicken noodle soup recipe to require chicken meat, instead of beef.
## Why It's Good For The Game
Seems more appropriate for the recipe.
## Testing
Visual inspection.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
tweak: The chicken noodle soup recipe now requires chicken meat, not beef.
/:cl: