### PR TITLE
Reduces the price of the breathing tube quirk to 1

### DIFF
--- a/code/modules/client/preference/quirks/positive_quirks.dm
+++ b/code/modules/client/preference/quirks/positive_quirks.dm
@@ -149,6 +149,6 @@
 /datum/quirk/breathing_tube
 	name = "Breathing Tube"
 	desc  = "You have been outfitted with a breathing tube."
-	cost = 2
+	cost = 1
 	species_flags = QUIRK_MACHINE_INCOMPATIBLE
 	organ_to_give = /obj/item/organ/internal/cyberimp/mouth/breathing_tube


### PR DESCRIPTION
## What Does This PR Do
Reduces the price of the breathing tube quirk to 1 point (from 2).
## Why It's Good For The Game
Currently, the breathing tube's primary benefit is that you no longer need a mask to use an internals tank, which only a substantial impact on vox and plasmamen by consistently freeing their face slot, as they still need their tank equipped and turned on to not suffocate.
## Testing
Compiled. Checked the quirks menu. Spawned.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: The breathing tube quirk now costs 1 point to select.
/:cl: