### PR TITLE
Improves Baseball Bat Deflect Mechanics

### DIFF
--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -171,6 +171,8 @@
 	var/homerun_ready = FALSE
 	var/homerun_able = FALSE
 	var/deflectmode = FALSE // deflect small/medium thrown objects
+	/// Is the bat made of metal?
+	var/is_metal = FALSE
 
 	new_attack_chain = TRUE
 
@@ -188,8 +190,11 @@
 		if(!deflectmode)
 			return
 		if(prob(10))
-			visible_message(SPAN_BOLDWARNING("[owner] Deflects [I] directly back at the thrower! It's a home run!"), SPAN_BOLDWARNING("You deflect [I] directly back at the thrower! It's a home run!"))
-			playsound(get_turf(owner), 'sound/weapons/homerun.ogg', 100, TRUE)
+			visible_message(SPAN_BOLDWARNING("[owner] Deflects [I] directly back at the thrower!"), SPAN_BOLDWARNING("You deflect [I] directly back at the thrower!"))
+			var/sound = 'sound/weapons/baseball_hit.ogg'
+			if(is_metal)
+				sound = 'sound/weapons/effects/batreflect1.ogg'
+			playsound(get_turf(owner), sound, 75, TRUE, -1)
 			do_attack_animation(I, ATTACK_EFFECT_DISARM)
 			I.throw_at(locateUID(I.thrownby), 20, 20, owner)
 			deflectmode = FALSE
@@ -204,15 +209,38 @@
 			if(!istype(I, /obj/item/beach_ball))
 				COOLDOWN_START(src, last_deflect, deflect_cooldown)
 			return FALSE
+		else if(prob(5) || homerun_ready)
+			visible_message(SPAN_BOLDWARNING("[owner] Deflects [I] far into the air! It's a homerun!"), SPAN_BOLDWARNING("You deflect [I] far into the air! It's a homerun!"))
+			playsound(get_turf(owner), 'sound/weapons/homerun.ogg', 100, TRUE)
+			do_attack_animation(src, ATTACK_EFFECT_DISARM)
+			hit_object(owner, I, TRUE)
+			homerun_ready = FALSE
+			return TRUE
 		else
 			visible_message(SPAN_WARNING("[owner] swings and deflects [I]!"), SPAN_WARNING("You swing and deflect [I]!"))
-			playsound(get_turf(owner), 'sound/weapons/baseball_hit.ogg', 50, TRUE, -1)
+			var/sound = 'sound/weapons/baseball_hit.ogg'
+			if(is_metal)
+				sound = 'sound/weapons/effects/batreflect1.ogg'
+			playsound(get_turf(owner), sound, 75, TRUE, -1)
 			do_attack_animation(src, ATTACK_EFFECT_DISARM)
-			I.throw_at(get_edge_target_turf(owner, pick(GLOB.cardinal)), rand(8,10), 14, owner)
-			deflectmode = FALSE
-			if(!istype(I, /obj/item/beach_ball))
-				COOLDOWN_START(src, last_deflect, deflect_cooldown)
+			hit_object(owner, I)
 			return TRUE
+
+/obj/item/melee/baseball_bat/proc/hit_object(mob/living/carbon/human/owner, obj/item/I, homerun = FALSE)
+	var/deflect_dir = round(get_angle(owner, I)) + (rand() - 0.5) * 120 // 90 degree angle in front of the user.
+	var/deflect_range = rand(5, 10)
+	if(homerun)
+		deflect_dir = round(get_angle(owner, I)) + (rand() - 0.5) * 90
+		deflect_range = 20
+		I.pass_flags |= PASSMOB
+		addtimer(CALLBACK(PROC_REF(reset_flags), I), 0.3 SECONDS)
+	I.throw_at(get_angle_target_turf(owner, deflect_dir, deflect_range), deflect_range, 14, owner)
+	deflectmode = FALSE
+	if(!istype(I, /obj/item/beach_ball))
+		COOLDOWN_START(src, last_deflect, deflect_cooldown)
+
+/obj/item/melee/baseball_bat/proc/reset_flags(obj/item/I)
+	I.pass_flags = initial(I.pass_flags)
 
 /obj/item/melee/baseball_bat/activate_self(mob/user)
 	if(..())
@@ -279,6 +307,7 @@
 	icon_state = "baseball_bat_metal"
 	force = 12
 	throwforce = 15
+	is_metal = TRUE
 
 /obj/item/melee/baseball_bat/ablative/IsReflect()//some day this will reflect thrown items instead of lasers
 	var/picksound = rand(1,2)

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -214,7 +214,6 @@
 			playsound(get_turf(owner), 'sound/weapons/homerun.ogg', 100, TRUE)
 			do_attack_animation(src, ATTACK_EFFECT_DISARM)
 			hit_object(owner, I, TRUE)
-			homerun_ready = FALSE
 			return TRUE
 		else
 			visible_message(SPAN_WARNING("[owner] swings and deflects [I]!"), SPAN_WARNING("You swing and deflect [I]!"))
@@ -227,15 +226,16 @@
 			return TRUE
 
 /obj/item/melee/baseball_bat/proc/hit_object(mob/living/carbon/human/owner, obj/item/I, homerun = FALSE)
-	var/deflect_dir = round(get_angle(owner, I)) + (rand() - 0.5) * 120 // 90 degree angle in front of the user.
+	var/deflect_dir = round(get_angle(owner, I)) + (rand() - 0.5) * 180 // 180 degree angle in front of the user.
 	var/deflect_range = rand(5, 10)
 	if(homerun)
-		deflect_dir = round(get_angle(owner, I)) + (rand() - 0.5) * 90
+		deflect_dir = round(get_angle(owner, I)) + (rand() - 0.5) * 120
 		deflect_range = 20
 		I.pass_flags |= PASSMOB
 		addtimer(CALLBACK(PROC_REF(reset_flags), I), 0.3 SECONDS)
 	I.throw_at(get_angle_target_turf(owner, deflect_dir, deflect_range), deflect_range, 14, owner)
 	deflectmode = FALSE
+	homerun_ready = FALSE
 	if(!istype(I, /obj/item/beach_ball))
 		COOLDOWN_START(src, last_deflect, deflect_cooldown)
 

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -210,7 +210,7 @@
 				COOLDOWN_START(src, last_deflect, deflect_cooldown)
 			return FALSE
 		else if(prob(5) || homerun_ready)
-			visible_message(SPAN_BOLDWARNING("[owner] Deflects [I] far into the air! It's a homerun!"), SPAN_BOLDWARNING("You deflect [I] far into the air! It's a homerun!"))
+			visible_message(SPAN_BOLDWARNING("[owner] deflects [I] far into the air! It's a homerun!"), SPAN_BOLDWARNING("You deflect [I] far into the air! It's a homerun!"))
 			playsound(get_turf(owner), 'sound/weapons/homerun.ogg', 100, TRUE)
 			do_attack_animation(src, ATTACK_EFFECT_DISARM)
 			hit_object(owner, I, TRUE)

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -190,7 +190,7 @@
 		if(!deflectmode)
 			return
 		if(prob(10))
-			visible_message(SPAN_BOLDWARNING("[owner] Deflects [I] directly back at the thrower!"), SPAN_BOLDWARNING("You deflect [I] directly back at the thrower!"))
+			visible_message(SPAN_BOLDWARNING("[owner] deflects [I] directly back at the thrower!"), SPAN_BOLDWARNING("You deflect [I] directly back at the thrower!"))
 			var/sound = 'sound/weapons/baseball_hit.ogg'
 			if(is_metal)
 				sound = 'sound/weapons/effects/batreflect1.ogg'

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -189,7 +189,13 @@
 	if(I.w_class <= WEIGHT_CLASS_NORMAL || istype(I, /obj/item/beach_ball)) // baseball bat deflecting
 		if(!deflectmode)
 			return
-		if(prob(10))
+		if(prob(5) || homerun_ready)
+			visible_message(SPAN_BOLDWARNING("[owner] deflects [I] far into the air! It's a homerun!"), SPAN_BOLDWARNING("You deflect [I] far into the air! It's a homerun!"))
+			playsound(get_turf(owner), 'sound/weapons/homerun.ogg', 100, TRUE)
+			do_attack_animation(src, ATTACK_EFFECT_DISARM)
+			hit_object(owner, I, TRUE)
+			return TRUE
+		else if(prob(10))
 			visible_message(SPAN_BOLDWARNING("[owner] deflects [I] directly back at the thrower!"), SPAN_BOLDWARNING("You deflect [I] directly back at the thrower!"))
 			var/sound = 'sound/weapons/baseball_hit.ogg'
 			if(is_metal)
@@ -209,12 +215,6 @@
 			if(!istype(I, /obj/item/beach_ball))
 				COOLDOWN_START(src, last_deflect, deflect_cooldown)
 			return FALSE
-		else if(prob(5) || homerun_ready)
-			visible_message(SPAN_BOLDWARNING("[owner] deflects [I] far into the air! It's a homerun!"), SPAN_BOLDWARNING("You deflect [I] far into the air! It's a homerun!"))
-			playsound(get_turf(owner), 'sound/weapons/homerun.ogg', 100, TRUE)
-			do_attack_animation(src, ATTACK_EFFECT_DISARM)
-			hit_object(owner, I, TRUE)
-			return TRUE
 		else
 			visible_message(SPAN_WARNING("[owner] swings and deflects [I]!"), SPAN_WARNING("You swing and deflect [I]!"))
 			var/sound = 'sound/weapons/baseball_hit.ogg'


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Baseball bats will now deflect thrown objects in a cone in the direction the object came from instead of into a random cardinal direction. They also now have a 5% chance to "home run" an object, sending it into a narrower cone at a range of 20, passing through mobs as the object sails over their heads.

## Why It's Good For The Game

Baseball bats should be good at baseball.

## Testing

Threw baseballs at bat-wielding assistants to verify all effects worked as intended.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Reworked how baseball bats deflect objects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
