### PR TITLE
Fixes delta alert state

### DIFF
--- a/code/modules/security_levels/security_level_datums.dm
+++ b/code/modules/security_levels/security_level_datums.dm
@@ -144,7 +144,12 @@
 	elevating_to_announcement_title = "Attention! Delta security level reached!"
 	elevating_to_announcement_text = "The station's self-destruct mechanism has been engaged. All crew are instructed to abandon the station immediately. This is not a drill."
 
-/datum/security_level/delta/overload
+/datum/security_level/delta_overload
 	number_level = SEC_LEVEL_DELTA_REACTOR
+	elevating_to_sound = 'sound/effects/delta_klaxon.ogg'
+	ai_announcement_sound = 'sound/AI/delta.ogg'
+	color = "orangered"
+	status_display_mode = STATUS_DISPLAY_ALERT
+	status_display_data = "deltaalert"
 	elevating_to_announcement_title = "Attention! Delta-AZ5 security level reached!"
 	elevating_to_announcement_text = "Central Command has disabled all nuclear fission reactor failsafes. Crew are instructed to ensure detonation of the station fission reactor at all costs."


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes the nuke not setting the station to Delta when armed.

## Why It's Good For The Game

People should know the station and them are about to be turned into radioactive space dust.

## Testing

Nuked the station.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed delta alert not being set properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
