### PR TITLE
Updates the Suspicious Medipen's examine text

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -293,7 +293,7 @@
 
 /obj/item/reagent_containers/hypospray/autoinjector/hyper_medipen
 	name = "suspicious medipen"
-	desc = "A cheap-looking medipen containing what seems to be a mix of nearly every medicine stored in the recently raided Nanotrasen warehouse."
+	desc = "A cheap-looking medipen. It contains a wide mix of medicines to fix most health issues. The reagent list seems to match up with the chemicals stolen from a recently-raided Nanotrasen warehouse."
 	icon_state = "hyperpen"
 	amount_per_transfer_from_this = 37
 	volume = 37


### PR DESCRIPTION
## What Does This PR Do
Updates the examine text of the Suspicious Medipen to no longer mention a singular Nanotrasen warehouse. 
Updates the examine text of the Suspicious Medipen to clarify that it heals almost everything.
Breaks up the examine text for easier reading. 

## Why It's Good For The Game
Examine text should be easy to read. Examine text should be accurate.
## Testing
Visual inspection.
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
tweak: The Suspicious Medipen's examine text has been updated and lengthened.
/:cl:
