### PR TITLE
Fixes energy shuriken runtime

### DIFF
--- a/code/modules/ninja/ninja_weapons.dm
+++ b/code/modules/ninja/ninja_weapons.dm
@@ -82,7 +82,7 @@
 /obj/item/energy_shuriken/Initialize(mapload)
 	. = ..()
 	// Only lasts so long. Delete self after some time.
-	addtimer(CALLBACK(src, PROC_REF(disintegrate)), 30 SECONDS)
+	addtimer(CALLBACK(src, GLOBAL_PROC_REF(qdel), src), 30 SECONDS)
 
 /obj/item/energy_shuriken/throw_impact(atom/target)
 	. = ..()
@@ -90,9 +90,6 @@
 		return
 	var/mob/living/carbon/human/H = target
 	H.apply_damage(60, STAMINA)
-
-/obj/item/energy_shuriken/proc/disintegrate()
-	qdel(src)
 
 /obj/item/shuriken_printer
 	name = "shuriken printer"

--- a/code/modules/ninja/ninja_weapons.dm
+++ b/code/modules/ninja/ninja_weapons.dm
@@ -82,7 +82,7 @@
 /obj/item/energy_shuriken/Initialize(mapload)
 	. = ..()
 	// Only lasts so long. Delete self after some time.
-	addtimer(CALLBACK(src, PROC_REF(qdel), src), 30 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(disintegrate)), 30 SECONDS)
 
 /obj/item/energy_shuriken/throw_impact(atom/target)
 	. = ..()
@@ -90,6 +90,9 @@
 		return
 	var/mob/living/carbon/human/H = target
 	H.apply_damage(60, STAMINA)
+
+/obj/item/energy_shuriken/proc/disintegrate()
+	qdel(src)
 
 /obj/item/shuriken_printer
 	name = "shuriken printer"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes a runtime with energy shurikens

## Why It's Good For The Game

Bugs bad.

## Testing

Energy shurikens properly deleted themselves

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed a runtime with energy shurikens
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
