### PR TITLE
add missing wound datum on rupture_lungs()

### DIFF
--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1110,9 +1110,7 @@
 	if(L && !L.linked_organ.is_bruised())
 		var/obj/item/organ/external/affected = get_organ("chest")
 		affected.custom_pain("You feel a stabbing pain in your chest!")
-		var/datum/wound/ruptured_lungs/rupture = new(L.linked_organ)
-		L.linked_organ.wound_list += rupture
-		L.linked_organ.damage = L.linked_organ.min_bruised_damage
+		L.linked_organ.receive_damage(max(L.linked_organ.min_bruised_damage - L.linked_organ.damage, 2))
 
 /mob/living/carbon/human/resist_restraints(attempt_breaking)
 	if(HAS_TRAIT(src, TRAIT_HULK))


### PR DESCRIPTION
## What Does This PR Do
`rupture_lung()` wasn't adding a wound datum despite claiming to rupture lungs. I added it in there.
## Why It's Good For The Game
This proc is never used but I used it for testing and it made me sad it didn't work.
## Testing
Called the proc on my mob, showed as ruptured lung.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC