### PR TITLE
If a buckled mob enters a bear trap, damage buckled object

### DIFF
--- a/code/game/objects/items/weapons/legcuffs.dm
+++ b/code/game/objects/items/weapons/legcuffs.dm
@@ -111,14 +111,14 @@
 
 		if(ishuman(entered))
 			var/mob/living/carbon/H = entered
-			if(H.buckled) //if you ride your wheelchair into the trap, snare that instead
+			if(H.buckled) // if you ride your wheelchair into the trap, snare that instead
 				var/obj/buckled_obj = H.buckled
 				buckled_obj.take_damage(trap_damage, BRUTE)
 			else if(IS_HORIZONTAL(H))
 				H.apply_damage(trap_damage, BRUTE, "chest")
 			else
 				H.apply_damage(trap_damage, BRUTE, pick("l_leg", "r_leg"))
-			if(!H.legcuffed && H.get_num_legs() >= 2 && !H.buckled) //beartrap can't cuff you leg if there's already a beartrap or legcuffs.
+			if(!H.legcuffed && H.get_num_legs() >= 2 && !H.buckled) // beartrap can't cuff you leg if there's already a beartrap or legcuffs.
 				H.legcuffed = src
 				forceMove(H)
 				H.update_inv_legcuffed()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Makes it so that if a buckled mob runs over a bear trap, for example, in a wheelchair, the trap will damage the wheelchair instead of the mob.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Fixes #28088.
Also, it's just kind of silly for a bear trap to grab your leg when it wasn't your leg that stepped in it.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted, spawned as paraplegic character, wheeled over an armed bear trap, checked chair's integrity.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed bear traps damaging chests of wheelchair users who wheeled over them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
