### PR TITLE
Fixes infinite soap mouth

### DIFF
--- a/code/game/objects/items/soap.dm
+++ b/code/game/objects/items/soap.dm
@@ -16,7 +16,7 @@
 	/// How many times a Drask has chewed on this bar of soap.
 	var/times_eaten = 0
 	/// The maximum amount of bites before the soap is depleted.
-	var/max_bites = 30 
+	var/max_bites = 30
 
 /obj/item/soap/Initialize(mapload)
 	. = ..()
@@ -41,7 +41,7 @@
 		SPAN_WARNING("[user] starts washing [target == user ? "[target.p_their()] own" : "[target]'s"] mouth out with [src]!"),
 		SPAN_NOTICE("You start washing [target == user ? "your own" : "[target]'s"] mouth out with [src]!")
 	)
-	if(do_after(user, cleanspeed, target = target))
+	if(do_after_once(user, cleanspeed, target = target))
 		user.visible_message(
 			SPAN_WARNING("[user] washes [target == user ? "[target.p_their()] own" : "[target]'s"] mouth out with [src]!"),
 			SPAN_WARNING("You wash [target == user ? "your own" : "[target]'s"] mouth out with [src]!")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes #31830

## Why It's Good For The Game

Oversights bad.

## Testing

Washed mouth out with soap. Couldn't do so infinitely.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed being able to spam wash your mouth with soap
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
