### PR TITLE
Updates the Observe prompt text

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -168,7 +168,7 @@
 			to_chat(usr, SPAN_WARNING("You must wait for the server to finish starting before you can join!"))
 			return FALSE
 
-		if(alert(usr, "Are you sure you wish to observe? You cannot normally join the round after doing this!", "Observe", "Yes", "No") == "Yes")
+		if(alert(usr, "Are you sure you wish to observe? There may be a delay before you can attempt to rejoin.", "Observe", "Yes", "No") == "Yes")
 			if(!client)
 				return TRUE
 			var/mob/dead/observer/observer = new(src, GHOST_FLAGS_START_AS_OBSERVER)


### PR DESCRIPTION
## What Does This PR Do
Updates the Observe prompt text in the main menu.

Previous:
> "Are you sure you wish to observe? You cannot normally join the round after doing this!"

New:
> "Are you sure you wish to observe? There may be a delay before you can attempt to rejoin."
## Why It's Good For The Game
Due to respawning being a mechanic, it is now possible for observers to join the round normally.
## Images of changes
<img width="534" height="140" alt="image" src="https://github.com/user-attachments/assets/46f01240-ad58-4323-85b6-00483dd4761b" />

## Testing
Compiled. Loaded server. Clicked observe.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
tweak: The Observe prompt in the main menu has had its text updated to reflect the ability to respawn.
/:cl: