### PR TITLE
Fixes `activate_self()` interactions for several `obj/stack` items.

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -90,6 +90,10 @@
 	if(..())
 		return ITEM_INTERACT_COMPLETE
 
+	// Don't bring up the crafting UI if there's nothing to craft.
+	if(!LAZYLEN(recipes))
+		return
+
 	ui_interact(user)
 	return ITEM_INTERACT_COMPLETE
 


### PR DESCRIPTION
## What Does This PR Do
Adds a check in `obj/stack`'s `activate_self()` proc that checks if an item has any recipies before opening the crafting UI and returning `ITEM_INTERACT_COMPLETE`.

Fixes #31847.
## Why It's Good For The Game
#31709 broke a few interactions due to the requirement for `activate_self()` to call parent, which would override activate_self() interactions on child objects due to always returning `ITEM_INTERACT_COMPLETE`.
## Testing
Used several stack items in hand including marker beacons, sutures, and gauze.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed stack items' in-hand use effects not working.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
