### PR TITLE
[s] fix RCL infinite cable production

### DIFF
--- a/code/game/objects/items/RCL.dm
+++ b/code/game/objects/items/RCL.dm
@@ -56,9 +56,10 @@
 		var/obj/item/stack/cable_coil/C = target
 		C.melee_attack_chain(user, src, list2params(modifiers))
 		return ITEM_INTERACT_COMPLETE
-	
-	loaded.melee_attack_chain(user, target, list2params(modifiers))
-	return ITEM_INTERACT_COMPLETE
+
+	if(isturf(target))
+		loaded.melee_attack_chain(user, target, list2params(modifiers))
+		return ITEM_INTERACT_COMPLETE
 
 /obj/item/rcl/proc/refresh_icon(mob/user)
 	update_icon(UPDATE_ICON_STATE|UPDATE_OVERLAYS)
@@ -206,7 +207,7 @@
 /obj/item/rcl/robot/AltClick(mob/user, modifiers)
 	if(..())
 		return ITEM_INTERACT_COMPLETE
-	
+
 	if(heavy_mode)
 		loaded.cable_type = /obj/structure/cable
 		loaded.cable_merge_id = CABLE_LOW_POWER


### PR DESCRIPTION
## What Does This PR Do
The RCL works by calling the attack chain of the loaded cable coil, letting it get forced out and put into a backpack, etc. This PR adds a turf check for the target. Only if it's a turf will it run the cable coil attack chain.
## Why It's Good For The Game
Infinite resource bad.
## Testing
Put an RCL in my backpack. No cable coil.
Clicked on turf, laid cable.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
sekrit chengis