### PR TITLE
Corrects the spelling of the Requisitions Specialist alternate title

### DIFF
--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -87,7 +87,7 @@
 		ACCESS_MINING_STATION,
 		ACCESS_SMITH,
 	)
-	alt_titles = list("Mail Carrier", "Courier", "Logistics Technician", "Requistions Specialist")
+	alt_titles = list("Mail Carrier", "Courier", "Logistics Technician", "Requisitions Specialist")
 	outfit = /datum/outfit/job/cargo_tech
 	standard_paycheck = CREW_PAY_LOW
 	difficulty = EASY_DIFFICULTY


### PR DESCRIPTION
## What Does This PR Do
Corrects the spelling of the Requisitions Specialist alternate title for Cargo Technician.
## Why It's Good For The Game
Proper spelling is good.
## Testing
Compiled. Spawned as Requisitions Specialist. Looked at ID.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: The Requisitions Specialist alternate job title is now spelt properly.
/:cl:
