### PR TITLE
fix burglar finnese runtiming on range check

### DIFF
--- a/code/modules/antagonists/heretic/magic/burglar_finesse.dm
+++ b/code/modules/antagonists/heretic/magic/burglar_finesse.dm
@@ -21,7 +21,7 @@
 /datum/spell/pointed/burglar_finesse/valid_target(target, user)
 	if(!ishuman(target))
 		return FALSE
-	if(!get_dist(target, user >= 10)) // no yoinking through cams or scopes.
+	if(!get_dist(target, user) >= 10) // no yoinking through cams or scopes.
 		return FALSE
 	var/mob/living/carbon/human/human_target = target
 	if(locate(/obj/item/storage/backpack) in human_target.contents)


### PR DESCRIPTION
## What Does This PR Do
Moves the comparison outside of the get_dist proc. Fixes #31656
## Why It's Good For The Game
No runtiming.
## Testing
Cast the spell on a mob and took something from their backpack.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Burglar finesse wont runtime.
/:cl: