### PR TITLE
Adds a Premium smithed crate

### DIFF
--- a/code/modules/supply/supply_packs/pack_engineering.dm
+++ b/code/modules/supply/supply_packs/pack_engineering.dm
@@ -264,6 +264,18 @@
 	containertype = /obj/structure/closet/crate/secure/engineering
 	containername = "Forged Nuclear Coolant crate"
 
+/datum/supply_packs/engineering/nuclear_premium_rods
+	name = "Forged Premium Nuclear Rods crate"
+	contains = list(
+		/obj/item/nuclear_rod/moderator/platinum_plating,
+		/obj/item/nuclear_rod/moderator/platinum_plating,
+		/obj/item/nuclear_rod/coolant/iridium_conductor,
+		/obj/item/nuclear_rod/coolant/iridium_conductor,
+	)
+	cost = 1500
+	containertype = /obj/structure/closet/crate/secure/engineering
+	containername = "Forged Premium Nuclear Rods crate"
+
 /* Commented out as the TEG is fully problematic. If the syndie base is changed to be dependant on another powersource, we can look at a rework.
 /datum/supply_packs/engineering/engine/teg
 	name = "Thermo-Electric Generator Crate"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a crate containing:
- 2 Iridium conductors rods
- 2 Platinum neutron plating rods
For the low-low cost of 1500 credits!
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It's very hard to find a smith nowadays, this should help obtain the last few missing rods
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
<img width="454" height="242" alt="image" src="https://github.com/user-attachments/assets/71035a31-079e-487a-94e0-ec633ee7fc82" />

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Adds a premium smithed NGCR rods pack to cargo, containing platinum and iridium rods
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
