### PR TITLE
Adds a single period to the power cable's description

### DIFF
--- a/code/modules/power/cables/cable.dm
+++ b/code/modules/power/cables/cable.dm
@@ -20,7 +20,7 @@ By design, d1 is the smallest direction and d2 is the highest
 */
 /obj/structure/cable
 	name = "power cable"
-	desc = "A low-cost superconducting cable"
+	desc = "A low-cost superconducting cable."
 	icon = 'icons/obj/power_cond/power_cond_white.dmi'
 	icon_state = "0-1"
 	level = 1


### PR DESCRIPTION
## What Does This PR Do
Adds a period to the end of the power cable's description.
## Why It's Good For The Game
Sentences should end properly.
## Testing
Compiled. Visually inspected.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Power cables now have proper punctuation.
/:cl: