### PR TITLE
fix rcl being unable to wire machinery and mobs

### DIFF
--- a/code/game/objects/items/RCL.dm
+++ b/code/game/objects/items/RCL.dm
@@ -57,9 +57,11 @@
 		C.melee_attack_chain(user, src, list2params(modifiers))
 		return ITEM_INTERACT_COMPLETE
 
-	if(isturf(target) || ismachinery(target) || ismob(target))
-		loaded.melee_attack_chain(user, target, list2params(modifiers))
-		return ITEM_INTERACT_COMPLETE
+	if(isstorage(target) || istable(target))
+		return ..()
+
+	loaded.melee_attack_chain(user, target, list2params(modifiers))
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/rcl/proc/refresh_icon(mob/user)
 	update_icon(UPDATE_ICON_STATE|UPDATE_OVERLAYS)


### PR DESCRIPTION
## What Does This PR Do
RCL now checks if it's a table or storage. If it is, it doesnt act like cable. Fixes #31629
## Why It's Good For The Game
Borgs can do work
## Testing
Wired an APC and fixed a burned IPC. Whipped the IPC on harm intent.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: RCL is able to wire machinery and mobs again.
/:cl: