### PR TITLE
add poisoned apples as an apple mutation

### DIFF
--- a/code/modules/hydroponics/grown/apple.dm
+++ b/code/modules/hydroponics/grown/apple.dm
@@ -13,7 +13,7 @@
 	icon_grow = "apple-grow"
 	icon_dead = "apple-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	mutatelist = list(/obj/item/seeds/apple/gold)
+	mutatelist = list(/obj/item/seeds/apple/gold, /obj/item/seeds/apple/poisoned)
 	reagents_add = list("vitamin" = 0.04, "plantmatter" = 0.1)
 
 /obj/item/food/grown/apple


### PR DESCRIPTION
## What Does This PR Do
Adds poisoned apples to the apple mutation list. fixes #30984

The seeds and apple are a carbon copy of the normal apple seeds as shown here:
<img width="151" height="100" alt="image" src="https://github.com/user-attachments/assets/36819c46-f77a-4287-85b3-d7abc0d17cfe" />

<img width="196" height="107" alt="image" src="https://github.com/user-attachments/assets/4eacf9a0-c870-4c47-8f9d-76c264373087" />

The one on the right is poisoned seeds/apple.

Stats for nerds:
<img width="460" height="533" alt="image" src="https://github.com/user-attachments/assets/0e8e1a8b-7d67-4ecf-a70e-7a1a6beebe2f" />

## Why It's Good For The Game
they're currently unobtainable and not mapped in anywhere.
## Testing
Mutated an apple tree into both.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: adds poisoned apples as an apple mutation
/:cl: