### PR TITLE
Somewhat rebalances CO2

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -35,7 +35,7 @@
 	/// Tracks how wet the mob is. Only used for examining the mob
 	var/wetlevel = 0
 
-	/// Used to track how much CO2 is in our system. Too much CO2 means you get stunned and die
+	/// Used to track how long CO2 has been in our system, too long and we pass out and die.
 	var/co2overloadtime = null
 
 	/*

--- a/code/modules/surgery/organs/organ_datums/lung_datum.dm
+++ b/code/modules/surgery/organs/organ_datums/lung_datum.dm
@@ -142,13 +142,15 @@
 		if(CO2_pp > safe_co2_max)
 			if(!H.co2overloadtime) // If it's the first breath with too much CO2 in it, lets start a counter, then have them pass out after 12s or so.
 				H.co2overloadtime = world.time
-			else if(world.time - H.co2overloadtime > 120)
-				H.Paralyse(6 SECONDS)
-				H.apply_damage_type(HUMAN_MAX_OXYLOSS, co2_damage_type) // Lets hurt em a little, let them know we mean business
-				if(world.time - H.co2overloadtime > 300) // They've been in here 30s now, lets start to kill them for their own good!
-					H.apply_damage_type(15, co2_damage_type)
+			else if(world.time - H.co2overloadtime > 80) // Throw the warning 4 seconds before they get knocked out.
 				H.throw_alert("too_much_co2", /atom/movable/screen/alert/too_much_co2)
-			if(prob(20)) // Lets give them some chance to know somethings not right though I guess.
+				if(world.time - H.co2overloadtime > 120)
+					H.Paralyse(6 SECONDS)
+					H.apply_damage_type(HUMAN_MAX_OXYLOSS, co2_damage_type) // Lets hurt em a little, let them know we mean business
+					if(world.time - H.co2overloadtime > 240) // They've been in here 30s now, lets start to kill them for their own good!
+						H.apply_damage_type(15, co2_damage_type)
+
+			if(prob(60)) // Lets give them some chance to know somethings not right.
 				H.emote("cough")
 
 		else

--- a/code/modules/surgery/organs/organ_datums/lung_datum.dm
+++ b/code/modules/surgery/organs/organ_datums/lung_datum.dm
@@ -146,7 +146,7 @@
 				H.Paralyse(6 SECONDS)
 				H.apply_damage_type(HUMAN_MAX_OXYLOSS, co2_damage_type) // Lets hurt em a little, let them know we mean business
 				H.throw_alert("too_much_co2", /atom/movable/screen/alert/too_much_co2)
-				if(world.time - H.co2overloadtime > 240) // They've been in here 30s now, lets start to kill them for their own good!
+				if(world.time - H.co2overloadtime > 240) // They've been in here 24s now, lets start to kill them for their own good!
 					H.apply_damage_type(15, co2_damage_type)
 
 			if(prob(60)) // Lets give them some chance to know somethings not right.

--- a/code/modules/surgery/organs/organ_datums/lung_datum.dm
+++ b/code/modules/surgery/organs/organ_datums/lung_datum.dm
@@ -142,16 +142,18 @@
 		if(CO2_pp > safe_co2_max)
 			if(!H.co2overloadtime) // If it's the first breath with too much CO2 in it, lets start a counter, then have them pass out after 12s or so.
 				H.co2overloadtime = world.time
-			else if(world.time - H.co2overloadtime > 80) // Throw the warning 4 seconds before they get knocked out.
+			else if(world.time - H.co2overloadtime > 120)
+				H.Paralyse(6 SECONDS)
+				H.apply_damage_type(HUMAN_MAX_OXYLOSS, co2_damage_type) // Lets hurt em a little, let them know we mean business
 				H.throw_alert("too_much_co2", /atom/movable/screen/alert/too_much_co2)
-				if(world.time - H.co2overloadtime > 120)
-					H.Paralyse(6 SECONDS)
-					H.apply_damage_type(HUMAN_MAX_OXYLOSS, co2_damage_type) // Lets hurt em a little, let them know we mean business
-					if(world.time - H.co2overloadtime > 240) // They've been in here 30s now, lets start to kill them for their own good!
-						H.apply_damage_type(15, co2_damage_type)
+				if(world.time - H.co2overloadtime > 240) // They've been in here 30s now, lets start to kill them for their own good!
+					H.apply_damage_type(15, co2_damage_type)
 
 			if(prob(60)) // Lets give them some chance to know somethings not right.
 				H.emote("cough")
+
+			if(prob(30)) // Subtle chat warning
+				to_chat(H, SPAN_WARNING("[pick("It feels hard to breathe.", "The air feels heavy.", "You try to cough but no air comes out.")]"))
 
 		else
 			H.co2overloadtime = 0


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it so Carbon Dioxide has a chance to throw small warnings in chat, increases the chance to cough from 20% to 60%

Makes Carbon Dioxide start dealing big damage a few seconds earlier.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Carbon Dioxide as of current can be used to knockout anyone without active internals with little (sometimes no) warning.

Ideally there should be some possible counterplay for carbon dioxide, coughing by itself can come from numerous causes, making it pretty unrealistic to identify the cause as CO2 without instantly scanning the air or looking at the nearby air alarm in the 12 seconds you have.

Partially in preparation for gas leak event
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
https://github.com/user-attachments/assets/3558c16c-6856-46eb-a673-8db8b9a39360

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

- Took a huff of CO2 in a small room
- Saw the warning in chat before I was knocked out
- Died of CO2 inhalation
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Made CO2 have a chance to give chat warnings
tweak: Made CO2 begin dealing increased damage quicker
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->