### PR TITLE
Fixes shelter capsules being blocked by large rocks and not removing wall plants + attack chain

### DIFF
--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -39,7 +39,9 @@
 	. += template.description
 
 /obj/item/survivalcapsule/activate_self(mob/user)
-	. = ..()
+	if(..())
+		return
+
 	// Can't grab when capsule is New() because templates aren't loaded then
 	get_template()
 	if(!used)
@@ -77,9 +79,8 @@
 
 		// get structures on turf, then delete large rocks and plants
 		var/affected_turfs = template.get_affected_turfs(deploy_location, TRUE)
-		for(var/turf/selected_turf in affected_turfs)
-			var/obj/structure/flora/ash/found_flora = locate(/obj/structure/flora/ash/, selected_turf)
-			if(found_flora != null)
+		for(var/turf/selected_turf as anything in affected_turfs)
+			for(var/obj/structure/flora/ash/found_flora in selected_turf)
 				qdel(found_flora)
 
 		SEND_GLOBAL_SIGNAL(COMSIG_GLOB_SHELTER_PLACED, T)

--- a/code/modules/mining/shelters.dm
+++ b/code/modules/mining/shelters.dm
@@ -24,7 +24,7 @@
 			return SHELTER_DEPLOY_BAD_TURFS
 
 		for(var/obj/O in T)
-			if(O.density && O.anchored && !istype(O, /obj/structure/flora/ash/)) // ignore large rocks
+			if(O.density && O.anchored && !istype(O, /obj/structure/flora/ash)) // ignore large rocks
 				return SHELTER_DEPLOY_ANCHORED_OBJECTS
 	return SHELTER_DEPLOY_ALLOWED
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Shelter capsules normally delete solid rock walls and plants on the ground such as cacti. This PR adds that functionality to large rocks. The PR also deletes plants from the walls of the shelter. And attack chain, because that is required. 

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

When you activate a shelter capsule you see that it clears solid rock walls and the plants off the ground, so its very confusing when the shelter gives you an error message because some large rocks (which are logically smaller than solid rock walls) blocks you. Plants remaining on top of the shelter walls have always looked bad.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Used a shelter capsule and a luxury shelter capsule. Confirmed they cleared large rocks and that no wall plants appeared. Confirmed the capsule would still be blocked as normal. 

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Shelter capsules (and luxury shelter capsules) now clears large rocks.
fix: Shelter capsules (and luxury shelter capsules) now clears plants off walls.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
