### PR TITLE
Mechs can now point blank fire. Also sends a message if you're facing the wrong way to hit something

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -244,38 +244,46 @@
 		return
 
 	var/dir_to_target = get_dir(src, target)
-	if(dir_to_target && !(dir_to_target & dir))//wrong direction
+	if(dir_to_target && !(dir_to_target & dir)) // Wrong direction
+		to_chat(user, SPAN_WARNING("You're facing the wrong way!"))
 		return
 
 	if(hasInternalDamage(MECHA_INT_CONTROL_LOST))
-		target = safepick(view(3,target))
+		target = safepick(view(3, target))
 		if(!target)
 			return
 
 	var/mob/living/L = user
-	if(!target.Adjacent(src))
-		if(selected && selected.is_ranged())
-			if(HAS_TRAIT(L, TRAIT_PACIFISM) && selected.harmful)
-				to_chat(L, SPAN_WARNING("You don't want to harm other living beings!"))
-				return
+	if(isliving(target) && selected.harmful && HAS_TRAIT(L, TRAIT_PACIFISM))
+		to_chat(user, SPAN_WARNING("You don't want to harm other living beings!"))
+		return
+
+	if(selected?.is_ranged())
+		if(!target.Adjacent(src) || (target.Adjacent(src) && (occupant.a_intent == INTENT_HELP || occupant.a_intent == INTENT_GRAB)))
 			if(user.mind?.martial_art?.no_guns)
 				to_chat(L, SPAN_WARNING("[L.mind.martial_art.no_guns_message]"))
 				return
 			selected.action(target, params)
-	else if(selected && selected.is_melee())
-		if(isliving(target) && selected.harmful && HAS_TRAIT(L, TRAIT_PACIFISM))
-			to_chat(user, SPAN_WARNING("You don't want to harm other living beings!"))
 			return
+
+		do_melee_attack(target)
+
+	else if(selected && selected.is_melee())
 		selected.action(target, params)
 	else
-		if(internal_damage & MECHA_INT_CONTROL_LOST)
-			target = safepick(oview(1, src))
-		if(mecha_melee_cooldown || !isatom(target))
-			return
-		if(iswallturf(target) || isliving(target) || isobj(target))
-			target.mech_melee_attack(src)
-			mecha_melee_cooldown = TRUE
-			addtimer(VARSET_CALLBACK(src, mecha_melee_cooldown, FALSE), melee_cooldown)
+		do_melee_attack(target)
+
+/obj/mecha/proc/do_melee_attack(atom/target)
+	if(internal_damage & MECHA_INT_CONTROL_LOST)
+		target = safepick(oview(1, src))
+
+	if(mecha_melee_cooldown || !isatom(target) || !target.Adjacent(src))
+		return
+	if(!iswallturf(target) && !isliving(target) && !isobj(target))
+		return
+	target.mech_melee_attack(src)
+	mecha_melee_cooldown = TRUE
+	addtimer(VARSET_CALLBACK(src, mecha_melee_cooldown, FALSE), melee_cooldown)
 
 /obj/mecha/proc/mech_toxin_damage(mob/living/target)
 	playsound(src, 'sound/effects/spray2.ogg', 50, 1)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -186,7 +186,7 @@
 		M.occupant_message(SPAN_DANGER("You hit [src]."))
 		visible_message(SPAN_DANGER("[M.name] hits [src]!"), SPAN_USERDANGER("[M.name] hits you!"))
 		add_attack_logs(M.occupant, src, "Mecha-meleed with [M]")
-	else
+	else if(M.occupant.a_intent == INTENT_DISARM)
 		step_away(src,M)
 		add_attack_logs(M.occupant, src, "Mecha-pushed with [M]", ATKLOG_ALL)
 		M.occupant_message(SPAN_WARNING("You push [src] out of the way."))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Mechs can now point blank fire at things.
- Help and Grab fire your gun
- Disarm shoves the mob, harm punches the mob

Sends a message if you're facing the wrong way to shoot/hit a mob
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This makes mechs significantly less clunkier
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Punched, shot and shoved a skrell inside a gygax
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: You can now fire your gun point-blank in a mech if you are on either help or grab intent
tweak: Mobs can only be shoved with disarm intent by a mech now
tweak: Facing the wrong way in a mech now sends a message
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
