### PR TITLE
Lowers the movement speed of the Mega Carp and halves the speed of any carp moving diagonally.

### DIFF
--- a/code/modules/mob/living/basic/hostile/carp.dm
+++ b/code/modules/mob/living/basic/hostile/carp.dm
@@ -14,7 +14,7 @@
 	response_help_simple = "pet"
 	response_disarm_continuous = "gently pushes aside"
 	response_disarm_simple = "gently push aside"
-	speed = 0
+	speed = 0.25
 	maxHealth = 25
 	health = 25
 
@@ -104,17 +104,6 @@
 /mob/living/basic/carp/revive()
 	..()
 	update_icon()
-
-/mob/living/basic/carp/Move(newloc, direct) // Make's the carp slow down when moving diagonally so it isn't going at the speed of light.
-	if(IS_DIR_DIAGONAL(direct))
-		var/slowdown = 2
-		if(type == /mob/living/basic/carp/megacarp)
-			slowdown = 3.5
-		speed /= slowdown
-		. = ..()
-		speed *= slowdown
-	else
-		. = ..()
 
 /mob/living/basic/carp/update_overlays()
 	. = ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
increases the movement delay of the mega carp from 0 seconds to 1.75 seconds and halves the speed of any carp that's moving diagonally so it doesn't move at double the speed. Fixes #30389
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
people will stop dying to unfair carps that go at crazy fast speeds. Also fixes #30389
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
join the game, spawn in a normal carp and mega carp and aggro both of them then RUN and see if the mega carp is slower and if they are not moving fast diagonally.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Lowered the speed of the mega carp.
fix: Makes carp move at half the speed diagonally (to stop them from going at double the speed like they used to)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
