### PR TITLE
Inedible botany plants correctly get extinguished by shadow demon cocoons

### DIFF
--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -63,9 +63,7 @@
 			for(var/datum/plant_gene/trait/T in seed.genes)
 				T.on_throw_impact(src, hit_atom)
 
-/obj/item/grown/extinguish_light(force = FALSE)
-	if(!force)
-		return
+/obj/item/grown/extinguish_light(force)
 	if(seed.get_gene(/datum/plant_gene/trait/glow/shadow))
 		return
 	set_light(0)


### PR DESCRIPTION
## What Does This PR Do
Lets inedible plants be extinguished by shadow cocoons, as the edible types already COULD be, just not the inedible types. which makes no sense.

## Why It's Good For The Game
This feels like a oversight from #25315 changing how it worked, im unsure. but botany gaming is a ubsurdly strong as is against shadow demon, they dont reaaaaly need a type of plant thats immune to the cocoon aoe extinguish

## Testing
made a inedible plant glow, put it next to a cocoon, watched it extinguish 

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<img width="1393" height="269" alt="Discord_TnQrWX6tbk" src="https://github.com/user-attachments/assets/68e35e76-060d-4e15-8329-7964adb07022" />

## Changelog

:cl:
tweak: Inedible plants are extinguished by shadow cocoons, like edible ones already get extinguished
/:cl:
