### PR TITLE
Moves the silence of CQC Kick to Consecutive CQC

### DIFF
--- a/code/modules/martial_arts/combos/cqc/consecutive.dm
+++ b/code/modules/martial_arts/combos/cqc/consecutive.dm
@@ -1,7 +1,7 @@
 /datum/martial_combo/cqc/consecutive
 	name = "Consecutive CQC"
 	steps = list(MARTIAL_COMBO_STEP_DISARM, MARTIAL_COMBO_STEP_DISARM, MARTIAL_COMBO_STEP_HARM)
-	explaination_text = "Mainly offensive move, dealing some brute damage, and huge amounts of stamina damage"
+	explaination_text = "Mainly offensive move, dealing some brute damage, huge amounts of stamina damage, and muting targets."
 
 /datum/martial_combo/cqc/consecutive/perform_combo(mob/living/carbon/human/user, mob/living/target, datum/martial_art/MA)
 	if(!target.stat)

--- a/code/modules/martial_arts/combos/cqc/kick.dm
+++ b/code/modules/martial_arts/combos/cqc/kick.dm
@@ -1,7 +1,7 @@
 /datum/martial_combo/cqc/kick
 	name = "CQC Kick"
 	steps = list(MARTIAL_COMBO_STEP_HARM, MARTIAL_COMBO_STEP_HARM)
-	explaination_text = "Knocks opponent away and slows them. Will instead deal massive stamina damage, inflict minor brain damage, and mute opponents who are on the ground."
+	explaination_text = "Knocks opponent away and slows them. Will instead deal massive stamina damage and inflict minor brain damage to those who are on the ground."
 
 /datum/martial_combo/cqc/kick/perform_combo(mob/living/carbon/human/user, mob/living/target, datum/martial_art/MA)
 	. = MARTIAL_COMBO_FAIL


### PR DESCRIPTION
## What Does This PR Do
Moves the silence from CQC's kick combo to the consecutive CQC combo. This means Kick will no longer silence, and instead Consecutive CQC will silence.
## Why It's Good For The Game
Moving the effects of martial arts combos around rebalances them, shifting the effectiveness of them so one combo is not disproportionately better than others.
## Testing
Kicked a skrell repeatedly. Forced them to speak. Heard.
Consecutive combo'd a skrell. Forced them to speak. Did not hear.
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<img width="932" height="128" alt="image" src="https://github.com/user-attachments/assets/cc045990-7179-40c9-ba2d-ddf64b53d04d" />

## Changelog

:cl:
tweak: The silencing effect has been removed from CQC's Kick combo and moved to Consecutive CQC.
/:cl:
