### PR TITLE
Replaces the unused RND servers with AI processing and network nodes.

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -55441,6 +55441,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
+"iqL" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery/white/hollow,
+/obj/effect/turf_decal/tiles/department/command,
+/obj/machinery/ai_node/processing_node,
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/server/coldroom)
 "iqM" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -84239,8 +84248,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery/white/hollow,
-/obj/machinery/r_n_d/server/station,
 /obj/effect/turf_decal/tiles/department/command,
+/obj/machinery/ai_node/network_node,
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/server/coldroom)
 "vJm" = (
@@ -135651,7 +135660,7 @@ ten
 jIA
 vwC
 cbd
-vIO
+iqL
 ukV
 crR
 vIO

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -33,7 +33,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
 	},
-/obj/machinery/r_n_d/server/station,
+/obj/machinery/ai_node/network_node,
 /turf/simulated/floor/plasteel/dark/telecomms{
 	icon_state = "bcircuit"
 	},
@@ -65841,7 +65841,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
 	},
-/obj/machinery/r_n_d/server/station,
+/obj/machinery/ai_node/processing_node,
 /turf/simulated/floor/plasteel/dark/telecomms{
 	icon_state = "bcircuit"
 	},

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -45314,8 +45314,8 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
 	},
-/obj/machinery/r_n_d/server/station,
 /obj/machinery/light/small,
+/obj/machinery/ai_node/network_node,
 /turf/simulated/floor/bluegrid{
 	icon_state = "gcircuit";
 	name = "Mainframe Floor";
@@ -45336,7 +45336,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
 	},
-/obj/machinery/r_n_d/server/station,
+/obj/machinery/ai_node/processing_node,
 /turf/simulated/floor/bluegrid{
 	icon_state = "gcircuit";
 	name = "Mainframe Floor";

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -28396,10 +28396,10 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/north,
-/obj/machinery/r_n_d/server/station,
 /obj/effect/turf_decal/tiles/department/command/side{
 	dir = 5
 	},
+/obj/machinery/ai_node/processing_node,
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/server/coldroom)
 "fHd" = (
@@ -112742,10 +112742,10 @@
 	name = "south bump";
 	pixel_y = -28
 	},
-/obj/machinery/r_n_d/server/station,
 /obj/effect/turf_decal/tiles/department/command/side{
 	dir = 6
 	},
+/obj/machinery/ai_node/network_node,
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/server/coldroom)
 "wAw" = (

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -40898,7 +40898,7 @@
 /obj/effect/turf_decal/siding{
 	dir = 8
 	},
-/obj/machinery/r_n_d/server/station,
+/obj/machinery/ai_node/processing_node,
 /turf/simulated/floor/bluegrid/telecomms/server,
 /area/station/science/server/coldroom)
 "hdX" = (
@@ -68405,7 +68405,7 @@
 /obj/effect/turf_decal/siding{
 	dir = 4
 	},
-/obj/machinery/r_n_d/server/station,
+/obj/machinery/ai_node/network_node,
 /turf/simulated/floor/bluegrid/telecomms/server,
 /area/station/science/server/coldroom)
 "quc" = (

--- a/code/__DEFINES/atmospherics_defines.dm
+++ b/code/__DEFINES/atmospherics_defines.dm
@@ -18,8 +18,8 @@
 /// -14C - Temperature used for kitchen cold room, medical freezer, etc.
 #define COLD_ROOM_TEMP			259.15
 
-/// -193C - Temperature used for server rooms
-#define SERVER_ROOM_TEMP			80
+/// 1C - Temperature used for server rooms
+#define SERVER_ROOM_TEMP			274
 
 #define MOLES_CELLSTANDARD		(ONE_ATMOSPHERE*CELL_VOLUME/(T20C*R_IDEAL_GAS_EQUATION))	//moles in a 2.5 m^3 cell at 101.325 Pa and 20 degC
 #define M_CELL_WITH_RATIO		(MOLES_CELLSTANDARD * 0.005) //compared against for superconductivity

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -195,7 +195,7 @@ GLOBAL_LIST_INIT(aalarm_modes, list(
 				"water vapor"      = new/datum/tlv(-1.0, -1.0, -1.0, -1.0), // Partial pressure, kpa
 				"other"          = new/datum/tlv(-1.0, -1.0, -1.0, -1.0), // Partial pressure, kpa
 				"pressure"       = new/datum/tlv(-1.0, -1.0, -1.0, -1.0), /* kpa */
-				"temperature"    = new/datum/tlv(0, 0, T20C + 5, T20C + 15), // K
+				"temperature"    = new/datum/tlv(T0C, T0C+5, T0C+80, T0C+100), // K
 			)
 		if(AALARM_PRESET_DISABLED)
 			no_cycle_after = TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Title + Adjusts the thermomachine and air alarm settings to make them suitable for AI nodes. Someone does still need to turn them on for the AI, since they default to being off.
## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The RND servers have been entirely decorative for a while now, and the AI nodes already need a controlled climate. I meant to make this change like a year ago and I entirely forgot until now.

## Testing

<!-- How did you test the PR, if at all? -->
Loaded into box, saw processing nodes and that the air alarm settings were correct.
Loaded into meta and saw that worked too
## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: The server rooms now start with AI nodes instead of servers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
