### PR TITLE
Cerebron: Adds Missing Firelock to Engi Hallway Door

### DIFF
--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -9650,7 +9650,8 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/spawner/random/dirt/frequent,
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
 "blr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple,


### PR DESCRIPTION
## What Does This PR Do
Adds a missing firelock to engineering maintenance in a doorway in the north wall of the engineering hallway on Cerebron.
## Why It's Good For The Game
All other doors in that section of maintenance were given firelocks previously, they should persist through further mapping changes.
## Images of changes
<img width="96" height="96" alt="image" src="https://github.com/user-attachments/assets/a8df4b47-4992-444c-9325-2828e2af3a2f" />

## Testing
Visual inspection.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
add: Adds a missing firelock from a maint door in cerebron engimaint.
/:cl: