### PR TITLE
Adds a photocopier to metastation's cargo office

### DIFF
--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -37633,6 +37633,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
+"fQu" = (
+/obj/effect/turf_decal/tiles/department/cargo/corner{
+	dir = 4
+	},
+/obj/item/kirbyplants/large,
+/turf/simulated/floor/plasteel,
+/area/station/supply/lobby)
 "fQE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -67232,7 +67239,6 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/aft)
 "qoL" = (
-/obj/item/kirbyplants/large,
 /obj/machinery/light_switch{
 	name = "north bump";
 	pixel_y = 24
@@ -67240,6 +67246,7 @@
 /obj/effect/turf_decal/tiles/department/cargo/side{
 	dir = 1
 	},
+/obj/machinery/photocopier,
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
 "qoQ" = (
@@ -108955,7 +108962,7 @@ pVY
 eTU
 tti
 iAF
-hBu
+fQu
 xyq
 uZZ
 eEh


### PR DESCRIPTION
## What Does This PR Do
Adds one (1) photocopier to metastation's cargo office. Also moves the plant in the office from said office to the cargo lobby.
## Why It's Good For The Game
The cargo photocopier is present on every station except this one. That's no good.
## Images of changes
<img width="384" height="192" alt="image" src="https://github.com/user-attachments/assets/893056ff-be8f-485d-8067-c090023630ad" />

## Testing
Visual inspection.
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Added a photocopier to metastation's cargo office.
/:cl: