### PR TITLE
Removes tarot decks from necropolis chests

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -73,7 +73,7 @@
 			new /obj/item/borg/upgrade/modkit/lifesteal(src)
 			new /obj/item/bedsheet/cult(src)
 		if(24)
-			switch(rand(1, 11))
+			switch(rand(1, 10))
 				if(1)
 					new /obj/item/blank_tarot_card(src)
 				if(2 to 5)
@@ -82,8 +82,6 @@
 					new /obj/item/tarot_card_pack/jumbo(src)
 				if(9, 10)
 					new /obj/item/tarot_card_pack/mega(src)
-				if(11)
-					new /obj/item/tarot_generator(src) // ~1/250? Seems reasonable
 
 //KA modkit design discs
 /obj/item/disk/design_disk/modkit_disk


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Removes the full tarot card deck from the lavaland tendril chests.

## Why It's Good For The Game

A handful of tarot cards is a good loot drop. An infinite generator of tarot cards is not.

## Testing

Compiled.
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<img width="1773" height="68" alt="image" src="https://github.com/user-attachments/assets/32d09817-6ee6-4642-abcd-488980903ecb" />

## Changelog

:cl:
tweak: Removed tarot card deck from lavaland loot chests
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
