### PR TITLE
Buffs Breach Cleaver

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -646,13 +646,13 @@
 		return
 	var/mob/living/carbon/human/H = owner
 	H.physiology.armor = H.physiology.armor.attachArmor(cleaving_armor_boost)
-	H.physiology.stamina_mod *= 0.8
+	H.physiology.stamina_mod *= 0.5
 
 /datum/status_effect/breaching_and_cleaving/on_remove()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		H.physiology.armor = H.physiology.armor.detachArmor(cleaving_armor_boost)
-		H.physiology.stamina_mod /= 0.8
+		H.physiology.stamina_mod /= 0.5
 	QDEL_NULL(cleaving_armor_boost)
 
 /datum/status_effect/hope

--- a/code/game/objects/items/weapons/melee/melee.dm
+++ b/code/game/objects/items/weapons/melee/melee.dm
@@ -400,7 +400,7 @@
 /obj/item/melee/breach_cleaver/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/two_handed, force_wielded = force_wield, force_unwielded = force, icon_wielded = "[base_icon_state]1", wield_callback = CALLBACK(src, PROC_REF(wield)), unwield_callback = CALLBACK(src, PROC_REF(unwield)))
-	AddComponent(/datum/component/parry, _stamina_constant = 2, _stamina_coefficient = 0.5, _parryable_attack_types = NON_PROJECTILE_ATTACKS)
+	AddComponent(/datum/component/parry, _stamina_constant = 2, _stamina_coefficient = 0.5, _parryable_attack_types = ALL_ATTACK_TYPES)
 
 /obj/item/melee/breach_cleaver/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Buffs the breach cleaver by allowing it to parry projectiles as well as reducing the stamina mod even more.

## Why It's Good For The Game

A 65 TC species-locked item should be able to compete with 50 TC, 60 TC, and 65 TC alternatives without feeling like a direct downgrade. The reduced stamina mod should let you take significantly more stam damage before being downed, and being able to parry projectiles will allow you to withstand some laser fire while closing distance.

## Testing

Compiled

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<img width="938" height="263" alt="image" src="https://github.com/user-attachments/assets/f82e4539-f0bb-4c97-8166-7265f9012dd7" />

## Changelog

:cl:
tweak: Buffed breach cleaver's stamina resistance and parry
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
