### PR TITLE
Attack Chain Migration: Trash

### DIFF
--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -9,6 +9,7 @@
 	resistance_flags = FLAMMABLE
 	// Recycle your litter, kids!
 	materials = list(MAT_PLASTIC = 100)
+	new_attack_chain = TRUE
 
 /obj/item/trash/decompile_act(obj/item/matter_decompiler/C, mob/user)
 	if(isdrone(user))
@@ -18,9 +19,6 @@
 		qdel(src)
 		return TRUE
 	return ..()
-
-/obj/item/trash/attack__legacy__attackchain(mob/M as mob, mob/living/user as mob)
-	return
 
 /obj/item/trash/raisins
 	name = "4no raisins"

--- a/code/modules/food_and_drinks/food/customizables.dm
+++ b/code/modules/food_and_drinks/food/customizables.dm
@@ -49,7 +49,7 @@ do {\
 /obj/item/trash/bowl/item_interaction(mob/living/user, obj/item/used, list/modifiers)
 	if(istype(used, /obj/item/food) && !(used.flags & NODROP))
 		var/obj/item/food/customizable/soup/S = new(get_turf(user))
-		S.item_interaction(used, user, modifiers)
+		S.item_interaction(user, used, modifiers)
 		qdel(src)
 		return ITEM_INTERACT_COMPLETE
 

--- a/code/modules/food_and_drinks/food/customizables.dm
+++ b/code/modules/food_and_drinks/food/customizables.dm
@@ -31,11 +31,12 @@ do {\
 		return ITEM_INTERACT_COMPLETE
 	..()
 
-/obj/item/trash/plate/attackby__legacy__attackchain(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/food) && !(W.flags & NODROP))
-		MAKE_CUSTOM_FOOD(W, user, /obj/item/food/customizable/fullycustom)
-		return
-	..()
+/obj/item/trash/plate/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	if(istype(used, /obj/item/food) && !(used.flags & NODROP))
+		MAKE_CUSTOM_FOOD(used, user, /obj/item/food/customizable/fullycustom)
+		return ITEM_INTERACT_COMPLETE
+
+	return ..()
 
 #undef MAKE_CUSTOM_FOOD
 
@@ -45,13 +46,14 @@ do {\
 	icon = 'icons/obj/food/custom.dmi'
 	icon_state = "soup"
 
-/obj/item/trash/bowl/attackby__legacy__attackchain(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/food) && !(I.flags & NODROP))
+/obj/item/trash/bowl/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	if(istype(used, /obj/item/food) && !(used.flags & NODROP))
 		var/obj/item/food/customizable/soup/S = new(get_turf(user))
-		S.item_interaction(I, user, params)
+		S.item_interaction(used, user, modifiers)
 		qdel(src)
-	else
-		..()
+		return ITEM_INTERACT_COMPLETE
+
+	return ..()
 
 /obj/item/food/customizable
 	name = "sandwich"


### PR DESCRIPTION
## What Does This PR Do
* Migrates trash to the new attack chain.
* Allows trash to attack people.
## Why It's Good For The Game
* Attack chain migration good.
* I have a god-given right to slap people with a used Mars Bar wrapper!
## Testing
Slapped a skrell with my empty candy packet.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: Trash items can now attack stuff.
/:cl: