### PR TITLE
Miner locker room change to prevent Brad from dying

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
@@ -1626,9 +1626,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/baseturf_helper/lava_land,
 /turf/simulated/floor/plasteel/dark,
 /area/mine/outpost/lockers)
@@ -2097,9 +2094,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/mine/outpost/lockers)
@@ -3576,6 +3570,16 @@
 /obj/effect/turf_decal/tiles/department/security/checker,
 /turf/simulated/floor/plasteel/dark,
 /area/mine/laborcamp)
+"uZ" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/tiles/department/science/corner{
+	dir = 8
+	},
+/obj/machinery/light/small,
+/obj/machinery/power/apc/directional/east,
+/obj/structure/cable,
+/turf/simulated/floor/plasteel/dark,
+/area/mine/outpost/lockers)
 "vd" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/crate,
@@ -5751,7 +5755,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/mine/outpost/lockers)
@@ -6217,10 +6221,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/mine/outpost/smith_workshop)
 "KJ" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/directional/west,
 /obj/effect/turf_decal/tiles/department/science/corner{
 	dir = 8
 	},
@@ -7319,6 +7319,15 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/mine/outpost/hallway/west)
+"Qy" = (
+/obj/structure/lattice/catwalk/mining,
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
+/obj/item/cigbutt/roach,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "Qz" = (
 /obj/item/cigbutt,
 /obj/effect/turf_decal/tiles/department/engineering,
@@ -8643,9 +8652,6 @@
 "Yo" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/mine/outpost/lockers)
@@ -14732,7 +14738,7 @@ VG
 VG
 Do
 zJ
-cc
+Qy
 XG
 cc
 LO
@@ -15057,7 +15063,7 @@ xM
 hY
 zJ
 Pw
-fh
+Pw
 Pw
 fh
 Ka
@@ -15868,7 +15874,7 @@ Lq
 zJ
 MW
 Hz
-ew
+uZ
 fh
 vB
 oO


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adjusts lavaland miner locker room:

- Moves Brad's bed and spawn to a dedicated space safe from weather next to the lavaland miner locker room.
- Replaces walls between the miner locker room and new Brad pen with reinforced plasma windows.
- Adjusts wall-mounted light fixtures in the miner locker room to reflect new windows and respect symmetry more.
- Gives Brad a roach-sized Ripley to pilot.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Prevents the death of a station pet during start, and more easily enables cockroaches to be submitted for DNA vault station goal. Also changes the light fixtures inside the locker room to be symmetrical.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Adjusted locker room and new pen.
<img width="580" height="338" alt="Screenshot 2026-01-24 162311" src="https://github.com/user-attachments/assets/e94e5958-f8cb-42e7-962e-da0be92fdda0" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Ran localhost, no runtimes/errors, all changes in place.
Allowed each type of lavaland weather to occur, Brad remained safe.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: New Brad pen. Ripley mech toy for Brad to pilot.
tweak: Light fixtures in lavaland miner locker room moved.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
