### PR TITLE
Make microwave use recipe make_food proc.

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -3,7 +3,7 @@
 
 /obj/machinery/kitchen_machine
 	name = "Base Kitchen Machine"
-	desc = "If you are seeing this, a coder/mapper messed up. Please report it."
+	desc = ABSTRACT_TYPE_DESC
 	density = TRUE
 	anchored = TRUE
 	idle_power_consumption = 5
@@ -352,7 +352,6 @@
 	if(!recipes_to_make)
 		return
 
-	var/datum/reagents/temp_reagents = new(500)
 	for(var/list/L as anything in recipes_to_make)
 		var/obj/source = L[1] // The machine or a mixing bowl
 		var/datum/recipe/recipe = L[2] // Valid recipe or RECIPE_FAIL
@@ -361,26 +360,7 @@
 			fail()
 			continue
 
-		for(var/obj/O in source.contents) // Process supplied ingredients
-			if(O.reagents)
-				O.reagents.del_reagent("nutriment")
-				O.reagents.update_total()
-				O.reagents.trans_to(temp_reagents, O.reagents.total_volume, no_react = TRUE) // Don't react with the abstract holder please
-
-			qdel(O)
-		source.reagents.clear_reagents()
-		var/portions = recipe.duplicate ? efficiency : 1
-		var/reagents_per_serving = temp_reagents.total_volume / portions
-		for(var/i in 1 to portions) // Extra servings when upgraded, ingredient reagents split equally
-			var/obj/cooked = new recipe.result(loc)
-			cooked.pixel_y = rand(-5, 5)
-			cooked.pixel_x = rand(-5, 5)
-			temp_reagents.trans_to(cooked, reagents_per_serving, no_react = TRUE) // Don't react with the abstract holder please
-		temp_reagents.clear_reagents()
-
-		var/obj/byproduct = recipe.get_byproduct()
-		if(byproduct)
-			new byproduct(loc)
+		recipe.make_food(source)
 
 	stop()
 

--- a/code/modules/food_and_drinks/recipes/recipes_microwave.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_microwave.dm
@@ -1,3 +1,28 @@
+/datum/recipe/microwave/make_food(obj/machinery/kitchen_machine/container)
+	var/datum/reagents/temp_reagents = new(500)
+	for(var/obj/object in container.contents) // Process supplied ingredients
+		if(object.reagents)
+			object.reagents.del_reagent("nutriment")
+			object.reagents.update_total()
+			object.reagents.trans_to(temp_reagents, object.reagents.total_volume, no_react = TRUE) // Don't react with the abstract holder please
+
+		qdel(object)
+	container.reagents.clear_reagents()
+	var/portions = 1
+	if(istype(container) && duplicate)
+		portions = container.efficiency
+	var/reagents_per_serving = temp_reagents.total_volume / portions
+	for(var/i in 1 to portions) // Extra servings when upgraded, ingredient reagents split equally
+		var/obj/cooked = new result(container.loc)
+		cooked.pixel_y = rand(-5, 5)
+		cooked.pixel_x = rand(-5, 5)
+		temp_reagents.trans_to(cooked, reagents_per_serving, no_react = TRUE) // Don't react with the abstract holder please
+	temp_reagents.clear_reagents()
+
+	var/obj/byproduct = get_byproduct()
+	if(byproduct)
+		new byproduct(container.loc)
+
 /datum/recipe/microwave/warmdonkpocket
 	duplicate = FALSE
 	items = list(


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Changes `kitchen_machine` logic to use a `recipe` datum's `make_food()` proc instead of rolling its own. Also, changes the base `kitchen_machine`'s description to `ABSTRACT_TYPE_DESC` while I'm in the neighborhood.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

I want to add microwave recipes that do something interesting, and it's kind of a headache when the microwave ignores the recipe's make procs.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Microwaved a donk pocket and received a warm donk pocket. Remicrowaved a previously warmed donk pocket and received a warm donk pocket. Microwaved a brain and it disappeared. These are the only 3 recipes that use this logic.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
