### PR TITLE
Fixes reanimators

### DIFF
--- a/code/modules/mob/living/basic/hostile/nether_mobs/skeleton_mob.dm
+++ b/code/modules/mob/living/basic/hostile/nether_mobs/skeleton_mob.dm
@@ -170,6 +170,8 @@
 	ranged_burst_interval = 0.35 SECONDS
 	projectile_sound = 'sound/magic/magic_missile.ogg'
 	ai_controller = /datum/ai_controller/basic_controller/incursion/reanimator
+	/// Are we reanimating?
+	var/reanimating = FALSE
 	/// List of actions the reanimator has
 	var/list/reanimator_actions = list(
 		/datum/action/cooldown/mob_cooldown/summon_skulls = BB_REANIMATOR_SKULL_ACTION,
@@ -184,6 +186,9 @@
 		return ..()
 	if(target.stat != DEAD)
 		return ..()
+	if(reanimating)
+		return
+	reanimating = TRUE
 	new /obj/effect/temp_visual/cult/rune_spawn/rune7(target.loc, 5 SECONDS, "#252525")
 	new /obj/effect/temp_visual/cult/rune_spawn/rune7/inner(target.loc, 5 SECONDS, "#252525")
 	new /obj/effect/temp_visual/cult/rune_spawn/rune7/center(target.loc, 5 SECONDS, "#252525")
@@ -197,6 +202,8 @@
 	if(do_after_once(src, 2 SECONDS, target = target, attempt_cancel_message = "You stop reanimating a corpse.", interaction_key = "reanimator_revive"))
 		sleep(3 SECONDS) // Locks the revitalizer down for 2 seconds, but gives the player 5 seconds to return
 		reanimate(target)
+	else
+		reanimating = FALSE
 
 /mob/living/basic/skeleton/incursion/reanimator/proc/reanimate(mob/living/carbon/human/H)
 	visible_message(SPAN_WARNING("[name] releases dark tendrils into the flesh of [H], morphing their corpse into a grotesque creature!"))
@@ -215,7 +222,7 @@
 
 	var/mob/dead/observer/chosen_ghost
 	var/list/candidates
-	candidates = SSghost_spawns.poll_candidates("Would you like to play as a Reanimated Blank?", ROLE_SENTIENT, FALSE, poll_time = 10 SECONDS, source = /mob/living/basic/netherworld/blankbody, role_cleanname = "blank")
+	candidates = SSghost_spawns.poll_candidates("Would you like to play as a Reanimated Blank?", ROLE_DEMON, FALSE, poll_time = 10 SECONDS, source = /mob/living/basic/netherworld/blankbody, role_cleanname = "blank")
 	if(length(candidates))
 		chosen_ghost = pick(candidates)
 	if(chosen_ghost && blank.stat != DEAD)
@@ -223,6 +230,7 @@
 		blank.cancel_camera()
 		dust_if_respawnable(chosen_ghost)
 		to_chat(blank, SPAN_USERDANGER("You have been raised by the dead to serve as a footsoldier in the incursion. Strike down your foes!"))
+	reanimating = FALSE
 
 /obj/projectile/magic/necrotic_bolt
 	name = "necrotic bolt"
@@ -269,4 +277,4 @@
 	attack_verb_simple = "bites"
 	speak_emote = list("chatters")
 	throw_blocked_message = "is shrugged off by"
-	ai_controller = /datum/ai_controller/basic_controller/simple/simple_hostile_obstacles/prowler
+	ai_controller = /datum/ai_controller/basic_controller/simple/simple_hostile_obstacles


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes a bug where reanimators cancel their own reanimation cycle.

## Why It's Good For The Game

The dead shouldn't be spammed, and the reanimators should actually revive people.

## Testing

Died in front of reanimator. Was reanimated.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed reanimators stopping their own do-afters.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
