### PR TITLE
fix ipc organs not being repaired by screwing

### DIFF
--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -420,7 +420,7 @@
 					SPAN_NOTICE("You repair [target]'s [I.name] with [tool]."),
 					chat_message_type = MESSAGE_TYPE_COMBAT
 				)
-			I.heal_internal_damage(I.max_damage)
+			I.heal_internal_damage(I.max_damage, TRUE)
 			I.surgeryize()
 			if(istype(tool, /obj/item/stack/nanopaste))
 				I.rejuvenate()


### PR DESCRIPTION
## What Does This PR Do
Adds a missing arg, letting IPC organs get fixed when theyre screwed. Fixes #31554
## Why It's Good For The Game
IPC repair
## Testing
Ioned an IPC and fixed it's organs.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Screwdrivers can fix IPC organs again.
/:cl: