### PR TITLE
Adds Printers to Delta Science + Sus Vent Movement and RND Floor Cleaning

### DIFF
--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -26942,6 +26942,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/storage)
+"ccR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/robotics)
 "ccU" = (
 /obj/machinery/light_switch{
 	name = "north bump";
@@ -39917,13 +39921,6 @@
 	},
 /turf/space,
 /area/station/engineering/solar/aft_starboard)
-"cZa" = (
-/obj/item/clothing/glasses/science{
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/science/rnd)
 "cZb" = (
 /obj/machinery/sleeper{
 	dir = 4
@@ -40060,17 +40057,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/electrical/aft_port)
 "cZs" = (
-/obj/structure/table/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm/directional/west,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = -5;
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 8
 	},
+/obj/machinery/photocopier,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/rnd)
 "cZt" = (
@@ -40326,12 +40318,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/research)
-"dav" = (
-/obj/effect/turf_decal/tiles/department/science/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/science/robotics)
 "daw" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/turf_decal/tiles/department/science/corner{
@@ -40419,6 +40405,7 @@
 /obj/item/clipboard,
 /obj/item/toy/figure/crew/scientist,
 /obj/item/clothing/glasses/welding,
+/obj/item/weldingtool/research,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/rnd)
 "daL" = (
@@ -40436,6 +40423,11 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = -5;
+	pixel_y = 5
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/rnd)
 "daM" = (
@@ -41174,6 +41166,10 @@
 /obj/item/pen,
 /obj/machinery/light,
 /obj/effect/turf_decal/tiles/department/science/corner,
+/obj/item/clothing/glasses/science{
+	pixel_x = 2;
+	pixel_y = 4
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/rnd)
 "ddI" = (
@@ -41774,7 +41770,6 @@
 	},
 /obj/item/paper_bin/nanotrasen,
 /obj/item/pen/multi,
-/obj/effect/turf_decal/delivery/hollow,
 /obj/item/paicard{
 	pixel_y = -2;
 	pixel_x = 5
@@ -42081,14 +42076,12 @@
 /obj/machinery/computer/message_monitor{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel/white,
 /area/station/command/office/rd)
 "die" = (
 /obj/structure/table/reinforced,
 /obj/item/aicard,
 /obj/item/circuitboard/aicore,
-/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -42413,11 +42406,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/station/command/office/rd)
 "djr" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel/white,
 /area/station/command/office/rd)
 "djv" = (
@@ -42711,30 +42704,8 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/abandoned_garden)
-"dkQ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/department/science/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/command/office/rd)
 "dkR" = (
 /obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel/white,
 /area/station/command/office/rd)
 "dkS" = (
@@ -42742,19 +42713,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/white,
 /area/station/command/office/rd)
 "dkT" = (
 /obj/structure/chair/office,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel/white,
 /area/station/command/office/rd)
 "dkV" = (
@@ -42985,11 +42949,7 @@
 /obj/machinery/power/apc/directional/west,
 /obj/item/kirbyplants/large,
 /obj/structure/cable,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery/hollow,
 /obj/effect/turf_decal/tiles/department/science/corner{
 	dir = 1
 	},
@@ -43296,7 +43256,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -43312,7 +43271,6 @@
 /obj/machinery/computer/card/minor/rd{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery/hollow,
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 4
 	},
@@ -43328,8 +43286,10 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/command/office/rd)
 "dnq" = (
@@ -43543,7 +43503,6 @@
 /area/station/maintenance/port2)
 "doJ" = (
 /obj/machinery/requests_console/directional/west,
-/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/computer/ai_resource{
 	dir = 4
 	},
@@ -43559,7 +43518,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery/hollow,
 /obj/effect/turf_decal/tiles/department/science/corner,
 /turf/simulated/floor/plasteel/white,
 /area/station/command/office/rd)
@@ -43573,9 +43531,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/turf_decal/tiles/department/science/side,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/white,
 /area/station/command/office/rd)
 "doN" = (
@@ -43729,7 +43687,6 @@
 	department = "Research Director's Office"
 	},
 /obj/machinery/newscaster/directional/south,
-/obj/effect/turf_decal/delivery/hollow,
 /obj/effect/turf_decal/tiles/department/science/corner{
 	dir = 8
 	},
@@ -43783,7 +43740,6 @@
 /obj/machinery/computer/robotics{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery/hollow,
 /obj/effect/turf_decal/tiles/department/science/corner,
 /turf/simulated/floor/plasteel/white,
 /area/station/command/office/rd)
@@ -44290,6 +44246,12 @@
 /obj/effect/turf_decal/tiles/department/cargo/side,
 /turf/simulated/floor/plasteel,
 /area/station/supply/expedition)
+"dtm" = (
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/south)
 "dto" = (
 /obj/structure/sign/science{
 	icon_state = "xenobio2"
@@ -44747,13 +44709,10 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics)
 "dvq" = (
-/obj/structure/mirror{
-	pixel_x = 32
-	},
-/obj/structure/sink/directional/east,
 /obj/effect/turf_decal/tiles/department/science/side{
-	dir = 5
+	dir = 1
 	},
+/obj/machinery/economy/vending/robodrobe,
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics)
 "dvr" = (
@@ -44891,14 +44850,14 @@
 /area/station/science/robotics)
 "dwq" = (
 /obj/structure/shelf/science,
-/obj/item/storage/belt/utility/full,
+/obj/effect/turf_decal/tiles/department/science/side{
+	dir = 8
+	},
+/obj/item/storage/belt/utility/full/multitool,
 /obj/item/clothing/head/welding,
 /obj/item/clothing/glasses/welding,
 /obj/item/mecha_parts/core,
 /obj/item/paicard,
-/obj/effect/turf_decal/tiles/department/science/side{
-	dir = 8
-	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics)
 "dwr" = (
@@ -44932,6 +44891,10 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	name = "east bump";
+	pixel_x = 30
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/south)
@@ -45203,12 +45166,10 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics)
 "dyO" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics)
 "dyR" = (
@@ -45314,10 +45275,6 @@
 /obj/item/cartridge/signal/toxins{
 	pixel_y = 6
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery/hollow,
 /obj/item/toy/figure/crew/rd,
 /obj/item/clipboard,
 /obj/effect/turf_decal/tiles/department/science/corner{
@@ -45649,19 +45606,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
 "dBO" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/machinery/button/windowtint{
-	dir = 8;
-	id = "RoboSurgery";
-	pixel_x = 24
-	},
-/obj/item/storage/firstaid/machine,
-/obj/item/storage/firstaid/machine,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/robotanalyzer,
 /obj/effect/turf_decal/tiles/department/science/side{
-	dir = 5
+	dir = 4
+	},
+/obj/structure/sink/directional/east,
+/obj/structure/mirror{
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics)
@@ -45721,6 +45671,12 @@
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/wood,
 /area/station/maintenance/theatre)
+"dCr" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/command/office/rd)
 "dCs" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/papersack/smiley,
@@ -46203,9 +46159,6 @@
 /turf/simulated/floor/carpet,
 /area/station/hallway/primary/aft/south)
 "dEX" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/structure/table,
 /obj/item/mmi/robotic_brain,
 /turf/simulated/floor/plasteel/dark,
@@ -46282,7 +46235,6 @@
 /turf/simulated/floor/carpet,
 /area/station/hallway/primary/aft/south)
 "dFw" = (
-/obj/structure/table/reinforced,
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
 	id = "RoboSurgery"
@@ -46290,11 +46242,11 @@
 /obj/item/mmi,
 /obj/item/mmi,
 /obj/item/mmi,
-/obj/effect/turf_decal/delivery/hollow,
 /obj/item/mmi,
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 8
 	},
+/obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics)
 "dFx" = (
@@ -46309,10 +46261,6 @@
 /area/station/hallway/primary/aft/south)
 "dFy" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery/hollow,
 /obj/item/storage/surgical_tray,
 /obj/item/storage/box/gloves{
 	pixel_x = 3;
@@ -46320,6 +46268,11 @@
 	},
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 4
+	},
+/obj/machinery/button/windowtint{
+	dir = 8;
+	id = "RoboSurgery";
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics)
@@ -46672,7 +46625,6 @@
 /area/station/hallway/primary/aft/south)
 "dHR" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/delivery/hollow,
 /obj/item/storage/box/bodybags{
 	pixel_x = -2;
 	pixel_y = 16
@@ -47773,12 +47725,14 @@
 /obj/structure/sign/nosmoking_2{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/delivery/hollow,
 /obj/item/tank/internals/anesthetic,
 /obj/item/clothing/mask/breath/medical,
 /obj/item/reagent_containers/glass/bottle/morphine,
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 6
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics)
@@ -49507,10 +49461,10 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat)
 "ecg" = (
-/obj/machinery/economy/vending/robodrobe,
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 1
 	},
+/obj/machinery/photocopier,
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics)
 "ecm" = (
@@ -50453,10 +50407,6 @@
 /turf/simulated/floor/carpet/black,
 /area/station/command/office/captain/bedroom)
 "etR" = (
-/obj/structure/extinguisher_cabinet{
-	name = "east bump";
-	pixel_x = 30
-	},
 /obj/effect/turf_decal/tiles/neutral/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/south)
@@ -53470,6 +53420,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/gambling_den)
+"fGV" = (
+/obj/effect/turf_decal/tiles/department/science/side{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/robotics)
 "fGW" = (
 /obj/machinery/power/apc/reinforced/directional/south,
 /obj/structure/cable{
@@ -57972,6 +57931,10 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/legal/courtroom/gallery)
+"hIo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/genetics)
 "hIQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -59437,10 +59400,6 @@
 /obj/effect/turf_decal/tiles/department/command/side,
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
-"ipU" = (
-/obj/item/weldingtool/research,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/rnd)
 "ipZ" = (
 /obj/machinery/economy/vending/cigarette,
 /turf/simulated/floor/plasteel/dark,
@@ -62378,6 +62337,22 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/misc_lab)
+"jIV" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/science/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/plasteel/white,
+/area/station/command/office/rd)
 "jJc" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -62928,9 +62903,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/port2)
 "jTj" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/alarm/directional/south,
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
@@ -67813,6 +67785,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"mdy" = (
+/obj/effect/turf_decal/tiles/department/science/side{
+	dir = 5
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/machine,
+/obj/item/storage/firstaid/machine,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/robotanalyzer,
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/robotics)
 "mej" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
@@ -72002,13 +71985,13 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/tiles/department/science/corner{
 	dir = 1
 	},
+/obj/machinery/photocopier,
 /turf/simulated/floor/plasteel/white,
 /area/station/command/office/rd)
 "nUK" = (
@@ -72849,10 +72832,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
@@ -73456,6 +73441,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/geneticist,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
 "oyz" = (
@@ -75140,6 +75126,10 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/control)
+"pkE" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/genetics)
 "pla" = (
 /obj/effect/spawner/random/barrier/wall_probably,
 /turf/simulated/floor/plating,
@@ -80338,12 +80328,6 @@
 /turf/simulated/floor/wood,
 /area/station/command/office/hop)
 "rwE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
@@ -80778,6 +80762,11 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/surgery/primary)
+"rEH" = (
+/obj/effect/turf_decal/tiles/department/science,
+/obj/item/kirbyplants/large,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/south)
 "rEP" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment{
@@ -81282,6 +81271,9 @@
 "rQf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
@@ -84428,6 +84420,7 @@
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 5
 	},
+/obj/machinery/photocopier,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
 "taP" = (
@@ -85424,12 +85417,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/hydroponics)
-"twU" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/science/genetics)
 "twX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -87587,8 +87574,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
 "ukz" = (
@@ -88045,12 +88033,6 @@
 /obj/effect/turf_decal/tiles/department/medical,
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/starboard)
-"uxc" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/science/genetics)
 "uxr" = (
 /obj/structure/morgue{
 	dir = 8
@@ -93835,6 +93817,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
 "wQD" = (
@@ -94533,6 +94518,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tiles/department/science/side,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
 "xdo" = (
@@ -94742,6 +94730,9 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tiles/department/science/side,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
 "xhW" = (
@@ -95115,11 +95106,6 @@
 /obj/effect/turf_decal/tiles/neutral/side,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
-"xoT" = (
-/obj/item/kirbyplants/large,
-/obj/effect/turf_decal/tiles/department/science,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/south)
 "xpf" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 4
@@ -131455,7 +131441,7 @@ dmq
 dmq
 dmq
 lOU
-twU
+drX
 rQf
 bex
 dta
@@ -131969,7 +131955,7 @@ egq
 vyp
 ppI
 drX
-uxc
+drX
 drX
 xdl
 fBk
@@ -131982,7 +131968,7 @@ dif
 djG
 dkR
 dsF
-dsF
+dCr
 doL
 hkY
 drz
@@ -132224,10 +132210,10 @@ nxD
 uHI
 gdm
 vyp
-drX
-drX
+pkE
+hIo
 oyv
-drX
+hIo
 xhB
 eEq
 dau
@@ -132493,7 +132479,7 @@ cPn
 hkY
 dhO
 djq
-djI
+jIV
 dkT
 nBZ
 dnq
@@ -132750,7 +132736,7 @@ cPn
 mWS
 dhP
 djr
-dkQ
+djI
 dzS
 dnn
 doK
@@ -134799,7 +134785,7 @@ cTR
 cVt
 cZA
 daJ
-cZa
+daJ
 daJ
 cvT
 ddD
@@ -135056,7 +135042,7 @@ cTR
 cVu
 cZA
 daJ
-ipU
+daJ
 daK
 cvT
 ddE
@@ -135074,8 +135060,8 @@ knL
 dws
 dvo
 dyO
-dyR
-opr
+ccR
+fGV
 dtN
 mxK
 lmg
@@ -135845,7 +135831,7 @@ dvr
 opr
 dXr
 dvq
-dav
+dyR
 dyS
 dzZ
 ddy
@@ -136101,7 +136087,7 @@ cTP
 rEc
 cTP
 dql
-dql
+mdy
 dBO
 dFy
 dQq
@@ -136356,9 +136342,9 @@ dfo
 dqp
 drK
 ank
-ank
-xoT
+rEH
 lkI
+dql
 dql
 dql
 dbg
@@ -136614,7 +136600,7 @@ mNM
 drL
 cVA
 cVA
-cVA
+dtm
 cZR
 dHT
 wiE
@@ -137385,8 +137371,8 @@ dEo
 jnu
 ank
 ank
-dfu
 lmh
+dfu
 dfu
 dfu
 dfu


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Adds a photocopier to Delta science RND, Robotics, RD office, Genetics.
- Rearranges some vents and scrubbers for better airflow on draught mode.
- Picks up the goggles and welder from the floor in RND.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Robotics requires paperwork for borging, it's a good idea to allow easy duplication of the paperwork.
Other public facing desks have been provided with printers since some material they can give out may require a paper trail too.
RD gets a printer because they really really should have access to one as the department head.

The airflow must be improved and it's a very minor additional change.

There shouldn't be stuff on the floor in RND (at round start).
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Genetics
<img width="192" height="160" alt="image" src="https://github.com/user-attachments/assets/900f383f-0e87-4701-9c24-4ae4dda1793d" />
RND
<img width="160" height="96" alt="image" src="https://github.com/user-attachments/assets/2b118aee-e57e-4d83-b5b7-e70210b849f6" />
Robotics.
<img width="384" height="256" alt="image" src="https://github.com/user-attachments/assets/e8ab222f-75fe-430e-a091-35c9d3bf2fd5" />
RD office.
<img width="224" height="288" alt="image" src="https://github.com/user-attachments/assets/7ab43b3d-45ec-4914-9055-5dff06db28b9" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Visual inspection.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Added a photocopier to Delta RND, Robotics, Genetics, and RD office.
tweak: Tidied up the stuff on the floor of Delta RND.
tweak: Moved vents and scrubbers around in Delta RND, Genetics, RD office for better airflow.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
