### PR TITLE
maplint tile turf decals + walls

### DIFF
--- a/tools/maplint/lints/turf_decals.yml
+++ b/tools/maplint/lints/turf_decals.yml
@@ -1,0 +1,3 @@
+/turf/simulated/wall:
+  banned_neighbors:
+  - /obj/effect/turf_decal/tiles


### PR DESCRIPTION
## What Does This PR Do
This PR ensures that the new plasteel decal turfs can't be mapped on wall turfs.
## Why It's Good For The Game
Because of whatever layers these are at, this is easy to miss:
<img width="751" height="366" alt="2025_12_31__14_13_24__paradise dme  boxstation dmm  - StrongDMM" src="https://github.com/user-attachments/assets/1c493ae1-a46a-43c5-afee-c0c40cf92038" />
## Testing
Ran maplint.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC