### PR TITLE
Fixes missing shutter button on metastation (Cerebron)

### DIFF
--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -11314,6 +11314,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/hos)
+"btx" = (
+/obj/machinery/door_control{
+	id = "kitchen_counter";
+	name = "Service Shutter Control";
+	pixel_x = 7;
+	pixel_y = 6;
+	req_access = list(28)
+	},
+/turf/simulated/wall,
+/area/station/service/kitchen)
 "btA" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -42657,7 +42667,8 @@
 /obj/machinery/light_switch{
 	dir = 4;
 	name = "west bump";
-	pixel_x = -24
+	pixel_x = -24;
+	pixel_y = -6
 	},
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
@@ -124488,7 +124499,7 @@ iOZ
 bsp
 bsp
 nqq
-bQI
+btx
 bQI
 bQI
 bQI


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a missing shutter button for the Kitchen-Bar shutters on metastation (NSS Cerebron).
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Prevents people from breaking into the kitchen, allows shutters to not be useless.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<img width="467" height="346" alt="image" src="https://github.com/user-attachments/assets/8aec85cf-2c6c-4c7e-bd7b-415f8d3ec6b0" />


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
![monkeysmashgif](https://github.com/user-attachments/assets/cc652995-9c2e-4941-87ac-623e0b4367a0)
Loaded into map, used button, shutter comes down. Checked files for unintended changes as well.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixes a missing shutter button for the kitchen shutters on the NSS Cerebron.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
