### PR TITLE
Update Pass on Box Maintenance Tunnels

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -138401,7 +138401,7 @@ aaa
 aaa
 aaa
 aaa
-alv
+amh
 aaa
 aaa
 aAf
@@ -139429,7 +139429,7 @@ aaa
 aaa
 aaa
 aaa
-alv
+amh
 alv
 aaa
 aaa
@@ -139692,7 +139692,7 @@ alv
 alv
 alv
 alv
-alv
+amh
 alv
 alv
 alv


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
General:
- Rolls out firelock, scrubber, air alarm, and fire alarm coverage on all sections of Box Station's maintenance tunnels.
- Adds hazard markings to maintenance APCs for easier recognition.
- Deletes several mapped-in mice. Mice are placed procedurally now and they do a perfectly good job of eating all the cables without any help from yet more mice.

Areas:
- Re-classifies the maintenance area inside medbay as Medical Maintenance (from aft-port secondary maintenance).
- Splits aft-starboard maintenance into two areas: Aft starboard maintenance and Starboard maintenance.
- Splits aft maintenance into two areas: Aft maintenance and aft secondary maintenance
- Splits fore-starboard maintenance into two areas: fore-starboard maintenance and fore-starboard secondary maintenance.
These changes make it easier to control the affected areas more granularly with air alarms and fire alarms, and also they're massive areas that are a bit too big anyway.

Other edits:
- Adds flooring to the mob room in aft-starboard maintenance (by the penguin room).
- Makes the fore-starboard maintenance atmos tank room into an actual atmos closet.
- Moves the some furnishings around below the fore-starboard solar array so the APC in that room has an exposed terminal.
- Ditto for Aft-starboard electrical maintenance.
- Removes a grille and replaces it with a reinforced window in abandoned medical storage.
- Replaces 2 varedited locked doors above engineering with normal doors that use locked door helpers.
- Ditto for the incincerator doors.
- Ditto for the aft-starboard mobster room.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
- Finishes rolling out scrubbers/firelocks/atmos equipment to all of Box maintenance all at once rather than doing it peacemeal over many more months.
- The entire contents of atmos's mixed air and oxygen tanks should no longer get drained because a single breach happened and the vents continued to stupidly blast air into space because they have no way of detecting if the area is becoming a vacuum zone or a way to contain the remaining air.
- The existance of the air alarms also means that if there is a breach in maint it can now be detected by the atmos alert computer/PDA app, allowing engineering to actually know there's a problem that needs to be fixed without needing to personally encounter it.
- When the APC in the medical maint room (which is in the central portion of the station) dies engineers will actually know where it is rather than trying to look around in the aft-starboard section of the station.


<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Fore-starboard maint area
<img width="1824" height="1216" alt="image" src="https://github.com/user-attachments/assets/4e22ca20-30a1-4dd7-8a61-be9ed5cd90cc" />
Aft-starboard maint area
<img width="1248" height="2368" alt="image" src="https://github.com/user-attachments/assets/ae070abe-ad26-49b7-88fd-027a564a7acc" />
Aft maint area
<img width="2144" height="1888" alt="image" src="https://github.com/user-attachments/assets/2648b9aa-8105-47b7-a5a6-060280f5bfd3" />
Mob room
<img width="256" height="288" alt="image" src="https://github.com/user-attachments/assets/31228394-7e07-4754-8df6-f98c5c9070c0" />
Representitive sample area showing new atmos protection systems.
<img width="448" height="544" alt="image" src="https://github.com/user-attachments/assets/8d09143f-baf1-4696-ad17-efafb24ca13d" />
New atmos closet
<img width="224" height="256" alt="image" src="https://github.com/user-attachments/assets/98e0ac8f-caac-4c80-8015-5cea4db40f55" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Visual inspection.
Pulled the fire alarm in every part of maint and verified all the places that should have firelocks did in fact have firelocks.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Added air alarms and fire alarms and firelocks and scrubbers to all parts of Box Station maintenance.
tweak: Added wooden flooring to the Box aft-starboard mobster room.
tweak: Made the fore-starboard Box atmos tank room into a proper atmos closet.
tweak: breaks up aft, aft-starboard, and fore-starboard maints of Box into 6 areas intead of 3.
del: deleted several mapped-in mice from Box.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
