### PR TITLE
Fixes skeleton reanimators spawning in xenobio

### DIFF
--- a/code/modules/events/demon_incursion.dm
+++ b/code/modules/events/demon_incursion.dm
@@ -119,7 +119,7 @@
 					/mob/living/basic/hellhound/whelp = 5, // Specialized mobs - tank
 					/mob/living/basic/skeleton/incursion/security = 5, // Specialized mobs - ranged
 					/mob/living/basic/giant_spider/flesh_spider = 5, // Specialized mobs - poison/harasser
-					/mob/living/basic/skeleton/reanimator = 4, // Specialized mobs - Summoner
+					/mob/living/basic/skeleton/incursion/reanimator = 4, // Specialized mobs - Summoner
 					/mob/living/basic/skeleton/incursion/mobster = 1,) // Specialized mobs - ranged
 	icon = 'icons/obj/structures/portal.dmi'
 	icon_state = "portal"
@@ -133,7 +133,7 @@
 		/mob/living/basic/giant_spider/flesh_spider,
 		/mob/living/basic/skeleton/incursion/security,
 		/mob/living/basic/skeleton/incursion/mobster,
-		/mob/living/basic/skeleton/reanimator)
+		/mob/living/basic/skeleton/incursion/reanimator)
 	/// Chance that a mob type is special
 	var/special_chance = 15
 	/// The event that spawned this portal

--- a/code/modules/mob/living/basic/hostile/nether_mobs/skeleton_mob.dm
+++ b/code/modules/mob/living/basic/hostile/nether_mobs/skeleton_mob.dm
@@ -159,7 +159,7 @@
 /obj/projectile/bullet/skeleton_smg
 	damage = 5
 
-/mob/living/basic/skeleton/reanimator
+/mob/living/basic/skeleton/incursion/reanimator
 	name = "skeletal reanimator"
 	desc = "A dark necromancer from the depths of an unknowable darkness."
 	icon_state = "skeleton_reanimator"
@@ -175,11 +175,11 @@
 		/datum/action/cooldown/mob_cooldown/summon_skulls = BB_REANIMATOR_SKULL_ACTION,
 	)
 
-/mob/living/basic/skeleton/reanimator/Initialize(mapload)
+/mob/living/basic/skeleton/incursion/reanimator/Initialize(mapload)
 	. = ..()
 	grant_actions_by_list(reanimator_actions)
 
-/mob/living/basic/skeleton/reanimator/melee_attack(mob/living/carbon/human/target, list/modifiers, ignore_cooldown)
+/mob/living/basic/skeleton/incursion/reanimator/melee_attack(mob/living/carbon/human/target, list/modifiers, ignore_cooldown)
 	if(!ishuman(target))
 		return ..()
 	if(target.stat != DEAD)
@@ -198,7 +198,7 @@
 		sleep(3 SECONDS) // Locks the revitalizer down for 2 seconds, but gives the player 5 seconds to return
 		reanimate(target)
 
-/mob/living/basic/skeleton/reanimator/proc/reanimate(mob/living/carbon/human/H)
+/mob/living/basic/skeleton/incursion/reanimator/proc/reanimate(mob/living/carbon/human/H)
 	visible_message("<span class='warning'>[name] releases dark tendrils into the flesh of [H], morphing their corpse into a grotesque creature!</span>")
 	var/mob/living/basic/netherworld/blankbody/blank = new(H.loc)
 	blank.name = "[H]"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes an issue in the skeleton reanimator mob path that makes it spawn in xenobio and have improper health.

## Why It's Good For The Game

Mobs that shouldn't spawn in xeno shouldn't spawn in xeno.

## Testing

Compiled

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixes skeleton reanimators spawning in xenobio
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
