### PR TITLE
Fixes typos and British spelling in Advanced Hypospray description

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -167,7 +167,7 @@
 	. = ..()
 	. += "The DeForest Medical Corporation's hypospray is a highly successful medical device currently under patent protection. Naturally, this has not stopped Nanotrasen from taking the design and tinkering with it."
 	. += ""
-	. += "Nanotrasen's version sports a chemical reservior over 3 times the size. The injector head is able to produce such a fine high-pressure stream that it can pierce through most armor. This \
+	. += "Nanotrasen's version sports a chemical reservoir over three times the size. The injector head is able to produce such a fine high-pressure stream that it can pierce through most armor. This \
 	pressurized jet is automatically adjusted to ensure no harm comes to patients with thinner or absent clothing. \
 	It is also able to interface with the autoinjector ports found on modern hardsuits and MODsuits. As this is a prototype, it currently lacks safety features to prevent harmful chemicals being added."
 	. += ""


### PR DESCRIPTION
## What Does This PR Do
Corrects spelling and grammatical errors in the Advanced Hypospray's examine text. Additionally, adds MODsuits to the examine text, as they were not referenced previously.
## Why It's Good For The Game
Examine text reading nicely is good.
## Testing
Visual inspection.
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
fix: The Advanced Hypospray's extended examine has had multiple grammar and spelling issues fixed.
fix: The Advanced Hypospray's extended examine now mentions MODsuits as well as hardsuits.
/:cl:
