### PR TITLE
Fixes Drones Not Having a Unique Ass

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -156,10 +156,10 @@
 	if(ishuman(copymob)) //Suit checks are in check_mob
 		var/mob/living/carbon/human/H = copymob
 		temp_img = icon('icons/obj/butts.dmi', H.dna.species.butt_sprite)
-	else if(isrobot(copymob))
-		temp_img = icon('icons/obj/butts.dmi', "machine")
 	else if(isdrone(copymob))
 		temp_img = icon('icons/obj/butts.dmi', "drone")
+	else if(isrobot(copymob))
+		temp_img = icon('icons/obj/butts.dmi', "machine")
 	else if(isnymph(copymob))
 		temp_img = icon('icons/obj/butts.dmi', "nymph")
 	else if(isalien(copymob) || istype(copymob,/mob/living/basic/alien)) //Xenos have their own asses, thanks to Pybro.


### PR DESCRIPTION
## What Does This PR Do
Fixes an bug introduced in #31321 that caused drones to not use their unique ass sprite when photocopying their ass. This is because drones are included in `isrobot()`, therefore the `isdrone()` check should have been placed first.
## Why It's Good For The Game
Bugs bad. Drones deserve their special ass.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
## Testing
Scanned a drone's ass. Printed an ass pic.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Fixed drones not having a unique ass image.
/:cl: