### PR TITLE
Adds new turret subtypes

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -1142,16 +1142,16 @@
 	shot_delay = 2 SECONDS
 
 /obj/machinery/porta_turret/ruin/lwap
-	projectile = /obj/projectile/beam/laser/sniper
-	eprojectile = /obj/projectile/beam/laser/sniper
+	projectile = /obj/projectile/beam/laser/sniper/pierce
+	eprojectile = /obj/projectile/beam/laser/sniper/pierce
 	shot_sound = 'sound/weapons/marauder.ogg'
 	eshot_sound = 'sound/weapons/marauder.ogg'
 	scan_range = 16
 	shot_delay = 3 SECONDS
 
 /obj/machinery/porta_turret/ruin/immolator
-	projectile = /obj/projectile/beam/immolator/strong
-	eprojectile = /obj/projectile/beam/immolator/strong
+	projectile = /obj/projectile/beam/immolator
+	eprojectile = /obj/projectile/beam/immolator
 	shot_sound = 'sound/weapons/laser3.ogg'
 	eshot_sound = 'sound/weapons/laser3.ogg'
 
@@ -1160,7 +1160,7 @@
 	eprojectile = /obj/projectile/beam/laser/accelerator
 	shot_sound = 'sound/weapons/lasercannonfire.ogg'
 	eshot_sound = 'sound/weapons/lasercannonfire.ogg'
-	scan_range = 10
+	scan_range = 12
 
 /obj/machinery/porta_turret/ruin/tesla
 	projectile = /obj/projectile/energy/tesla_bolt


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Adds a handful of turret subtypes for use in ruins and events.

These turrets are porta-turrets that are hostile to anything that is not sharing their faction. Likewise, they cannot be changed by AI/silicons. Any turret that states a range has an altered alert and fire range.

Turret types:
- Xray (range 10)
- LWAP (range 16)
- Immolator
- Accelerator (range 12)
- Tesla Bolt
- Charged Plasma

## Why It's Good For The Game

Mapping assets good. Event assets good.

## Testing

Tested live during an event on 2/7/2026

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<img width="1095" height="208" alt="image" src="https://github.com/user-attachments/assets/c1dce56e-c496-4e39-abc6-fe8d45159ead" />

## Changelog

:cl:
add: Added new turret subtypes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
