### PR TITLE
add missing usr argument to tgui window in VV delete all

### DIFF
--- a/code/game/objects/obj_vv.dm
+++ b/code/game/objects/obj_vv.dm
@@ -26,7 +26,7 @@
 		if(tgui_alert(usr, "Are you really sure you want to delete all objects of type [type]?", "Confirm", list("Yes", "No")) != "Yes")
 			return
 
-		if(tgui_alert("Second confirmation required. Delete?", "Confirm", list("Yes", "No")) != "Yes")
+		if(tgui_alert(usr, "Second confirmation required. Delete?", "Confirm", list("Yes", "No")) != "Yes")
 			return
 
 		var/O_type = type


### PR DESCRIPTION
## What Does This PR Do
Adds a missing usr argument to the 2nd tgui confirmation window when deleting all of a type. It passed the string as the user.
## Why It's Good For The Game
No runtime
## Testing
I deleted all clowncars. It didn't runtime.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC