### PR TITLE
Adds flavor messages for IPC reagents

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol.dm
@@ -1249,10 +1249,10 @@
 	return ..()
 
 /datum/reagent/consumable/ethanol/synthanol/reaction_mob(mob/living/M, method=REAGENT_TOUCH, volume)
-	if(method == REAGENT_INGEST)
+	if(method == REAGENT_INGEST & !ismachineperson(M) & !isvox(M)) // vox don't get a message
 		to_chat(M, pick(SPAN_WARNING("That was awful!"), SPAN_WARNING("Yuck!")))
-		if(ismachineperson(M))
-			to_chat(M, SPAN_NOTICE("Your components feel smoother."))
+	if(method == REAGENT_INGEST & ismachineperson(M))
+		to_chat(M, SPAN_NOTICE("Your components feel smoother."))
 
 /datum/reagent/consumable/ethanol/synthanol/robottears
 	name = "Robot Tears"


### PR DESCRIPTION
## What Does This PR Do
Adds special notice messages for IPCs when they drink synthanol, oil, or other reagents with the SYNTHETIC process flag. This does not affect vox.
## Why It's Good For The Game
More variety and flavor text is fun.
## Images of changes
nada
## Testing
Spawned an IPC, a human, and a vox. Consumed reagents as all three. Messages showed as expected.
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
add: Added new things
del: Removed old things
tweak: Tweaked a few things
fix: Fixed a few things
wip: Added a few works in progress
soundadd: Added a new sound thingy
sounddel: Removed an old sound thingy
imageadd: Added some icons and images
imagedel: Deleted some icons and images
spellcheck: Fixed a few typos
experiment: Added an experimental thingy
/:cl: