### PR TITLE
fix carrot fries recipe failing

### DIFF
--- a/code/modules/cooking/recipes/midway_recipes.dm
+++ b/code/modules/cooking/recipes/midway_recipes.dm
@@ -78,8 +78,8 @@
 	// recipe with only one item
 	for(var/datum/cooking/recipe/recipe in GLOB.pcwj_recipe_dictionary[/obj/item/reagent_containers/cooking/deep_basket])
 		if(length(recipe.steps) == 2) // One add step and one deep fry step
-			var/datum/cooking/recipe_step/add_item/add_item_step = recipe.steps[1]
-			if(istype(add_item_step) && (src != add_item_step) && add_item_step.check_conditions_met(added_item, tracker) == PCWJ_CHECK_VALID)
+			var/datum/cooking/recipe_step/add_step = recipe.steps[1]
+			if((src != add_step) && add_step.check_conditions_met(added_item, tracker) == PCWJ_CHECK_VALID)
 				return PCWJ_CHECK_INVALID
 
 	return PCWJ_CHECK_VALID


### PR DESCRIPTION
## What Does This PR Do
This PR fixes an issue where the "deep-fried anything" recipe would clobber recipes that added produce instead of a non-produce item. We were only checking add_item steps, not for the presence of add_produce steps, but in actuality the step type doesn't matter since we can just ask it if it works or not.
## Why It's Good For The Game
Bugfix.
## Testing
Ensured I could deepfry both sliced carrots and a random food item.
<img width="765" height="460" alt="2025_11_25__15_05_08__Paradise Station 13" src="https://github.com/user-attachments/assets/9a89f379-9d94-4d1f-8861-e72d4d5e1b5e" />

## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
fix: The recipe for carrot fries should work as expected.
/:cl:
