### PR TITLE
Replaces the random barricade tile of the Cerebron warehouse

### DIFF
--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -53235,10 +53235,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/xenobio_north)
-"lil" = (
-/obj/effect/spawner/random/barrier/obstruction,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "lio" = (
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/solar/aft_port)
@@ -109095,7 +109091,7 @@ cjo
 qrk
 wBn
 loD
-lil
+bZP
 crG
 crG
 qXm


### PR DESCRIPTION
## What Does This PR Do
Replaces the random barricade tile on the south side of the Cerebron's cargo warehouse with a consistent wall tile.
## Why It's Good For The Game
Departmental areas should be consistent in their walling.
## Images of changes
<img width="247" height="285" alt="image" src="https://github.com/user-attachments/assets/ff41eb39-1358-463d-a32b-bc0295ab1c99" />

## Testing
Compiled. Walked over.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
tweak: The previously random barricade spawner on the south side of the Cerebron cargo warehouse has been replaced with a solid wall.
/:cl: