### PR TITLE
Fixes helmets sometimes getting stuck on the screen after closing your inventory

### DIFF
--- a/code/datums/elements/clothing_adjustment.dm
+++ b/code/datums/elements/clothing_adjustment.dm
@@ -81,10 +81,6 @@
 /datum/element/clothing_adjustment/skulk_headgear/on_item_dropped(datum/source, mob/target)
 	UnregisterSignal(target, list(COMSIG_CARBON_APPLY_OVERLAY))
 
-	var/mob/living/carbon/human/human = target
-	if(!istype(human))
-		return
-
 /datum/element/clothing_adjustment/skulk_headgear/proc/on_carbon_apply_overlay(mob/living/carbon/human/source, cache_index)
 	SIGNAL_HANDLER // COMSIG_CARBON_APPLY_OVERLAY
 	if(cache_index != HEAD_LAYER || !istype(source))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Title, Fixes #31356 by removing an extraneous proc call.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bugs bad

## Testing
Tried to reproduce the bug the known way, failed.
Equipped/Unequipped hats and glasses on a Skulkkin, no weird icons noticed
<!-- How did you test the PR, if at all? -->

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixes helmets sometimes staying rendered when closing the inventory
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
