### PR TITLE
Rod Chamber Circuits now cost 2 plasma and 2 titanium to create - removes plastitanium sheets rod chamber machine frame requirement

### DIFF
--- a/code/game/machinery/machine_frame.dm
+++ b/code/game/machinery/machine_frame.dm
@@ -494,12 +494,11 @@ to destroy them and players will be able to make replacements.
 	icon_state = "engineering"
 	build_path = /obj/machinery/atmospherics/reactor_chamber
 	origin_tech = "engineering=2"
-	materials = list(MAT_GLASS = 2000)
+	materials = list(MAT_GLASS = 2000, MAT_PLASMA = 4000, MAT_TITANIUM = 4000)
 	req_components = list(
 		/obj/item/stack/cable_coil = 5,
 		/obj/item/stock_parts/manipulator = 1,
 		/obj/item/stack/sheet/metal = 2,
-		/obj/item/stack/sheet/mineral/plastitanium = 2,
 	)
 
 /obj/item/circuitboard/recharger

--- a/code/modules/power/engines/fission/rod_chamber.dm
+++ b/code/modules/power/engines/fission/rod_chamber.dm
@@ -52,7 +52,6 @@
 	component_parts = list()
 	component_parts += new /obj/item/circuitboard/machine/reactor_chamber(src)
 	component_parts += new /obj/item/stock_parts/manipulator(src)
-	component_parts += new /obj/item/stack/sheet/mineral/plastitanium(src, 2)
 	component_parts += new /obj/item/stack/sheet/metal(src, 2)
 	component_parts += new /obj/item/stack/cable_coil(src, 5)
 	RefreshParts()

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -153,7 +153,7 @@
 	id = "reactor_chamber"
 	req_tech = list("programming" = 4, "materials" = 4, "magnets" = 4, "plasmatech" = 3)
 	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 2000)
+	materials = list(MAT_GLASS = 2000, MAT_PLASMA = 4000, MAT_TITANIUM = 4000)
 	build_path = /obj/item/circuitboard/machine/reactor_chamber
 	category = list("Power", "Engineering Machinery", "Misc")
 


### PR DESCRIPTION
Removes the 2 plastitanium sheets from the rod chamber's machine frame construction requirement and instead adds 4000 cm^3 (equal to 2 sheets) of plasma and titanium cost to the circuit board.

<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Instead of using plastitanium sheets to construct fuel rod chambers, the material cost of 2 sheets is used to create the fuel rod chambers' circuit board.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
2 effects:
* There will be less fumbling with dropped material when constructing/moving rod chambers.

* Engineering cyborgs will actually be able to play with the reactor beyond the single setup that is possible using the default rod chamber configuration. I do not think that such exclusion is helpful or desirable.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Produced rod circuits in the fabricator. Built rod chamber. Deconstructed and reconstructed another rod chamber.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Moved the plasteel requirement of fuel rod chambers from the machine frame to crafting the circuit board.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
