### PR TITLE
adds 'exterior' lights

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_winter.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_winter.dmm
@@ -284,12 +284,12 @@
 /turf/simulated/floor/pod/dark,
 /area/ruin/powered/snow_biodome)
 "hA" = (
-/obj/machinery/light/built{
+/obj/effect/mapping_helpers/no_lava,
+/obj/machinery/light/exterior/outdoors{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/pod/dark/lavaland_air,
-/area/ruin/powered/snow_biodome)
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/explored)
 "jE" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/wood,

--- a/_maps/map_files/RandomRuins/SpaceRuins/casino.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/casino.dmm
@@ -413,10 +413,8 @@
 /turf/simulated/floor/mineral/plastitanium,
 /area/ruin/space/powered/casino/security)
 "kx" = (
-/obj/machinery/light{
-	dir = 4;
-	brightness_color = "#FF0000";
-	color = "#FF0000"
+/obj/machinery/light/exterior/warning{
+	dir = 4
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -466,10 +464,8 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/powered/casino/security)
 "lZ" = (
-/obj/machinery/light{
-	dir = 1;
-	brightness_color = "#FF0000";
-	color = "#FF0000"
+/obj/machinery/light/exterior/warning{
+	dir = 1
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -1036,10 +1032,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/powered/casino/maints)
 "DL" = (
-/obj/machinery/light{
-	brightness_color = "#FF0000";
-	color = "#FF0000"
-	},
+/obj/machinery/light/exterior/warning,
 /turf/template_noop,
 /area/template_noop)
 "DM" = (
@@ -1514,10 +1507,8 @@
 /turf/simulated/floor/plasteel/freezer,
 /area/ruin/space/powered/casino/hall)
 "TA" = (
-/obj/machinery/light{
-	dir = 8;
-	brightness_color = "#FF0000";
-	color = "#FF0000"
+/obj/machinery/light/exterior/warning{
+	dir = 8
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -1695,14 +1686,12 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/powered/casino/maints)
 "Xe" = (
-/obj/machinery/light{
-	dir = 8;
-	brightness_color = "#FF0000";
-	color = "#FF0000"
-	},
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/light/exterior/warning{
+	dir = 8
 	},
 /turf/template_noop,
 /area/template_noop)

--- a/code/modules/power/exterior_lights.dm
+++ b/code/modules/power/exterior_lights.dm
@@ -1,0 +1,38 @@
+/// Exterior lights use the powernet of the wall they're installed on,
+/// not the tile they're placed on. This allows them to be in a different
+/// area than the area that powers them, making it possible to have a light
+/// "outside" a structure that shares its power state.
+/obj/machinery/light/exterior
+
+/obj/machinery/light/exterior/Initialize(mapload)
+	. = ..()
+
+	reregister_machine()
+
+/obj/machinery/light/exterior/reregister_machine()
+	var/turf/mounted = get_step(src, dir)
+	var/area/machine_area = get_area(mounted)
+
+	if(machine_powernet?.powernet_area != machine_area)
+		if(machine_area)
+			var/old_power_mode = power_state
+			change_power_mode(NO_POWER_USE) // Take away our current power from the old network
+			machine_powernet?.unregister_machine(src)
+			machine_powernet = machine_area.powernet
+			machine_powernet.register_machine(src)
+			change_power_mode(old_power_mode) // add it to the new network
+
+/obj/machinery/light/exterior/power_change()
+	var/turf/mounted = get_step(src, dir)
+	var/area/machine_area = get_area(mounted)
+
+	if(machine_area)
+		seton(machine_area.lightswitch && machine_area.powernet.has_power(PW_CHANNEL_LIGHTING))
+
+/obj/machinery/light/exterior/outdoors
+	brightness_color = "#facd7f"
+	nightshift_light_color = "#facd7f"
+
+/obj/machinery/light/exterior/warning
+	brightness_color = COLOR_RED_LIGHT
+	nightshift_light_color = COLOR_RED_LIGHT

--- a/paradise.dme
+++ b/paradise.dme
@@ -3086,6 +3086,7 @@
 #include "code\modules\power\alien_cache.dm"
 #include "code\modules\power\cell.dm"
 #include "code\modules\power\electrolyzer.dm"
+#include "code\modules\power\exterior_lights.dm"
 #include "code\modules\power\gravitygenerator.dm"
 #include "code\modules\power\laser_terminal.dm"
 #include "code\modules\power\lights.dm"


### PR DESCRIPTION
## What Does This PR Do
This PR adds "exterior" lights, which draw power from the powernet of the wall that they're mounted on, rather than the powernet of the tile that they're on. They're not buildable in-game yet, just available for mappers. It also replaces the lights on the outside of the snow biodome and casino with them as example usage.
## Why It's Good For The Game
Useful for locations where you don't want to extend areas/powernets outside of a confined space, such as buildings, since areas convey much more behavior than powernets such as safety from weather, atmos, etc.
## Images of changes
<img width="1655" height="778" alt="2026_02_23__12_22_51__Paradise Station 13" src="https://github.com/user-attachments/assets/0594a95b-d064-4480-8364-c02d17b2944e" />
<img width="786" height="1131" alt="2026_02_23__12_23_04__Paradise Station 13" src="https://github.com/user-attachments/assets/5c9e4f54-0c98-4753-aab6-eafe6e092c88" />
## Testing
See above.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
tweak: Some lights on the exterior of locations, such as the snow biodome and casino, draw power from the location's powernet.
/:cl:
