### PR TITLE
Gives NCT's Bureaucratic Immunity

### DIFF
--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -9,7 +9,8 @@
 		/datum/job/blueshield,
 		/datum/job/chaplain,
 		/datum/job/officer,
-		/datum/job/warden
+		/datum/job/warden,
+		/datum/job/nanotrasentrainer
 	)
 
 	/// Jobs that pass an additional 40% chance per roll to be picked for the bureaucratic error


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Makes NCT's immune to the bureaucratic error event.

Fixes #31434

## Why It's Good For The Game

NCT's are a mentor-only role for teaching new players. They shouldn't be subject to the whims of bureaucracy or the event manager's mercy.

## Testing

Compiled.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed NCT jobs being affected by the bureaucratic error event
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
