### PR TITLE
Fix slime lungs wrongfully reporting ruptured lungs

### DIFF
--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1095,7 +1095,8 @@
 
 /mob/living/carbon/human/proc/is_lung_ruptured()
 	var/datum/organ/lungs/L = get_int_organ_datum(ORGAN_DATUM_LUNGS)
-
+	if(L?.linked_organ.is_merged_organ)
+		return
 	return L?.linked_organ.is_bruised()
 
 /mob/living/carbon/human/proc/rupture_lung()

--- a/code/modules/surgery/organs/brain.dm
+++ b/code/modules/surgery/organs/brain.dm
@@ -207,6 +207,7 @@
 	icon_state = "green slime extract"
 	mmi_icon_state = "slime_mmi"
 	organ_datums = list(/datum/organ/heart, /datum/organ/lungs/slime)
+	is_merged_organ = TRUE
 
 /obj/item/organ/internal/brain/golem
 	name = "Runic mind"

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -8,6 +8,8 @@
 	var/unremovable = FALSE //Whether it shows up as an option to remove during surgery.
 	/// An associated list of organ datums that this organ has.
 	var/list/datum/organ/organ_datums
+	/// If this organ is multiple organs combined. Used to snowflake things like slime brains misreporting ruptured lung.
+	var/is_merged_organ = FALSE
 	/// This contains the hidden RnD levels of an organ to prevent rnd from using it.
 	var/hidden_origin_tech
 	/// What is the level of tech for the hidden tech type?


### PR DESCRIPTION
## What Does This PR Do
Adds a var to organs, `is_merged_organ` to prevent merged organs presenting wrong information. Ala slime brains being the lungs too causes them to show as ruptured lungs inside the body scanner. That leads to new doctors prying a slime open to fix the nonexistent lungs. Fixes #27637
## Why It's Good For The Game
Confusion bad.
## Images of changes

<img width="700" height="600" alt="image" src="https://github.com/user-attachments/assets/665a2896-f1fe-4eca-9587-f5527d1a2bad" />

## Testing
Viewed brain damaged slime inside of a body scanner.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Slime people won't wrongfully report ruptured lungs when they have brain damage.
/:cl: