### PR TITLE
fix PDA recipe for supermatter sandwich

### DIFF
--- a/code/modules/cooking/recipes/cutting_board_recipes.dm
+++ b/code/modules/cooking/recipes/cutting_board_recipes.dm
@@ -546,6 +546,9 @@
 
 	return ..()
 
+/datum/cooking/recipe_step/add_item/supermatter_sliver/get_pda_formatted_desc()
+	return "Add a sliver of a supermatter crystal."
+
 /datum/cooking/recipe/supermatter_sandwich
 	container_type = /obj/item/reagent_containers/cooking/board
 	product_type = /obj/item/food/supermatter_sandwich


### PR DESCRIPTION
## What Does This PR Do
This PR adds proper text for the "add supermatter sliver" recipe step so it shows up as expected in the recipe book.
## Why It's Good For The Game
Improves recipe book quality.
## Images of changes
### Before
<img width="411" height="179" alt="2026_04_20__12_16_10__" src="https://github.com/user-attachments/assets/306d615c-49e9-4c82-8fe1-016ff0830590" />

### After
<img width="469" height="175" alt="2026_04_20__12_22_17__" src="https://github.com/user-attachments/assets/d6c728a3-e623-419f-b689-b6bf55ec632c" />

## Testing
See above
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
fix: The supermatter sandwich recipe is now properly formatted in the recipe book PDA app.
/:cl: