### PR TITLE
Make spiderlings finish their ventcrawl behaviour upon exiting a vent

### DIFF
--- a/code/datums/ai/movement/ventcrawl.dm
+++ b/code/datums/ai/movement/ventcrawl.dm
@@ -24,9 +24,16 @@
 	var/obj/machinery/atmospherics/exit = controller.blackboard[BB_VENTCRAWL_EXIT]
 	var/datum/pipeline/exit_pipeline = exit?.returnPipenet()
 	var/obj/machinery/atmospherics/current = controller.pawn.loc
+	// We're no longer in pipes. Cease trying to navigate pipes.
+	if(!istype(current))
+		complete_ventcrawl(controller)
+		return
 	if(current?.returnPipenet() in exit_pipeline?.get_connected_pipelines()) // they're still connected... let it try to find another route.
 		return
 	// they're not connected, give us another chance to find a way out.
+	complete_ventcrawl(controller)
+
+/datum/ai_movement/ventcrawl/proc/complete_ventcrawl(datum/ai_controller/controller)
 	controller.set_blackboard_key(BB_VENTCRAWL_ENTRANCE, null)
 	controller.set_blackboard_key(BB_VENTCRAWL_EXIT, null)
 	controller.cancel_actions()


### PR DESCRIPTION
## What Does This PR Do
Spiders would try to check if their pipenet is still connected to the exit vent. They would continue doing this after exiting a vent, since their movement isn't immediately reset. This PR adds a check to see if our current loc is an atmospheric machine and if not, it nulls the vents in the blackboard and finishes the ventcrawl behaviour, letting us go back to JPS movement. Fixes #31339
## Why It's Good For The Game
No 1.5k runtimes. (Pretty sure I've seen a round with 3k runtimes from this too)
## Testing
Imprisoned 50 spiderlings on a vent in the cyberiad. They didn't runtime upon exiting vents.
Watched a spiderling crawl through a vent. Upon exiting, it reset its movement to JPS without a runtime and started running from humans.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC