### PR TITLE
Updates important information for Warden and Detective

### DIFF
--- a/code/game/jobs/job/security_jobs.dm
+++ b/code/game/jobs/job/security_jobs.dm
@@ -111,6 +111,7 @@
 	blacklisted_disabilities = list(DISABILITY_FLAG_BLIND, DISABILITY_FLAG_DEAF, DISABILITY_FLAG_MUTE, DISABILITY_FLAG_DIZZY, DISABILITY_FLAG_NERVOUS, DISABILITY_FLAG_LISP, DISABILITY_FLAG_PARAPLEGIC)
 	missing_limbs_allowed = FALSE
 	outfit = /datum/outfit/job/warden
+	important_information = "Space Law is the law, not a suggestion."
 	standard_paycheck = CREW_PAY_MEDIUM
 	difficulty = HARD_DIFFICULTY
 	description = "The Warden has the responsibility of monitoring prisoners.\n\n\
@@ -173,7 +174,7 @@
 	blacklisted_disabilities = list(DISABILITY_FLAG_BLIND, DISABILITY_FLAG_DEAF, DISABILITY_FLAG_MUTE, DISABILITY_FLAG_DIZZY, DISABILITY_FLAG_PARAPLEGIC)
 	missing_limbs_allowed = FALSE
 	outfit = /datum/outfit/job/detective
-	important_information = "Track, investigate, and look cool while doing it."
+	important_information = "Track, investigate, and look cool while doing it. Space Law is not a suggestion."
 	standard_paycheck = CREW_PAY_MEDIUM
 	difficulty = MEDIUM_DIFFICULTY
 	description = "The Detective has the responsibility of solving crimes and uncovering criminals.\n\n\


### PR DESCRIPTION
## What Does This PR Do
Adds "Space Law is the law, not a suggestion." to the Warden's important information tab. This will now show when you spawn as one, similar to security officers.

Adds "Space Law is not a suggestion." to the end of the detective's information field, as the role already had information shown ("Track, investigate, and look cool while doing it.")
## Why It's Good For The Game
Both of these roles should be following Space Law to the same extent regular officers do.
## Images of changes
<img width="630" height="317" alt="image" src="https://github.com/user-attachments/assets/3ee9492f-c475-4104-896f-f57652416614" />
<img width="632" height="351" alt="image" src="https://github.com/user-attachments/assets/21971e22-19a7-4162-8737-028190bd82d1" />

## Testing
Compiled. Spawned as both roles. Observed visually.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: The warden and detective roles now have "Space Law is not a suggestion" in their join blurbs.
/:cl: