### PR TITLE
Turns off quick gather for duffel bag's and add's a duffel bag zip/unzip notice in chat.

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -377,7 +377,6 @@
 	handle_zipping(user)
 
 /obj/item/storage/backpack/duffel/proc/handle_zipping(mob/user)
-
 	if(!Adjacent(user))
 		return
 	visible_message(


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

This fixes the #24220 issue by disabling quick gather mode for duffel bag's also adds a notice in the chat when the user zips or unzips the bag shown in the gif below.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Stops the conflicting keybind related to quick gather from working on duffel bag's since it's useless and makes an annoying message every time you unzip/zip the bag. the zip/unzip message tells people nearby that there's a person zipping/unzipping the duffel bag. This PR also fixes #24220
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![Medal_AbAcvUWOWa](https://github.com/user-attachments/assets/b419057b-7a25-4bdd-b191-8c8cfec26057)
later changed it to a notice instead of a warning so it wont be red.

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
zip/unzip the duffelbag, observe the chat at the bottom right. examine the duffelbag to see if the keybind has changed.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x ] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweaked: added a notice in the chat when a duffelbag is being zipped/unzipped.
fix: Fixed the conflicting duffel bag keybind by removing the ability to change the duffel bag's quick gather mode.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
