### PR TITLE
metastation kitchen remap tweaks

### DIFF
--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -9444,10 +9444,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/random/tech_storage/silicon,
 /obj/effect/turf_decal/trimline/department/command/line{
 	dir = 4
 	},
+/obj/effect/spawner/random/tech_storage/comms,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/tech_storage)
 "bhJ" = (
@@ -9869,10 +9869,10 @@
 /area/station/public/storage/tools/auxiliary)
 "bjv" = (
 /obj/structure/rack,
-/obj/effect/spawner/random/tech_storage/silicon,
 /obj/effect/turf_decal/trimline/department/command/line{
 	dir = 6
 	},
+/obj/effect/spawner/random/tech_storage/rnd,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/tech_storage)
 "bjw" = (
@@ -15244,6 +15244,9 @@
 /obj/item/eftpos/register,
 /obj/item/wrench,
 /obj/effect/turf_decal/tiles/dark/checker,
+/obj/machinery/camera{
+	c_tag = "Kitchen"
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
 "bHS" = (


### PR DESCRIPTION
## What Does This PR Do
This PR:
- adds sinks back to the metastation kitchen and freezer
- adds a camera back to the kitchen
- fixes the duplicate secure board spawners in tech storage
## Why It's Good For The Game
Regressions.
## Testing
Visual inspection.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
fix: Cerebron: The kitchen and freezer have proper sinks again.
fix: Cerebron: The kitchen has a proper camera again.
fix: Cerebron: Secure tech storage now has the correct boards.
/:cl:
