### PR TITLE
Fixes unsealed art not returning cloth

### DIFF
--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -1,6 +1,6 @@
 /*///////////////Circuit Imprinter (By Darem)////////////////////////
 	Used to print new circuit boards (for computers and similar systems) and AI modules. Each circuit board pattern are stored in
-a /datum/design on the linked R&D console. You can then print them out in a fasion similar to a regular lathe. However, instead of
+a /datum/desgin on the linked R&D console. You can then print them out in a fasion similar to a regular lathe. However, instead of
 using metal and glass, it uses glass and reagents (usually sulfuric acis).
 
 */

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -521,16 +521,6 @@
 	build_path = /obj/item/circuitboard/deepfryer
 	category = list("Misc. Machinery")
 
-/datum/design/stovetop
-	name = "Machine Board (Stovetop)"
-	desc = "The circuit board for a Stovetop."
-	id = "stove"
-	req_tech = list("biotech" = 1)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000)
-	build_path = /obj/item/circuitboard/cooking/stove
-	category = list("Misc. Machinery")
-
 /datum/design/orion_trail
 	name = "Machine Board (Orion Trail Arcade Machine)"
 	desc = "Allows for the construction of circuit boards used to build a new Orion Trail machine."


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #31605 where 3 pieces of cloth aren't returned to the player when uncovering a covered artwork, also fixed the issue where 3 pieces of cloth weren't subtracted from the player's inventory when covering an artwork.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/fed5c8a1-a11e-4697-9ab4-2339cd257a1b" />
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in test area as heretic (to not succumb to the effects of the artworks), spawned all variations of the unsealed_artwork, spawned three pieces of cloth and was able to successfully cover and uncover all artworks without gaining or losing pieces of cloth.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Cloth is now properly subtracted when covering an artwork, and returned when uncovering.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
