### PR TITLE
Nerfs Kingstons

### DIFF
--- a/code/datums/diseases/kingstons.dm
+++ b/code/datums/diseases/kingstons.dm
@@ -37,8 +37,6 @@
 		if(4)
 			if(prob(5))
 				if(istajaran(affected_mob))
-					affected_mob.visible_message(SPAN_DANGER("[affected_mob] coughs up a hairball!"), \
-													SPAN_USERDANGER("You cough up a hairball!"))
 					affected_mob.custom_emote(EMOTE_VISIBLE, "coughs up a hairball!", FALSE)
 					affected_mob.SetDizzy(6 SECONDS)
 				else


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Replaces the 10 second hairball stun with a custom emote and a 6 second dizzy effect.

## Why It's Good For The Game

Hardstuns bad.

## Testing

Compiled.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:tweak: Hairball from Kingstons makes you dizzy and not stunned.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
