### PR TITLE
[AFD] Makes sec equipment more friendly sounding to the crew

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -289,7 +289,7 @@
 	return TRUE
 
 /obj/item/melee/baton/proc/play_hit_sound()
-	playsound(src, 'sound/weapons/egloves.ogg', 50, TRUE, -1)
+	playsound(src, 'sound/items/squeaktoy.ogg', 50, TRUE, -1)
 
 /obj/item/melee/baton/proc/thrown_baton_stun(mob/living/carbon/human/L)
 	if(!COOLDOWN_FINISHED(src, stun_cooldown))
@@ -317,7 +317,7 @@
 	L.store_last_attacker(user)
 	L.visible_message(SPAN_DANGER("[src] stuns [L]!"))
 	add_attack_logs(user, L, "stunned")
-	playsound(src, 'sound/weapons/egloves.ogg', 50, TRUE, -1)
+	playsound(src, 'sound/items/squeaktoy.ogg', 50, TRUE, -1)
 	deductcharge(hitcost)
 	return TRUE
 

--- a/code/modules/projectiles/ammunition/energy_lens.dm
+++ b/code/modules/projectiles/ammunition/energy_lens.dm
@@ -187,7 +187,7 @@
 	muzzle_flash_color = LIGHT_COLOR_LIGHTBLUE
 	select_name  = "disable"
 	e_cost = 50
-	fire_sound = 'sound/weapons/taser2.ogg'
+	fire_sound = 'sound/items/bikehorn.ogg'
 	harmful = FALSE
 	delay = 0.6 SECONDS
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Changes the sound of the Baton and disabler to be more friendly sounding ;)

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Sec could do with some image improvement to not be so scary to the crew and improve cooperation!

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

spawned changed items and they played the changed sounds

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.


## Changelog

:cl:
tweak: Tweaked the sound of disabler beams and stun batons to be more friendly sounding
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
