### PR TITLE
QOL: Improves Mech Light Replacer Targeting

### DIFF
--- a/code/game/mecha/equipment/tools/janitor_tools.dm
+++ b/code/game/mecha/equipment/tools/janitor_tools.dm
@@ -132,11 +132,11 @@
 	to_chat(user, SPAN_NOTICE("You short out the safeties on [src]."))
 
 /obj/item/mecha_parts/mecha_equipment/janitor/light_replacer/action(atom/target)
-	if(istype(target, /obj/machinery/light))
-		chassis.Beam(target, icon_state = "rped_upgrade", icon = 'icons/effects/effects.dmi', time = 5)
+	var/turf/T = get_turf(target)
+	for(var/obj/machinery/light/bulb in T)
+		chassis.Beam(bulb, icon_state = "rped_upgrade", icon = 'icons/effects/effects.dmi', time = 5)
 		playsound(src, 'sound/items/pshoom.ogg', 40, 1)
-		var/obj/machinery/light/light_to_fix = target
-		light_to_fix.fix(chassis.occupant, src, emagged)
+		bulb.fix(chassis.occupant, src, emagged)
 
 // Mecha spray
 /obj/item/mecha_parts/mecha_equipment/janitor/mega_spray


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

You can now click the turf to replace a light with the NT-12 illuminator.

## Why It's Good For The Game

Quality of Life. Less pixel hunting.

## Testing

Fixed a light using a mech.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Imrpoved NT-12 illuminator light targeting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
