### PR TITLE
Cooldown for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## What Does This PR Do
Adds a cooldown for dependably on GitHub-actions (7 days).
## Why It's Good For The Game
It prevents us from jumping the gun on merging possible dependency changes that may have security vulnerabilities. 
## Testing
???
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog

:cl:
NPFC
/:cl: