### PR TITLE
Titanium moderator buffs

### DIFF
--- a/code/modules/power/engines/fission/nuclear_rods.dm
+++ b/code/modules/power/engines/fission/nuclear_rods.dm
@@ -346,9 +346,9 @@
 	name = "titanium moderator"
 	desc = "A nuclear moderation rod comprised primarily of cast titanium. For what it lacks in power amplification, it makes up for in versatility and durability."
 	icon_state = "mod_titanium"
-	max_durability = 5000
-	heat_amp_mod = 1.1
-	power_amp_mod = 1.3
+	max_durability = 5500
+	heat_amp_mod = 0.7
+	power_amp_mod = 1.5
 	craftable = TRUE
 	materials = list(MAT_METAL = 2000, MAT_TITANIUM = 2000)
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gives the titanium moderator an actual niche instead of being a waste
It now has a heat modifier of 0.7 and a power modifier of 1.5
This allows it to exist in setups where the high heat is very rough, but you are forced to use a moderator for adjacencies
Being able to last quite a bit longer than most other rods helps too, hence the 10% durability increase
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Titanium moderators are just a waste of materials atm, and can fit in no setup since their impact is negligible
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
It compiled, it's a value change
<!-- How did you test the PR, if at all? -->

## Declaration
<img width="342" height="102" alt="image" src="https://github.com/user-attachments/assets/c36fa8ab-ccbc-4ade-803a-5d7d9ca6eab7" />

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Titanium moderators now have a heat amp of 0.7, and a power amp of 1.5. Their durability has also been increased
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
