### PR TITLE
Fixes smith knife names

### DIFF
--- a/code/modules/smithing/components/knife_components.dm
+++ b/code/modules/smithing/components/knife_components.dm
@@ -37,13 +37,13 @@
 	finished_product = /obj/item/kitchen/knife/smithed/utility
 
 /obj/item/smithed_item/component/knife_handle/throwing
-	name = "throwing knife blade"
+	name = "throwing knife handle"
 	desc = "Lightweight smithed component part of a knife. There is a small ring on the end of the handle."
 	materials = list(MAT_METAL = 3000, MAT_TITANIUM = 3000)
 	finished_product = /obj/item/kitchen/knife/smithed/thrown
 
 /obj/item/smithed_item/component/knife_handle/combat
-	name = "combat knife blade"
+	name = "combat knife handle"
 	desc = "Heavyweight smithed component part of a knife. The handle is thick and rugged."
 	materials = list(MAT_TITANIUM = 3000, MAT_PLASMA = 3000)
 	finished_product = /obj/item/kitchen/knife/smithed/combat


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes the names of some components in the smithing cast.

Fixes #31309

## Why It's Good For The Game

Things should be named right.

## Testing

Compiled

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed smith knife handle components being named wrong
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
