### PR TITLE
Fixes mobs talking in dchat

### DIFF
--- a/code/datums/ai/ai_controller.dm
+++ b/code/datums/ai/ai_controller.dm
@@ -615,7 +615,14 @@ RESTRICT_TYPE(/datum/ai_controller)
 /datum/ai_controller/proc/on_sentience_lost()
 	SIGNAL_HANDLER // COMSIG_MOB_LOGOUT
 	UnregisterSignal(pawn, COMSIG_MOB_LOGOUT)
-	set_ai_status(AI_STATUS_IDLE)
+	if(ismob(pawn))
+		var/mob/ai_pawn = pawn
+		if(ai_pawn.stat == DEAD)
+			set_ai_status(AI_STATUS_OFF)
+		else
+			set_ai_status(AI_STATUS_IDLE)
+	else
+		set_ai_status(AI_STATUS_IDLE)
 	RegisterSignal(pawn, COMSIG_MOB_LOGIN, PROC_REF(on_sentience_gained))
 
 /// Turn the controller off if the pawn has been qdeleted.


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Mobs no longer emote to dchat.

Fixes #31484

## Why It's Good For The Game

Bugs bad

## Testing

Spawned a mouse. Smote it. Saw the controller turned off.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed mobs emoting in dchat
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
