### PR TITLE
update runner for codedocs

### DIFF
--- a/.github/workflows/generate_autodoc.yml
+++ b/.github/workflows/generate_autodoc.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   generate_docs:
     name: 'Generate Documentation'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: 'Update Branch'
       uses: actions/checkout@v6


### PR DESCRIPTION
## What Does This PR Do
This PR updates the runner for codedocs generation.
## Why It's Good For The Game
Codedocs haven't been updated in 9 months with the scheduled job failing due to lack of available runners, presumably because a runner with this version of ubuntu is no longer available
## Testing
Prayer
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC