### PR TITLE
Fixes being able to use !build_rust on PRs (Probably)

### DIFF
--- a/.github/workflows/build_rust.yml
+++ b/.github/workflows/build_rust.yml
@@ -1,4 +1,9 @@
 name: Build Rust library
+
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   issue_comment:
     types: created


### PR DESCRIPTION
## What Does This PR Do
Updates the workflow to hopefully fix GitHub's stupidity. 
## Why It's Good For The Game
Allows for rust builds to be triggered properly.
## Testing
Skip. Next question.
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

NPFC