### PR TITLE
add flash protection to structure attack chain test puppet

### DIFF
--- a/code/tests/_game_test_puppeteer.dm
+++ b/code/tests/_game_test_puppeteer.dm
@@ -184,3 +184,9 @@
 
 /datum/test_puppeteer/proc/drop_held_item()
 	puppet.drop_item_to_ground(puppet.get_active_hand())
+
+/datum/test_puppeteer/proc/add_trait(trait)
+	ADD_TRAIT(puppet, trait, TRAIT_GENERIC)
+
+/datum/test_puppeteer/proc/remove_trait(trait)
+	REMOVE_TRAIT(puppet, trait, TRAIT_GENERIC)

--- a/code/tests/attack_chain/test_attack_chain_structures.dm
+++ b/code/tests/attack_chain/test_attack_chain_structures.dm
@@ -19,6 +19,7 @@
 /datum/game_test/room_test/attack_chain_structures/Run()
 	var/datum/test_puppeteer/player = new(src)
 	player.puppet.name = "Player"
+	player.add_trait(TRAIT_FLASH_PROTECTION)
 
 	player.puppet.mind.add_antag_datum(/datum/antagonist/cultist)
 	player.spawn_obj_in_hand(/obj/item/melee/cultblade/dagger)


### PR DESCRIPTION
## What Does This PR Do
This PR adds flash protection to the puppet in the attack chain test for structures.
## Why It's Good For The Game
This human does a bunch of welding during the tests and the chat messages about eye damage cause flaky tests.
## Testing
CI.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC