### PR TITLE
Fix bananades casings not responding to anything.

### DIFF
--- a/code/game/objects/items/weapons/grenades/bananade.dm
+++ b/code/game/objects/items/weapons/grenades/bananade.dm
@@ -31,9 +31,6 @@
 	icon_state = "banana_casing"
 	deliveryamt = 0
 
-/obj/item/grenade/bananade/casing/attack_hand()
-	return // No activating an empty grenade
-
 /obj/item/grenade/bananade/casing/attack_self__legacy__attackchain()
 	return // Stop trying to break stuff
 


### PR DESCRIPTION
## What Does This PR Do
Removes an attack_hand override for bananade casings, which caused them to not respond to anything. Fixes #31900
## Why It's Good For The Game
Working bananades
## Testing
Made a bananade
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: bananades actually work
/:cl: