### PR TITLE
Updates HC CODEOWNERS for server config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,4 +37,4 @@ rustlibs_516_prod.dll @AffectedArc07
 
 ### Multiple Owners
 # Config Stuff
-/config/ @AffectedArc07 @Burzah @warriorstar-orion
+/config/ @AffectedArc07 @Burzah @Contrabang @DGamerL @PollardTheDragon


### PR DESCRIPTION
## What Does This PR Do
Updates the CODEOWNERS list to include our new HCs (@Contrabang,  @DgamerL, @PollardTheDragon) and removes a retired one.
## Why It's Good For The Game
The right people will now be pinged automatically when a contributor makes a config change to our example `config.toml`.
## Testing
Trust me, bro.
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

NPFC