### PR TITLE
[AFD] Updates the soulless examine text

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -257,7 +257,7 @@
 				if(!check_ghost_client()) // our ghost is offline or no ghost attached to body
 					msg += "; there are no signs of life"
 				if(!get_ghost() && !key) // no ghost attached to body
-					msg += " and [p_their()] soul has departed"
+					msg += " and [p_their()] life insurance has expired"
 			msg += "...</span>\n"
 
 	if(!get_int_organ(/obj/item/organ/internal/brain))


### PR DESCRIPTION
## What Does This PR Do
See title.
Updates the "...and their soul has departed text." with an arguably much more fitting "...and their life insurance has expired."
## Why It's Good For The Game
This _is_ a corporate environment, after all.
## Testing
I didn't.
## Declaration
- [as if] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
Nothing to see here.
