### PR TITLE
Fix forgotten new calls

### DIFF
--- a/code/game/machinery/clonepod.dm
+++ b/code/game/machinery/clonepod.dm
@@ -272,7 +272,7 @@
 						return
 
 					var/list/EO_path = clone.dna.species.has_limbs[current_limb]["path"]
-					var/obj/item/organ/external/EO = new EO_path(clone) //Passing a human to a limb's New() proc automatically attaches it
+					var/obj/item/organ/external/EO = new EO_path(clone, clone) // Passing a human to a limb's Initialize() proc automatically attaches it
 					desc_flavor = "You see \a [EO.name] growing from [clone]'[clone.p_s()] [EO.amputation_point]."
 					current_limb = null
 					EO.brute_dam = desired_data.limbs[EO.limb_name][1]

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -173,7 +173,7 @@
 		icon_state = "[initial(icon_state)]_impregnated"
 
 		if(!target.get_int_organ(/obj/item/organ/internal/body_egg/alien_embryo))
-			new /obj/item/organ/internal/body_egg/alien_embryo(target)
+			new /obj/item/organ/internal/body_egg/alien_embryo(target, target)
 			SSblackbox.record_feedback("tally", "alien_growth", 1, "people_infected")
 	else
 		target.visible_message(SPAN_DANGER("[src] violates [target]'s face!"), \

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1041,12 +1041,12 @@
 		if(!(limb_type in H.bodyparts_by_name))
 			var/list/organ_data = H.dna.species.has_limbs[limb_type]
 			var/limb_path = organ_data["path"]
-			var/obj/item/organ/external/O = new limb_path(temp_holder)
+			var/obj/item/organ/external/O = new limb_path(temp_holder, temp_holder)
 			if(H.get_limb_by_name(O.name)) //Check to see if the user already has an limb with the same name as the 'missing limb'. If they do, skip regrowth.
 				continue					//In an example, this will prevent duplication of the mob's right arm if the mob is a Human and they have a Diona right arm, since,
 											//while the limb with the name 'right_arm' the mob has may not be listed in their species' bodyparts definition, it is still viable and has the appropriate limb name.
 			else
-				O = new limb_path(H) //Create the limb on the player.
+				O = new limb_path(H, H) //Create the limb on the player.
 				O.owner = H
 				H.bodyparts |= H.bodyparts_by_name[O.limb_name]
 				if(O.body_part == HEAD) //They're sprouting a fresh head so lets hook them up with their genetic stuff so their new head looks like the original.
@@ -1060,12 +1060,12 @@
 	for(var/index in species_organs)
 		var/organ = species_organs[index]
 		if(!(organ in types_of_int_organs)) //If the mob is missing this particular organ...
-			var/obj/item/organ/internal/I = new organ(temp_holder) //Create the organ inside our holder so we can check it before implantation.
+			var/obj/item/organ/internal/I = new organ(temp_holder, temp_holder) //Create the organ inside our holder so we can check it before implantation.
 			if(H.get_organ_slot(I.slot)) //Check to see if the user already has an organ in the slot the 'missing organ' belongs to. If they do, skip implantation.
 				continue				 //In an example, this will prevent duplication of the mob's eyes if the mob is a Human and they have Nian eyes, since,
 										//while the organ in the eyes slot may not be listed in the mob's species' organs definition, it is still viable and fits in the appropriate organ slot.
 			else
-				I = new organ(H) //Create the organ inside the player.
+				I = new organ(H, H) //Create the organ inside the player.
 				I.insert(H)
 	qdel(temp_holder)
 
@@ -1125,7 +1125,7 @@
 
 	if(blood_volume < BLOOD_VOLUME_STABLE + 50)
 		blood_volume = BLOOD_VOLUME_STABLE + 50
-	
+
 	. = ..()
 	if(.) // if revived successfully
 		set_heartattack(FALSE)

--- a/code/modules/mob/living/carbon/human/species/slimepeople.dm
+++ b/code/modules/mob/living/carbon/human/species/slimepeople.dm
@@ -190,7 +190,7 @@
 			return // No rayman for you
 		// Grah this line will leave a "not used" warning, in spite of the fact that the new() proc WILL do the thing.
 		// Bothersome.
-		var/obj/item/organ/external/new_limb = new limb_path(H)
+		var/obj/item/organ/external/new_limb = new limb_path(H, H)
 		new_limb.open = ORGAN_CLOSED // This is just so that the compiler won't think that new_limb is unused, because the compiler is horribly stupid.
 		H.adjustBruteLoss(stored_brute)
 		H.adjustFireLoss(stored_burn)

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/white.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/white.dm
@@ -46,7 +46,7 @@
 	if(L.can_inject(null, FALSE, inject_target, FALSE) || (HAS_TRAIT(L, TRAIT_HANDS_BLOCKED) && HAS_TRAIT(L, TRAIT_IMMOBILIZED)))
 		if(!IsTSInfected(L) && ishuman(L))
 			visible_message(SPAN_DANGER("[src] buries its long fangs deep into the [inject_target] of [L]!"))
-			new /obj/item/organ/internal/body_egg/terror_eggs(L)
+			new /obj/item/organ/internal/body_egg/terror_eggs(L, L)
 			if(!ckey)
 				LoseTarget()
 				GLOB.move_manager.move_away(src,L,2,1)
@@ -67,7 +67,8 @@
 
 /obj/item/organ/internal/body_egg/terror_eggs/event_cost()
 	. = list()
-	if(is_station_level((get_turf(src)).z) && owner)
+	var/turf/T = get_turf(src)
+	if(is_station_level(T.z) && owner)
 		return list(ASSIGNMENT_MEDICAL = 1)
 
 /obj/item/organ/internal/body_egg/terror_eggs/insert(mob/living/carbon/M, special)
@@ -97,4 +98,4 @@
 			var/inject_target = pick("chest","head")
 			if(C.can_inject(null, FALSE, inject_target, FALSE))
 				to_chat(C, SPAN_DANGER("[src] slices into you!"))
-				new /obj/item/organ/internal/body_egg/terror_eggs(C)
+				new /obj/item/organ/internal/body_egg/terror_eggs(C, C)

--- a/code/modules/reagents/chemistry/reagents/disease.dm
+++ b/code/modules/reagents/chemistry/reagents/disease.dm
@@ -9,7 +9,7 @@
 	if(volume > 2.5)
 		if(iscarbon(M))
 			if(!M.get_int_organ(/obj/item/organ/internal/body_egg))
-				new/obj/item/organ/internal/body_egg/spider_eggs(M) //Yes, even Xenos can fall victim to the plague that is spider infestation.
+				new/obj/item/organ/internal/body_egg/spider_eggs(M, M) //Yes, even Xenos can fall victim to the plague that is spider infestation.
 	return ..()
 
 /datum/reagent/nanomachines


### PR DESCRIPTION
## What Does This PR Do
Fixes some new calls that I'd forgotten about during the migration. These were the ones I managed to find, I don't really know how many more there are given there's 3 ways to create an object and only 2 of them involve the path.
## Why It's Good For The Game
no bug
## Testing
Nuggeted carbon mobs and rejuved them, delimbed an IPC and reattached its limb, extracted and put organs back into a mob, infected a mob with spider eggs/xeno larva and took them out, regrew limbs as a slime person. Spawned as an NNO and used my implants. Cloned a mob without a limb and it regrew it.. Cloned a mob without a limb and it used one from the cloner storage.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Rejuvenate works properly.
fix: Terror eggs infect mobs properly.
fix: Alien larvae infect mobs properly.
fix: Cloner re-creates limbs properly.
fix: Slimepeople can regrow limbs properly.
fix: Spider eggs reagent infects mobs properly.
/:cl: