### PR TITLE
You no longer need a permit for a medbeam gun

### DIFF
--- a/code/modules/projectiles/guns/medbeam.dm
+++ b/code/modules/projectiles/guns/medbeam.dm
@@ -5,6 +5,7 @@
 	icon_state = "chronogun"
 	worn_icon_state = null
 	inhand_icon_state = null
+	needs_permit = FALSE
 	var/mob/living/current_target
 	var/last_check = 0
 	var/check_delay = 10 //Check los as often as possible, max resolution is SSobj tick though


### PR DESCRIPTION
## What Does This PR Do
Removes the permit requirement for the medbeam(and by extension, the damaged one)

## Why It's Good For The Game
Being attacked by beepsky for having a medgun is hilarious but really shouldn't happen since the gun is literally less than harmless unless theres two of them, but ya'know

## Testing
held a medgun, didn't get bonked
held a lasergun got bonked

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
probably a case could be made for this being a nukie buff? but its way more common else where right now


## Changelog

:cl:
tweak: Beepsky no longer treats you like a murder for having a medbeam gun(you don't need a permit for it anymore)
/:cl: