### PR TITLE
fix json spawned mobs immediately dying

### DIFF
--- a/code/modules/persistence/persistence.dm
+++ b/code/modules/persistence/persistence.dm
@@ -78,6 +78,14 @@ in their list
 	if(!path)
 		throw EXCEPTION("Path not found: [path]")
 
-	var/atom/movable/thing = new path(loc)
+	// Since Initialize() eats the first argument
+	// we need to pass loc twice for organs, otherwise
+	// they'll never attach to the mob. But if it's passed
+	// for everything, it'll break shit cause it gets passed random args.
+	var/atom/movable/thing
+	if(ispath(path, /obj/item/organ))
+		thing = new path(loc, loc)
+	else
+		thing = new path(loc)
 	thing.deserialize(data)
 	return thing


### PR DESCRIPTION
## What Does This PR Do
Crimes against coder-kind.

Fixes json spawned mobs from instantly dying. Adds an organ check in `json_to_object()` in order to pass the loc twice. Because of Initialize() eating the first argument, without this, organs will get created without attaching to the mob, causing it to instantly die.
## Why It's Good For The Game
Admin spawn chars work.
## Images of changes

https://github.com/user-attachments/assets/b56e2e69-22ee-4ab3-850d-af61c2e01f71

## Testing
Spawned a json character.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Json serialized characters can now be spawned again.
/:cl: