### PR TITLE
Adds action button for opening/closing nian wings

### DIFF
--- a/code/modules/mob/living/carbon/human/species/moth.dm
+++ b/code/modules/mob/living/carbon/human/species/moth.dm
@@ -82,6 +82,8 @@
 	..()
 	var/datum/action/innate/cocoon/cocoon = new()
 	cocoon.Grant(H)
+	var/datum/action/innate/toggle_wings/wings_toggle = new()
+	wings_toggle.Grant(H)
 	RegisterSignal(H, COMSIG_LIVING_FIRE_TICK, PROC_REF(check_burn_wings))
 	RegisterSignal(H, COMSIG_LIVING_AHEAL, PROC_REF(on_aheal))
 	RegisterSignal(H, COMSIG_HUMAN_CHANGE_BODY_ACCESSORY, PROC_REF(on_change_body_accessory))
@@ -91,6 +93,8 @@
 	..()
 	for(var/datum/action/innate/cocoon/cocoon in H.actions)
 		cocoon.Remove(H)
+	for(var/datum/action/innate/toggle_wings/wings_toggle in H.actions)
+		wings_toggle.Remove(H)
 	UnregisterSignal(H, COMSIG_LIVING_FIRE_TICK)
 	UnregisterSignal(H, COMSIG_LIVING_AHEAL)
 	UnregisterSignal(H, COMSIG_HUMAN_CHANGE_BODY_ACCESSORY)
@@ -193,6 +197,16 @@
 		addtimer(CALLBACK(src, PROC_REF(emerge), C), COCOON_EMERGE_DELAY, TIMER_UNIQUE)
 	else
 		to_chat(H, SPAN_WARNING("You need to hold still in order to weave a cocoon!"))
+
+/datum/action/innate/toggle_wings
+	name = "Toggle Wings"
+	desc = "Open or close your wings! While your wings are open, you can fly in pressurized 0G environments!"
+	check_flags = AB_CHECK_RESTRAINED | AB_CHECK_STUNNED | AB_CHECK_CONSCIOUS
+	button_icon = 'icons/mob/sprite_accessories/moth/moth_wings.dmi'
+	button_icon_state = "monarch_BEHIND"
+
+/datum/action/innate/toggle_wings/Activate()
+	owner.emote("wings")
 
 /**
  * Removes moth from cocoon, restores burnt wings


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Nians now have an action button to toggle their wings.

## Why It's Good For The Game

Easier access to their species trait.

## Images of changes

<img width="321" height="184" alt="image" src="https://github.com/user-attachments/assets/43130320-401e-4801-ba39-dd6ef679322f" />

## Testing

Spawned as a moth and fluttered around for a bit.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Added an action button for nians to toggle their wing state
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
