### PR TITLE
[AFD] Buffs Vampire without Design Team Approval

### DIFF
--- a/code/controllers/subsystem/non_firing/SSlate_mapping.dm
+++ b/code/controllers/subsystem/non_firing/SSlate_mapping.dm
@@ -65,7 +65,7 @@ SUBSYSTEM_DEF(late_mapping)
  */
 /datum/controller/subsystem/late_mapping/proc/maintenance_mice()
 	var/watch = start_watch()
-	log_startup_progress("Populating maintenance with mice...")
+	log_startup_progress("Populating maintenance with mi- what the fuck, did a mouse just screech at me?!?!?")
 
 	// Looking up for maintenance floors specifically as possible spawn points
 	var/list/maintenance_turfs = list()
@@ -80,13 +80,13 @@ SUBSYSTEM_DEF(late_mapping)
 		return
 
 	// The ratio is based on turfs per mice. Using Boxstation as an example, it would average between 20 to 30 mice.
-	var/floor_tiles_per_one_mice = rand(125, 200)
+	var/floor_tiles_per_one_mice = rand(250, 325)
 	var/mice_number = ceil(length(maintenance_turfs) / floor_tiles_per_one_mice)
 
 	for(var/i in 1 to mice_number)
 		if(prob(1))
-			new /mob/living/basic/mouse/white/linter(pick_n_take(maintenance_turfs))
+			new /mob/living/carbon/human/monkey/angry(pick_n_take(maintenance_turfs))
 		else
-			new /mob/living/basic/mouse(pick_n_take(maintenance_turfs))
+			new /mob/living/carbon/human/monkey(pick_n_take(maintenance_turfs))
 
 	log_debug("Spawned [mice_number] mice over in [stop_watch(watch)]s")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Replaces mice maintenance spawners with monkeys.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

<img width="640" height="640" alt="image" src="https://github.com/user-attachments/assets/e9df56a2-b797-48c8-b642-35070b8c8fcc" />

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

saw monkey. punch monkey. die to monkey.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Tweaked mice maintenance spawning
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
