### PR TITLE
Adds smithed knives to smith spawners

### DIFF
--- a/code/game/objects/effects/spawners/random/misc_spawners.dm
+++ b/code/game/objects/effects/spawners/random/misc_spawners.dm
@@ -199,7 +199,7 @@
 		/obj/item/smithed_item/lens/efficiency,
 		/obj/item/kitchen/knife/smithed/utility,
 		/obj/item/kitchen/knife/smithed/thrown,
-		/obj/item/kitchen/knife/smithed/combat
+		/obj/item/kitchen/knife/smithed/combat,
 	)
 
 /obj/effect/spawner/random/smithed_item/insert
@@ -235,7 +235,7 @@
 	loot = list(
 		/obj/item/kitchen/knife/smithed/utility,
 		/obj/item/kitchen/knife/smithed/thrown,
-		/obj/item/kitchen/knife/smithed/combat
+		/obj/item/kitchen/knife/smithed/combat,
 	)
 
 /obj/effect/spawner/random/space_pirate


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Adds premade smithed knives to the random smithed item spawners, and adds a spawner specifically for smithed knives.

## Why It's Good For The Game

Consistency with other smithed items, and easier debugging of smithed knives.

## Testing

Spawned knives with spawner.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Added smithed knives to random smithed item spawners.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
