### PR TITLE
Adds a system for testmerge configs

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -19,6 +19,9 @@ GLOBAL_DATUM(test_runner, /datum/test_runner)
 	// If this instance is listening on port 6666, the server will look for config/overrides_6666.toml
 	GLOB.configuration.load_overrides("config/overrides_[world.port].toml")
 
+	// Adds a hook for loading TM specific configs we can keep in repo.
+	GLOB.configuration.load_overrides("code/testmerge_config.toml")
+
 	#ifdef TEST_CONFIG_OVERRIDE
 	GLOB.configuration.load_overrides("config/tests/config_[TEST_CONFIG_OVERRIDE].toml")
 	#endif

--- a/code/testmerge_config.toml
+++ b/code/testmerge_config.toml
@@ -1,0 +1,11 @@
+# This config file exists for you to place overrides in if you are doing a testmerge that has config changes.
+# It is in this folder as the entire /config/ dir is a static managed by TGS, so /config/example/ wont work.
+# This will not help you for SQL changes.
+
+# Code reviewers, if anything is in this file while you are reviewing before merge, it **NEEDS** binning.
+
+# Anything in here still needs the section header as per regular config.
+# Example below:
+
+#[general_configuration]
+#lobby_time = 99999999


### PR DESCRIPTION
## What Does This PR Do
Adds a new config file outside of the config directory (explained why later) designed to be kept in sync with the repo and not a static file.

Why? Well its called `testmerge_config.toml` for a reason. Having this as a config file in repo allows TM'd PRs to inline config changes that will be overridden on the server as part of a TM if required.

This cant go in `/config/example/` because the entire `/config/` is a separated static on the server, so any edits to example config for example also are not mirrored over, so putting it in `code` made sense, as its designed to be kept in sync with the rest of the code. Discuss as you need.

## Why It's Good For The Game
Means we dont need temp edits to the config repo.

## Images of changes
N/A

## Testing
Did an override for a super long lobby time

<img width="366" height="147" alt="image" src="https://github.com/user-attachments/assets/25d67bfe-7313-476d-abe5-b85ad9092273" />

It worked

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.


## Changelog
NPFC