### PR TITLE
Removes Solar Flare From Rotation

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -166,7 +166,6 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, /datum/event/rogue_drone, 7),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE,	/datum/event/spacevine, 15),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE,	/datum/event/meteor_wave, 8, _first_run_time = 40 MINUTES),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE,	/datum/event/solar_flare, 12),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE,	/datum/event/dust/meaty, 8, _first_run_time = 40 MINUTES),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE,	/datum/event/communications_blackout, 10),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE,	/datum/event/prison_break, 7),

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -166,6 +166,7 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, /datum/event/rogue_drone, 7),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE,	/datum/event/spacevine, 15),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE,	/datum/event/meteor_wave, 8, _first_run_time = 40 MINUTES),
+		//new /datum/event_meta(EVENT_LEVEL_MODERATE,	/datum/event/solar_flare, 12),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE,	/datum/event/dust/meaty, 8, _first_run_time = 40 MINUTES),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE,	/datum/event/communications_blackout, 10),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE,	/datum/event/prison_break, 7),


### PR DESCRIPTION
## What Does This PR Do
Removes the solar flare moderate event from rotation. It remains available to be called manually by admins.
## Why It's Good For The Game
* Solar flare is an inferior form of Radiation Storm that only affects departments that just so happen to have windows (dispreportionately Supply, and theoretically the bridge if not for the bridge shutters that can block view of space tiles).
* Most departments are not adjacent to windows and are so completely unaffected by the event, not achieving the goal of moving people around.
* Unlike the superior radstorm, there is no way to use a solar flare to one's advantage if they have access to radiation resistance to perform evil deeds in empty departments while everyone else is stuck hiding in maintnenace.
* The gimmick of multiplying solar array power by 40x no longer means anything, even if solars were to be hotwired, the maint cable network already runs hot, so it cannot punish engineering for this practice (which was also made obsolete by SMESs refunding unspent power they sent out).
* The existance of solar flare actively discourages both players in-game and mappers from using glass flooring because of the possibility of solar flares. The loss of creative expression this causes is a tragedy that the solar flare does not make up for in any way.
## Testing
I deleted all but one of the moderate events, changed the weights to overwhelmingly favour the commented-out event. Solar flare failed to run.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
del: Removed Solar Flare from event rotation.
/:cl: