### PR TITLE
Fixes Cmagged Door Cleaning

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -285,7 +285,7 @@
 		return ITEM_INTERACT_COMPLETE
 
 	if(HAS_TRAIT(src, TRAIT_CMAGGED) && used.can_clean()) //If the cmagged door is being hit with cleaning supplies, don't open it, it's being cleaned!
-		return ITEM_INTERACT_SKIP_TO_AFTER_ATTACK
+		return ..()
 
 	if(!(used.flags & NOBLUDGEON) && user.a_intent != INTENT_HARM && !istype(used, /obj/item/card/id/heretic))
 		try_to_activate_door(user)


### PR DESCRIPTION
## What Does This PR Do
Fixes #31859, an inability to fix cmagged doors by cleaning them.
## Why It's Good For The Game
Bugs bad.
## Testing
Cmagged a door, verified it was cmagged, cleaned it with soap, verified it was not cmagged.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Cmagged doors can be cleaned again.
/:cl: