### PR TITLE
Fix being able to point while dead

### DIFF
--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -2266,8 +2266,8 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	if(next_move >= world.time)
 		return
 
-	if(stat)
-		return FALSE
+	if(stat != CONSCIOUS)
+		return
 
 	if(istype(A, /obj/effect/temp_visual/point) || istype(A, /atom/movable/emissive_blocker))
 		return FALSE


### PR DESCRIPTION
## What Does This PR Do
Stop the dead from pointing. Fixes #31247
## Why It's Good For The Game
The dead cant point.
## Testing
Tried pointing while dead.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Prevent corpses being able to point.
/:cl: