### PR TITLE
Fixes issue #31117, limbless mindflayers can no longer summon weapons

### DIFF
--- a/code/modules/antagonists/mind_flayer/powers/flayer_weapon_powers.dm
+++ b/code/modules/antagonists/mind_flayer/powers/flayer_weapon_powers.dm
@@ -49,30 +49,7 @@
 	RegisterSignal(user, COMSIG_MOB_WILLINGLY_DROP, PROC_REF(retract), user)
 	RegisterSignal(user, COMSIG_FLAYER_RETRACT_IMPLANTS, PROC_REF(retract), user)
 	return weapon_ref
-/*
-/datum/spell/flayer/self/weapon/cast(list/targets, mob/living/carbon/human/user)
-	if(weapon_ref && (user.l_hand == weapon_ref || user.r_hand == weapon_ref))
-		retract(user, TRUE)
-		return
 
-	if(!weapon_ref)
-		if(HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !(user.get_organ("r_hand") && user.get_organ("l_hand")) || (user.get_active_hand() && !user.drop_item()))
-			flayer.send_swarm_message("We cannot manifest our weapon into our active hand...")
-			return FALSE
-		else
-			create_new_weapon()
-
-	// Just in case the item doesn't start with both of these, or somehow loses them.
-	weapon_ref.flags |= ABSTRACT
-	weapon_ref.set_nodrop(TRUE, user)
-
-	SEND_SIGNAL(user, COMSIG_MOB_WEAPON_APPEARS)
-	user.put_in_hands(weapon_ref)
-	playsound(get_turf(user), 'sound/mecha/mechmove03.ogg', 25, TRUE, ignore_walls = FALSE)
-	RegisterSignal(user, COMSIG_MOB_WILLINGLY_DROP, PROC_REF(retract), user)
-	RegisterSignal(user, COMSIG_FLAYER_RETRACT_IMPLANTS, PROC_REF(retract), user)
-	return weapon_ref
-*/
 /datum/spell/flayer/self/weapon/proc/retract(mob/owner, any_hand = FALSE)
 	SIGNAL_HANDLER // COMSIG_MOB_WILLINGLY_DROP + COMSIG_FLAYER_RETRACT_IMPLANTS
 	if(!any_hand && !istype(owner.get_active_hand(), weapon_type))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Stops limbless mindflayers from summoning their weapon
Fixes #31117
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
No more mindflayer parts on the ground
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in, toolboxed my arms off, tried to summon a swarmprod with 1 arm attached (successful) and with 0 arms attached (unsuccessful)
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed limbless mindflayers dropping their weapons
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->

PS: My first PR, hope I didnt mess anything up
