### PR TITLE
Buffs the nkarrdem mega sprays regen and capacity

### DIFF
--- a/code/game/mecha/equipment/tools/janitor_tools.dm
+++ b/code/game/mecha/equipment/tools/janitor_tools.dm
@@ -150,11 +150,13 @@
 	/// Toggle for refilling itself
 	var/refill_enabled = TRUE
 	/// Rate per process() tick spray refills itself
-	var/refill_rate = 1
+	var/refill_rate = 10
 	/// Power use per process to refill reagents
-	var/refill_cost = 25
+	var/refill_cost = 100
 	/// What reagent to refill with
 	var/refill_reagent = "cleaner"
+	/// The internal reagent container capacity
+	var/spray_capacity = 250
 	/// The range of tiles the sprayer will reach.
 	var/spray_range = 4
 	/// Internal sprayer object
@@ -166,8 +168,8 @@
 	spray_controller.loc = src
 	spray_controller.spray_maxrange = spray_range
 	spray_controller.spray_currentrange = spray_range
-	spray_controller.volume = 100
-	spray_controller.reagents.add_reagent("cleaner", 100)
+	spray_controller.volume = spray_capacity
+	spray_controller.reagents.add_reagent("cleaner", spray_capacity)
 	START_PROCESSING(SSobj, src)
 
 /obj/item/mecha_parts/mecha_equipment/janitor/mega_spray/emag_act(mob/user)
@@ -180,7 +182,7 @@
 	refill_rate = 5
 
 /obj/item/mecha_parts/mecha_equipment/janitor/mega_spray/action(atom/target)
-	if(spray_controller.reagents.total_volume < 15) // Needs at least enough reagents to apply the full spray
+	if(spray_controller.reagents.total_volume <= 20) // Needs at least enough reagents to apply the full spray
 		to_chat(chassis.occupant, SPAN_DANGER("*click*"))
 		playsound(src, 'sound/weapons/empty.ogg', 100, 1)
 		return
@@ -198,7 +200,7 @@
 
 // Auto-regeneration of space cleaner. Takes energy.
 /obj/item/mecha_parts/mecha_equipment/janitor/mega_spray/process()
-	if(spray_controller.reagents.total_volume < 100)
+	if(spray_controller.reagents.total_volume < spray_capacity)
 		spray_controller.reagents.add_reagent(refill_reagent, refill_rate)
 		chassis.use_power(refill_cost)
 		update_equip_info()


### PR DESCRIPTION
## What Does This PR Do
Ups the regen of space cleaner to 10u a tick(this is 50u/s)
Increases the capacity of the spray to 250
Fixes a runtime with the spray spraying when the spray couldn't spray enough reagents
Makes the max capacity a var rather than it being in 3 separate spots
The power draw has also been upped to 100, from 25

## Why It's Good For The Game
The spray in its current state is just not worth using, the mop out classes it massively due to the space cleaner refilling 5/s but spraying 10 each spray, so you'd have to wait two seconds per spray to not run out, not very useful when the mop exists..
The capacity was also to address it.
Runtime bad, its possible the check can be `<= 15` but it worked on 20 so 
And the capacity being a var is just better for code stuff, better to change one var then 3 separate instances of the same thing. and easier for admins to var edit it for.. fun 


## Testing
Sprayed the spray, watched the spray refill what it sprays so it can spray again, and made sure it couldn't spray when the spray didn't actually have enough spray in the spray container to spray out that'd lead to the spray runtiming

## Declaration
I don't believe i need approval for this
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
tweak: Buffs the nkarrdem mega sprays regen and capacity, at the cost of power draw
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
