### PR TITLE
Reduces the cost of the culinary processor quirk to 1

### DIFF
--- a/code/modules/client/preference/quirks/positive_quirks.dm
+++ b/code/modules/client/preference/quirks/positive_quirks.dm
@@ -117,7 +117,7 @@
 /datum/quirk/culinary_implant
 	name = "IPC Culinary Implant"
 	desc = "Either you or your creator wanted you to seem more organic, and gave you an artificial mouth and stomach."
-	cost = 2
+	cost = 1
 	species_flags = QUIRK_ORGANIC_INCOMPATIBLE
 	organ_to_give = /obj/item/organ/internal/cyberimp/chest/ipc_food
 


### PR DESCRIPTION
## What Does This PR Do
Reduces the cost of the culinary processor quirk to 1 point (from 2).
## Why It's Good For The Game
The culinary processor implant does not grant any mechanical benefits to IPCs that have it installed, since eating food does not give them any energy.
## Testing
Compiled. Checked the quirks menu. Spawned.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: The culinary processor quirk has had its cost reduced to 1 point (from 2).
/:cl: