### PR TITLE
Fixes RCL Flagellation

### DIFF
--- a/code/game/objects/items/RCL.dm
+++ b/code/game/objects/items/RCL.dm
@@ -75,7 +75,7 @@
 	if(!istype(target, /obj/item/stack/cable_coil))	
 		..()
 		is_empty(user)
-		return ITEM_INTERACT_COMPLETE
+		return NONE
 
 	load_cable(user, target)
 	return ITEM_INTERACT_COMPLETE


### PR DESCRIPTION
## What Does This PR Do
Fixes the RCL being unable to flagellate.
## Why It's Good For The Game
Previously working mechanic was broken. Now it is fixed again.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
## Testing
Flagellated a skrell with an RCL.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: RCL flagellation now works again.
/:cl: