### PR TITLE
Fix json serialization exception for paths

### DIFF
--- a/code/modules/persistence/persistence.dm
+++ b/code/modules/persistence/persistence.dm
@@ -76,7 +76,7 @@ in their list
 		throw EXCEPTION("No 'type' field in the data")
 	var/path = text2path(data["type"])
 	if(!path)
-		throw EXCEPTION("Path not found: [path]")
+		throw EXCEPTION("Path not found: [data["type"]]")
 
 	// Since Initialize() eats the first argument
 	// we need to pass loc twice for organs, otherwise


### PR DESCRIPTION
## What Does This PR Do
Replaces the path var with the value from the json data. text2path will return a path only if that path exists, otherwise it returns null. That makes the exception quite useless as you can't actually see what it tried to spawn.
## Why It's Good For The Game
No mystical runtimes.
## Testing
Malformed a json datum in the db and spawned it in-game.

Before:
`[2026-02-01T23:59:15] Runtime in code/modules/persistence/persistence.dm:79: Path not found:
   usr: Rosa Jerome (CKEY) (/mob/living/carbon/human)
   usr.loc: The shuttle floor (127,127,2) (/turf/simulated/floor/mineral/titanium/blue)
`

After
`[2026-02-01T23:59:15] Runtime in code/modules/persistence/persistence.dm:79: Path not found: /not/a/real/path
   usr: Rosa Jerome (CKEY) (/mob/living/carbon/human)
   usr.loc: The shuttle floor (127,127,2) (/turf/simulated/floor/mineral/titanium/blue)
`
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC