### PR TITLE
Nerfs Hecksuit/Drake Armor off Lavaland

### DIFF
--- a/code/modules/clothing/suits/armor_suits.dm
+++ b/code/modules/clothing/suits/armor_suits.dm
@@ -820,6 +820,13 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 
+/obj/item/clothing/suit/hooded/drake/on_changed_z_level(turf/old_turf, turf/new_turf, notify_contents)
+	. = ..()
+	if(!is_mining_level(new_turf.z))
+		armor = list(MELEE = 45, BULLET = 35, LASER = 25, ENERGY = 25, BOMB = 150, RAD = INFINITY, FIRE = INFINITY, ACID = INFINITY) // Still good. Not OP.
+		return
+	armor = list(MELEE = 115, BULLET = 35, LASER = 25, ENERGY = 25, BOMB = 150, RAD = INFINITY, FIRE = INFINITY, ACID = INFINITY)
+
 /obj/item/clothing/head/hooded/drake
 	name = "drake helmet"
 	desc = "The skull of a dragon."
@@ -830,6 +837,13 @@
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	flags = BLOCKHAIR
 	flags_cover = HEADCOVERSEYES
+
+/obj/item/clothing/head/hooded/drake/on_changed_z_level(turf/old_turf, turf/new_turf, notify_contents)
+	. = ..()
+	if(!is_mining_level(new_turf.z))
+		armor = list(MELEE = 45, BULLET = 35, LASER = 25, ENERGY = 25, BOMB = 150, RAD = INFINITY, FIRE = INFINITY, ACID = INFINITY) // Still good. Not OP.
+		return
+	armor = list(MELEE = 115, BULLET = 35, LASER = 25, ENERGY = 25, BOMB = 150, RAD = INFINITY, FIRE = INFINITY, ACID = INFINITY)
 
 /obj/item/clothing/suit/hooded/goliath
 	name = "goliath cloak"

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -67,6 +67,13 @@
 	. = ..()
 	START_PROCESSING(SSobj, src)
 
+/obj/item/clothing/suit/space/hostile_environment/on_changed_z_level(turf/old_turf, turf/new_turf, notify_contents)
+	. = ..()
+	if(!is_mining_level(new_turf.z))
+		armor = list(MELEE = 60, BULLET = 35, LASER = 25, ENERGY = 25, BOMB = 150, RAD = INFINITY, FIRE = INFINITY, ACID = INFINITY) // Still good. Not OP.
+		return
+	armor = list(MELEE = 120, BULLET = 35, LASER = 25, ENERGY = 25, BOMB = 150, RAD = INFINITY, FIRE = INFINITY, ACID = INFINITY)
+
 /obj/item/clothing/suit/space/hostile_environment/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	return ..()
@@ -95,6 +102,13 @@
 		"Vulpkanin" = 'icons/mob/clothing/species/vulpkanin/head.dmi',
 		"Unathi" = 'icons/mob/clothing/species/unathi/head.dmi'
 	)
+
+/obj/item/clothing/head/helmet/space/hostile_environment/on_changed_z_level(turf/old_turf, turf/new_turf, notify_contents)
+	. = ..()
+	if(!is_mining_level(new_turf.z))
+		armor = list(MELEE = 50, BULLET = 35, LASER = 25, ENERGY = 25, BOMB = 150, RAD = INFINITY, FIRE = INFINITY, ACID = INFINITY) // Still good. Not OP.
+		return
+	armor = list(MELEE = 120, BULLET = 35, LASER = 25, ENERGY = 25, BOMB = 150, RAD = INFINITY, FIRE = INFINITY, ACID = INFINITY)
 
 /obj/item/clothing/suit/space/prisoner_gulag
 	name = "prisoner gulag suit"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

When you leave lavaland, your melee armor value in the hecksuit or drakesuit drops. This is goes from 120 -> 60 and 115 -> 45 respectively. Both of these armor values are still quite high, but they are no longer unassailable by melee threats on-station. When they return to lavaland, their armor values are restored.

## Why It's Good For The Game

Hecksuit and Drake Armor are oppressive on station due to their absurdly-high melee armor. This brings them more in line while not nerfing them against megafauna or lavaland threats.

## Testing

Compiled.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<img width="578" height="64" alt="image" src="https://github.com/user-attachments/assets/eba502f2-578a-45a3-986a-580912363f6d" />

## Changelog

:cl:
tweak: Hecksuit and Drake Armor are nerfed off-mining z-level
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
