### PR TITLE
Fixes smith knives not being able to embed

### DIFF
--- a/code/modules/smithing/smithed_items/knives.dm
+++ b/code/modules/smithing/smithed_items/knives.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/smithing.dmi'
 	icon_state = "debug"
 	slot_flags = ITEM_SLOT_BELT
+	embedded_ignore_throwspeed_threshold = TRUE
 
 	new_attack_chain = TRUE
 	/// The quality of the item
@@ -136,6 +137,7 @@
 	name = "throwing knife"
 	desc = "A lightweight, balanced throwing knife. The sharp blade enhances the chance to embed."
 	icon_state = "throwing_knife"
+	throw_speed = 4
 	base_speed_mod = -0.25
 	base_productivity_mod = -0.25
 	throw_force_increase = 6 // 16 throw force at standard, 22 throw force at masterwork


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes smithed knives not being able to embed when thrown.

## Why It's Good For The Game

Smith knives that are advertised as being able to embed into targets should be able to embed into targets.

## Testing

Made a knife. Embedded it in a skrell's leg.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed smithed knives not embedding when thrown at a target
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
