### PR TITLE
Temporary Revert "Fixes credits"

### DIFF
--- a/code/modules/credits/credits.dm
+++ b/code/modules/credits/credits.dm
@@ -24,7 +24,7 @@ GLOBAL_LIST(end_titles)
 
 	verbs += /client/proc/clear_credits
 	for(var/I in GLOB.end_titles)
-		if(!credits)
+		if(!length(credits))
 			return
 		var/atom/movable/screen/credit/T = new(null, null, I, src)
 		credits += T


### PR DESCRIPTION
Reverts ParadiseSS13/Paradise#31210 temporary due to an issue with the rounds not ending.