### PR TITLE
fix ai controller debugger UI state

### DIFF
--- a/code/modules/tgui/modules/ai_controller_debugger.dm
+++ b/code/modules/tgui/modules/ai_controller_debugger.dm
@@ -14,7 +14,7 @@
 	controller = controller_
 
 /datum/ui_module/ai_controller_debugger/ui_state(mob/user)
-	return GLOB.default_state
+	return GLOB.always_state
 
 /datum/ui_module/ai_controller_debugger/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)


### PR DESCRIPTION
## What Does This PR Do
This PR uses always_state for the AI debugger controller, so that it's valid to access it as an in-game mob or an observer. It still closes when switching between observer and non-observer mob but that seems to be the case for other UIs as well so that switch is probably somewhere else.
## Why It's Good For The Game
Debugging tools should be properly accessible.
## Testing
Spawned in as a carbon, opened the VV -> debugger controller on Betsy. Ensured I could access it. Ghosted. Opened the debugger controller again, ensured I could access it.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
NPFC