### PR TITLE
migrate /mob/living/silicon to Initialize()

### DIFF
--- a/code/game/objects/items/devices/radio/radio_objects.dm
+++ b/code/game/objects/items/devices/radio/radio_objects.dm
@@ -733,8 +733,6 @@ GLOBAL_LIST_EMPTY(deadsay_radio_systems)
 
 	for(var/ch_name in channels)
 		if(!SSradio)
-			sleep(30) // Waiting for SSradio to be created.
-		if(!SSradio)
 			name = "broken radio"
 			return
 

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -264,7 +264,7 @@
 			if(!aisync)
 				lawsync = FALSE
 
-			var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(get_turf(loc), unfinished = 1, connect_to_AI = aisync, ai_to_sync_to = forced_ai)
+			var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(get_turf(loc), TRUE, FALSE, aisync, forced_ai)
 			if(!O)
 				return
 

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -264,7 +264,7 @@
 			if(!aisync)
 				lawsync = FALSE
 
-			var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(get_turf(loc), TRUE, FALSE, aisync, forced_ai)
+			var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(get_turf(loc), aisync, forced_ai)
 			if(!O)
 				return
 

--- a/code/modules/mob/living/silicon/ai/ai_mob.dm
+++ b/code/modules/mob/living/silicon/ai/ai_mob.dm
@@ -184,7 +184,8 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 	remove_verb(src, GLOB.ai_verbs_default)
 	remove_verb(src, silicon_subsystems)
 
-/mob/living/silicon/ai/New(loc, datum/ai_laws/L, obj/item/mmi/B, safety = 0)
+/mob/living/silicon/ai/Initialize(mapload, datum/ai_laws/L, obj/item/mmi/B, safety = 0)
+	. = ..()
 	announcer = new(config_type = /datum/announcement_configuration/ai)
 	announcer.author = name
 
@@ -266,8 +267,7 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 
 			on_mob_init()
 
-	spawn(5)
-		new /obj/machinery/ai_powersupply(src)
+	addtimer(CALLBACK(src, PROC_REF(create_power_supply)), 5 DECISECONDS)
 
 	eyeobj = new /mob/camera/eye/ai(loc, name, src, src)
 
@@ -283,11 +283,10 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 	for(var/I in 1 to 4)
 		stored_locations += "unset" //This is checked in ai_keybinds.dm.
 
-	..()
-
-/mob/living/silicon/ai/Initialize(mapload)
-	. = ..()
 	REMOVE_TRAIT(src, TRAIT_CAN_STRIP, TRAIT_GENERIC)
+
+/mob/living/silicon/ai/proc/create_power_supply()
+	new /obj/machinery/ai_powersupply(src)
 
 /mob/living/silicon/ai/Destroy()
 	GLOB.ai_list -= src

--- a/code/modules/mob/living/silicon/robot/drone/maint_drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/maint_drone.dm
@@ -57,7 +57,7 @@
 		/mob/living/silicon/proc/subsystem_power_monitor)
 
 
-/mob/living/silicon/robot/drone/Initialize(mapload, unfinished, alien, connect_to_AI, mob/living/silicon/ai/ai_to_sync_to)
+/mob/living/silicon/robot/drone/Initialize(mapload, connect_to_AI, mob/living/silicon/ai/ai_to_sync_to)
 	. = ..()
 
 	remove_language("Robot Talk")
@@ -112,7 +112,7 @@
 	// Drones have laws to not attack people
 	ADD_TRAIT(src, TRAIT_PACIFISM, INNATE_TRAIT)
 
-/mob/living/silicon/robot/drone/init(alien = FALSE, mob/living/silicon/ai/ai_to_sync_to = null)
+/mob/living/silicon/robot/drone/init(mob/living/silicon/ai/ai_to_sync_to = null)
 	laws = new /datum/ai_laws/drone()
 	set_connected_ai(null)
 

--- a/code/modules/mob/living/silicon/robot/drone/maint_drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/maint_drone.dm
@@ -57,8 +57,8 @@
 		/mob/living/silicon/proc/subsystem_power_monitor)
 
 
-/mob/living/silicon/robot/drone/New()
-	..()
+/mob/living/silicon/robot/drone/Initialize(mapload, unfinished, alien, connect_to_AI, mob/living/silicon/ai/ai_to_sync_to)
+	. = ..()
 
 	remove_language("Robot Talk")
 	remove_language("Galactic Common")

--- a/code/modules/mob/living/silicon/robot/robot_mob.dm
+++ b/code/modules/mob/living/silicon/robot/robot_mob.dm
@@ -169,7 +169,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 /mob/living/silicon/robot/get_cell()
 	return cell
 
-/mob/living/silicon/robot/Initialize(mapload, unfinished = FALSE, alien = FALSE, connect_to_AI = TRUE, mob/living/silicon/ai/ai_to_sync_to = null)
+/mob/living/silicon/robot/Initialize(mapload, connect_to_AI = TRUE, mob/living/silicon/ai/ai_to_sync_to = null)
 	. = ..()
 	spark_system = new /datum/effect_system/spark_spread()
 	spark_system.set_up(5, 0, src)
@@ -215,7 +215,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	var/obj/item/stock_parts/cell/C = cell || new default_cell_type(src)
 	cell_component.install(C)
 
-	init(alien, connect_to_AI, ai_to_sync_to)
+	init(connect_to_AI, ai_to_sync_to)
 
 	diag_hud_set_borgcell()
 	scanner = new(src)
@@ -233,7 +233,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 		if(!has_gravity(T))
 			new /obj/effect/particle_effect/ion_trails(T, _dir)
 
-/mob/living/silicon/robot/proc/init(alien, connect_to_AI = TRUE, mob/living/silicon/ai/ai_to_sync_to = null)
+/mob/living/silicon/robot/proc/init(connect_to_AI = TRUE, mob/living/silicon/ai/ai_to_sync_to = null)
 	aiCamera = new/obj/item/camera/siliconcam/robot_camera(src)
 	make_laws()
 	additional_law_channels["Binary"] = ":b "
@@ -1710,7 +1710,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	default_cell_type = /obj/item/stock_parts/cell/bluespace
 	has_advanced_reagent_vision = TRUE
 
-/mob/living/silicon/robot/deathsquad/init(alien = FALSE, connect_to_AI = TRUE, mob/living/silicon/ai/ai_to_sync_to = null)
+/mob/living/silicon/robot/deathsquad/init(connect_to_AI = TRUE, mob/living/silicon/ai/ai_to_sync_to = null)
 	laws = new /datum/ai_laws/deathsquad
 	module = new /obj/item/robot_module/deathsquad(src)
 	module.add_languages(src)
@@ -1744,13 +1744,13 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	has_advanced_reagent_vision = TRUE
 
 
-/mob/living/silicon/robot/ert/init(alien = FALSE, connect_to_AI = TRUE, mob/living/silicon/ai/ai_to_sync_to = null)
+/mob/living/silicon/robot/ert/init(connect_to_AI = TRUE, mob/living/silicon/ai/ai_to_sync_to = null)
 	laws = new /datum/ai_laws/ert_override
 	radio = new /obj/item/radio/borg/ert(src)
 	radio.recalculateChannels()
 	aiCamera = new/obj/item/camera/siliconcam/robot_camera(src)
 
-/mob/living/silicon/robot/ert/Initialize(mapload, unfinished, alien, connect_to_AI, mob/living/silicon/ai/ai_to_sync_to)
+/mob/living/silicon/robot/ert/Initialize(mapload, connect_to_AI, mob/living/silicon/ai/ai_to_sync_to)
 	. = ..()
 	var/rnum = rand(1,1000)
 	var/borgname = "[eprefix] ERT [rnum]"
@@ -1798,7 +1798,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	default_cell_type = /obj/item/stock_parts/cell/bluespace
 	has_advanced_reagent_vision = TRUE
 
-/mob/living/silicon/robot/destroyer/init(alien = FALSE, connect_to_AI = TRUE, mob/living/silicon/ai/ai_to_sync_to = null)
+/mob/living/silicon/robot/destroyer/init(connect_to_AI = TRUE, mob/living/silicon/ai/ai_to_sync_to = null)
 	aiCamera = new/obj/item/camera/siliconcam/robot_camera(src)
 	additional_law_channels["Binary"] = ":b "
 	laws = new /datum/ai_laws/deathsquad

--- a/code/modules/mob/living/silicon/robot/robot_mob.dm
+++ b/code/modules/mob/living/silicon/robot/robot_mob.dm
@@ -169,7 +169,8 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 /mob/living/silicon/robot/get_cell()
 	return cell
 
-/mob/living/silicon/robot/New(loc, syndie = FALSE, unfinished = FALSE, alien = FALSE, connect_to_AI = TRUE, mob/living/silicon/ai/ai_to_sync_to = null)
+/mob/living/silicon/robot/Initialize(mapload, unfinished = FALSE, alien = FALSE, connect_to_AI = TRUE, mob/living/silicon/ai/ai_to_sync_to = null)
+	. = ..()
 	spark_system = new /datum/effect_system/spark_spread()
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)
@@ -202,8 +203,6 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	for(var/V in components) if(V != "power cell")
 		var/datum/robot_component/C = components[V]
 		C.install(new C.external_type, FALSE)
-
-	..()
 
 	add_robot_verbs()
 
@@ -1751,8 +1750,8 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	radio.recalculateChannels()
 	aiCamera = new/obj/item/camera/siliconcam/robot_camera(src)
 
-/mob/living/silicon/robot/ert/New(loc)
-	..(loc)
+/mob/living/silicon/robot/ert/Initialize(mapload, unfinished, alien, connect_to_AI, mob/living/silicon/ai/ai_to_sync_to)
+	. = ..()
 	var/rnum = rand(1,1000)
 	var/borgname = "[eprefix] ERT [rnum]"
 	name = borgname

--- a/code/modules/mob/living/silicon/robot/syndicate_robot.dm
+++ b/code/modules/mob/living/silicon/robot/syndicate_robot.dm
@@ -22,8 +22,8 @@
 							Your cyborg LMG will slowly produce ammunition from your power supply, and your operative pinpointer will find and locate fellow nuclear operatives. \
 							<i>Help the operatives secure the disk at all costs!</i></b>"
 
-/mob/living/silicon/robot/syndicate/New(loc)
-	..()
+/mob/living/silicon/robot/syndicate/Initialize(mapload, unfinished, alien, connect_to_AI, mob/living/silicon/ai/ai_to_sync_to)
+	. = ..()
 	cell = new /obj/item/stock_parts/cell/bluespace(src)
 
 /mob/living/silicon/robot/syndicate/init(alien = FALSE, mob/living/silicon/ai/ai_to_sync_to = null)

--- a/code/modules/mob/living/silicon/robot/syndicate_robot.dm
+++ b/code/modules/mob/living/silicon/robot/syndicate_robot.dm
@@ -22,11 +22,11 @@
 							Your cyborg LMG will slowly produce ammunition from your power supply, and your operative pinpointer will find and locate fellow nuclear operatives. \
 							<i>Help the operatives secure the disk at all costs!</i></b>"
 
-/mob/living/silicon/robot/syndicate/Initialize(mapload, unfinished, alien, connect_to_AI, mob/living/silicon/ai/ai_to_sync_to)
+/mob/living/silicon/robot/syndicate/Initialize(mapload, connect_to_AI, mob/living/silicon/ai/ai_to_sync_to)
 	. = ..()
 	cell = new /obj/item/stock_parts/cell/bluespace(src)
 
-/mob/living/silicon/robot/syndicate/init(alien = FALSE, mob/living/silicon/ai/ai_to_sync_to = null)
+/mob/living/silicon/robot/syndicate/init(mob/living/silicon/ai/ai_to_sync_to = null)
 	laws = new /datum/ai_laws/syndicate_override
 	module = new /obj/item/robot_module/syndicate(src)
 
@@ -59,7 +59,7 @@
 						Your energy saw functions as a circular saw, but can be activated to deal more damage, and your operative pinpointer will find and locate fellow nuclear operatives. \
 						<i>Help the operatives secure the disk at all costs!</i></b>"
 
-/mob/living/silicon/robot/syndicate/medical/init(alien = FALSE, mob/living/silicon/ai/ai_to_sync_to = null)
+/mob/living/silicon/robot/syndicate/medical/init(mob/living/silicon/ai/ai_to_sync_to = null)
 	..()
 	module = new /obj/item/robot_module/syndicate_medical(src)
 
@@ -84,7 +84,7 @@
 						Be aware that physical contact or taking damage will break your disguise. \
 						<i>Help the operatives secure the disk at all costs!</i></b>"
 
-/mob/living/silicon/robot/syndicate/saboteur/init(alien = FALSE, mob/living/silicon/ai/ai_to_sync_to = null)
+/mob/living/silicon/robot/syndicate/saboteur/init(mob/living/silicon/ai/ai_to_sync_to = null)
 	..()
 	module = new /obj/item/robot_module/syndicate_saboteur(src)
 

--- a/code/modules/mob/living/silicon/silicon_mob.dm
+++ b/code/modules/mob/living/silicon/silicon_mob.dm
@@ -83,16 +83,9 @@
 	/// The delay used when toggling door bolts or electrification
 	var/door_bolt_delay = 3 SECONDS
 
-/mob/living/silicon/New()
-	GLOB.silicon_mob_list |= src
-	..()
-	add_language("Galactic Common")
-	init_subsystems()
-	RegisterSignal(GLOB.alarm_manager, COMSIG_TRIGGERED_ALARM, PROC_REF(alarm_triggered))
-	RegisterSignal(GLOB.alarm_manager, COMSIG_CANCELLED_ALARM, PROC_REF(alarm_cancelled))
-
 /mob/living/silicon/Initialize(mapload)
 	. = ..()
+	GLOB.silicon_mob_list |= src
 	for(var/hud_key, hud in GLOB.huds)
 		var/datum/atom_hud/data/diagnostic/diag_hud = hud
 		if(!istype(diag_hud))
@@ -108,6 +101,10 @@
 		stack_trace("Invalid type [armor.type] found in .armor during /obj Initialize()")
 	regenerate_icons()
 
+	add_language("Galactic Common")
+	init_subsystems()
+	RegisterSignal(GLOB.alarm_manager, COMSIG_TRIGGERED_ALARM, PROC_REF(alarm_triggered))
+	RegisterSignal(GLOB.alarm_manager, COMSIG_CANCELLED_ALARM, PROC_REF(alarm_cancelled))
 
 /mob/living/silicon/med_hud_set_health()
 	return //we use a different hud

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -63,7 +63,7 @@
 	invisibility = 101
 
 	// Creating a new borg here will connect them to a default AI and notify that AI, if `connect_to_default_AI` is TRUE.
-	var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(loc, FALSE, FALSE, TRUE, connect_to_default_AI)
+	var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(loc, FALSE, FALSE, connect_to_default_AI)
 
 	// If `AI` is passed in, we want to connect to that AI specifically.
 	if(AI)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -63,7 +63,7 @@
 	invisibility = 101
 
 	// Creating a new borg here will connect them to a default AI and notify that AI, if `connect_to_default_AI` is TRUE.
-	var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(loc, connect_to_AI = connect_to_default_AI)
+	var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(loc, FALSE, FALSE, TRUE, connect_to_default_AI)
 
 	// If `AI` is passed in, we want to connect to that AI specifically.
 	if(AI)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -63,7 +63,7 @@
 	invisibility = 101
 
 	// Creating a new borg here will connect them to a default AI and notify that AI, if `connect_to_default_AI` is TRUE.
-	var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(loc, FALSE, FALSE, connect_to_default_AI)
+	var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(loc, connect_to_default_AI)
 
 	// If `AI` is passed in, we want to connect to that AI specifically.
 	if(AI)


### PR DESCRIPTION
## What Does This PR Do
Migrates silicon mobs to Initialize. Removed a redundant arg `syndie` in the Initialize.
## Why It's Good For The Game
GLORY TO THE GREAT INITIALIZER!
## Testing
Spawned each single silicon mob, ensured their subsystems are there, languages, huds, ensured the AI gets its power supply, ensured non-NT sillycons are not announced to AI, double checked the new calls for sillycons
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC