### PR TITLE
Increases the chance for heretics to roll the hijack objective.

### DIFF
--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -563,7 +563,7 @@
 	if(num_heads >= 2)
 		var/datum/objective/major_sacrifice/other_sac_objective = new()
 		add_antag_objective(other_sac_objective)
-	if(prob(5))
+	if(prob(20))
 		add_antag_objective(/datum/objective/hijack)
 	else
 		add_antag_objective(/datum/objective/escape)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

This PR raises the chance for heretics to roll hijack, which allows them to ascend, from 5% to 20%.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

IMO, ascension is a very interesting part of heretic that we barely see. AFAIK, there have been no natural hijack heretic spawns since heretics were merged. The main objections people had to hijack traitors was people rushing the round with stuff like, roundstart plasmafloods and murderboning, etc... The progressive nature of heretics however, gives them basically no resources to start murderboning roundstart, and ascension, the end goal of hijack heretics, is something extremely difficult and time consuming.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

Not really possible to be tested

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<img width="899" height="190" alt="{656B19C1-9B93-4389-8A5A-0BD2C355380D}" src="https://github.com/user-attachments/assets/4723e6d0-53d8-4c8b-818d-1905dfc8bf04" />


## Changelog

:cl:
tweak: Increased chance for heretics to roll hijack
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
