### PR TITLE
NSS Kerberos' / Deltastation's Holodeck Glassification

### DIFF
--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -35204,7 +35204,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/fitness)
 "cFF" = (
-/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -36463,13 +36462,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/fitness)
 "cJF" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/light/floor,
 /turf/simulated/floor/plasteel,
 /area/station/public/fitness)
 "cJG" = (
@@ -50839,13 +50836,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/station/turret_protected/ai_upload)
-"eCO" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tiles/neutral/corner,
-/turf/simulated/floor/plasteel,
-/area/station/public/fitness)
 "eDh" = (
 /obj/structure/closet/bombclosetsecurity,
 /turf/simulated/floor/plasteel/dark,
@@ -59672,6 +59662,13 @@
 /obj/structure/table/wood,
 /turf/simulated/floor/wood,
 /area/station/maintenance/library)
+"iwt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plasteel,
+/area/station/public/fitness)
 "iwu" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -60648,6 +60645,13 @@
 /obj/effect/turf_decal/tiles/neutral/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/west)
+"iRp" = (
+/obj/effect/turf_decal/tiles/neutral/side{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/turf/simulated/floor/plasteel,
+/area/station/public/fitness)
 "iRs" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 2
@@ -76467,15 +76471,6 @@
 /obj/effect/turf_decal/tiles/department/security/side,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"pMg" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/fitness)
 "pMq" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/structure/rack,
@@ -82976,9 +82971,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/sleeper)
-"stD" = (
-/turf/space,
-/area/station/public/fitness)
 "stH" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable,
@@ -87107,6 +87099,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
+"ubo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/light/floor,
+/turf/simulated/floor/plasteel,
+/area/station/public/fitness)
 "ubB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -90754,6 +90754,10 @@
 /obj/effect/turf_decal/tiles/department/engineering,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
+"vEc" = (
+/obj/machinery/light/floor,
+/turf/simulated/floor/plasteel,
+/area/station/public/fitness)
 "vEh" = (
 /obj/structure/table/reinforced,
 /obj/item/taperecorder,
@@ -152311,7 +152315,7 @@ cze
 cze
 cze
 cJB
-cLu
+iRp
 cuM
 xSg
 ema
@@ -153338,10 +153342,10 @@ cAv
 cAv
 cAv
 cFD
-pMg
+cFv
 gTT
 cHa
-eCO
+cWh
 cJD
 cMR
 cMR
@@ -153595,10 +153599,10 @@ iuY
 iuY
 iuY
 cFE
-csi
 iuY
 iuY
-csi
+iuY
+iuY
 cJE
 iuY
 iuY
@@ -153851,11 +153855,11 @@ aaa
 aaa
 abj
 iuY
-cFF
-csi
-stD
-stD
-csi
+ubo
+iuY
+abj
+abj
+iuY
 cJF
 iuY
 abj
@@ -154109,10 +154113,10 @@ tkb
 mFS
 mFS
 cFG
-csi
 iuY
 iuY
-csi
+iuY
+iuY
 cJG
 eOT
 eOT
@@ -155909,9 +155913,9 @@ abj
 aaa
 iuY
 cFF
-csi
-csi
-cJF
+vEc
+vEc
+iwt
 iuY
 aaa
 abj


### PR DESCRIPTION
## What Does This PR Do

- Replaces deltastation's holodeck's walls with reinforced glass windows and grilles in order to offer a full view of the holodeck to the spectators.
- Adds lattice between the reinforced glass station-side.
- Adds an extra row of chairs in the center of the holodeck's front.
- Removes the two walls next to the holodeck control's room.
- Replaces the light tubes lights that would be fixed to reinforced windows with floor lights.
- Adds a floorlight between the boxing ring and pool so that it is not too dark due to the removal of the holodeck's light tubes lights facing towards the fitness room.
- Removed a chair from the boxing ring's south row so it did not hide the floor light.


## Why It's Good For The Game

<img width="349" height="314" alt="south_spectator" src="https://github.com/user-attachments/assets/586a7793-8817-40aa-9910-0db88e214a6d" />
<img width="344" height="349" alt="north_spectator" src="https://github.com/user-attachments/assets/2171abb3-fe7d-44f8-a16b-a9f244bf80e7" />
<img width="376" height="376" alt="control_spectator" src="https://github.com/user-attachments/assets/b38ae59d-b82e-48ba-8c4a-20d32308629a" />


## Images of changes

<img width="257" height="383" alt="Delta_Holodeck" src="https://github.com/user-attachments/assets/42ab4ed7-b630-4779-b2dc-668af594e750" />
<img width="255" height="383" alt="Delta_Holodeck_Area" src="https://github.com/user-attachments/assets/f33d763e-9d53-4958-b9ba-274798f919b5" />
<img width="124" height="310" alt="Delta_Fitness_Light_Center" src="https://github.com/user-attachments/assets/82481b3e-5f44-48b7-a22a-7661d6a93183" />

## Testing

- Loaded the map, went to the holodeck, confirmed I did not accidentally make the holodeck or fitness room spaced round start. 
- Confirmed the lights were on.
- Squinted really hard to see if github hid a mapping conflict from me again, did not see anything about it being the case.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl: leboucliervert
tweak: The NSS Kerberos' holodeck now offers a better viewing experience to spectators.
tweak: A floorlight was added between the NSS Kerberos' pool and boxing ring. The central chair of the boxing ring's south row was removed so that it may shine unimpeded.
/:cl:
