### PR TITLE
Heretic ID Fix

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -116,9 +116,8 @@
 			continue
 		var/obj/item/card/id/heretic/heretic_card = new result(our_turf)
 		for(var/obj/item/card/id/card in selected_atoms)
-			if(!isnull(card))
-				heretic_card.eat_card(card, user)
-				selected_atoms -= card
+			heretic_card.eat_card(card, user)
+			selected_atoms -= card
 
 /datum/heretic_knowledge/mark/lock_mark
 	name = "Mark of Lock"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

The heretic ID card was supposed to hold the original card it was made with. This fixes it to actually do that.

## Why It's Good For The Game

Returning the card to its original function.

## Testing

sacrificed my ID, turned it into the ID it ate, unlocked a door

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Heretic ID properly eats its creation ID now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
