### PR TITLE
Fixes single-product smithing cast descriptions

### DIFF
--- a/code/modules/smithing/smithing_cast.dm
+++ b/code/modules/smithing/smithing_cast.dm
@@ -21,8 +21,9 @@
 
 /obj/item/smithing_cast/examine(mob/user)
 	. = ..()
-	. += "It is currently configured to make [amount_to_make == 1 ? "a" : "[amount_to_make]"] [selected_product.name][amount_to_make == 1 ? "" : "s"]."
-	. += SPAN_NOTICE("You can select the desired product by using [src] in your hand.")
+	if(length(possible_products) > 1)
+		. += "It is currently configured to make [amount_to_make == 1 ? "a" : "[amount_to_make]"] [selected_product.name][amount_to_make == 1 ? "" : "s"]."
+		. += SPAN_NOTICE("You can select the desired product by using [src] in your hand.")
 
 /obj/item/smithing_cast/activate_self(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Ensures single-product smithing casts don't have needless stuff in their examines.

Fixes #31276

## Why It's Good For The Game

Bugs bad

## Testing

Examined gun parts cast. Did not see useless information.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed excess lines in examine text for single-product smithing casts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
