### PR TITLE
remove test_atmos map datum

### DIFF
--- a/code/datums/mapping/station_maps.dm
+++ b/code/datums/mapping/station_maps.dm
@@ -48,9 +48,3 @@
 	technical_name = "test_tgui"
 	map_path = "_maps/map_files/test_tiny/test_tgui.dmm"
 	voteable = FALSE
-
-/datum/map/test_atmos
-	fluff_name = "test_atmos"
-	technical_name = "test_atmos"
-	map_path = "_maps/map_files/test_tiny/test_atmos.dmm"
-	voteable = FALSE


### PR DESCRIPTION
## What Does This PR Do
This PR removes a map datum that was missing a corresponding DMM file.
## Why It's Good For The Game
Dead code cleanup.
## Testing
CI
## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
NPFC