### PR TITLE
Kidneying fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/human_life.dm
+++ b/code/modules/mob/living/carbon/human/human_life.dm
@@ -983,9 +983,15 @@
 	adjustOxyLoss(20)
 
 /mob/living/carbon/human/proc/handle_kidneys()
+	if(NO_BLOOD in dna.species.species_traits)
+		return
+
 	var/obj/item/organ/kidneys = get_int_organ(/obj/item/organ/internal/kidneys)
 	if(isslimeperson(src))
 		kidneys = get_int_organ(/obj/item/organ/internal/brain)
+	if(isdrask(src))
+		// Drask have their liver fulfill the same function as kidneys
+		kidneys = get_int_organ(/obj/item/organ/internal/liver)
 
 	var/damage_percentage = 0
 	if(kidneys && !(kidneys.status & ORGAN_DEAD)) // No kidneys = full damage


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Drask won't perish to chemicals (nobody knew they didn't have kidneys)
The kidneying now respects not having blood (oops)

Resolves #31387
Resolves #31401 
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Golems, skeletons, abductors and drask should not have to interact with kidneys at all
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
IPC did not take damage from chemicals
Skrell didn't take damage from chemicals, they did take damage when enough kidney damage was taken
Drask behaved the same as the skrell
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Drask livers now work as kidneys, so no damage from chemicals roundstart
fix: Species with no blood now don't interact with kidney mechanics
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
