### PR TITLE
Adjusts CONTRIBUTING.md to reflect technical staff appropriately 

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -203,7 +203,6 @@ included in this role are:
 - [Contrabang](https://github.com/Contrabang)
 - [DGamerL](https://github.com/DGamerL)
 - [PollardTheDragon](https://github.com/PollardTheDragon)
-- [Warriorstar](https://github.com/warriorstar-orion)
 
 ---
 
@@ -212,12 +211,8 @@ PRs. People included in this role are:
 
 - [AffectedArc07](https://github.com/AffectedArc07)
 - [Charliminator](https://github.com/hal9000PR)
-- [Contrabang](https://github.com/Contrabang)
-- [DGamerL](https://github.com/DGamerL)
 - [FunnyMan3595](https://github.com/FunnyMan3595)
 - [lewcc](https://github.com/lewcc)
-- [PollardTheDragon](https://github.com/PollardTheDragon)
-- [S34N](https://github.com/S34NW)
 - [SteelSlayer](https://github.com/SteelSlayer)
 - [Warriorstar](https://github.com/warriorstar-orion)
 
@@ -226,18 +221,9 @@ PRs. People included in this role are:
 `Review Team` members are people who are denoted as having reviews which can
 affect mergeability status. People included in this role are:
 
-- [Charliminator](https://github.com/hal9000PR)
-- [Contrabang](https://github.com/Contrabang)
-- [DGamerL](https://github.com/DGamerL)
-- [FunnyMan3595](https://github.com/FunnyMan3595)
 - [JimKil3](https://github.com/JimKil3)
-- [lewcc](https://github.com/lewcc)
-- [PollardTheDragon](https://github.com/PollardTheDragon)
 - [Pooble](https://github.com/poobsie)
-- [S34N](https://github.com/S34NW)
 - [Sirryan2002](https://github.com/Sirryan2002)
-- [SteelSlayer](https://github.com/SteelSlayer)
-- [Warriorstar](https://github.com/warriorstar-orion)
 - [Wilkson](https://github.com/BiancaWilkson)
 
 ---


### PR DESCRIPTION
## What Does This PR Do
Updates and fixes `CONTRIBUTING.md` to finally be formatted correctly.
## Why It's Good For The Game
It is good for my mental health, it has been like this for too long.
## Testing
I viewed it through my IDE's markdown viewer. 
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

NPFC