### PR TITLE
fix ore bag pickups for cyborgs

### DIFF
--- a/code/game/objects/items/storage/storage_base.dm
+++ b/code/game/objects/items/storage/storage_base.dm
@@ -583,12 +583,18 @@
 	if(isrobot(user))
 		return //Robots can't interact with storage items.
 
+	try_insert_item(I, user)
+
+/// Checks if an item can be inserted, then insertsit. Riveting, I know.
+/// Mostly exists to bypass the robot restriction for using storage (for like ore bags).
+/obj/item/storage/proc/try_insert_item(obj/item/I, mob/user)
 	if(!can_be_inserted(I))
 		if(length(contents) >= storage_slots) //don't use items on the backpack if they don't fit
 			return TRUE
 		return FALSE
 
 	handle_item_insertion(I, user)
+	return TRUE
 
 /obj/item/storage/attack_hand(mob/user)
 	if(ishuman(user))

--- a/code/game/turfs/simulated/floor/asteroid_floors.dm
+++ b/code/game/turfs/simulated/floor/asteroid_floors.dm
@@ -64,7 +64,7 @@
 
 	if(S.pickup_all_on_tile)
 		for(var/obj/item/stack/ore/O in contents)
-			S.attackby__legacy__attackchain(O, user)
+			S.try_insert_item(O, user)
 			return
 
 /turf/simulated/floor/plating/asteroid/item_interaction(mob/living/user, obj/item/used, list/modifiers)


### PR DESCRIPTION
## What Does This PR Do
Fixes #31864
Moves out the inventory insertion into its own proc and makes ore pickups call that directly, bypassing the robot check.
## Why It's Good For The Game
Allows cyborgs to use the ore bags like they're meant to.
## Testing
Picked up ore as a cyborg without clicking on it.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: fixed ore bag pickups for cyborgs
/:cl: