### PR TITLE
Adds logging for if a grenade is primed by damage received

### DIFF
--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -39,6 +39,12 @@
 
 /obj/item/grenade/deconstruct(disassembled = TRUE)
 	if(!disassembled)
+		var/turf/bombturf = get_turf(src)
+		var/area/A = get_area(bombturf)
+		message_admins("Damage has caused [src] to be primed for detonation at <a href='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[bombturf.x];Y=[bombturf.y];Z=[bombturf.z]'>[A.name] (JMP)</a>")
+		log_game("Damage has caused [src] has be primed for detonation at [A] ([bombturf.x],[bombturf.y],[bombturf.z])")
+		investigate_log("Damage has caused [src] has be primed for detonation at [A] ([bombturf.x],[bombturf.y],[bombturf.z])", INVESTIGATE_BOMB)
+		add_attack_logs(null, src, "has primed for detonation by damage.", ATKLOG_FEW)
 		prime()
 	if(!QDELETED(src))
 		qdel(src)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

When a grenade blows up by damage received, logs it.

## Why It's Good For The Game

Logging good.

## Testing

Shot a grenade. Saw logs.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
