### PR TITLE
Terror spider event subtypes

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -228,7 +228,11 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_DISASTER, /datum/event/nothing, 5730),
 		new /datum/event_meta(EVENT_LEVEL_DISASTER, /datum/event/blob, 100, TRUE),
 		new /datum/event_meta(EVENT_LEVEL_DISASTER, /datum/event/alien_infestation, 100, TRUE),
-		new /datum/event_meta(EVENT_LEVEL_DISASTER, /datum/event/spider_terror, 100, TRUE)
+		new /datum/event_meta(EVENT_LEVEL_DISASTER, /datum/event/spider_terror, 100, TRUE),
+		new /datum/event_meta(EVENT_LEVEL_DISASTER, /datum/event/spider_terror/prince, 0, TRUE),
+		new /datum/event_meta(EVENT_LEVEL_DISASTER, /datum/event/spider_terror/white, 0, TRUE),
+		new /datum/event_meta(EVENT_LEVEL_DISASTER, /datum/event/spider_terror/princess, 0, TRUE),
+		new /datum/event_meta(EVENT_LEVEL_DISASTER, /datum/event/spider_terror/queen, 0, TRUE),
 		)
 	var/activation_counter = 0
 	var/event_rolls = 0

--- a/code/modules/events/spider_terror.dm
+++ b/code/modules/events/spider_terror.dm
@@ -9,6 +9,8 @@
 	role_requirements = list(ASSIGNMENT_SECURITY = 3, ASSIGNMENT_CREW = 45, ASSIGNMENT_MEDICAL = 4)
 	var/spawncount = 1
 	var/successSpawn = FALSE	//So we don't make a command report if nothing gets spawned.
+	/// Specific type of terror spawn
+	var/infestation_type
 
 /datum/event/spider_terror/setup()
 	announceWhen = rand(announceWhen, announceWhen + 30)
@@ -36,11 +38,11 @@
 
 /datum/event/spider_terror/proc/wrappedstart()
 	var/spider_type
-	var/infestation_type
-	if((length(GLOB.clients)) < TS_HIGHPOP_TRIGGER)
-		infestation_type = pick(TS_INFESTATION_PRINCE_SPIDER, TS_INFESTATION_WHITE_SPIDER, TS_INFESTATION_PRINCESS_SPIDER)
-	else
-		infestation_type = pick(TS_INFESTATION_PRINCE_SPIDER, TS_INFESTATION_WHITE_SPIDER, TS_INFESTATION_PRINCESS_SPIDER, TS_INFESTATION_QUEEN_SPIDER)
+	if(!infestation_type)
+		if((length(GLOB.clients)) < TS_HIGHPOP_TRIGGER)
+			infestation_type = pick(TS_INFESTATION_PRINCE_SPIDER, TS_INFESTATION_WHITE_SPIDER, TS_INFESTATION_PRINCESS_SPIDER)
+		else
+			infestation_type = pick(TS_INFESTATION_PRINCE_SPIDER, TS_INFESTATION_WHITE_SPIDER, TS_INFESTATION_PRINCESS_SPIDER, TS_INFESTATION_QUEEN_SPIDER)
 	switch(infestation_type)
 		if(TS_INFESTATION_PRINCE_SPIDER)
 			// Fairly weak. Dangerous in single combat but has little staying power. Always gets whittled down.
@@ -81,5 +83,21 @@
 		kill()
 	SSticker.record_biohazard_start(infestation_type)
 	SSevents.biohazards_this_round += infestation_type
+
+/datum/event/spider_terror/prince
+	name = "terror prince"
+	infestation_type = TS_INFESTATION_PRINCE_SPIDER
+
+/datum/event/spider_terror/white
+	name = "white terror spiders"
+	infestation_type = TS_INFESTATION_WHITE_SPIDER
+
+/datum/event/spider_terror/princess
+	name = "princess terror spiders"
+	infestation_type = TS_INFESTATION_PRINCESS_SPIDER
+
+/datum/event/spider_terror/queen
+	name = "queen of terror spiders"
+	infestation_type = TS_INFESTATION_QUEEN_SPIDER
 
 #undef TS_HIGHPOP_TRIGGER


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Adds 4 0-weight terror spider events so that a specific type of terror spider can be forced. As these have 0 weight, they do not effect the event spawn rate.

## Why It's Good For The Game

Sometimes admins want to send a prince of terror instead of princesses. Sometimes they want to send a queen instead.

## Testing

Opened event manager, forced a prince of terror.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Added subtypes of terror spider event to the event manager
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
