### PR TITLE
Adds the tape recorder to the loadout menu

### DIFF
--- a/code/modules/client/preference/loadout/loadout_general.dm
+++ b/code/modules/client/preference/loadout/loadout_general.dm
@@ -57,6 +57,10 @@
 	display_name = "Camera"
 	path = /obj/item/camera
 
+/datum/gear/taperecorder
+	display_name = "Universal recorder"
+	path = /obj/item/taperecorder
+
 /datum/gear/redfoxplushie
 	display_name = "Red fox plushie"
 	path = /obj/item/toy/plushie/red_fox


### PR DESCRIPTION
## What Does This PR Do
Adds the universal recorder to the loadout menu.
## Why It's Good For The Game
Character equipment and roleplay variety. Easier access to translation for getting past language barriers.
## Testing
Compiled. Inspected. Selected.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
add: Added the universal recorder to the loadout menu.
/:cl:
