### PR TITLE
Makes Burzah codeowner of yarn.lock

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,6 +33,7 @@ rustlibs_516_prod.dll @AffectedArc07
 # TGUI stuff
 /tgui/bin @Burzah
 /tgui/docs @Burzah
+/tgui/yarn.lock @Burzah
 
 
 ### Multiple Owners


### PR DESCRIPTION
## What Does This PR Do
Adds myself as codeowner to yarn.lock, which is part of our TGUI setup.
## Why It's Good For The Game
It is good for me, so I can get automatically tagged for review when processing dependabot updates.
## Testing
Skip. Next question.
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog

NPFC