### PR TITLE
Removes throwforce from bedsheets

### DIFF
--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -12,7 +12,6 @@ LINEN BINS
 	lefthand_file = 'icons/mob/inhands/bedsheet_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/bedsheet_righthand.dmi'
 	layer = MOB_LAYER
-	throwforce = 0
 	throw_speed = 1
 	throw_range = 2
 	w_class = WEIGHT_CLASS_TINY


### PR DESCRIPTION
## What Does This PR Do
Sets the throwforce value of bedsheets and their subtypes to 0, disabling them from breaking or damaging anything when thrown.
## Why It's Good For The Game
Due to their ease of access, being located inside every brig cell, they should not be able to function as an immediate method for prisoners to break out with. It's also counterintuitive that a linen sheet would damage anything it gets thrown at.
## Testing
Compiled. Spawned bedsheet and subtypes. Tossed at window and skrell. Nothing happened.
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
del: The throwforce of bedsheets has been set to 0. This means they can no longer break or damage anything when thrown.
/:cl:
