### PR TITLE
Allows Janitorial Carts to Hold Any Spray Bottle (Fixes #31208)

### DIFF
--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -14,7 +14,7 @@
 	var/obj/item/storage/bag/trash/my_bag = null
 	var/obj/item/mop/my_mop = null
 	var/obj/item/push_broom/my_broom = null
-	var/obj/item/reagent_containers/spray/cleaner/my_spray = null
+	var/obj/item/reagent_containers/spray/my_spray = null
 	var/obj/item/lightreplacer/my_replacer = null
 	var/signs = 0
 	var/const/max_signs = 4
@@ -123,7 +123,7 @@
 			return
 		item_present = TRUE
 
-	if(istype(used, /obj/item/reagent_containers/spray/cleaner))
+	if(istype(used, /obj/item/reagent_containers/spray))
 		if(!my_spray)
 			my_spray = used
 			put_in_cart(user, used)


### PR DESCRIPTION
## What Does This PR Do
Title. The janitorial cart can now store any kind of spray bottle. Yes, even the clown's flower.

## Why It's Good For The Game
Fixes #31208 

## Testing

- Spawned a full janitorial cart and checked if it still started with a space cleaner spray bottle. It did.
- Spawned every kind of spray bottles and attempted to fit them in the janitorial cart. I was able to do so.
- Spawned every cyborgs containing spray bottles a drone. Possessed them one by one and attempted to store their spray bottle in the janitorial cart. I was **not** able to do so.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl: leboucliervert
tweak: Janitorial carts can now store any kind of spray bottle
/:cl:
