### PR TITLE
Heretic end round completion text no longer breaks

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1754,6 +1754,7 @@
 			return A
 		else if(A.type == datum_type)
 			return A
+	return null
 
 /datum/mind/proc/prepare_announce_objectives(title = TRUE)
 	if(!current)

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -668,7 +668,10 @@
 
 	var/list/text = list("<br><font size=3>[SPAN_BOLD("The heretics were:")]</font>")
 	for(var/datum/mind/heretic in heretics)
-
+		var/datum/antagonist/heretic/heretic_datum = heretic.has_antag_datum(/datum/antagonist/heretic)
+		// Skip heretic monster summons.
+		if(!heretic_datum)
+			continue
 		text += "<br>[heretic.get_display_key()] was [heretic.name] ("
 		if(heretic.current)
 			if(heretic.current.stat == DEAD)
@@ -678,27 +681,26 @@
 		else
 			text += "body destroyed"
 		text += ")"
-		var/datum/antagonist/heretic/our_heretic = heretic.has_antag_datum(/datum/antagonist/heretic)
-		text += "<br><b>Sacrifices Made:</b> [our_heretic.total_sacrifices]"
-		text += "<br>The heretic's sacrifice targets were: [english_list(our_heretic.all_sac_targets, nothing_text = "No one")]."
+		text += "<br><b>Sacrifices Made:</b> [heretic_datum.total_sacrifices]"
+		text += "<br>The heretic's sacrifice targets were: [english_list(heretic_datum.all_sac_targets, nothing_text = "No one")]."
 		var/list/all_objectives = heretic.get_all_objectives()
 
-		if(length(all_objectives))//If the traitor had no objectives, don't need to process this.
+		if(length(all_objectives)) // If the traitor had no objectives, don't need to process this.
 			var/count = 1
 			for(var/datum/objective/objective in all_objectives)
 				text += "<br><b>Objective #[count]</b>: [objective.explanation_text]</b></font>"
 				count++
-		if(our_heretic.feast_of_owls)
+		if(heretic_datum.feast_of_owls)
 			text += SPAN_GREENTEXT("<br>Ascension Forsaken")
-		if(our_heretic.ascended)
+		if(heretic_datum.ascended)
 			text += SPAN_HIEROPHANT_WARNING("<br>THE HERETIC ASCENDED!")
 
 		text += "<br><b>Knowledge Researched:</b> "
 
 		var/list/string_of_knowledge = list()
 
-		for(var/knowledge_index in our_heretic.researched_knowledge)
-			var/datum/heretic_knowledge/knowledge = our_heretic.researched_knowledge[knowledge_index]
+		for(var/knowledge_index in heretic_datum.researched_knowledge)
+			var/datum/heretic_knowledge/knowledge = heretic_datum.researched_knowledge[knowledge_index]
 			string_of_knowledge += knowledge.name
 
 		text += english_list(string_of_knowledge)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Heretic end round completion text now skips members of the gamemode `heretics` list with `/datum/antagonist/mindslave/heretic_monster`. 
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
bug
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I can't test this locally
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Heretic end round text no longer breaks because of heretic monster summons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
