### PR TITLE
[AFD] Adds immersion to laying down

### DIFF
--- a/code/modules/mob/living/living_status_procs.dm
+++ b/code/modules/mob/living/living_status_procs.dm
@@ -129,7 +129,7 @@ STATUS EFFECTS
 	if(client)
 		var/atom/movable/plane_master_controller/pm = hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
 		for(var/key in pm.controlled_planes)
-			animate(pm.controlled_planes[key], transform = matrix(angle, MATRIX_ROTATE))
+			animate(pm.controlled_planes[key], transform = matrix(-angle, MATRIX_ROTATE))
 
 /mob/living/proc/on_standing_up()
 	if(layer == LYING_MOB_LAYER || HAS_TRAIT(src, TRAIT_CONTORTED_BODY))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Adds immersion to laying/getting knocked down and standing up.


<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

There has long been complaints about the RP level of the server, and I believe immersion to be the main cause of this. Players simply don't feel *immersed* enough in the game, this PR solves this once and for all.

## Images of changes

<img width="495" height="460" alt="image" src="https://github.com/user-attachments/assets/543b3cf4-7d09-43f2-a5fa-2637311c55d6" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

<!-- How did you test the PR, if at all? -->
Laid down and stood up a few times both IRL and in game. Confirmed the experience matched.
The emissive layer of lights is a bit bugged, but I think that is an okay sacrifice for this level of improvement to the game.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Immersion
fix: The game
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
