### PR TITLE
Adds an isskeleton() check to spooky xylophone playing

### DIFF
--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -400,7 +400,7 @@
 
 	to_chat(src, chat_box_examine(status_list.Join("<br>")))
 
-	if H.isskeleton() && (!H.w_uniform) && (!H.wear_suit))
+	if((isskeleton(H) || HAS_TRAIT(H, TRAIT_SKELETONIZED)) && (!H.w_uniform) && (!H.wear_suit))
 		H.play_xylophone()
 
 /mob/living/carbon/can_be_flashed(intensity = 1, override_blindness_check = 0)


### PR DESCRIPTION
## What Does This PR Do
Adds an isskeleton() check for the xylophone playing check. This means skeletons and their subtypes will be able to play the spooky xylophone on themselves more reliably.
## Why It's Good For The Game
Skeletons should be able to reliably play the xylophone on themselves.
Fixes #31405 
## Testing
Spawned in as an ancient skeleton, lich skeleton, and brittle skeleton. Clicked self with torso targeted.
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
fix: Skeletons should now be able to play the xylophone on themselves.
/:cl:
