### PR TITLE
[s] fixes an issue with RCL

### DIFF
--- a/code/game/objects/items/RCL.dm
+++ b/code/game/objects/items/RCL.dm
@@ -12,6 +12,7 @@
 	max_amount = RCL_MAX_SPOOL_SIZE
 	amount = RCL_MAX_SPOOL_SIZE
 	color = null
+	allow_splitting = FALSE
 	/// Are we rapidly laying cable?
 	var/active = FALSE
 	var/spool_color

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -36,6 +36,8 @@
 	var/dynamic_icon_state = FALSE
 	/// Whether this stack can't stack with subtypes.
 	var/parent_stack = FALSE
+	/// Whether this stack can be split into multiple independent stacks.
+	var/allow_splitting = TRUE
 
 /obj/item/stack/examine(mob/user)
 	. = ..()
@@ -196,8 +198,10 @@
 
 /obj/item/stack/attack_hand(mob/user)
 	if(!user.is_in_inactive_hand(src) && get_amount() > 1)
-		..()
-		return
+		return ..()
+
+	if(!allow_splitting)
+		return ..()
 
 	change_stack(user, 1)
 	if(src && user.machine == src)
@@ -316,6 +320,9 @@
 	return to_transfer
 
 /obj/item/stack/proc/split(mob/user, amount)
+	if(!allow_splitting)
+		return
+
 	var/obj/item/stack/material = new type(loc, amount, FALSE)
 	material.copy_evidences(src)
 	if(isliving(user))
@@ -326,6 +333,9 @@
 	return material
 
 /obj/item/stack/proc/change_stack(mob/user,amount)
+	if(!allow_splitting)
+		return
+
 	var/obj/item/stack/material = new type(user, amount, FALSE)
 	. = material
 	material.copy_evidences(src)


### PR DESCRIPTION
## What Does This PR Do
Removes RCL mitosis.
Adds a variable that allows stack items to have stack splitting mechanics disabled.
## Why It's Good For The Game
RCL mitosis is bad and unintentional.
New var can be used for other non splittable stacks.
## Testing
Tried to perform RCL mitosis. Failed.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Fixed RCLs being able to perform mitosis.
/:cl: