### PR TITLE
Color-codes the ready and cancel ready buttons

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -62,7 +62,7 @@
 		if(!ready)
 			output += "<p><a href='byond://?src=[UID()];ready=1'><font color='lime'><b>Declare Ready</b></font></a></p>"
 		else
-			output += "<p><b>You are ready</b> (<a href='byond://?src=[UID()];ready=2'><font color='orange'><b>Cancel</b></font></A>)</p>"
+			output += "<p><b>You are ready</b> (<a href='byond://?src=[UID()];ready=2'><font color='orange'><b>Cancel</b></font></a>)</p>"
 	else
 		output += "<p><a href='byond://?src=[UID()];manifest=1'>View the Crew Manifest</A></p>"
 		output += "<p><a href='byond://?src=[UID()];late_join=1'>Join Game!</A></p>"


### PR DESCRIPTION
## What Does This PR Do
Colors the 'declare ready' and 'cancel ready' buttons on the main menu, set to green and orange respectively.
## Why It's Good For The Game
The toggle ready button, which decides if you're sent into the game at the start of the round, should be more visible.
## Images of changes
<img width="130" height="71" alt="image" src="https://github.com/user-attachments/assets/64e52a44-15ed-48e2-a617-e301e0f9776e" />
<img width="207" height="44" alt="image" src="https://github.com/user-attachments/assets/178f2c34-a951-4e31-befd-e24c38214b2b" />


## Testing
Compiled. Clicked. Clicked again.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: The 'declare ready' and 'cancel ready' buttons have been color-coded green and orange respectively.
/:cl:
