### PR TITLE
Removes experimental projectile pathing from syndie mobs

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
@@ -303,51 +303,6 @@
 		if(melee_type == MELEE_WEAPON_DSWORD && prob(50))
 			jedi_spin()
 
-/mob/living/simple_animal/hostile/syndicate/Shoot(atom/targeted_atom)
-	if(QDELETED(targeted_atom) || targeted_atom == targets_from.loc || targeted_atom == targets_from)
-		return
-	var/turf/startloc = get_turf(targets_from)
-	var/turf/target_turf = get_turf(targeted_atom)
-	if(!target_turf)
-		return
-	if(casingtype)
-		// I know that is ABSOLUTELY terrible way to do that, but.. i don't know how to make it properly. I wasted a lot of time trying to, but only this is working somewhat good enough.
-		var/dx = abs(target_turf.x - startloc.x)
-		var/dy = abs(target_turf.y - startloc.y)
-		if(target_turf.x < startloc.x && target_turf.y > startloc.y)
-			if(dy > dx)
-				target_turf.pixel_x = 14
-				target_turf.pixel_y = 14
-			else if(dy < dx)
-				target_turf.pixel_x = -14
-				target_turf.pixel_y = -14
-		else if(target_turf.x < startloc.x && target_turf.y < startloc.y)
-			if(dy > dx)
-				target_turf.pixel_x = 14
-				target_turf.pixel_y = -14
-			else if(dy < dx)
-				target_turf.pixel_x = -14
-				target_turf.pixel_y = 14
-		else if(target_turf.x > startloc.x && target_turf.y > startloc.y)
-			if(dy > dx)
-				target_turf.pixel_x = -14
-				target_turf.pixel_y = 14
-			else if(dy < dx)
-				target_turf.pixel_x = 14
-				target_turf.pixel_y = -14
-		else if(target_turf.x > startloc.x && target_turf.y < startloc.y)
-			if(dy > dx)
-				target_turf.pixel_x = -14
-				target_turf.pixel_y = -14
-			else if(dy < dx)
-				target_turf.pixel_x = 14
-				target_turf.pixel_y = 14
-		var/obj/item/ammo_casing/casing = new casingtype(startloc)
-		playsound(src, projectilesound, 100, 1)
-		casing.fire(targeted_atom, src, zone_override = ran_zone(), firer_source_atom = src)
-		target_turf.pixel_x = initial(target_turf.pixel_x)
-		target_turf.pixel_y = initial(target_turf.pixel_y)
-
 /mob/living/simple_animal/hostile/syndicate/LoseTarget()
 	. = ..()
 	if(syndie_flags & SWORD && melee_type != MELEE_WEAPON_NONE)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

No longer override shoot() proc for syndie mobs that i made 7 months ago

This PR took me way too long, should've never be added into the game

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

1. it's awful
2. it works 50/50

if i'd like to return it, i'll have to make it in a better way rather than varediting turfs

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Checked their parent shoot() proc, it wasn't changed after introduction of experimental projectile pathing

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
del: Removed odd projectile pathing from human-like syndicate mobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
