### PR TITLE
Multitile component machinery can now optionally deconstruct itself if it doesn't fit in the required space

### DIFF
--- a/code/datums/components/multitile.dm
+++ b/code/datums/components/multitile.dm
@@ -16,7 +16,7 @@
  */
 
 //distance_from_center does not include src itself
-/datum/component/multitile/Initialize(new_filler_map)
+/datum/component/multitile/Initialize(new_filler_map, dense_blocking_construction = FALSE)
 	if(!length(new_filler_map))
 		return COMPONENT_INCOMPATIBLE
 
@@ -33,8 +33,7 @@
 	for(var/i in 1 to length(new_filler_map))
 		if(length(new_filler_map[i] != max_width))
 			stack_trace("A multitile component was passed a list wich did not have the same length every row. Atom parent is: [parent]")
-			var/obj/machinery/machine = parent
-			machine.deconstruct()
+			decon_parent()
 			return COMPONENT_INCOMPATIBLE
 
 		for(var/j in 1 to length(new_filler_map[i]))
@@ -46,13 +45,11 @@
 	var/distance_from_center_y = (max_height - 1) / 2
 
 	if(owner.x - offset_x + distance_from_center_x > world.maxx || owner.x + offset_x - distance_from_center_x < 1)
-		var/obj/machinery/machine = parent
-		machine.deconstruct()
+		decon_parent()
 		return COMPONENT_INCOMPATIBLE
 
 	if(owner.y + offset_y + distance_from_center_y > world.maxy || owner.y - offset_y - distance_from_center_y < 1)
-		var/obj/machinery/machine = parent
-		machine.deconstruct()
+		decon_parent()
 		return COMPONENT_INCOMPATIBLE
 
 	var/current_height = 0
@@ -63,8 +60,15 @@
 	owner.x - offset_x - distance_from_center_x, owner.y + offset_y - distance_from_center_y, owner.z,
 	owner.x - offset_x + distance_from_center_x, owner.y + offset_y + distance_from_center_y, owner.z,
 	))
-		//Last check is for filler row lists of length 1.
+		// Last check is for filler row lists of length 1.
 		if(new_filler_map[max_height - current_height][current_width] == 1) // Because the `block()` proc always works from the bottom left to the top right, we have to loop through our list in reverse
+			if(dense_blocking_construction && filler_turf.is_blocked_turf())
+				// Turf blocked? No workey
+				decon_parent()
+				// Still instant but the code doesn't like it if you qdel(src) here
+				QDEL_IN(src, 1 DECISECONDS)
+				return // Not an incompatible component, just invalid construction
+
 			var/obj/structure/filler/new_filler = new(filler_turf)
 			all_fillers += new_filler
 			new_filler.parent = owner
@@ -79,3 +83,8 @@
 /datum/component/multitile/Destroy(force, silent)
 	QDEL_LIST_CONTENTS(all_fillers)
 	return ..()
+
+/datum/component/multitile/proc/decon_parent()
+	var/obj/machinery/machine = parent
+	machine.visible_message("[machine] is blocked from placement here!")
+	machine.deconstruct()

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -177,10 +177,10 @@ GLOBAL_LIST_INIT(non_simple_animals, typecacheof(list(/mob/living/carbon/human/m
 			break
 
 	AddComponent(/datum/component/multitile, list(
-		list(0, 1, MACH_CENTER, 1, 0),
-		list(0, 1,		 0,	   1, 0),
-		list(0, 1,		 0,	   1, 0)
-	))
+		list(1, MACH_CENTER, 1),
+		list(1,		 0,		 1),
+		list(1,		 0,		 1)), TRUE)
+
 /obj/machinery/dna_vault/update_icon_state()
 	if(stat & NOPOWER)
 		icon_state = "vaultoff"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Multitile component machinery can now optionally deconstruct itself if it doesn't fit in the required space
Currently only enables it for the DNA vault, design can decide if they want more machines to behave this way
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It's so you can make sure that the machine won't go out of bounds
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in a DNA vault in an invalid placement, it didn't appear since it's not Initialized with components.
I turned the setting temporarily on for radars, and it spawned in a deconstructed version of it
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Various multitile machinery can now deconstruct itself if it doesn't fit in the given space
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
