### PR TITLE
Area-Based Light Ambience

### DIFF
--- a/code/__DEFINES/lighting_defines.dm
+++ b/code/__DEFINES/lighting_defines.dm
@@ -72,6 +72,15 @@
 #define LIGHT_COLOR_TUNGSTEN   "#FAE1AF" //Extremely diluted yellow, close to skin color (for some reason). rgb(250, 225, 175)
 #define LIGHT_COLOR_HALOGEN    "#F0FAFA" //Barely visible cyan-ish hue, as the doctor prescribed. rgb(240, 250, 250)
 
+// Station Area Lights
+#define LIGHT_COLOR_STATION_HALL		 "#fafaeb" // Slight warm, for station halls.
+#define LIGHT_COLOR_STATION_HALL_NIGHT	 "#fcf4dc" // ^Ditto^, but warmer.
+#define LIGHT_COLOR_STATION_WORK		 "#fae5c9" // Moderately warm, for standard work environments.
+#define LIGHT_COLOR_STATION_WORK_NIGHT	 "#fcd3b1" // ^Ditto^, but warmer.
+#define LIGHT_COLOR_STATION_OFFICE		 "#fac192" // Quite warm, for offices and private rooms.
+#define LIGHT_COLOR_STATION_OFFICE_NIGHT "#e29a5f" // ^Ditto^, but warmer.
+
+
 #define LIGHT_RANGE_FIRE		3 //How many tiles standard fires glow.
 
 #define LIGHTING_PLANE_ALPHA_VISIBLE 255

--- a/code/__DEFINES/lighting_defines.dm
+++ b/code/__DEFINES/lighting_defines.dm
@@ -80,7 +80,6 @@
 #define LIGHT_COLOR_STATION_OFFICE		 "#fac192" // Quite warm, for offices and private rooms.
 #define LIGHT_COLOR_STATION_OFFICE_NIGHT "#e29a5f" // ^Ditto^, but warmer.
 
-
 #define LIGHT_RANGE_FIRE		3 //How many tiles standard fires glow.
 
 #define LIGHTING_PLANE_ALPHA_VISIBLE 255
@@ -95,7 +94,6 @@
 #define DYNAMIC_LIGHTING_FORCED 2 //dynamic lighting enabled even if the area doesn't require power
 #define DYNAMIC_LIGHTING_IFSTARLIGHT 3 //dynamic lighting enabled only if starlight is.
 #define IS_DYNAMIC_LIGHTING(A) A.dynamic_lighting
-
 
 //code assumes higher numbers override lower numbers.
 #define LIGHTING_NO_UPDATE 0

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -114,8 +114,8 @@
 	*/
 	luminosity = TRUE
 	var/dynamic_lighting = DYNAMIC_LIGHTING_ENABLED
-	var/area_light_color = "#FFFFFF"
-	var/area_nightlight_color = "#fafaeb"
+	var/area_light_color = null
+	var/area_nightlight_color = null
 
 /area/New(loc, ...)
 	if(!there_can_be_many) // Has to be done in New else the maploader will fuck up and find subtypes for the parent

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -114,8 +114,8 @@
 	*/
 	luminosity = TRUE
 	var/dynamic_lighting = DYNAMIC_LIGHTING_ENABLED
-	var/area_light_color = null
-	var/area_nightlight_color = null
+	var/area_light_color = ""
+	var/area_nightlight_color = ""
 
 /area/New(loc, ...)
 	if(!there_can_be_many) // Has to be done in New else the maploader will fuck up and find subtypes for the parent

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -114,8 +114,8 @@
 	*/
 	luminosity = TRUE
 	var/dynamic_lighting = DYNAMIC_LIGHTING_ENABLED
-	var/area_light_color = ""
-	var/area_nightlight_color = ""
+	var/area_light_color = "#FFFFFF"
+	var/area_nightlight_color = "#fafaeb"
 
 /area/New(loc, ...)
 	if(!there_can_be_many) // Has to be done in New else the maploader will fuck up and find subtypes for the parent

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -114,6 +114,8 @@
 	*/
 	luminosity = TRUE
 	var/dynamic_lighting = DYNAMIC_LIGHTING_ENABLED
+	var/area_light_color = null
+	var/area_nightlight_color = null
 
 /area/New(loc, ...)
 	if(!there_can_be_many) // Has to be done in New else the maploader will fuck up and find subtypes for the parent

--- a/code/game/area/ss13_areas/command_areas.dm
+++ b/code/game/area/ss13_areas/command_areas.dm
@@ -3,8 +3,8 @@
 
 /area/station/command
 	airlock_wires = /datum/wires/airlock/command
-	area_light_color = "#fae5c9"
-	area_nightlight_color = "#fcd3b1"
+	area_light_color = LIGHT_COLOR_STATION_WORK
+	area_nightlight_color = LIGHT_COLOR_STATION_WORK_NIGHT
 
 /area/station/command/bridge
 	name = "\improper Bridge"
@@ -23,8 +23,8 @@
 	request_console_announces = TRUE
 
 /area/station/command/office
-	area_light_color = "#fac192"
-	area_nightlight_color =  "#e29a5f"
+	area_light_color = LIGHT_COLOR_STATION_OFFICE
+	area_nightlight_color = LIGHT_COLOR_STATION_OFFICE_NIGHT
 
 /area/station/command/office/captain
 	name = "\improper Captain's Office"

--- a/code/game/area/ss13_areas/command_areas.dm
+++ b/code/game/area/ss13_areas/command_areas.dm
@@ -3,6 +3,8 @@
 
 /area/station/command
 	airlock_wires = /datum/wires/airlock/command
+	area_light_color = "#fae5c9"
+	area_nightlight_color = "#fcd3b1"
 
 /area/station/command/bridge
 	name = "\improper Bridge"
@@ -19,6 +21,10 @@
 	request_console_flags = RC_ASSIST | RC_INFO
 	request_console_name = "Bridge"
 	request_console_announces = TRUE
+
+/area/station/command/office
+	area_light_color = "#fac192"
+	area_nightlight_color =  "#e29a5f"
 
 /area/station/command/office/captain
 	name = "\improper Captain's Office"

--- a/code/game/area/ss13_areas/engineering_areas.dm
+++ b/code/game/area/ss13_areas/engineering_areas.dm
@@ -41,6 +41,8 @@
 	ambientsounds = ENGINEERING_SOUNDS
 	sound_environment = SOUND_AREA_LARGE_ENCLOSED
 	airlock_wires = /datum/wires/airlock/engineering
+	area_light_color = "#fae5c9"
+	area_nightlight_color = "#fcd3b1"
 
 /area/station/engineering/smes
 	name = "\improper Engineering SMES"

--- a/code/game/area/ss13_areas/engineering_areas.dm
+++ b/code/game/area/ss13_areas/engineering_areas.dm
@@ -41,8 +41,8 @@
 	ambientsounds = ENGINEERING_SOUNDS
 	sound_environment = SOUND_AREA_LARGE_ENCLOSED
 	airlock_wires = /datum/wires/airlock/engineering
-	area_light_color = "#fae5c9"
-	area_nightlight_color = "#fcd3b1"
+	area_light_color = LIGHT_COLOR_STATION_WORK
+	area_nightlight_color = LIGHT_COLOR_STATION_WORK_NIGHT
 
 /area/station/engineering/smes
 	name = "\improper Engineering SMES"

--- a/code/game/area/ss13_areas/legal_areas.dm
+++ b/code/game/area/ss13_areas/legal_areas.dm
@@ -15,6 +15,8 @@
 	icon_state = "law"
 	sound_environment = SOUND_AREA_SMALL_SOFTFLOOR
 	request_console_name = "Internal Affairs Office"
+	area_light_color = "#fac192"
+	area_nightlight_color =  "#e29a5f"
 
 /area/station/legal/magistrate
 	name = "\improper Magistrate's Office"
@@ -22,3 +24,5 @@
 	sound_environment = SOUND_AREA_SMALL_SOFTFLOOR
 	request_console_flags = RC_ASSIST | RC_INFO
 	request_console_name = "Magistrate"
+	area_light_color = "#fac192"
+	area_nightlight_color =  "#e29a5f"

--- a/code/game/area/ss13_areas/legal_areas.dm
+++ b/code/game/area/ss13_areas/legal_areas.dm
@@ -15,8 +15,8 @@
 	icon_state = "law"
 	sound_environment = SOUND_AREA_SMALL_SOFTFLOOR
 	request_console_name = "Internal Affairs Office"
-	area_light_color = "#fac192"
-	area_nightlight_color =  "#e29a5f"
+	area_light_color = LIGHT_COLOR_STATION_OFFICE
+	area_nightlight_color = LIGHT_COLOR_STATION_OFFICE_NIGHT
 
 /area/station/legal/magistrate
 	name = "\improper Magistrate's Office"
@@ -24,5 +24,5 @@
 	sound_environment = SOUND_AREA_SMALL_SOFTFLOOR
 	request_console_flags = RC_ASSIST | RC_INFO
 	request_console_name = "Magistrate"
-	area_light_color = "#fac192"
-	area_nightlight_color =  "#e29a5f"
+	area_light_color = LIGHT_COLOR_STATION_OFFICE
+	area_nightlight_color = LIGHT_COLOR_STATION_OFFICE_NIGHT

--- a/code/game/area/ss13_areas/maintenance_areas.dm
+++ b/code/game/area/ss13_areas/maintenance_areas.dm
@@ -5,6 +5,9 @@
 	valid_territory = FALSE
 	sound_environment = SOUND_AREA_TUNNEL_ENCLOSED
 	airlock_wires = /datum/wires/airlock/maint
+	area_light_color = "#fac192"
+	area_nightlight_color = "#e29a5f"
+
 
 /area/station/maintenance/engimaint
 	name = "Engineering Maintenance"

--- a/code/game/area/ss13_areas/maintenance_areas.dm
+++ b/code/game/area/ss13_areas/maintenance_areas.dm
@@ -5,9 +5,6 @@
 	valid_territory = FALSE
 	sound_environment = SOUND_AREA_TUNNEL_ENCLOSED
 	airlock_wires = /datum/wires/airlock/maint
-	area_light_color = "#fac192"
-	area_nightlight_color = "#e29a5f"
-
 
 /area/station/maintenance/engimaint
 	name = "Engineering Maintenance"

--- a/code/game/area/ss13_areas/procedure_areas.dm
+++ b/code/game/area/ss13_areas/procedure_areas.dm
@@ -2,3 +2,5 @@
 	name = "\improper Trainer's Office"
 	icon_state = "procedure_nct"
 	airlock_wires = /datum/wires/airlock/command // This or security
+	area_light_color = "#fac192"
+	area_nightlight_color =  "#e29a5f"

--- a/code/game/area/ss13_areas/procedure_areas.dm
+++ b/code/game/area/ss13_areas/procedure_areas.dm
@@ -2,5 +2,5 @@
 	name = "\improper Trainer's Office"
 	icon_state = "procedure_nct"
 	airlock_wires = /datum/wires/airlock/command // This or security
-	area_light_color = "#fac192"
-	area_nightlight_color =  "#e29a5f"
+	area_light_color = LIGHT_COLOR_STATION_OFFICE
+	area_nightlight_color = LIGHT_COLOR_STATION_OFFICE_NIGHT

--- a/code/game/area/ss13_areas/public_areas.dm
+++ b/code/game/area/ss13_areas/public_areas.dm
@@ -6,8 +6,8 @@
 /area/station/hallway
 	valid_territory = FALSE //too many areas with similar/same names, also not very interesting summon spots
 	sound_environment = SOUND_AREA_STANDARD_STATION
-	area_light_color = "#fafaeb"
-	area_nightlight_color = "#fcf4dc"
+	area_light_color = LIGHT_COLOR_STATION_HALL
+	area_nightlight_color = LIGHT_COLOR_STATION_HALL
 
 /area/station/hallway/primary/fore
 	name = "\improper Fore Primary Hallway"
@@ -175,8 +175,8 @@
 // Other public areas
 
 /area/station/public
-	area_light_color = "#fafaeb"
-	area_nightlight_color = "#fcf4dc"
+	area_light_color = LIGHT_COLOR_STATION_HALL
+	area_nightlight_color = LIGHT_COLOR_STATION_HALL_NIGHT
 
 /area/station/public/dorms
 	name = "\improper Dormitories"

--- a/code/game/area/ss13_areas/public_areas.dm
+++ b/code/game/area/ss13_areas/public_areas.dm
@@ -6,6 +6,8 @@
 /area/station/hallway
 	valid_territory = FALSE //too many areas with similar/same names, also not very interesting summon spots
 	sound_environment = SOUND_AREA_STANDARD_STATION
+	area_light_color = "#fafaeb"
+	area_nightlight_color = "#fcf4dc"
 
 /area/station/hallway/primary/fore
 	name = "\improper Fore Primary Hallway"
@@ -172,6 +174,9 @@
 
 // Other public areas
 
+/area/station/public
+	area_light_color = "#fafaeb"
+	area_nightlight_color = "#fcf4dc"
 
 /area/station/public/dorms
 	name = "\improper Dormitories"

--- a/code/game/area/ss13_areas/security_areas.dm
+++ b/code/game/area/ss13_areas/security_areas.dm
@@ -3,8 +3,8 @@
 	ambientsounds = HIGHSEC_SOUNDS
 	sound_environment = SOUND_AREA_STANDARD_STATION
 	airlock_wires = /datum/wires/airlock/security
-	area_light_color = "#fae5c9"
-	area_nightlight_color = "#fcd3b1"
+	area_light_color = LIGHT_COLOR_STATION_WORK
+	area_nightlight_color = LIGHT_COLOR_STATION_WORK_NIGHT
 
 /area/station/security/main
 	name = "\improper Security Office"

--- a/code/game/area/ss13_areas/security_areas.dm
+++ b/code/game/area/ss13_areas/security_areas.dm
@@ -3,6 +3,8 @@
 	ambientsounds = HIGHSEC_SOUNDS
 	sound_environment = SOUND_AREA_STANDARD_STATION
 	airlock_wires = /datum/wires/airlock/security
+	area_light_color = "#fae5c9"
+	area_nightlight_color = "#fcd3b1"
 
 /area/station/security/main
 	name = "\improper Security Office"

--- a/code/game/area/ss13_areas/service_areas.dm
+++ b/code/game/area/ss13_areas/service_areas.dm
@@ -1,5 +1,7 @@
 /area/station/service
 	airlock_wires = /datum/wires/airlock/service
+	area_light_color = "#fae5c9"
+	area_nightlight_color = "#fcd3b1"
 
 /area/station/service/cafeteria
 	name = "\improper Cafe"

--- a/code/game/area/ss13_areas/service_areas.dm
+++ b/code/game/area/ss13_areas/service_areas.dm
@@ -1,7 +1,7 @@
 /area/station/service
 	airlock_wires = /datum/wires/airlock/service
-	area_light_color = "#fae5c9"
-	area_nightlight_color = "#fcd3b1"
+	area_light_color = LIGHT_COLOR_STATION_WORK
+	area_nightlight_color = LIGHT_COLOR_STATION_WORK_NIGHT
 
 /area/station/service/cafeteria
 	name = "\improper Cafe"

--- a/code/game/area/ss13_areas/supply_areas.dm
+++ b/code/game/area/ss13_areas/supply_areas.dm
@@ -4,6 +4,8 @@
 	icon_state = "quart"
 	sound_environment = SOUND_AREA_STANDARD_STATION
 	airlock_wires = /datum/wires/airlock/cargo
+	area_light_color = "#fae5c9"
+	area_nightlight_color = "#fcd3b1"
 
 /area/station/supply/lobby
 	name = "\improper Cargo Lobby"

--- a/code/game/area/ss13_areas/supply_areas.dm
+++ b/code/game/area/ss13_areas/supply_areas.dm
@@ -4,8 +4,8 @@
 	icon_state = "quart"
 	sound_environment = SOUND_AREA_STANDARD_STATION
 	airlock_wires = /datum/wires/airlock/cargo
-	area_light_color = "#fae5c9"
-	area_nightlight_color = "#fcd3b1"
+	area_light_color = LIGHT_COLOR_STATION_WORK
+	area_nightlight_color = LIGHT_COLOR_STATION_WORK_NIGHT
 
 /area/station/supply/lobby
 	name = "\improper Cargo Lobby"

--- a/code/modules/power/lights.dm
+++ b/code/modules/power/lights.dm
@@ -270,7 +270,7 @@
 	/// Light intensity when in night shift mode
 	var/nightshift_light_power = 0.45
 	/// The colour of the light while it's in night shift mode
-	var/nightshift_light_color = "#e0eeff"
+	var/nightshift_light_color = "#fafaeb"
 	/// The colour of the light while it's in emergency mode
 	var/bulb_emergency_colour = "#FF3232"
 
@@ -291,7 +291,7 @@
 	exposure_icon_state = "circle"
 	base_state = "bulb"
 	brightness_range = 4
-	brightness_color = "#faca92"
+	brightness_color = "#fac192"
 	nightshift_light_range = 4
 	nightshift_light_color = "#e29a5f" // #a0a080
 	light_type = /obj/item/light/bulb
@@ -378,6 +378,9 @@
 	var/area/A = get_area(src)
 	if(A && !A.requires_power)
 		on = TRUE
+
+	brightness_color = A.area_light_color
+	nightshift_light_color = A.area_nightlight_color
 
 	switch(base_state)
 		if("tube")

--- a/code/modules/power/lights.dm
+++ b/code/modules/power/lights.dm
@@ -394,10 +394,9 @@
 				break_light_tube(TRUE)
 	update(FALSE, TRUE, FALSE)
 
-	if(A.area_light_color == null)
-		return
-	else
+	if(A.area_light_color)
 		brightness_color = A.area_light_color
+	if(A.area_nightlight_color)
 		nightshift_light_color = A.area_nightlight_color
 
 /obj/machinery/light/proc/on_security_level_change_planned(datum/source, previous_level_number, new_level_number)

--- a/code/modules/power/lights.dm
+++ b/code/modules/power/lights.dm
@@ -379,9 +379,6 @@
 	if(A && !A.requires_power)
 		on = TRUE
 
-	brightness_color = A.area_light_color
-	nightshift_light_color = A.area_nightlight_color
-
 	switch(base_state)
 		if("tube")
 			brightness_range = 8
@@ -396,6 +393,12 @@
 			if(prob(3))
 				break_light_tube(TRUE)
 	update(FALSE, TRUE, FALSE)
+
+	if(A.area_light_color == null)
+		return
+	else
+		brightness_color = A.area_light_color
+		nightshift_light_color = A.area_nightlight_color
 
 /obj/machinery/light/proc/on_security_level_change_planned(datum/source, previous_level_number, new_level_number)
 	SIGNAL_HANDLER


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gives areas different light colour vars for ambience, all station lights simply get warmer, areas without these vars set will have the lights be their normal colour.
In order from Neutral (white) to Warmest;
- "Sterile" areas (Medical, Science) | Default white
- Hallways
- Other departments
- Offices
- Maints

This only affects lights on initialization, so manually painted lights and newly constructed ones will retain whatever colour you pick/default
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Having the station be in completely pure white light all the time gets a bit dull, and typically lighting just isn't pure white for entire structures.

More ambience.

Areas can now be given unique lighting without a light subtype.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Box Cargo - Old Normal Lighting
<img width="1243" height="881" alt="image" src="https://github.com/user-attachments/assets/0fa58810-f69f-442a-b8a4-f3072d18472d" />
Box Cargo - New Normal Lighting
<img width="1247" height="898" alt="image" src="https://github.com/user-attachments/assets/bec35599-ffae-4bc2-878f-0330bea0382c" />
Same Location - New Night Lighting
<img width="1207" height="874" alt="image" src="https://github.com/user-attachments/assets/38e3e491-3c63-4142-80ba-dd7677e1c6c1" />
Box Captains Office - New Normal Lighting
<img width="532" height="669" alt="image" src="https://github.com/user-attachments/assets/a8d7aef9-20af-4b28-beee-152aef727aec" />
Same Location - Night Lighting
<img width="531" height="664" alt="image" src="https://github.com/user-attachments/assets/094aaeae-a767-45ea-8d7c-dd971bc8850b" />
Box Engineering - Night Lighting
<img width="1255" height="986" alt="image" src="https://github.com/user-attachments/assets/0611f430-b743-4d8a-8ffd-ae0e0ab17ca2" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

<!-- How did you test the PR, if at all? -->
- Made sure lights correctly got their area colour.
- Made sure lights in an area without a set colour defaulted to their regular colour.
- Made sure lights could still be painted and stay painted.
- Looked at the lights.
## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Roundstart lights are now a bit warmer based on their area
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
