### PR TITLE
fix wrong cyborg modules getting unselected when losing one to damage

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_inventory.dm
+++ b/code/modules/mob/living/silicon/robot/robot_inventory.dm
@@ -29,7 +29,8 @@
 			A.Remove(src)
 	all_active_items[index] = CYBORG_EMPTY_MODULE
 	SEND_SIGNAL(O, COMSIG_CYBORG_ITEM_DEACTIVATED, src)
-	selected_item = null
+	if(selected_item == O)
+		selected_item = null
 	var/atom/movable/screen/robot/active_module/screen = inventory_screens[index]
 	screen.icon_state = screen.deactivated_icon_string
 


### PR DESCRIPTION
## What Does This PR Do
Fixes #31829
Module unequipping now checks if if the selected item is the item being unequipped, preventing you wrongly losing input to your item.
## Why It's Good For The Game
You lose the 3rd module, doesn't make sense to have to requip your 1st module.
## Testing
Equipped a KA as a cyborg, unequipped it. Active item was nulled.
Put KA in 1st slot, beat myself until I lost my 3rd slot, I could still shoot the KA without unequipping
Put KA in 3rd slot, beat myself until I lost my 3rd slot, I couldn't shoot the KA (active item got deselected)
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Cyborgs will no longer wrongly deselect a different active module when losing one to damage.
/:cl: