### PR TITLE
Cerebron: Adds missing arrivals fire alarm & rearranges signs for pleasing symmetry.

### DIFF
--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -1328,7 +1328,7 @@
 	},
 /obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/lounge)
+/area/station/hallway/secondary/entry/east)
 "apl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13965,7 +13965,7 @@
 "bDC" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/lounge)
+/area/station/hallway/secondary/entry/east)
 "bDE" = (
 /obj/machinery/economy/vending/snack,
 /obj/machinery/light,
@@ -32797,7 +32797,7 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/lounge)
+/area/station/hallway/secondary/entry/east)
 "evr" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/xenobio_south)
@@ -48958,7 +48958,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel,
 /area/station/public/construction)
 "jPv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -106209,7 +106209,7 @@ vXe
 vXe
 vXe
 vXe
-hSu
+vXe
 hSu
 ody
 wIK
@@ -106466,7 +106466,7 @@ vXe
 mZP
 mZP
 mZP
-hSu
+vXe
 qrO
 gLO
 wDL
@@ -107494,7 +107494,7 @@ vXe
 auu
 bAQ
 eFl
-hSu
+vXe
 hZZ
 vzv
 bvD

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -2004,6 +2004,10 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/item/radio/intercom{
+	name = "north bump";
+	pixel_y = 28
+	},
 /turf/simulated/floor/plasteel/full,
 /area/station/hallway/secondary/entry/east)
 "auy" = (
@@ -86339,7 +86343,10 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/firealarm/directional/north,
+/obj/item/radio/intercom{
+	name = "north bump";
+	pixel_y = 28
+	},
 /turf/simulated/floor/plasteel/full,
 /area/station/hallway/secondary/entry/west)
 "wzx" = (

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -8429,9 +8429,6 @@
 /obj/structure/sign/public/cryo,
 /turf/simulated/wall,
 /area/station/maintenance/fore)
-"bfG" = (
-/turf/simulated/wall,
-/area/station/hallway/secondary/entry/lounge)
 "bfH" = (
 /obj/machinery/light{
 	dir = 4
@@ -106469,7 +106466,7 @@ vXe
 mZP
 mZP
 mZP
-bfG
+hSu
 qrO
 gLO
 wDL

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -1320,23 +1320,13 @@
 /area/station/maintenance/apmaint)
 "ape" = (
 /obj/machinery/door/firedoor,
-/obj/structure/sign/directions/medical{
-	pixel_x = -32;
-	pixel_y = 8
-	},
-/obj/structure/sign/directions/engineering{
-	pixel_x = -32
-	},
-/obj/structure/sign/directions/evac{
-	pixel_x = -32;
-	pixel_y = -8
-	},
 /obj/effect/turf_decal/tiles/white/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/tiles/department/medical/corner{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/lounge)
 "apl" = (
@@ -32798,6 +32788,17 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tiles/department/medical/corner,
+/obj/structure/sign/directions/science{
+	pixel_x = 32;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/bridge{
+	pixel_x = 32
+	},
+/obj/structure/sign/directions/security{
+	pixel_x = 32;
+	pixel_y = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/lounge)
 "evr" = (
@@ -40948,6 +40949,17 @@
 	},
 /obj/effect/turf_decal/tiles/department/medical/corner{
 	dir = 1
+	},
+/obj/structure/sign/directions/evac{
+	pixel_x = -32;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/engineering{
+	pixel_x = -32
+	},
+/obj/structure/sign/directions/medical{
+	pixel_x = -32;
+	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/west)
@@ -52434,7 +52446,6 @@
 /obj/effect/turf_decal/tiles/department/medical/corner{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/west)
 "kWj" = (
@@ -57633,7 +57644,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/machinery/access_button/offset/north,
+/obj/machinery/access_button/offset/southeast,
 /turf/simulated/floor/plasteel/dark,
 /area/station/hallway/secondary/entry/west)
 "mNp" = (
@@ -81726,17 +81737,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/sign/directions/security{
-	pixel_x = 32;
-	pixel_y = 8
-	},
-/obj/structure/sign/directions/bridge{
-	pixel_x = 32
-	},
-/obj/structure/sign/directions/science{
-	pixel_x = 32;
-	pixel_y = -8
-	},
 /obj/effect/turf_decal/tiles/white/corner{
 	dir = 4
 	},
@@ -81744,6 +81744,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/west)
 "vaG" = (
@@ -86341,6 +86342,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/plasteel/full,
 /area/station/hallway/secondary/entry/west)
 "wzx" = (


### PR DESCRIPTION
## What Does This PR Do
Adds a missing fire alarm to the cerebron arrivals.
Changes the location of the opposing fire alarm so that they are both symmetric and can be opened from both sides.
## Why It's Good For The Game
Missing fire alarm bad.
Symmetry pleasing.
In the event of firelock activation, it's important that ingress and egress of arrivals is easy, to facilitate getting out of the spawn area and fixing the spawn area if damaged.
## Images of changes
<img width="800" height="288" alt="image" src="https://github.com/user-attachments/assets/0342fde2-21ba-4e8c-bc3b-5cc4f9685263" />

## Testing
Visual inspection.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog
:cl:
fix: Adds missing fire alarm to cerebron arrivals.
tweak: Cerebron arrivals firelocks can now be opened/closed from both sides.
/:cl:
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
