### PR TITLE
Adds a Zero-Damage Hitsound to Cable Coils

### DIFF
--- a/code/modules/power/cables/cable_coil.dm
+++ b/code/modules/power/cables/cable_coil.dm
@@ -14,6 +14,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe/cable_restrain
 	icon_state = "coil"
 	inhand_icon_state = "coil"
 	belt_icon = "cable_coil"
+	hitsound = 'sound/weapons/whip.ogg'
 	amount = MAXCOIL
 	max_amount = MAXCOIL
 	merge_type = /obj/item/stack/cable_coil // This is here to let its children merge between themselves
@@ -41,6 +42,9 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe/cable_restrain
 	update_icon()
 	recipes = GLOB.cable_coil_recipes
 	update_wclass()
+
+/obj/item/stack/cable_coil/should_play_hitsound(damage)
+	return TRUE
 
 /obj/item/stack/cable_coil/random/change_stack(mob/user, amount)
 	var/obj/item/stack/cable_coil/new_stack = ..()


### PR DESCRIPTION
## What Does This PR Do
Cable coils now use `whip.ogg` as a hitsound.
## Why It's Good For The Game
The sound accompanies the large danger text that people get when they are whipped by a cable coil already.
## Testing
Flagellated a skrell.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
soundadd: cable coils now make a whip sound when attacking.
/:cl: