### PR TITLE
[s] Fixes a issue with modsuits

### DIFF
--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -309,7 +309,7 @@
 			bag?.dump_storage(M, over_object)
 			return
 
-		if(!M.restrained() && !HAS_TRAIT(M, TRAIT_HANDS_BLOCKED))
+		if(!HAS_TRAIT(M, TRAIT_HANDS_BLOCKED))
 			playsound(loc, "rustle", 50, TRUE, -5)
 
 			if(istype(over_object, /atom/movable/screen/inventory/hand))


### PR DESCRIPTION
## What Does This PR Do
Fixes being able to eat modsuits when you shouldn't be able to

## Why It's Good For The Game
Probably shouldn't be doing that.

## Testing
yeah
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed being able to eat modsuits when you shouldn't
/:cl:

