### PR TITLE
Adds phosphoric acid. A rust remover.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -444,6 +444,42 @@
 	else
 		H.adjustBruteLoss(min(5, volume * 0.25))
 
+/datum/reagent/phosacid
+	name = "Phosphoric acid"
+	id = "phosacid"
+	description = "A clear and odourless moderately strong acid. It's a pretty good rust remover."
+	color = "#0080ff"
+	taste_description = "sour"
+	goal_department = "Science"
+	goal_difficulty = REAGENT_GOAL_EASY
+
+/datum/reagent/phosacid/reaction_mob(mob/living/carbon/human/H, method = REAGENT_TOUCH, volume)
+	if(method != REAGENT_TOUCH)
+		to_chat(H, SPAN_WARNING("The transparent acidic substance stings[volume < 15 ? " you, but isn't concentrated enough to harm you" : null]!"))
+		if(volume >= 15)
+			H.adjustBruteLoss(2)
+			H.emote("scream")
+		return
+
+	if(H.wear_mask || H.head)
+		return
+
+	if(volume >= 25 && prob(75))
+		var/obj/item/organ/external/affecting = H.get_organ("head")
+		if(istype(affecting))
+			affecting.disfigure()
+		H.adjustBruteLoss(5)
+		H.adjustFireLoss(15)
+		H.emote("scream")
+	else
+		H.adjustBruteLoss(min(5, volume * 0.25))
+
+/datum/reagent/phosacid/reaction_turf(turf/T)
+	if(!HAS_TRAIT(T, TRAIT_RUSTY))
+		return
+	T.RemoveElement(/datum/element/rust)
+	T.RemoveElement(/datum/element/rust/heretic)
+
 /datum/reagent/carpotoxin
 	name = "Carpotoxin"
 	id = "carpotoxin"

--- a/code/modules/reagents/chemistry/recipes/toxins_reactions.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins_reactions.dm
@@ -60,6 +60,13 @@
 	min_temp = T0C + 100
 	mix_message = "The mixture deepens to a dark blue, and slowly begins to corrode its container."
 
+/datum/chemical_reaction/phosacid
+	name = "Phosphoric acid"
+	result = "phosacid"
+	required_reagents = list("sacid" = 2, "phosphorus" = 1)
+	result_amount = 3
+	mix_message = "The mixture goes clear."
+
 /datum/chemical_reaction/initropidril
 	name = "Initropidril"
 	id = "initropidril"


### PR DESCRIPTION
## What Does This PR Do
Adds phosphoric acid, that acts as a rust remover
it can be made by mixing 2 parts sulfuric acid, and one part phosphorus 

## Why It's Good For The Game
With how prevalent rust heritics are, and to a lesser extent revenants, and the fact both can apply the rust much faster than crew can remove with welders, a need to remove rust faster has been brought up a few times. this adds that  

## Testing
sprayed the spray on rusted tiles, both heretic rust, and normal rust, both cleaned the rust
also made the reagent 
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
add: Added phosphoric acid, a weak acid that acts as a rust remover. This can be made by mixing 2 parts sulfuric acid, to one part phosphorus 
/:cl: