### PR TITLE
Fixes a bunch of bugs with chemical flamethrower canisters

### DIFF
--- a/code/game/objects/items/weapons/chemical_flamethrower/chemical_flamethrower.dm
+++ b/code/game/objects/items/weapons/chemical_flamethrower/chemical_flamethrower.dm
@@ -258,7 +258,6 @@
 
 	if(has_filled_reagent && (reagents.get_master_reagent_id() != current_reagent_id))
 		audible_message("<span class='notice'>[src]'s speaker beeps: chemical override started!</span>")
-		sleep(1 SECONDS)
 
 	if(!(reagents.get_master_reagent_id() in accepted_chemicals))
 		reagents.clear_reagents()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Canisters won't brick themselves if they already had a reagent inside. They will now start an "override" to  change the reagent inside of the canister.
- If you are filling a canister with the reagent that's already inside it, it recognizes that and will refill the canister if you put enough reagents inside of it again
- Pyrotechnical canisters now actually are named that  instead of being called extended canisters. oops
- Internal variable cleanup, now actually shows the reagent name instead of the reagent ID on examine

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bugfix good
Resolves #29219

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<img width="820" height="88" alt="image" src="https://github.com/user-attachments/assets/2cacd01c-084f-431a-8246-b8fcf9b62157" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
See above, filled a bunch of canisters a few times and they didn't brick
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixes a bunch of bugs with chemical flamethrower canisters. They won't brick as easily now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
