### PR TITLE
Fixes an icon with mining borg mobs

### DIFF
--- a/code/modules/mob/living/basic/hostile/silicon/evil_cyborgs.dm
+++ b/code/modules/mob/living/basic/hostile/silicon/evil_cyborgs.dm
@@ -133,7 +133,7 @@
 /mob/living/basic/malfborg/mining
 	name = "mining cyborg"
 	desc = "It digs holes in organic flesh."
-	icon_state = "Noble-DIG"
+	icon_state = "Noble-Mining"
 	melee_damage_lower = 20
 	melee_damage_upper = 30
 	attack_verb_simple = "mine"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

During the PR, the borg icons were renamed. This fixes a missing icon.

## Why It's Good For The Game

Mobs should have icons.

## Testing

Compiled

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed hostile mining borgs having no sprite
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
