### PR TITLE
Removes Contrabang from config codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,4 +38,4 @@ rustlibs_516_prod.dll @AffectedArc07
 
 ### Multiple Owners
 # Config Stuff
-/config/ @AffectedArc07 @Burzah @Contrabang @DGamerL @PollardTheDragon
+/config/ @AffectedArc07 @Burzah @DGamerL @PollardTheDragon


### PR DESCRIPTION
## What Does This PR Do
Title

## Why It's Good For The Game
He isn't a headcoder anymore.
## Testing
I saved the file and reopened it
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

NPFC
