### PR TITLE
Replaces Quicksilver Form passing through windows

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -981,7 +981,7 @@
 	var/should_deflect = FALSE
 
 /atom/movable/screen/alert/status_effect/quicksilver_form
-	name = "Quicksilver body"
+	name = "Quicksilver Form"
 	desc = "Your body is much less solid."
 	icon_state = "high"
 
@@ -1005,7 +1005,7 @@
 		ADD_TRAIT(owner, TRAIT_DEFLECTS_PROJECTILES, UNIQUE_TRAIT_SOURCE(src))
 	ADD_TRAIT(owner, TRAIT_HANDS_BLOCKED, "[id]")
 	temporary_flag_storage = owner.pass_flags
-	owner.pass_flags |= (PASSTABLE | PASSGRILLE | PASSMOB | PASSFENCE | PASSGIRDER | PASSGLASS | PASSTAKE | PASSBARRICADE)
+	owner.pass_flags |= (PASSTABLE | PASSGRILLE | PASSMOB | PASSFENCE | PASSGIRDER | PASSTAKE | PASSBARRICADE | PASSDOOR)
 	owner.add_atom_colour(COLOR_ALUMINIUM, TEMPORARY_COLOUR_PRIORITY)
 	return TRUE
 


### PR DESCRIPTION
## What Does This PR Do
Replaces the `PASSGLASS` tag in Quicksilver Form with `PASSDOOR`. This removes the ability for Mindflayers to walk freely through windows, and instead gives them the ability to walk through unbolted doors.
## Why It's Good For The Game
Walking into space in the middle of being chased doesn't seem very fun for the people chasing you.
## Testing
Compiled.
Activated Quicksilver Form.
Stopped by glass. Stopped by bolted door. Walked through unbolted door.
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<img width="532" height="109" alt="image" src="https://github.com/user-attachments/assets/a06a0ed2-a66c-4487-b9d4-8158ad94ebb5" />

## Changelog

:cl:
del: Removed the ability for Quicksilver Form to move through windows.
add: Added the ability for Quicksilver Form to pass through any unbolted door.
/:cl:
