### PR TITLE
Fixes a single pipe on the Box SM submap

### DIFF
--- a/_maps/map_files/stations/submaps/boxstation.dmm
+++ b/_maps/map_files/stations/submaps/boxstation.dmm
@@ -2905,7 +2905,6 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
 "Ro" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible/green,
 /obj/machinery/atmospherics/meter,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -2915,6 +2914,9 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 4
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changed a 4 way manifold pipe into a t manifold
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Roundstart pipes should be oriented correctly and not have unfinished ends.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Old, New
<img width="593" height="471" alt="image" src="https://github.com/user-attachments/assets/f859aa74-a402-400a-a7b6-28bee73a48e6" />
<img width="325" height="350" alt="image" src="https://github.com/user-attachments/assets/e7095ca0-63ca-4f8d-bd66-d60acd6aae71" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
The pipe pipes gas successfully
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Replaces a incorrectly placed 4 way manifold with a t manifold
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
