### PR TITLE
Nerfs Aggressive Spread

### DIFF
--- a/code/modules/antagonists/heretic/magic/aggressive_spread.dm
+++ b/code/modules/antagonists/heretic/magic/aggressive_spread.dm
@@ -33,10 +33,12 @@
 		if(prob(chance_of_not_rusting))
 			continue
 		for(var/atom/victim in target_turfs)
+			if(isairlock(victim))
+				continue
 			if(isliving(user))
 				user.do_rust_heretic_act(victim)
-			else
-				victim.rust_heretic_act()
+				continue
+			victim.rust_heretic_act()
 		if(isliving(user))
 			user.do_rust_heretic_act(target_turfs)
 		else


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Heretic "Aggressive Spread" spell no longer damages airlocks.

## Why It's Good For The Game

The spell already deals large amounts of damage to the station, and often results in areas being both unlivable and unnavigable. This reduces the damage somewhat. Rust heretics can still use their grasp to break airlocks.

## Testing

Cast spell. Door no break.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<img width="1609" height="299" alt="image" src="https://github.com/user-attachments/assets/efa98a74-715b-4f35-acb5-ad136733d6ed" />

## Changelog

:cl:
tweak: Removed Aggressive Spread airlock damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
