### PR TITLE
Fixes Eternal Zombie Claws After Zombie Cure

### DIFF
--- a/code/datums/diseases/zombie_virus.dm
+++ b/code/datums/diseases/zombie_virus.dm
@@ -168,6 +168,9 @@
 	return cure_stage >= required_reagent
 
 /datum/disease/zombie/cure()
+	var/obj/item/zombie_claw/claws = affected_mob.get_active_hand()
+	if(claws)
+		claws.activate_self()
 	affected_mob.mind?.remove_antag_datum(/datum/antagonist/zombie)
 	REMOVE_TRAIT(affected_mob, TRAIT_I_WANT_BRAINS, ZOMBIE_TRAIT)
 	var/mob/living/carbon/human/H = affected_mob

--- a/code/modules/antagonists/zombie/zombie_spells.dm
+++ b/code/modules/antagonists/zombie/zombie_spells.dm
@@ -73,6 +73,7 @@
 
 /obj/item/zombie_claw/Initialize(mapload, new_parent_spell)
 	. = ..()
+	AddComponent(/datum/component/two_handed, require_twohands = TRUE)
 	if(new_parent_spell)
 		parent_spell = new_parent_spell
 		RegisterSignal(parent_spell.action.owner, COMSIG_MOB_WILLINGLY_DROP, PROC_REF(dispel))


### PR DESCRIPTION
## What Does This PR Do
Adds the two-handed component to zombie claws (for simplified targeting of the claw, also they're ostensibly using both hands to claw at stuff, like the hemomancer claws). This shouldn't affect zombie gameplay, as their hands are dead and unable to interact with stuff already.
Calls `activate_self()` on the user's active hand just before the zombie datum is removed from them to force the claws to retract during curing.
## Why It's Good For The Game
Being stuck with an undroppable set of 21 damage claws that can infect people with the zombie virus is bad.
## Testing
Became a zombie, deployed claws, applied cure, stoped being a zombie, claws were gone.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Zombie claws now dispel when being cured of the zombie virus.
/:cl: