### PR TITLE
Legion cores no longer can be preserved if they go inert

### DIFF
--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -14,6 +14,10 @@
 		to_chat(user, SPAN_WARNING("The stabilizer only works on certain types of monster organs, generally regenerative in nature."))
 		return ..()
 
+	if(C.inert)
+		to_chat(user, SPAN_WARNING("[M] is inert! The stabilizer won't function as the regenerative enzymes have dissolved!"))
+		return ..()
+
 	C.preserved()
 	to_chat(user, SPAN_NOTICE("You inject [M] with the stabilizer. It will no longer go inert."))
 	qdel(src)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Legion cores that have decayed can no longer be rejuvenated with a stabilizer.

## Why It's Good For The Game

Decayed legion cores should remain decayed.

## Testing

Tried to inject a decayed core. Failed.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

<img width="752" height="78" alt="image" src="https://github.com/user-attachments/assets/b06c098c-24eb-41b8-81ec-c170014d3494" />

## Changelog

:cl:
tweak: Decayed cores can no longer be stabilized
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
