### PR TITLE
Fixed swarmers spawning in spaced areas

### DIFF
--- a/code/modules/events/swarmers.dm
+++ b/code/modules/events/swarmers.dm
@@ -16,7 +16,11 @@
 	var/list/area_turfs = get_area_turfs(impact_area)
 	for(var/i in 1 to length(area_turfs))
 		var/turf/T = pick_n_take(area_turfs)
-		if(T.is_blocked_turf())
+		var/datum/gas_mixture/environment = T.get_readonly_air()
+		var/datum/tlv/cur_tlv = new/datum/tlv(ONE_ATMOSPHERE * 0.80, ONE_ATMOSPHERE  *0.90, ONE_ATMOSPHERE * 1.10,ONE_ATMOSPHERE * 1.20) /* kpa */
+		var/environment_pressure = environment.return_pressure()
+		var/pressure_dangerlevel = cur_tlv.get_danger_level(environment_pressure)
+		if(T.is_blocked_turf() || pressure_dangerlevel)
 			shuffle(area_turfs)
 			continue
 		// Give ghosts some time to jump there before it begins.


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Ensures swarmers do not spawn in spaced areas or areas otherwise unsafe, such as the turbine burn room or solar arrays.

Fixes #31591

## Why It's Good For The Game

Swarmers should actually be able to do something when rolled.

## Testing

Spawned swarmer event 10 times. No issues.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed swarmers spawning in places they cannot operate in
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
