### PR TITLE
QOL: Improves AI Light Replacer Program Targeting

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai_programs.dm
+++ b/code/modules/mob/living/silicon/ai/ai_programs.dm
@@ -743,27 +743,35 @@
 		to_chat(user, SPAN_WARNING("No valid target!"))
 		revert_cast()
 		return
-	var/obj/machinery/light/target = targets[1]
-	if(!check_camera_vision(user, target))
-		revert_cast()
-		return
-	if(!istype(target))
-		to_chat(user, SPAN_WARNING("You can only repair lights!"))
-		revert_cast()
-		return
+	var/turf/target_turf = targets[1]
 	var/mob/living/silicon/ai/AI = user
+	if(!check_camera_vision(user, target_turf))
+		revert_cast()
+		return
+	var/repaired = FALSE
 	if(!AI.program_picker.spend_nanites(program.nanite_cost))
 		to_chat(user, SPAN_WARNING("Not enough nanites!"))
 		revert_cast()
 		return
-	// Handle repairs here since we're using a spell and not a tool
-	target.status = LIGHT_OK
-	target.switchcount = 0
-	target.emagged = FALSE
-	target.on = target.has_power()
-	target.update(TRUE, TRUE, FALSE)
-	AI.play_sound_remote(target, 'sound/machines/ding.ogg', 50)
-	camera_beam(target, "rped_upgrade", 'icons/effects/effects.dmi', 5)
+	for(var/obj/machinery/light/target in target_turf.contents)
+		// Handle repairs here since we're using a spell and not a tool
+		if(target.status == LIGHT_OK)
+			continue
+		target.status = LIGHT_OK
+		target.switchcount = 0
+		target.emagged = FALSE
+		target.on = target.has_power()
+		target.update(TRUE, TRUE, FALSE)
+		AI.play_sound_remote(target, 'sound/machines/ding.ogg', 50)
+		camera_beam(target, "rped_upgrade", 'icons/effects/effects.dmi', 5)
+		repaired = TRUE
+
+	if(!repaired)
+		to_chat(user, SPAN_WARNING("You can only repair lights!"))
+		AI.program_picker.refund_nanites(program.nanite_cost)
+		revert_cast()
+		return
+
 
 /datum/spell/ai_spell/ranged/light_repair/on_purchase_upgrade()
 	cooldown_handler.recharge_duration = max(base_cooldown - (spell_level * 5 SECONDS), cooldown_min)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Light replacer program now can trigger on turf click instead of only on lights.

## Why It's Good For The Game

Quality of Life. Less pixel hunting.

## Testing

Fixed some broken lights as the AI

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Improved AI light replacer program's quality of life
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
