### PR TITLE
Puts server regions behind a define

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -15,6 +15,9 @@
 // Uncomment this to enable support for multiple instances
 // #define MULTIINSTANCE
 
+// Uncomment this to enable support for server regions
+// #define SERVERREGIONS
+
 #ifdef LOCAL_GAME_TESTS
 #define GAME_TESTS
 #define MAP_TESTS

--- a/code/controllers/configuration/sections/system_configuration.dm
+++ b/code/controllers/configuration/sections/system_configuration.dm
@@ -29,7 +29,9 @@
 	/// Map datum of the map to use, overriding the defaults, and `data/next_map.txt`
 	var/override_map = null
 	/// Assoc list of region names and their server IPs. Used for geo-routing.
+	#ifdef SERVERREGIONS
 	var/list/region_map = list()
+	#endif
 	/// Send a system toast on init completion?
 	var/toast_on_init_complete = FALSE
 	/// The URL for a ss13-yt-wrap server (https://github.com/Absolucy/ss13-yt-wrap) to use.
@@ -59,7 +61,9 @@
 
 
 	// Load region overrides
+	#ifdef SERVERREGIONS
 	if(islist(data["regional_servers"]))
 		region_map.Cut()
 		for(var/list/kvset in data["regional_servers"])
 			region_map[kvset["name"]] = kvset["ip"]
+	#endif

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -159,6 +159,7 @@ GLOBAL_LIST_EMPTY(world_topic_handlers)
 	// Send the reboot banner to all players
 	for(var/client/C in GLOB.clients)
 		C?.tgui_panel?.send_roundrestart()
+		#ifdef SERVERREGIONS
 		if(C.prefs.server_region)
 			// Keep them on the same relay
 			C << link(GLOB.configuration.system.region_map[C.prefs.server_region])
@@ -166,6 +167,11 @@ GLOBAL_LIST_EMPTY(world_topic_handlers)
 			// Use the default
 			if(GLOB.configuration.url.server_url) // If you set a server location in config.txt, it sends you there instead of trying to reconnect to the same world address. -- NeoFite
 				C << link("byond://[GLOB.configuration.url.server_url]")
+		#else
+		// Use the default
+		if(GLOB.configuration.url.server_url) // If you set a server location in config.txt, it sends you there instead of trying to reconnect to the same world address. -- NeoFite
+			C << link("byond://[GLOB.configuration.url.server_url]")
+		#endif
 
 	// And begin the real shutdown
 	rustlibs_log_close_all() // Past this point, no logging procs can be used, at risk of data loss.

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -455,9 +455,12 @@
 
 	if(holder && holder.restricted_by_2fa)
 		to_chat(src,SPAN_BOLDANNOUNCEOOC("<big>You do not have 2FA enabled. Admin verbs will be unavailable until you have enabled 2FA.\nTo setup 2FA, head to the following menu: <a href='byond://?_src_=prefs;preference=tab;tab=[TAB_GAME]'>Game Preferences</a>"))  // Very fucking obvious
+
+	#ifdef SERVERREGIONS
 	// Tell client about their connection
 	to_chat(src, SPAN_NOTICE("You are currently connected [prefs.server_region ? "via the <b>[prefs.server_region]</b> relay" : "directly"] to Paradise."))
 	to_chat(src, SPAN_NOTICE("You can change this using the <code>Change Region</code> verb in the OOC tab, as selecting a region closer to you may reduce latency."))
+	#endif
 	display_job_bans(TRUE)
 
 /client/proc/is_connecting_from_localhost()
@@ -1150,6 +1153,7 @@
 	popup.set_content(output)
 	popup.open(FALSE)
 
+#ifdef SERVERREGIONS
 /client/verb/change_region()
 	set category = "OOC"
 	set name = "Change Region"
@@ -1178,6 +1182,7 @@
 		src << link("byond://[GLOB.configuration.url.server_url]")
 	else
 		src << link(GLOB.configuration.system.region_map[choice])
+#endif
 
 /client/proc/set_eye(new_eye)
 	if(new_eye == eye)

--- a/code/modules/client/preference/preferences_mysql.dm
+++ b/code/modules/client/preference/preferences_mysql.dm
@@ -69,9 +69,12 @@
 			map_vote_pref_json = json_decode(raw_fptp)
 		catch
 			map_vote_pref_json = list()
+
+	#ifdef SERVERREGIONS
 	// Sanitize the region
 	if(!(server_region in GLOB.configuration.system.region_map))
 		server_region = null // This region doesnt exist anymore
+	#endif
 
 	return TRUE
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -83,8 +83,10 @@
 	if(GLOB.join_tos)
 		output += "<p><a href='byond://?src=[UID()];tos=1'>Terms of Service</A></p>"
 
+	#ifdef SERVERREGIONS
 	if(length(GLOB.configuration.system.region_map))
 		output += "<p><a href='byond://?src=[UID()];setregion=1'>Set region (reduces ping)</A></p>"
+	#endif
 
 	output += "</center>"
 
@@ -211,9 +213,11 @@
 		privacy_consent()
 		return FALSE
 
+	#ifdef SERVERREGIONS
 	if(href_list["setregion"])
 		usr.client.change_region()
 		return FALSE
+	#endif
 
 	if(href_list["late_join"])
 		if(!client.tos_consent)


### PR DESCRIPTION
## What Does This PR Do
Given I am shutting down the relays for the time being, this is the best way to make it still exist in the code but entirely disabled with no other changes.

Why not a config? Because it adds a verb to the client and I didnt want the verb removal hack to make it disappear.

## Why It's Good For The Game
Redundant feature. Rest in peace.

## Testing
- Started server - region option gone
- Region verb gone
- Rebooted - standard reboot behaviour works

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl: AffectedArc07
del: Removed options for relays - hopefully just for now
/:cl:
