### PR TITLE
Adds Solo Ops nuclear operations lowpop variant

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -102,8 +102,6 @@
 
 	for(var/obj/effect/landmark/spawner/syndie/S in GLOB.landmarks_list)
 		synd_spawn += get_turf(S)
-		qdel(S)
-		continue
 
 	var/obj/machinery/nuclearbomb/syndicate/the_bomb
 	var/nuke_code = rand(10000, 99999)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -7,9 +7,9 @@
 	name = "nuclear emergency"
 	config_tag = "nuclear"
 	tdm_gamemode = TRUE
-	required_players = 30	// 30 players - 5 players to be the nuke ops = 25 players remaining
-	required_enemies = 5
-	recommended_enemies = 5
+	required_players = 10	// 10 players, solo ops. 30 players - 5 players to be the nuke ops = 25 players remaining
+	required_enemies = 1
+	recommended_enemies = 1
 	single_antag_positions = list()
 
 	var/const/agents_possible = 5 //If we ever need more syndicate agents.
@@ -27,6 +27,14 @@
 /datum/game_mode/nuclear/can_start()//This could be better, will likely have to recode it later
 	if(!..())
 		return 0
+
+	var/playerC = 0
+	for(var/mob/new_player/player in GLOB.player_list)
+		if((player.client) && (player.ready))
+			playerC++
+
+	if(playerC < 30)
+		agents_possible = 1
 
 	var/list/possible_syndicates = get_players_for_role(ROLE_OPERATIVE)
 	var/agent_number = 0

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -12,7 +12,7 @@
 	recommended_enemies = 1
 	single_antag_positions = list()
 
-	var/const/agents_possible = 5 //If we ever need more syndicate agents.
+	var/agents_possible = 5 //If we ever need more syndicate agents.
 
 	var/nukes_left = 1 //Call 3714-PRAY right now and order more nukes! Limited offer!
 	var/nuke_off_station = 0 //Used for tracking if the syndies actually haul the nuke to the station

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -88,7 +88,7 @@
 			var/client/C = G.client
 			var/mob/living/carbon/human/M = new/mob/living/carbon/human(synd_spawn[operative_number])
 
-			var/agent_number = LAZYLEN(SSticker.mode.syndicates) - 1
+			var/agent_number = LAZYLEN(SSticker.mode.syndicates)
 			M.real_name = "[syndicate_name()] Operative #[agent_number]"
 
 			M.key = C.key

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -60,7 +60,7 @@
 
 	// No. of player - Min. Player to dec, divided by player per bonus, then multipled by TC per bonus. Rounded.
 	total_tc = CHALLENGE_TELECRYSTALS + round(((length(get_living_players(exclude_nonhuman = FALSE, exclude_offstation = TRUE)) - CHALLENGE_MIN_PLAYERS)/CHALLENGE_SCALE_PLAYER) * CHALLENGE_SCALE_BONUS)
-	if(length(GLOB.nuclear_uplink_list == 1)) // Solo ops
+	if(length(GLOB.nuclear_uplink_list) == 1) // Solo ops
 		total_tc = total_tc / 5
 	share_telecrystals()
 	SSshuttle.refuel_delay = CHALLENGE_SHUTTLE_DELAY
@@ -86,7 +86,7 @@
 	if(declaring_war)
 		to_chat(user, "You are already in the process of declaring war! Make your mind up.")
 		return FALSE
-	if(length((get_living_players(exclude_nonhuman = FALSE, exclude_offstation = TRUE)) < CHALLENGE_MIN_PLAYERS) && GLOB.nuclear_uplink_list > 1) // If there's only one uplink, there's only one nukie.
+	if((length(get_living_players(exclude_nonhuman = FALSE, exclude_offstation = TRUE)) < CHALLENGE_MIN_PLAYERS) && length(GLOB.nuclear_uplink_list) > 1) // If there's only one uplink, there's only one nukie.
 		to_chat(user, "The enemy crew is too small to be worth declaring war on.")
 		return FALSE
 	if(!is_admin_level(user.z))

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -60,6 +60,8 @@
 
 	// No. of player - Min. Player to dec, divided by player per bonus, then multipled by TC per bonus. Rounded.
 	total_tc = CHALLENGE_TELECRYSTALS + round(((length(get_living_players(exclude_nonhuman = FALSE, exclude_offstation = TRUE)) - CHALLENGE_MIN_PLAYERS)/CHALLENGE_SCALE_PLAYER) * CHALLENGE_SCALE_BONUS)
+	if(GLOB.nuclear_uplink_list == 1) // Solo ops
+		total_tc = total_tc / 5
 	share_telecrystals()
 	SSshuttle.refuel_delay = CHALLENGE_SHUTTLE_DELAY
 	qdel(src)
@@ -84,7 +86,7 @@
 	if(declaring_war)
 		to_chat(user, "You are already in the process of declaring war! Make your mind up.")
 		return FALSE
-	if(length(get_living_players(exclude_nonhuman = FALSE, exclude_offstation = TRUE)) < CHALLENGE_MIN_PLAYERS)
+	if(length((get_living_players(exclude_nonhuman = FALSE, exclude_offstation = TRUE)) < CHALLENGE_MIN_PLAYERS) && GLOB.nuclear_uplink_list > 1) // If there's only one uplink, there's only one nukie.
 		to_chat(user, "The enemy crew is too small to be worth declaring war on.")
 		return FALSE
 	if(!is_admin_level(user.z))

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -72,7 +72,7 @@
 	qdel(src)
 
 /obj/item/nuclear_challenge/proc/add_new_operatives(number)
-	var/poll_icon = image(icon = 'icons/mob/simple_human.dmi', icon_state = "syndicate_space_sword")
+	var/poll_icon = image(icon = 'icons/mob/simple_human.dmi', icon_state = "syndicate")
 	var/list/turf/synd_spawn = list()
 
 	for(var/obj/effect/landmark/spawner/syndie/S in GLOB.landmarks_list)

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -60,7 +60,7 @@
 
 	// No. of player - Min. Player to dec, divided by player per bonus, then multipled by TC per bonus. Rounded.
 	total_tc = CHALLENGE_TELECRYSTALS + round(((length(get_living_players(exclude_nonhuman = FALSE, exclude_offstation = TRUE)) - CHALLENGE_MIN_PLAYERS)/CHALLENGE_SCALE_PLAYER) * CHALLENGE_SCALE_BONUS)
-	if(GLOB.nuclear_uplink_list == 1) // Solo ops
+	if(length(GLOB.nuclear_uplink_list == 1)) // Solo ops
 		total_tc = total_tc / 5
 	share_telecrystals()
 	SSshuttle.refuel_delay = CHALLENGE_SHUTTLE_DELAY

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -61,52 +61,63 @@
 	// No. of player - Min. Player to dec, divided by player per bonus, then multipled by TC per bonus. Rounded.
 	total_tc = CHALLENGE_TELECRYSTALS + round(((length(get_living_players(exclude_nonhuman = FALSE, exclude_offstation = TRUE)) - CHALLENGE_MIN_PLAYERS)/CHALLENGE_SCALE_PLAYER) * CHALLENGE_SCALE_BONUS)
 	total_tc = total_tc / 5 // Total TC per nukie
-	total_tc = total_tc * length(GLOB.nuclear_uplink_list) // Adds it based on number of operatives
 	declaring_war = TRUE
 	if(length(GLOB.nuclear_uplink_list) < min(5, round_down(1 + ((length(GLOB.player_list) - 10) / 5)))) // 1 nukie at 10, 2 at 15, 3 at 20, 4 at 25, full team at 30
 		add_new_operatives(min(4, round_down((length(GLOB.player_list) - 10) / 5)))
 	else
+		total_tc = total_tc * length(GLOB.nuclear_uplink_list) // Adds it based on number of operatives
 		share_telecrystals()
 	declaring_war = FALSE
 	SSshuttle.refuel_delay = CHALLENGE_SHUTTLE_DELAY
 	qdel(src)
 
 /obj/item/nuclear_challenge/proc/add_new_operatives(number)
-	var/poll_icon = image(icon = 'icons/mob/simple_human.dmi', icon_state = "syndicate")
 	var/list/turf/synd_spawn = list()
-
 	for(var/obj/effect/landmark/spawner/syndie/S in GLOB.landmarks_list)
 		synd_spawn += get_turf(S)
 
+	var/initial_tc = 100
+
+	for(var/obj/item/radio/uplink/nuclear/U in GLOB.nuclear_uplink_list)
+		initial_tc = U.hidden_uplink.uses
+
 	var/operative_number = 2
 	for(var/i in 1 to number)
-		var/list/nuke_candidates = SSghost_spawns.poll_candidates("Do you want to play as a Nuclear Operative?", ROLE_OPERATIVE, TRUE, 15 SECONDS, source = poll_icon)
-		if(length(nuke_candidates))
-			if(QDELETED(src))
-				return
-			var/mob/dead/observer/G = pick(nuke_candidates)
-			var/client/C = G.client
-			var/mob/living/carbon/human/M = new/mob/living/carbon/human(synd_spawn[operative_number])
+		INVOKE_ASYNC(src, PROC_REF(spawn_new_operative), initial_tc, operative_number, synd_spawn)
+		operative_number++
+	addtimer(CALLBACK(src, PROC_REF(finalize_team)), 16 SECONDS)
 
-			var/agent_number = LAZYLEN(SSticker.mode.syndicates)
-			M.real_name = "[syndicate_name()] Operative #[agent_number]"
+/obj/item/nuclear_challenge/proc/spawn_new_operative(tc_amount, operative_number, list/synd_spawn)
+	var/poll_icon = image(icon = 'icons/mob/simple_human.dmi', icon_state = "syndicate")
+	var/list/nuke_candidates = SSghost_spawns.poll_candidates("Do you want to play as a Nuclear Operative?", ROLE_OPERATIVE, TRUE, 15 SECONDS, source = poll_icon)
+	if(length(nuke_candidates))
+		if(QDELETED(src))
+			return
+		var/mob/dead/observer/G = pick(nuke_candidates)
+		var/client/C = G.client
+		var/mob/living/carbon/human/M = new/mob/living/carbon/human(synd_spawn[operative_number])
 
-			M.key = C.key
+		var/agent_number = LAZYLEN(SSticker.mode.syndicates)
+		M.real_name = "[syndicate_name()] Operative #[agent_number]"
 
-			SSticker.mode.syndicates += M.mind
-			SSticker.mode.update_synd_icons_added(M.mind)
+		M.key = C.key
 
-			M.mind.assigned_role = SPECIAL_ROLE_NUKEOPS
-			M.mind.special_role = SPECIAL_ROLE_NUKEOPS
-			M.mind.offstation_role = TRUE
+		SSticker.mode.syndicates += M.mind
+		SSticker.mode.update_synd_icons_added(M.mind)
 
-			M.faction = list("syndicate")
-			SSticker.mode.forge_syndicate_objectives(M.mind)
-			SSticker.mode.greet_syndicate(M.mind)
-			SSticker.mode.create_syndicate(M.mind)
-			SSticker.mode.equip_syndicate(M, 0)
-			SSticker.mode.update_syndicate_id(M.mind, FALSE)
-			dust_if_respawnable(G)
+		M.mind.assigned_role = SPECIAL_ROLE_NUKEOPS
+		M.mind.special_role = SPECIAL_ROLE_NUKEOPS
+		M.mind.offstation_role = TRUE
+
+		M.faction = list("syndicate")
+		SSticker.mode.forge_syndicate_objectives(M.mind)
+		SSticker.mode.greet_syndicate(M.mind)
+		SSticker.mode.create_syndicate(M.mind)
+		SSticker.mode.equip_syndicate(M, tc_amount)
+		SSticker.mode.update_syndicate_id(M.mind, FALSE)
+		dust_if_respawnable(G)
+
+/obj/item/nuclear_challenge/proc/finalize_team()
 	total_tc = total_tc * length(GLOB.nuclear_uplink_list) // Adds it based on number of operatives
 	share_telecrystals()
 

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -60,11 +60,55 @@
 
 	// No. of player - Min. Player to dec, divided by player per bonus, then multipled by TC per bonus. Rounded.
 	total_tc = CHALLENGE_TELECRYSTALS + round(((length(get_living_players(exclude_nonhuman = FALSE, exclude_offstation = TRUE)) - CHALLENGE_MIN_PLAYERS)/CHALLENGE_SCALE_PLAYER) * CHALLENGE_SCALE_BONUS)
-	if(length(GLOB.nuclear_uplink_list) == 1) // Solo ops
-		total_tc = total_tc / 5
-	share_telecrystals()
+	total_tc = total_tc / 5 // Total TC per nukie
+	total_tc = total_tc * length(GLOB.nuclear_uplink_list) // Adds it based on number of operatives
+	declaring_war = TRUE
+	if(length(GLOB.nuclear_uplink_list) < min(5, round_down(1 + ((length(GLOB.player_list) - 10) / 5)))) // 1 nukie at 10, 2 at 15, 3 at 20, 4 at 25, full team at 30
+		add_new_operatives(min(4, round_down((length(GLOB.player_list) - 10) / 5)))
+	else
+		share_telecrystals()
+	declaring_war = FALSE
 	SSshuttle.refuel_delay = CHALLENGE_SHUTTLE_DELAY
 	qdel(src)
+
+/obj/item/nuclear_challenge/proc/add_new_operatives(number)
+	var/poll_icon = image(icon = 'icons/mob/simple_human.dmi', icon_state = "syndicate_space_sword")
+	var/list/turf/synd_spawn = list()
+
+	for(var/obj/effect/landmark/spawner/syndie/S in GLOB.landmarks_list)
+		synd_spawn += get_turf(S)
+
+	var/operative_number = 2
+	for(var/i in 1 to number)
+		var/list/nuke_candidates = SSghost_spawns.poll_candidates("Do you want to play as a Nuclear Operative?", ROLE_OPERATIVE, TRUE, 15 SECONDS, source = poll_icon)
+		if(length(nuke_candidates))
+			if(QDELETED(src))
+				return
+			var/mob/dead/observer/G = pick(nuke_candidates)
+			var/client/C = G.client
+			var/mob/living/carbon/human/M = new/mob/living/carbon/human(synd_spawn[operative_number])
+
+			var/agent_number = LAZYLEN(SSticker.mode.syndicates) - 1
+			M.real_name = "[syndicate_name()] Operative #[agent_number]"
+
+			M.key = C.key
+
+			SSticker.mode.syndicates += M.mind
+			SSticker.mode.update_synd_icons_added(M.mind)
+
+			M.mind.assigned_role = SPECIAL_ROLE_NUKEOPS
+			M.mind.special_role = SPECIAL_ROLE_NUKEOPS
+			M.mind.offstation_role = TRUE
+
+			M.faction = list("syndicate")
+			SSticker.mode.forge_syndicate_objectives(M.mind)
+			SSticker.mode.greet_syndicate(M.mind)
+			SSticker.mode.create_syndicate(M.mind)
+			SSticker.mode.equip_syndicate(M, 0)
+			SSticker.mode.update_syndicate_id(M.mind, FALSE)
+			dust_if_respawnable(G)
+	total_tc = total_tc * length(GLOB.nuclear_uplink_list) // Adds it based on number of operatives
+	share_telecrystals()
 
 /obj/item/nuclear_challenge/proc/share_telecrystals()
 	var/player_tc
@@ -86,7 +130,7 @@
 	if(declaring_war)
 		to_chat(user, "You are already in the process of declaring war! Make your mind up.")
 		return FALSE
-	if((length(get_living_players(exclude_nonhuman = FALSE, exclude_offstation = TRUE)) < CHALLENGE_MIN_PLAYERS) && length(GLOB.nuclear_uplink_list) > 1) // If there's only one uplink, there's only one nukie.
+	if((length(get_living_players(exclude_nonhuman = FALSE, exclude_offstation = TRUE)) < CHALLENGE_MIN_PLAYERS) && length(GLOB.nuclear_uplink_list) > 3) // Small teams can war dec freely
 		to_chat(user, "The enemy crew is too small to be worth declaring war on.")
 		return FALSE
 	if(!is_admin_level(user.z))

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -23,7 +23,7 @@
 
 /obj/item/antag_spawner/nuke_ops/Initialize(mapload)
 	. = ..()
-	poll_icon = image(icon = 'icons/mob/simple_human.dmi', icon_state = "syndicate_space_sword")
+	poll_icon = image(icon = 'icons/mob/simple_human.dmi', icon_state = "syndicate")
 
 /obj/item/antag_spawner/nuke_ops/proc/before_candidate_search(user)
 	return TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Adds a variant of nuclear operatives that triggers at lowpop, with a minimum crew count of 10. If there is more than 30, it rolls standard nuclear ops instead

This variant spawns only a single nuclear operative, with full capability to declare war and all that that entails.

## Why It's Good For The Game

Variety of gamemodes is good. Having the rounds be constantly the same gamemode gets grating.

## Testing

Spawned as a nukie. Hard to test locally. TM this.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<img width="1062" height="423" alt="image" src="https://github.com/user-attachments/assets/03a20345-2494-4ffa-8a28-211287387ebb" />


## Changelog

:cl:
add: Added lowpop solo operative nuclear operations mode
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
