### PR TITLE
Fix an emote runtime

### DIFF
--- a/code/datums/emote.dm
+++ b/code/datums/emote.dm
@@ -531,7 +531,7 @@
 			return FALSE
 		if(HAS_TRAIT(user, TRAIT_FAKEDEATH))
 			if(istype(user, /mob/living))
-				var/mob/living/L
+				var/mob/living/L = user
 				if(!L.has_status_effect(/datum/status_effect/ghoul))
 					return FALSE
 			else


### PR DESCRIPTION
## What Does This PR Do
L is never assigned to the user, causing this to runtime every time a mob runs through this check.
## Why It's Good For The Game
No runtimes.
## Testing
In compiling I trust.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC