### PR TITLE
fix radio not working on shuttle, for real

### DIFF
--- a/code/game/machinery/tcomms/tcomms_core.dm
+++ b/code/game/machinery/tcomms/tcomms_core.dm
@@ -19,7 +19,7 @@
 	/// The NTTC config for this device
 	var/datum/nttc_configuration/nttc = new()
 	/// List of all reachable devices
-	var/list/reachable_zlevels = list()
+	var/alist/reachable_zlevels = alist()
 	/// List of all linked relays
 	var/list/linked_relays = list()
 	/// Password for linking stuff together
@@ -127,7 +127,7 @@
   */
 /obj/machinery/tcomms/core/proc/refresh_zlevels()
 	// Refresh the list
-	reachable_zlevels = list()
+	reachable_zlevels = alist()
 	// Add itself as a reachable Z-level
 	reachable_zlevels |= loc.z
 	// Add all the linked relays in
@@ -137,7 +137,7 @@
 			reachable_zlevels |= R.loc.z
 	for(var/zlevel in GLOB.space_manager.z_list)
 		if(check_level_trait(zlevel, TCOMM_RELAY_ALWAYS))
-			reachable_zlevels |= zlevel
+			reachable_zlevels |= text2num(zlevel)
 
 
 /**


### PR DESCRIPTION
## What Does This PR Do
This PR makes sure that z-levels with TCOMM_RELAY_ALWAYS are properly recognized when sending out messages. This is a place where we were using lists like alists, and it just never bit us. The space manager is another place where we do this goofy back and forth interpolating z-levels into string indexes but that's a larger refactor for later.
## Why It's Good For The Game
Bugfix.
## Testing
VV'd a human with a hotmic'd headset to say something while on the shuttle, while my character stood on the station, ensured I could hear them.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog

:cl:
fix: Radio communication while on the shuttle should properly work now.
/:cl:
