### PR TITLE
Adds photo album to the loadout menu

### DIFF
--- a/code/modules/client/preference/loadout/loadout_general.dm
+++ b/code/modules/client/preference/loadout/loadout_general.dm
@@ -202,6 +202,10 @@
 	display_name = "Wizard's staff"
 	path = /obj/item/staff
 
+/datum/gear/photo_album
+	display_name = "Photo album"
+	path = /obj/item/storage/photo_album
+
 //////////////////////
 //		Mugs		//
 //////////////////////


### PR DESCRIPTION
## What Does This PR Do
Adds the photo album item to the loadout menu under the 'general' section.
## Why It's Good For The Game
It's convenient for camera users.
## Testing
Compiled. Inspected visually.
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.


## Changelog

:cl:
add: Added photo album to the loadout menu.
/:cl:
