### PR TITLE
Remove repeated element getting added on xeno maids

### DIFF
--- a/code/modules/mob/living/basic/hostile/alien/alien_mob_maid.dm
+++ b/code/modules/mob/living/basic/hostile/alien/alien_mob_maid.dm
@@ -15,10 +15,6 @@
 	/// How fast do we clean?
 	var/cleanspeed = 15
 
-/mob/living/basic/alien/maid/Initialize(mapload)
-	. = ..()
-	AddElement(/datum/element/ai_retaliate)
-
 /// Clean instead of attack.
 /mob/living/basic/alien/maid/early_melee_attack(atom/target, list/modifiers, ignore_cooldown)
 	. = ..()


### PR DESCRIPTION
## What Does This PR Do
Removes the Initialize on the xeno maid. All it does is add the retaliate element, which is already added by the alien type. Fixes a runtime related to overriding signals.
## Why It's Good For The Game
No runtime
## Testing
Loaded, spawned a maid, no runtime. Hit a maid, she ran away.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC