### PR TITLE
add ai controller debugger to context menu

### DIFF
--- a/code/modules/admin/verbs/ai_controller_debugger_verb.dm
+++ b/code/modules/admin/verbs/ai_controller_debugger_verb.dm
@@ -1,0 +1,7 @@
+USER_CONTEXT_MENU(open_ai_controller_debugger, R_DEV_TEAM, "\[Dev\] AI Controller Debugger", atom/A as mob|obj in view())
+	if(!istype(A.ai_controller))
+		to_chat(client, SPAN_WARNING("[A] does not have a valid AI controller."))
+		return
+
+	var/datum/ui_module/ai_controller_debugger/AICD = new(A.ai_controller)
+	AICD.ui_interact(client.mob)

--- a/paradise.dme
+++ b/paradise.dme
@@ -1644,6 +1644,7 @@
 #include "code\modules\admin\verbs\adminjump.dm"
 #include "code\modules\admin\verbs\adminpm.dm"
 #include "code\modules\admin\verbs\adminsay.dm"
+#include "code\modules\admin\verbs\ai_controller_debugger_verb.dm"
 #include "code\modules\admin\verbs\antag-ooc.dm"
 #include "code\modules\admin\verbs\asays.dm"
 #include "code\modules\admin\verbs\atmosdebug.dm"


### PR DESCRIPTION
## What Does This PR Do
This PR adds the ability to view the AI controller debugger to the context menu of objects and mobs.

Trying to add a dev-facing tool to VV is currently painful because the VV system has its own permissions it checks for. In effect, no VV dropdown verbs (or anything else that goes through the `_vars_` src) can be run unless the client has R_VAREDIT, and there's currently a growing list of hardcoded exceptions to requiring R_ADMIN on the way into interacting with the VV item that I don't want to add to.

So until I clean that up, I'm stuffing this in a context menu item, where it's clear what permissions you need right in the verb and I don't have to think about any of that.

I would love to prevent this from showing up if the right-clicked item doesn't have an active AI controller but where the menu item shows up seems predicated on the `in view()` of `atom/A as mob|obj in view()`. I could try and give it an arbitrary function returning all mobs that have active AI controllers instead but I'm not going to. I'll also point out things like "Give Kudos" are also in every mob's right click menu so, it's kind of an ongoing problem anyway.

I'm sorry if I'm encroaching on people's muscle memory for the right-click menu but that right now is one of the clean surfaces to attach this kind of permissioned stuff to. If I refactor how VV actions deal with permission, I can come back and remove this later.

## Why It's Good For The Game
I've been trying to get devs access to see this for like a month. AI controllers are complicated and guessing about what they're doing wastes time.

## Images of changes
<img width="537" height="355" alt="2025_12_17__18_14_16__Paradise Station 13" src="https://github.com/user-attachments/assets/d7124c61-17a8-4b9a-8435-4382aa91b03a" />

## Testing
Right clicked on various atoms, ensured my client could open the TGUI window.

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
NPFC