### PR TITLE
Removes the "bork, bork, bork!" from the sweed accent

### DIFF
--- a/code/game/dna/mutations/disabilities.dm
+++ b/code/game/dna/mutations/disabilities.dm
@@ -395,8 +395,6 @@
 	message = replacetextEx(message,"bo","bjo")
 	message = replacetextEx(message,"O",pick("Ö","Ø","O"))
 	message = replacetextEx(message,"o",pick("ö","ø","o"))
-	if(prob(30) && !M.is_muzzled() && !M.is_facehugged())
-		message += " Bork[pick("",", bork",", bork, bork")]!"
 	return message
 
 // WAS: /datum/bioEffect/unintelligable


### PR DESCRIPTION
## What Does This PR Do
Removes the "bork, bork!" text injection from the swedish accent 'disability'

## Why It's Good For The Game
Its annoying, messes with the flow of some sentences and moods(';help im dying bork bork bork!'), and rather immersion breaking(for me)
Its not even a swedish word, its a reference to the chef from the muppets
plus this doesn't remove the ability to say it, just removes the forced part of it

## Testing
Tested saying a few things a handful of times, worked as expected

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
from what i understand this doesn't need it

## Changelog

:cl:
tweak: You no longer say "bork, bork bork!" if you have the swedish accent
/:cl:
