### PR TITLE
Moves cryo oversight console at labour camp.

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
@@ -1202,10 +1202,6 @@
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 4
 	},
-/obj/machinery/computer/cryopod{
-	pixel_x = 30;
-	dir = 8
-	},
 /obj/machinery/computer/prisoner{
 	dir = 8
 	},
@@ -8173,6 +8169,10 @@
 	},
 /obj/effect/turf_decal/tiles/department/cargo/side{
 	dir = 10
+	},
+/obj/machinery/computer/cryopod{
+	pixel_x = -30;
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #31758 by moving the cryogenic oversight console on the lavaland labour camp from the security office to the brig itself.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It fixes the cryogenic freezer allowing it to be used again, with the downside that security is forced to move into the brig area to use the cryo oversight console.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<img width="809" height="642" alt="image" src="https://github.com/user-attachments/assets/314a1630-35b7-406a-b96c-dc0d2c7e91ce" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Spawned in, got into the cryo freezer, ghosted and then observed how my character was successfully despawned. Also verified that I could not retrieve any items as a prisoner.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Changed the position of the labour camp's cryogenic oversight console.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
