### PR TITLE
Fixes the DVORAK malf borgs being invisible

### DIFF
--- a/code/modules/awaymissions/mission_code/ruins/telecomns.dm
+++ b/code/modules/awaymissions/mission_code/ruins/telecomns.dm
@@ -344,7 +344,7 @@ GLOBAL_LIST_EMPTY(telecomms_trap_tank)
 	name = "Security cyborg"
 	desc = "Oh god they still have access to these!"
 	icon = 'icons/mob/robots.dmi'
-	icon_state = "Noble-SEC"
+	icon_state = "Noble-Security"
 	health = 200
 	maxHealth = 200
 	faction = list("malf_drone")


### PR DESCRIPTION
## What Does This PR Do
Fixes DVORAK from obtaining advanced stealth tech from the local space ninja gang

## Why It's Good For The Game
DVORAK ruin isn't very possible currently
fixes #31269 

## Testing
Checked in game, saw the borg

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog

:cl:
fix: DVORAKs security force are visible again
/:cl:

