### PR TITLE
Fix bodyscanner showing ruptured lung in the wrong limbs

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -360,7 +360,8 @@
 
 			organData["status"] = organStatus
 
-			if(istype(E, /obj/item/organ/external/chest) && occupant.is_lung_ruptured())
+			var/obj/item/organ/internal/lung_organ = occupant.get_int_organ_by_datum(ORGAN_DATUM_LUNGS)
+			if(E == occupant.get_organ(lung_organ?.parent_organ) && occupant.is_lung_ruptured())
 				organData["lungRuptured"] = TRUE
 
 			if(E.status & ORGAN_INT_BLEEDING)
@@ -503,7 +504,8 @@
 
 			if(e.status & ORGAN_INT_BLEEDING)
 				ailments |= "Internal Bleeding"
-			if(istype(e, /obj/item/organ/external/chest) && occupant.is_lung_ruptured())
+			var/obj/item/organ/internal/lung_organ = occupant.get_int_organ_by_datum(ORGAN_DATUM_LUNGS)
+			if(e == occupant.get_organ(lung_organ?.parent_organ) && occupant.is_lung_ruptured())
 				ailments |= "Lung Ruptured"
 			if(e.status & ORGAN_SPLINTED)
 				ailments |= "Splinted"

--- a/code/modules/surgery/organs/organ_helpers.dm
+++ b/code/modules/surgery/organs/organ_helpers.dm
@@ -16,6 +16,11 @@
 /mob/living/carbon/get_int_organ(typepath)
 	return (locate(typepath) in internal_organs)
 
+/mob/living/carbon/proc/get_int_organ_by_datum(tag_to_check)
+	RETURN_TYPE(/obj/item/organ/internal)
+	var/datum/organ/organ_datum = internal_organ_datums[tag_to_check]
+	return organ_datum?.linked_organ
+
 /mob/living/carbon/proc/get_int_organ_datum(tag_to_check)
 	RETURN_TYPE(/datum/organ)
 	return internal_organ_datums[tag_to_check]


### PR DESCRIPTION
## What Does This PR Do
Makes ruptured lung appear in the organ containing the lung. It crawls up the organ tree by returning a datums linked organ. We then get the linked organs parent organ and apply ruptured lung to that only. There's prolly a better fix out there, but this has been haunting me for an year and keeping me up at night. Fixes #27637
## Why It's Good For The Game
Less confusion.
## Images of changes

<img width="700" height="600" alt="0R3TpEFRse" src="https://github.com/user-attachments/assets/0307d666-84e9-49da-be74-60b965644245" />

## Testing
Ruptured the lung of a human, gave a slime brain damage and spawned an IPC. Human showed ruptured lung in the chest, slime showed ruptured lung in the head (where the core is), IPC showed nothing and didnt runtime.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Body scanner will report Ruptured Lung in the correct external organs.
/:cl: