### PR TITLE
Allow robots to ride the janicart again.

### DIFF
--- a/code/modules/vehicle/janivehicle.dm
+++ b/code/modules/vehicle/janivehicle.dm
@@ -64,7 +64,7 @@
 	var/mob/living/carbon/human/driver = M
 	var/obj/item/organ/external/l_leg = driver.get_organ("l_leg")
 	var/obj/item/organ/external/r_leg = driver.get_organ("r_leg")
-	if(istype(M, /mob/living/carbon) && !l_leg && !r_leg)
+	if(iscarbon(M) && !l_leg && !r_leg)
 		to_chat(user, SPAN_WARNING("[src] requires legs to ride!"))
 		return
 	return ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Allows robots and other non-carbon mobs that will never have "legs" to ride the janicart again.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Requested by a cyborg player on the discord.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted, put a cyborg on a janicart.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Allowed cyborgs to ride janicarts again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
