### PR TITLE
Updates False Alarm Event

### DIFF
--- a/code/game/gamemodes/miniantags/tourist/tourist_arrivals.dm
+++ b/code/game/gamemodes/miniantags/tourist/tourist_arrivals.dm
@@ -97,6 +97,11 @@
 		var/raffle_name = pick("Galactic Getaway Raffle", "Cosmic Jackpot Raffle", "Nebula Nonsense Raffle", "Greytide Giveaway Raffle", "Toolbox Treasure Raffle")
 		GLOB.minor_announcement.Announce("The lucky winners of the Nanotrasen raffle, 'Nanotrasen [raffle_name],' are arriving at [station_name()] shortly. Please welcome them warmly, they'll be staying with you until the end of your shift!")
 
+/datum/event/tourist_arrivals/fake_announce()
+	var/raffle_name = pick("Galactic Getaway Raffle", "Cosmic Jackpot Raffle", "Nebula Nonsense Raffle", "Greytide Giveaway Raffle", "Toolbox Treasure Raffle")
+	GLOB.minor_announcement.Announce("The lucky winners of the Nanotrasen raffle, 'Nanotrasen [raffle_name],' are arriving at [station_name()] shortly. Please welcome them warmly, they'll be staying with you until the end of your shift!")
+	return TRUE
+
 // Greets the player, announces objectives!
 /datum/event/tourist_arrivals/proc/greeting(mob/living/carbon/human/M)
 	var/list/greeting = list()

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -54,7 +54,9 @@ GLOBAL_LIST_EMPTY(current_pending_diseases)
 		else
 			to_chat(M, chat_box_examine(SPAN_DEADSAY("<b>Disease outbreak:</b> The next new arrival is a carrier of a \"[chosen_disease.severity]\" disease: [chosen_disease.name]!")))
 
-/datum/event/disease_outbreak/announce()
+/datum/event/disease_outbreak/announce(false_alarm)
+	if(false_alarm)
+		severity = pick(EVENT_LEVEL_MAJOR, EVENT_LEVEL_MODERATE, EVENT_LEVEL_MUNDANE)
 	switch(severity)
 		if(EVENT_LEVEL_MAJOR)
 			GLOB.major_announcement.Announce("Lethal viral pathogen detected aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/effects/siren-spooky.ogg', new_sound2 = 'sound/AI/outbreak_virus.ogg')

--- a/code/modules/events/false_alarm.dm
+++ b/code/modules/events/false_alarm.dm
@@ -19,9 +19,15 @@
 		/datum/event/rogue_drone,
 		/datum/event/solar_flare,
 		/datum/event/spider_infestation,
+		/datum/event/spider_terror,
 		/datum/event/tear,
+		/datum/event/tear/honk,
 		/datum/event/traders,
-		/datum/event/vent_clog
+		/datum/event/disease_outbreak,
+		/datum/event/vent_clog,
+		/datum/event/disposals_clog,
+		/datum/event/demon_incursion,
+		/datum/event/shuttle_loan,
 	) + subtypesof(/datum/event/anomaly) + subtypesof(/datum/event/carp_migration)
 
 	var/datum/event/working_event

--- a/code/modules/events/tear_honk.dm
+++ b/code/modules/events/tear_honk.dm
@@ -8,7 +8,18 @@
 	HE = new /obj/effect/tear/honk(location)
 
 /datum/event/tear/honk/announce()
-	GLOB.minor_announcement.Announce("A Honknomoly has opened. Expected location: [impact_area.name].", "Honknomoly Alert", 'sound/items/airhorn.ogg')
+	var/area/target_area = impact_area
+	if(!target_area)
+		if(false_alarm)
+			target_area = findEventArea()
+			if(isnull(target_area))
+				log_debug("Tried to announce a false-alarm honk tear without a valid area!")
+				kill()
+		else
+			log_debug("Tried to announce a honk tear without a valid area!")
+			kill()
+			return
+	GLOB.minor_announcement.Announce("A Honknomoly has opened. Expected location: [target_area.name].", "Honknomoly Alert", 'sound/items/airhorn.ogg')
 
 /datum/event/tear/honk/end()
 	if(HE)

--- a/code/modules/events/tear_honk.dm
+++ b/code/modules/events/tear_honk.dm
@@ -7,7 +7,7 @@
 /datum/event/tear/honk/spawn_tear(location)
 	HE = new /obj/effect/tear/honk(location)
 
-/datum/event/tear/honk/announce()
+/datum/event/tear/honk/announce(false_alarm)
 	var/area/target_area = impact_area
 	if(!target_area)
 		if(false_alarm)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Adds the following possibilities to the false alarm event:
- Honknomaly
- Demonic Incursion
- Disposals Clog
- Trade Shuttle Loan
- Terror spiders
- Disease Outbreak

## Why It's Good For The Game

False alarm should include *all* possible false alarms.

## Testing

Ran a ton of false alarm events.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Updated False Alarm event
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
