### PR TITLE
Rainbow jumpsuits no longer are just "rainbow"

### DIFF
--- a/code/modules/clothing/under/color.dm
+++ b/code/modules/clothing/under/color.dm
@@ -252,7 +252,7 @@
 	icon_state = "darkredskirt"
 
 /obj/item/clothing/under/color/rainbow
-	name = "rainbow"
+	name = "rainbow jumpsuit"
 	desc = "rainbow."
 	icon_state = "rainbow"
 	inhand_icon_state = "rainbow"


### PR DESCRIPTION
## What Does This PR Do

Adds the word "jumpsuit" to the rainbow jumpsuits' name.

## Why It's Good For The Game

I do not want to get scammed and then find out I did not buy an actual rainbow.
<img width="206" height="34" alt="Rainbow_what_game" src="https://github.com/user-attachments/assets/67797541-8f60-458b-b1d7-4e5cd3376de9" />

## Images of changes

<img width="429" height="107" alt="oh_a_rainbow_that" src="https://github.com/user-attachments/assets/af5a5584-974e-46ba-930a-1012b2104804" />

## Testing

- Checked the name was correct in vendors. It was
- Checked the name was correct on examine and hovering. It was.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl: leboucliervert
fix: Rainbow jumpsuits are now actually named jumpsuits and not just "rainbow"
/:cl:
