### PR TITLE
Migrates Defibrillator to the New Attack Chain

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -12,6 +12,7 @@
 	origin_tech = "biotech=4"
 	actions_types = list(/datum/action/item_action/toggle_paddles)
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, RAD = 0, FIRE = 50, ACID = 50)
+	new_attack_chain = TRUE
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/clothing/species/vox/back.dmi'
 		)
@@ -96,23 +97,29 @@
 	if(ishuman(user) && Adjacent(user))
 		toggle_paddles(user)
 
-/obj/item/defibrillator/attackby__legacy__attackchain(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/stock_parts/cell))
-		var/obj/item/stock_parts/cell/C = W
+/obj/item/defibrillator/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	if(istype(used, /obj/item/stock_parts/cell))
+		var/obj/item/stock_parts/cell/C = used
 		if(cell)
 			to_chat(user, SPAN_NOTICE("[src] already has a cell."))
-		else
-			if(C.maxcharge < paddles.revivecost)
-				to_chat(user, SPAN_NOTICE("[src] requires a higher capacity cell."))
-				return
-			if(user.drop_item(C))
-				W.forceMove(src)
-				cell = C
-				to_chat(user, SPAN_NOTICE("You install a cell in [src]."))
-	if(W == paddles)
-		toggle_paddles(user)
+			return ITEM_INTERACT_COMPLETE
 
-	update_icon(UPDATE_OVERLAYS)
+		if(C.maxcharge < paddles.revivecost)
+			to_chat(user, SPAN_NOTICE("[src] requires a higher capacity cell."))
+			return ITEM_INTERACT_COMPLETE
+
+		if(user.drop_item(C))
+			used.forceMove(src)
+			cell = C
+			to_chat(user, SPAN_NOTICE("You install a cell in [src]."))
+			update_icon(UPDATE_OVERLAYS)
+			return ITEM_INTERACT_COMPLETE
+
+	if(used == paddles)
+		toggle_paddles(user)
+		return ITEM_INTERACT_COMPLETE
+
+	return ..()
 
 /obj/item/defibrillator/screwdriver_act(mob/living/user, obj/item/I)
 	if(!cell)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Migrates the defibrillator to the new attack chain.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It good.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Screwdrivered defib to remove cell.
Put cell back in.
Took paddles off and put them back on via clicking on defib.
Revived a dead skrell.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog
NPFC
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
