### PR TITLE
Hopefully makes surplus safer

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -654,11 +654,12 @@
 /obj/structure/closet/crate/surplus/Initialize(mapload, obj/item/uplink/U, crate_value, cost, mob/user)
 	. = ..()
 	var/list/temp_uplink_list = get_uplink_items(U, user)
+	var/list/temp_buyable_items = list() // Extra safety so we don't even have the items with no surplus in the final list
 	var/list/buyable_items = list()
 	for(var/category in temp_uplink_list)
-		buyable_items += temp_uplink_list[category]
+		temp_buyable_items += temp_uplink_list[category]
 
-	for(var/datum/uplink_item/uplink_item in buyable_items)
+	for(var/datum/uplink_item/uplink_item in temp_buyable_items)
 		if(!uplink_item.surplus) // Otherwise we'll just have an element with a weight of 0 in our weighted list
 			continue
 		buyable_items[uplink_item] = uplink_item.surplus


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The surplus now uses another temporary list to store all possible items in it
I suspect that because the items with a surplus of 0 were left in the list, it treated them as an item with a weight of 1
Since the surplus chance is usually between 10 and 100, these would be incredibly rare to find, while also having such a high price that they would often be unpurchaseable.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
No contractor kits in surplus anymore
Hopefully resolves #31094
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned 15 surplus crates, no contractor kit
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: The contractor kit hopefully doesn't spawn in the surplus crate anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
