### PR TITLE
Set airlock directions correctly at map-level

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -942,10 +942,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/mineral/bananium/lubed/lavaland_air,
 /area/ruin/powered/clownplanet)
-"bZ" = (
-/obj/machinery/door/airlock/bananium,
-/turf/simulated/floor/mineral/bananium/lubed/lavaland_air,
-/area/ruin/powered/clownplanet)
 "ca" = (
 /obj/item/bikehorn,
 /obj/effect/decal/cleanable/dirt,
@@ -1087,6 +1083,12 @@
 	invisibility = 101
 	},
 /turf/simulated/wall/r_wall,
+/area/ruin/powered/clownplanet)
+"JO" = (
+/obj/machinery/door/airlock/bananium{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/bananium/lubed/lavaland_air,
 /area/ruin/powered/clownplanet)
 "KX" = (
 /obj/item/grown/bananapeel{
@@ -1724,7 +1726,7 @@ bN
 bM
 bU
 bM
-bZ
+JO
 bB
 bH
 bB

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_winter.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_winter.dmm
@@ -78,10 +78,6 @@
 "aq" = (
 /turf/simulated/wall/mineral/wood,
 /area/ruin/powered/snow_cabin)
-"ar" = (
-/obj/machinery/door/airlock/wood,
-/turf/simulated/floor/plating,
-/area/ruin/powered/snow_cabin)
 "as" = (
 /obj/structure/fans,
 /turf/simulated/wall/mineral/wood,
@@ -127,10 +123,6 @@
 /obj/structure/flora/tree/dead,
 /turf/simulated/floor/plating/asteroid/snow/atmosphere,
 /area/ruin/powered/snow_biodome)
-"aD" = (
-/obj/machinery/door/airlock/wood,
-/turf/simulated/floor/wood,
-/area/ruin/powered/snow_cabin)
 "aE" = (
 /obj/structure/extinguisher_cabinet{
 	name = "custom placement"
@@ -177,11 +169,6 @@
 /obj/structure/bed/dogbed,
 /turf/simulated/floor/wood,
 /area/ruin/powered/snow_cabin)
-"aO" = (
-/obj/machinery/door/airlock/multi_tile/glass,
-/obj/structure/fans/tiny,
-/turf/simulated/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
 "aP" = (
 /obj/structure/fans/tiny,
 /turf/simulated/floor/pod/dark,
@@ -332,6 +319,13 @@
 "tl" = (
 /turf/simulated/floor/pod/light,
 /area/ruin/powered/snow_biodome)
+"tP" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/pod/dark,
+/area/ruin/powered/snow_cabin)
 "tZ" = (
 /turf/simulated/floor/mineral/silver/biodome_snow,
 /area/ruin/powered/snow_biodome)
@@ -340,10 +334,11 @@
 /obj/structure/barricade/wooden/crude/snow,
 /turf/simulated/floor/wood,
 /area/ruin/powered/snow_cabin)
-"vf" = (
-/obj/machinery/door/airlock/multi_tile/glass,
-/obj/structure/fans/tiny,
-/turf/simulated/floor/pod/dark,
+"wd" = (
+/obj/machinery/door/airlock/wood{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
 /area/ruin/powered/snow_cabin)
 "wM" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
@@ -356,6 +351,13 @@
 /area/ruin/powered/snow_biodome)
 "AM" = (
 /obj/machinery/economy/vending/coffee/free,
+/turf/simulated/floor/pod/dark,
+/area/ruin/powered/snow_biodome)
+"AR" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/pod/dark,
 /area/ruin/powered/snow_biodome)
 "BF" = (
@@ -379,11 +381,6 @@
 /obj/structure/barricade/wooden/crude/snow,
 /turf/simulated/floor/mineral/silver/biodome_snow,
 /area/ruin/powered/snow_biodome)
-"Ez" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/multi_tile/glass,
-/turf/simulated/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
 "FP" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -406,8 +403,21 @@
 "HP" = (
 /turf/simulated/floor/pod/dark,
 /area/ruin/powered/snow_biodome)
+"IV" = (
+/obj/machinery/door/airlock/wood{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ruin/powered/snow_cabin)
 "Mp" = (
 /obj/item/clothing/mask/balaclava,
+/turf/simulated/floor/pod/dark,
+/area/ruin/powered/snow_biodome)
+"Mz" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
 /turf/simulated/floor/pod/dark,
 /area/ruin/powered/snow_biodome)
 "MA" = (
@@ -827,10 +837,10 @@ tb
 Wg
 ad
 af
-ar
+IV
 bw
 et
-aD
+wd
 jE
 aL
 aq
@@ -929,7 +939,7 @@ at
 at
 aH
 aM
-vf
+tP
 ak
 ak
 ak
@@ -945,10 +955,10 @@ ao
 ak
 ak
 ak
-aO
+AR
 tl
 tl
-Ez
+Mz
 Qa
 "}
 (16,1,1) = {"

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_althland_excavation.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_althland_excavation.dmm
@@ -622,6 +622,16 @@
 	nitrogen = 0
 	},
 /area/lavaland/surface/outdoors)
+"fE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/turf/simulated/floor/pod/light/lavaland_air{
+	oxygen = 0;
+	nitrogen = 0
+	},
+/area/ruin/unpowered/althland_excavation)
 "fH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1248,14 +1258,6 @@
 	nitrogen = 0
 	},
 /area/lavaland/surface/outdoors)
-"Lt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch,
-/turf/simulated/floor/pod/light/lavaland_air{
-	oxygen = 0;
-	nitrogen = 0
-	},
-/area/ruin/unpowered/althland_excavation)
 "Lz" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -1702,7 +1704,7 @@ sj
 TN
 TN
 aU
-Lt
+fE
 am
 iW
 OX

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_basalt_lab.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_basalt_lab.dmm
@@ -78,14 +78,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/basalt_lab)
-"dj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered/basalt_lab)
 "dy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/machinery/light/small{
@@ -135,16 +127,6 @@
 	},
 /obj/structure/barricade/wooden/crude,
 /turf/simulated/wall/indestructible/fakeglass,
-/area/ruin/unpowered/basalt_lab)
-"ha" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
 /area/ruin/unpowered/basalt_lab)
 "hr" = (
 /obj/effect/turf_decal/tiles/department/science/corner,
@@ -301,12 +283,6 @@
 /obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"nW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered/basalt_lab)
 "of" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -365,12 +341,6 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel/freezer,
-/area/ruin/unpowered/basalt_lab)
-"pz" = (
-/obj/effect/spawner/random/blood/often,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
 /area/ruin/unpowered/basalt_lab)
 "pH" = (
 /obj/effect/map_effect/dynamic_airlock/door/interior,
@@ -448,6 +418,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered/basalt_lab)
+"sO" = (
+/obj/effect/spawner/random/blood/often,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered/basalt_lab)
 "sW" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /obj/effect/turf_decal/tiles/department/engineering/corner{
@@ -511,6 +489,18 @@
 "wc" = (
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"wt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered/basalt_lab)
 "wu" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/tiles/department/engineering/corner{
@@ -593,6 +583,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered/basalt_lab)
+"AC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered/basalt_lab)
 "AS" = (
 /obj/machinery/light{
 	dir = 1
@@ -671,6 +672,14 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 4
 	},
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered/basalt_lab)
+"Dk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered/basalt_lab)
 "DM" = (
@@ -934,15 +943,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered/basalt_lab)
-"MV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered/basalt_lab)
 "Nn" = (
 /obj/machinery/power/apc/reinforced/directional/south,
 /obj/structure/cable,
@@ -997,6 +997,13 @@
 /obj/effect/spawner/random/trash/spread_tiles,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"OW" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered/basalt_lab)
 "PL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -1159,6 +1166,17 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered/basalt_lab)
+"Vb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered/basalt_lab)
 "Vl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -1289,11 +1307,6 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered/basalt_lab)
-"ZE" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered/basalt_lab)
 "ZO" = (
@@ -1472,7 +1485,7 @@ FX
 AS
 Cj
 Rb
-ZE
+OW
 be
 So
 mX
@@ -1498,7 +1511,7 @@ FX
 op
 Ed
 WL
-ha
+wt
 wC
 PL
 DV
@@ -1546,7 +1559,7 @@ FX
 in
 Cz
 aN
-dj
+Vb
 Rf
 kp
 Nn
@@ -1557,7 +1570,7 @@ QK
 lT
 HK
 sj
-pz
+sO
 Zk
 Qo
 mw
@@ -1583,7 +1596,7 @@ pI
 GI
 kd
 YW
-nW
+Dk
 SJ
 Mx
 AA
@@ -1602,7 +1615,7 @@ FX
 DS
 kf
 Js
-ZE
+OW
 be
 mX
 oh
@@ -1628,7 +1641,7 @@ FX
 AS
 Li
 Zu
-MV
+AC
 aH
 DM
 aY

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_envy.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_envy.dmm
@@ -94,11 +94,6 @@
 	},
 /turf/simulated/floor/plating/damaged,
 /area/ruin/powered/envy)
-"p" = (
-/obj/machinery/door/airlock/hatch,
-/obj/structure/fans/tiny/invisible,
-/turf/simulated/floor/plating,
-/area/ruin/powered/envy)
 "q" = (
 /obj/effect/baseturf_helper/lava/mapping_lava,
 /turf/simulated/floor/plating,
@@ -107,6 +102,13 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"Z" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/simulated/floor/plating,
+/area/ruin/powered/envy)
 
 (1,1,1) = {"
 a
@@ -236,7 +238,7 @@ i
 i
 i
 i
-p
+Z
 A
 a
 "}

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_gluttony.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_gluttony.dmm
@@ -88,6 +88,13 @@
 	},
 /turf/simulated/floor/plasteel/freezer,
 /area/ruin/powered/gluttony)
+"H" = (
+/obj/machinery/door/airlock/uranium{
+	dir = 4
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/simulated/floor/plasteel/freezer,
+/area/ruin/powered/gluttony)
 "R" = (
 /turf/simulated/wall/indestructible/uranium,
 /area/ruin/powered/gluttony)
@@ -335,7 +342,7 @@ i
 i
 i
 i
-S
+H
 u
 u
 "}

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -169,6 +169,13 @@
 "pL" = (
 /turf/simulated/floor/catwalk,
 /area/shuttle/freegolem)
+"qF" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/spawner/random/dirt/maybe,
+/turf/simulated/floor/plating,
+/area/shuttle/freegolem)
 "qT" = (
 /obj/structure/table,
 /obj/item/book/manual/research_and_development{
@@ -215,6 +222,12 @@
 /obj/effect/turf_decal/delivery/hollow,
 /obj/effect/turf_decal/tiles/white/corner{
 	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/shuttle/freegolem)
+"uQ" = (
+/obj/machinery/door/airlock/titanium/glass{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/shuttle/freegolem)
@@ -302,6 +315,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
+/area/shuttle/freegolem)
+"Ah" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/obj/effect/spawner/random/dirt/maybe,
+/turf/simulated/floor/plating,
 /area/shuttle/freegolem)
 "Aw" = (
 /obj/structure/chair/comfy/purp{
@@ -645,7 +666,7 @@ xQ
 ca
 AT
 Jg
-Ob
+uQ
 YN
 zn
 hg
@@ -720,10 +741,10 @@ wN
 ca
 AT
 Jg
-bQ
+qF
 pa
 Sz
-MD
+Ah
 EE
 "}
 (12,1,1) = {"
@@ -742,10 +763,10 @@ oD
 oD
 oD
 hu
-bQ
+qF
 pL
 Sz
-MD
+Ah
 EE
 "}
 (13,1,1) = {"

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_greed.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_greed.dmm
@@ -116,8 +116,10 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/engine/cult,
 /area/ruin/powered/greed)
-"J" = (
-/obj/machinery/door/airlock/gold,
+"D" = (
+/obj/machinery/door/airlock/gold{
+	dir = 4
+	},
 /obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/engine/cult,
 /area/ruin/powered/greed)
@@ -340,7 +342,7 @@ m
 m
 m
 m
-J
+D
 a
 a
 a

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
@@ -126,14 +126,6 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/pod/dark,
 /area/ruin/powered)
-"D" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 1
-	},
-/obj/machinery/door/airlock/survival_pod/glass,
-/obj/structure/fans/tiny,
-/turf/simulated/floor/pod/dark,
-/area/ruin/powered)
 "E" = (
 /obj/structure/shuttle/engine/propulsion/burst{
 	dir = 8
@@ -166,6 +158,16 @@
 "K" = (
 /obj/effect/baseturf_helper,
 /turf/simulated/floor/plating,
+/area/ruin/powered)
+"P" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/obj/machinery/door/airlock/survival_pod/glass{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/pod/dark,
 /area/ruin/powered)
 "Q" = (
 /obj/effect/mapping_helpers/no_lava,
@@ -228,7 +230,7 @@ t
 w
 y
 y
-D
+P
 Q
 Q
 a

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_mining_telecomms.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_mining_telecomms.dmm
@@ -165,18 +165,20 @@
 /obj/effect/spawner/random/rarely_meteor_strike,
 /turf/simulated/floor/pod,
 /area/ruin/lavaland_relay)
-"O" = (
-/obj/machinery/door/airlock/survival_pod/glass,
-/obj/effect/spawner/random/rarely_meteor_strike,
-/obj/structure/fans/tiny,
-/turf/simulated/floor/pod,
-/area/ruin/lavaland_relay)
 "Q" = (
 /obj/structure/railing{
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored)
+"U" = (
+/obj/machinery/door/airlock/survival_pod/glass{
+	dir = 4
+	},
+/obj/effect/spawner/random/rarely_meteor_strike,
+/obj/structure/fans/tiny,
+/turf/simulated/floor/pod,
+/area/ruin/lavaland_relay)
 "X" = (
 /obj/structure/table/glass/reinforced/plastitanium,
 /obj/effect/turf_decal/stripes/line,
@@ -241,7 +243,7 @@ E
 J
 m
 q
-O
+U
 p
 a
 "}

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
@@ -16,12 +16,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/mine/outpost/smith_workshop)
-"aj" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/spawner/random/dirt/maybe,
-/obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/plating,
-/area/mine/outpost/maintenance/south)
 "al" = (
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/structure/fans/tiny,
@@ -32,6 +26,36 @@
 /obj/effect/turf_decal/tiles/department/security/mono,
 /turf/simulated/floor/plasteel/dark/full,
 /area/mine/laborcamp/security)
+"ao" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/maintenance/external/glass{
+	name = "Landing Pad";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/turf_decal/tiles/department/security/mono,
+/turf/simulated/floor/plasteel/dark/full,
+/area/mine/laborcamp/security)
+"ap" = (
+/obj/machinery/door/airlock/glass{
+	name = "Cafeteria";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining_station,
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white{
+	icon_regular_floor = "yellowsiding"
+	},
+/area/mine/outpost/cafeteria)
 "ar" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -121,6 +145,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/white,
 /area/mine/laborcamp)
+"be" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Central Hallway Maintence";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
+/turf/simulated/floor/plating,
+/area/mine/outpost/hallway/west)
 "bg" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -188,6 +226,23 @@
 "bT" = (
 /turf/simulated/floor/plating,
 /area/mine/outpost/maintenance/south)
+"bX" = (
+/obj/machinery/door/airlock/maintenance/external{
+	name = "Processing Room";
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/turf/simulated/floor/plating,
+/area/mine/outpost/production)
 "bY" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -261,18 +316,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
-"cw" = (
-/obj/machinery/door/airlock/glass{
-	name = "Construction Site"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/cap/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/mine/outpost/maintenance/south)
 "cz" = (
 /obj/structure/disposaloutlet,
 /obj/structure/lattice/catwalk/mining,
@@ -386,24 +429,6 @@
 /obj/structure/railing,
 /turf/simulated/floor/lava/mapping_lava,
 /area/lavaland/surface/outdoors/outpost/catwalk)
-"dg" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/door/airlock/atmos{
-	name = "Life Support"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/any/supply/mining_station,
-/turf/simulated/floor/catwalk,
-/area/mine/outpost/hallway/west)
 "dh" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -413,16 +438,6 @@
 "dk" = (
 /turf/simulated/wall,
 /area/mine/outpost/airlock)
-"dp" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/maintenance/external/glass{
-	name = "Landing Pad"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
-/obj/effect/spawner/random/dirt/maybe,
-/turf/simulated/floor/catwalk,
-/area/mine/outpost/hallway/west)
 "dv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -497,6 +512,14 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/mine/laborcamp)
+"dD" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/spawner/random/dirt/maybe,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine/outpost/maintenance/south)
 "dI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -532,6 +555,17 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/mine/outpost/hallway/west)
+"dK" = (
+/obj/structure/fans/tiny,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/sign/cargo/xenos{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/mine/outpost/airlock)
 "dL" = (
 /obj/structure/railing{
 	dir = 1
@@ -673,6 +707,23 @@
 /obj/item/clothing/mask/balaclava,
 /turf/simulated/floor/wood,
 /area/mine/laborcamp)
+"eC" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/maintenance/external{
+	name = "Catwalk Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/catwalk,
+/area/mine/outpost/engineering)
 "eG" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -706,6 +757,22 @@
 /obj/machinery/economy/vending/coffee,
 /turf/simulated/floor/plasteel/dark,
 /area/mine/outpost/hallway/west)
+"eV" = (
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Labor Camp Security";
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Labor";
+	name = "labor camp blast door"
+	},
+/obj/effect/turf_decal/tiles/department/security/mono,
+/turf/simulated/floor/plasteel/dark/full,
+/area/mine/laborcamp/security)
 "eY" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/railing/corner{
@@ -1131,14 +1198,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/mine/outpost/smith_workshop)
-"gS" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
-/obj/machinery/door/airlock/maintenance{
-	name = "Infirmary Maintence"
-	},
-/turf/simulated/floor/plating,
-/area/mine/outpost/medbay)
 "gU" = (
 /obj/structure/chair{
 	dir = 1
@@ -1549,17 +1608,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/mine/outpost/smith_workshop)
-"iW" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Infirmary"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/turf_decal/tiles/department/medical/checker,
-/turf/simulated/floor/plasteel/white,
-/area/mine/laborcamp)
 "iY" = (
 /obj/structure/railing{
 	dir = 9
@@ -1627,15 +1675,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/mine/outpost/smith_workshop)
-"jw" = (
-/obj/structure/fans/tiny,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/structure/sign/cargo/xenos{
-	pixel_x = 32
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/mine/outpost/airlock)
 "jz" = (
 /obj/effect/mapping_helpers/no_lava,
 /obj/structure/sign/nanotrasen{
@@ -1684,16 +1723,6 @@
 	},
 /turf/simulated/floor/catwalk,
 /area/mine/laborcamp)
-"jQ" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	name = "Main Airlock";
-	dir = 4
-	},
-/obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/mine/outpost/airlock)
 "jR" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -1882,6 +1911,14 @@
 /mob/living/basic/cockroach/brad,
 /turf/simulated/floor/plating,
 /area/mine/outpost/lockers)
+"lk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock{
+	name = "Organic Toilet";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/mine/laborcamp)
 "ln" = (
 /turf/simulated/floor/plasteel/dark,
 /area/mine/laborcamp/security)
@@ -1987,6 +2024,15 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/mine/outpost/smith_workshop)
+"lO" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
+/obj/machinery/door/airlock/maintenance{
+	name = "Infirmary Maintence";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine/outpost/medbay)
 "lQ" = (
 /obj/effect/turf_decal/box,
 /turf/simulated/floor/plasteel/dark,
@@ -2028,13 +2074,6 @@
 "lW" = (
 /turf/simulated/floor/plasteel,
 /area/mine/outpost/mechbay)
-"lX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock{
-	name = "Synthetic Toilet"
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/mine/laborcamp)
 "ma" = (
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -2046,17 +2085,6 @@
 /area/mine/outpost/mechbay)
 "md" = (
 /obj/item/cigbutt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/mine/laborcamp)
-"me" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Labor Camp Equipment Storage"
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
@@ -2297,13 +2325,6 @@
 /obj/effect/spawner/random/cobweb/right/rare,
 /turf/simulated/floor/plating,
 /area/mine/outpost/maintenance/south)
-"nt" = (
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/machinery/door/airlock/titanium/glass{
-	name = "Labor Shuttle Airlock"
-	},
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/shuttle/siberia)
 "nu" = (
 /obj/machinery/camera{
 	c_tag = "Labor Camp External";
@@ -2515,18 +2536,6 @@
 /obj/effect/spawner/random/engineering/tools,
 /turf/simulated/floor/plating,
 /area/mine/outpost/maintenance/south)
-"oC" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "EVA Storage"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
-/turf/simulated/floor/plasteel/dark,
-/area/mine/outpost/storage)
 "oD" = (
 /obj/machinery/door/firedoor,
 /obj/effect/spawner/window/reinforced/plasma/grilled,
@@ -2929,23 +2938,6 @@
 /obj/effect/turf_decal/tiles/department/security/mono,
 /turf/simulated/floor/plasteel/dark/full,
 /area/mine/laborcamp)
-"qU" = (
-/obj/machinery/door/airlock/glass{
-	name = "Cafeteria"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
-/obj/effect/mapping_helpers/airlock/access/any/supply/mining_station,
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white{
-	icon_regular_floor = "yellowsiding"
-	},
-/area/mine/outpost/cafeteria)
 "qV" = (
 /obj/effect/baseturf_helper/lava_land,
 /turf/simulated/floor/mineral/titanium,
@@ -3027,6 +3019,20 @@
 	temperature = 500
 	},
 /area/lavaland/surface/gulag_rock)
+"rD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Labor Camp Equipment Storage";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "rI" = (
 /obj/machinery/light_switch{
 	pixel_x = -24;
@@ -3255,6 +3261,14 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/mine/outpost/airlock)
+"sM" = (
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/door/airlock/titanium/glass{
+	name = "Labor Shuttle Airlock";
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/siberia)
 "sO" = (
 /turf/simulated/mineral/random/volcanic/labormineral,
 /area/lavaland/surface/gulag_rock)
@@ -3276,16 +3290,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/mine/outpost/hallway/west)
-"sT" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/maintenance/external/glass{
-	name = "Landing Pad"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/effect/turf_decal/tiles/department/security/mono,
-/turf/simulated/floor/plasteel/dark/full,
-/area/mine/laborcamp)
 "sU" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
@@ -3436,22 +3440,18 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/siberia)
-"tv" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/maintenance/external{
-	name = "Catwalk Access"
+"tt" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Airlock Maintence";
+	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/catwalk,
-/area/mine/outpost/engineering)
+/turf/simulated/floor/plating,
+/area/mine/outpost/airlock)
 "tw" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/poddoor/preopen{
@@ -3471,11 +3471,6 @@
 /obj/machinery/suit_storage_unit/gulag,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
-"tB" = (
-/obj/machinery/door/firedoor,
-/obj/effect/spawner/window/reinforced/plasma/grilled,
-/turf/simulated/floor/plating,
-/area/mine/outpost/cafeteria)
 "tC" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -3683,16 +3678,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
-"uy" = (
-/obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
-/obj/effect/spawner/random/dirt/maybe,
-/obj/machinery/door/airlock/maintenance/external/glass{
-	name = "Landing Pad"
-	},
-/turf/simulated/floor/catwalk,
-/area/mine/outpost/hallway/west)
 "uz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/baseturf_helper/lava_land,
@@ -3758,6 +3743,22 @@
 /obj/effect/mapping_helpers/turfs/rust/maybe,
 /turf/simulated/wall,
 /area/mine/outpost/lockers)
+"uS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/supply,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/door/airlock/engineering{
+	name = "Labor Camp Maintenance";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
+/area/mine/laborcamp)
 "uU" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/turf_decal/tiles/department/cargo/side{
@@ -3795,6 +3796,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/mine/outpost/production)
+"vh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/maintenance/external{
+	name = "Processing Room Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine/outpost/maintenance/south)
 "vi" = (
 /obj/structure/chair{
 	dir = 8
@@ -3898,19 +3915,6 @@
 /obj/structure/flora/ash/tall_shroom,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/gulag_rock)
-"vJ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Central Hallway Maintence"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
-/turf/simulated/floor/plating,
-/area/mine/outpost/hallway/west)
 "vL" = (
 /obj/structure/lattice/catwalk/mining,
 /turf/simulated/floor/lava/mapping_lava,
@@ -3942,16 +3946,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/mine/outpost/production)
-"vP" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/multi_tile/glass{
-	name = "Main Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/mine/outpost/airlock)
 "vR" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -4010,28 +4004,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/dark,
 /area/mine/outpost/hallway/west)
-"we" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Quartermaster's Office"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/supply/qm,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "mining qm"
-	},
-/obj/structure/sign/command/head{
-	pixel_x = 32
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/mine/outpost/quartermaster)
 "wf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4362,23 +4334,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/catwalk,
 /area/mine/outpost/storage)
-"xS" = (
-/obj/machinery/door/firedoor,
-/obj/effect/spawner/window/reinforced/plasma/grilled,
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plating,
-/area/mine/outpost/cafeteria)
-"xT" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Airlock Maintence"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/mine/outpost/airlock)
 "xU" = (
 /obj/effect/baseturf_helper/lava_land,
 /turf/simulated/floor/plasteel/dark,
@@ -4530,6 +4485,15 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/siberia)
+"yI" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Main Airlock"
+	},
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel/dark,
+/area/mine/outpost/airlock)
 "yL" = (
 /obj/structure/chair{
 	dir = 4
@@ -4547,6 +4511,19 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/mine/outpost/smith_workshop)
+"yP" = (
+/obj/machinery/door/airlock/glass{
+	name = "Construction Site";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/cap/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/mine/outpost/maintenance/south)
 "yR" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/railing{
@@ -4557,6 +4534,17 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
+"yS" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/maintenance/external/glass{
+	name = "Landing Pad";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/turf_decal/tiles/department/security/mono,
+/turf/simulated/floor/plasteel/dark/full,
+/area/mine/laborcamp)
 "yW" = (
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/mining)
@@ -4911,6 +4899,13 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/mine/laborcamp)
+"AW" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/spawner/window/reinforced/plasma/grilled,
+/turf/simulated/floor/plating,
+/area/mine/outpost/storage)
 "Ba" = (
 /obj/structure/sign/fire,
 /obj/effect/baseturf_helper/lava_land,
@@ -5006,22 +5001,6 @@
 	},
 /turf/simulated/floor/catwalk,
 /area/mine/laborcamp)
-"BG" = (
-/obj/machinery/door/airlock/maintenance/external{
-	name = "Processing Room"
-	},
-/obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
-/turf/simulated/floor/plating,
-/area/mine/outpost/production)
 "BJ" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/closet/crate/internals,
@@ -5090,11 +5069,6 @@
 "BW" = (
 /turf/simulated/mineral/random/high_chance/volcanic,
 /area/lavaland/surface/gulag_rock)
-"BY" = (
-/obj/machinery/door/firedoor,
-/obj/effect/spawner/window/reinforced/plasma/grilled,
-/turf/simulated/floor/plating,
-/area/mine/outpost/airlock)
 "BZ" = (
 /obj/effect/spawner/window/shuttle,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -5104,6 +5078,31 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/siberia)
+"Cc" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Quartermaster's Office";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/supply/qm,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "mining qm"
+	},
+/obj/structure/sign/command/head{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/mine/outpost/quartermaster)
 "Ch" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -5835,21 +5834,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
-"FT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/maintenance/external{
-	name = "Processing Room Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/mine/outpost/maintenance/south)
 "FU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6097,6 +6081,14 @@
 /obj/machinery/status_display,
 /turf/simulated/wall,
 /area/mine/outpost/mechbay)
+"Hg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock{
+	name = "Synthetic Toilet";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/mine/laborcamp)
 "Hh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -6195,19 +6187,27 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/mine/outpost/hallway/west)
-"HJ" = (
+"HM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/machinery/door/airlock/engineering{
-	name = "Labor Camp Maintenance"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/atmos{
+	name = "Life Support";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining_station,
 /turf/simulated/floor/catwalk,
-/area/mine/laborcamp)
+/area/mine/outpost/hallway/west)
 "HN" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/effect/mapping_helpers/no_lava,
@@ -6433,6 +6433,21 @@
 /obj/structure/sign/cargo/mining,
 /turf/simulated/floor/plating,
 /area/mine/outpost/hallway/west)
+"IW" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "EVA Storage";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
+/turf/simulated/floor/plasteel/dark,
+/area/mine/outpost/storage)
 "IZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7465,6 +7480,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine/laborcamp)
+"Oe" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/maintenance/external/glass{
+	name = "Landing Pad";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
+/obj/effect/spawner/random/dirt/maybe,
+/turf/simulated/floor/catwalk,
+/area/mine/outpost/hallway/west)
 "Oj" = (
 /obj/structure/table,
 /obj/item/toy/figure/crew/assistant,
@@ -7762,19 +7788,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/mine/outpost/hallway/east)
-"PZ" = (
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Labor Camp Security"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Labor";
-	name = "labor camp blast door"
-	},
-/obj/effect/turf_decal/tiles/department/security/mono,
-/turf/simulated/floor/plasteel/dark/full,
-/area/mine/laborcamp/security)
 "Qd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7838,20 +7851,6 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/lava/mapping_lava,
 /area/lavaland/surface/outdoors/outpost/catwalk)
-"Qq" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mining{
-	name = "Box Storage"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/mine/outpost/storage)
 "Qr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -7861,6 +7860,20 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/mine/outpost/smith_workshop)
+"Qs" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Infirmary";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/turf_decal/tiles/department/medical/checker,
+/turf/simulated/floor/plasteel/white,
+/area/mine/laborcamp)
 "Qt" = (
 /obj/machinery/access_button{
 	autolink_id = "labor_btn_ext";
@@ -8080,15 +8093,6 @@
 /obj/effect/spawner/random/dirt/maybe,
 /turf/simulated/floor/plating,
 /area/mine/outpost/maintenance/south)
-"Rq" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/maintenance/external/glass{
-	name = "Landing Pad"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/effect/turf_decal/tiles/department/security/mono,
-/turf/simulated/floor/plasteel/dark/full,
-/area/mine/laborcamp/security)
 "Rr" = (
 /obj/effect/turf_decal/tiles/dark/checker,
 /obj/machinery/light{
@@ -8512,6 +8516,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
+"Tq" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/spawner/window/reinforced/plasma/grilled,
+/turf/simulated/floor/plating,
+/area/mine/outpost/airlock)
 "Tr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -8647,13 +8658,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
-"Uh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock{
-	name = "Organic Toilet"
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/mine/laborcamp)
 "Un" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
@@ -8942,6 +8946,19 @@
 /obj/effect/turf_decal/box,
 /turf/simulated/floor/plasteel/dark,
 /area/mine/outpost/smith_workshop)
+"Wc" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Main Airlock";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/mine/outpost/airlock)
 "Wf" = (
 /obj/effect/turf_decal/tiles/department/cargo/side,
 /turf/simulated/floor/plasteel,
@@ -9007,6 +9024,17 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/engine/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
+"Wr" = (
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
+/obj/effect/spawner/random/dirt/maybe,
+/obj/machinery/door/airlock/maintenance/external/glass{
+	name = "Landing Pad";
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
+/area/mine/outpost/hallway/west)
 "Ws" = (
 /obj/structure/chair/stool/bar{
 	dir = 8
@@ -9180,6 +9208,18 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining_station,
 /turf/simulated/floor/plasteel/dark,
 /area/mine/outpost/medbay)
+"Xj" = (
+/obj/machinery/door/airlock/maintenance/external/glass{
+	name = "Catwalk Access";
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/mine/outpost/hallway/west)
 "Xm" = (
 /obj/machinery/light,
 /obj/machinery/economy/vending/cola,
@@ -9337,6 +9377,13 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
+"XV" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/spawner/window/reinforced/plasma/grilled,
+/turf/simulated/floor/plating,
+/area/mine/outpost/cafeteria)
 "XW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -9392,15 +9439,6 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/targetable)
-"Yf" = (
-/obj/machinery/door/airlock/maintenance/external/glass{
-	name = "Catwalk Access"
-	},
-/obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/mine/outpost/hallway/west)
 "Yh" = (
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/lava/mapping_lava,
@@ -9409,6 +9447,23 @@
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/mining)
+"Yj" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/mining{
+	name = "Box Storage";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/mine/outpost/storage)
 "Yk" = (
 /obj/structure/reagent_dispensers/oil,
 /obj/item/reagent_containers/drinks/oilcan,
@@ -9692,6 +9747,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
+"ZL" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/spawner/window/reinforced/plasma/grilled,
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plating,
+/area/mine/outpost/cafeteria)
 "ZM" = (
 /obj/structure/shuttle/engine/propulsion/burst,
 /turf/simulated/floor/plating/airless,
@@ -11128,7 +11191,7 @@ WB
 fD
 Qj
 gW
-nt
+sM
 fr
 qV
 GD
@@ -11774,13 +11837,13 @@ lR
 YN
 Sf
 Sf
-Rq
+ao
 tM
 IS
 ez
 PA
 qo
-sT
+yS
 Sf
 Ot
 HN
@@ -12588,7 +12651,7 @@ ou
 ln
 ln
 Fn
-PZ
+eV
 UI
 NL
 DP
@@ -12754,7 +12817,7 @@ Zj
 gm
 NY
 zj
-Uh
+lk
 gj
 tb
 EH
@@ -13078,7 +13141,7 @@ Jl
 RV
 na
 DP
-lX
+Hg
 Mv
 BT
 EH
@@ -13726,7 +13789,7 @@ wb
 Hh
 EG
 TU
-iW
+Qs
 PR
 qa
 eu
@@ -14361,7 +14424,7 @@ ux
 oG
 LN
 TU
-me
+rD
 XL
 cT
 TU
@@ -14697,7 +14760,7 @@ kd
 GJ
 iO
 vr
-HJ
+uS
 jO
 iZ
 jf
@@ -15042,9 +15105,9 @@ tL
 ZV
 ZV
 Hl
-dp
+Oe
 Qw
-uy
+Wr
 HT
 ZV
 ZV
@@ -16336,7 +16399,7 @@ ph
 QY
 vs
 No
-we
+Cc
 fX
 mt
 Up
@@ -16823,7 +16886,7 @@ MF
 DS
 HP
 Py
-dg
+HM
 Zb
 Sn
 rs
@@ -17140,7 +17203,7 @@ QZ
 Vx
 Vx
 Vx
-tv
+eC
 XX
 XN
 Uq
@@ -17165,7 +17228,7 @@ fR
 sp
 GL
 Mf
-Yf
+Xj
 vn
 Yr
 oO
@@ -17642,11 +17705,11 @@ oA
 mp
 Pj
 Rp
-FT
+vh
 Gr
 Gr
 Gr
-BG
+bX
 wf
 Cs
 Nm
@@ -17798,7 +17861,7 @@ Ag
 OE
 wd
 AK
-vJ
+be
 Rp
 VL
 GY
@@ -17948,7 +18011,7 @@ kC
 Yh
 Yh
 IJ
-tB
+XV
 zs
 hf
 SU
@@ -18110,7 +18173,7 @@ VM
 Yh
 Yh
 Yh
-tB
+XV
 uh
 Gb
 Vd
@@ -18272,7 +18335,7 @@ dd
 IJ
 Yh
 Yh
-tB
+XV
 VH
 Gb
 lf
@@ -18440,7 +18503,7 @@ Ox
 xn
 Bm
 Ei
-qU
+ap
 Ld
 LL
 Xs
@@ -18596,7 +18659,7 @@ dd
 Yh
 fw
 Yh
-tB
+XV
 yL
 Sl
 Jz
@@ -18617,7 +18680,7 @@ Kn
 XF
 nr
 bT
-aj
+dD
 mN
 rp
 Yr
@@ -18758,7 +18821,7 @@ VM
 Yh
 Yh
 IJ
-xS
+ZL
 uh
 gU
 Ku
@@ -18920,7 +18983,7 @@ Qu
 Mi
 Yh
 Yh
-tB
+XV
 vi
 Gb
 fl
@@ -19238,7 +19301,7 @@ IJ
 Yh
 Yh
 Yh
-pA
+AW
 Yl
 vE
 ww
@@ -19262,7 +19325,7 @@ Ra
 Xo
 dv
 vV
-cw
+yP
 IF
 bT
 sC
@@ -19400,7 +19463,7 @@ Yh
 Yh
 Yh
 IJ
-pA
+AW
 TG
 ut
 QO
@@ -19567,7 +19630,7 @@ kH
 WR
 zE
 Ym
-oC
+IW
 dQ
 wr
 LT
@@ -19724,7 +19787,7 @@ Yh
 Yh
 Yr
 Yr
-pA
+AW
 TG
 zI
 cQ
@@ -19737,7 +19800,7 @@ GP
 kT
 CJ
 hA
-gS
+lO
 Pn
 qf
 Gf
@@ -19886,7 +19949,7 @@ IJ
 Yr
 Yr
 Yr
-pA
+AW
 nx
 Fi
 JI
@@ -20056,7 +20119,7 @@ pW
 dk
 sH
 IE
-xT
+tt
 jZ
 wP
 hA
@@ -20376,14 +20439,14 @@ pW
 LQ
 Kp
 uF
-Qq
+Yj
 Zy
 ZH
 tq
-vP
+Wc
 RA
 RF
-BY
+Tq
 Yr
 sm
 IJ
@@ -20542,10 +20605,10 @@ pW
 SR
 jn
 lt
-jw
+dK
 qB
 Gg
-BY
+Tq
 IJ
 IJ
 IJ
@@ -20706,7 +20769,7 @@ dk
 dk
 dk
 py
-jQ
+yI
 dk
 IJ
 IJ

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
@@ -61,6 +61,13 @@
 	},
 /turf/simulated/floor/mineral/silver/lavaland_air,
 /area/ruin/powered/pride)
+"o" = (
+/obj/machinery/door/airlock/diamond{
+	dir = 4
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/simulated/floor/mineral/silver/lavaland_air,
+/area/ruin/powered/pride)
 "r" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/mineral/silver/lavaland_air,
@@ -75,11 +82,6 @@
 "P" = (
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"Y" = (
-/obj/machinery/door/airlock/diamond,
-/obj/structure/fans/tiny/invisible,
-/turf/simulated/floor/mineral/silver/lavaland_air,
-/area/ruin/powered/pride)
 
 (1,1,1) = {"
 P
@@ -209,7 +211,7 @@ g
 g
 g
 g
-Y
+o
 P
 P
 "}

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -163,6 +163,12 @@
 /obj/item/book/manual/wiki/hydroponics,
 /turf/simulated/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
+"pA" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/ruin/powered/seedvault)
 "qI" = (
 /obj/machinery/smartfridge,
 /turf/simulated/floor/plasteel/freezer,
@@ -689,14 +695,14 @@ no
 Pg
 vt
 vt
-Bf
+pA
 vt
 no
 Bf
 Bf
 no
 vt
-Bf
+pA
 vt
 vt
 AG
@@ -949,14 +955,14 @@ no
 vJ
 vt
 vt
-Bf
+pA
 vt
 vt
 ZQ
 oy
 vt
 vt
-Bf
+pA
 vt
 vt
 iV

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_survivalpod.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_survivalpod.dmm
@@ -94,12 +94,6 @@
 /obj/effect/decal/cleanable/blood/tracks/mapped,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"t" = (
-/obj/machinery/door/airlock/survival_pod/glass,
-/obj/effect/decal/cleanable/blood/tracks/mapped,
-/obj/structure/fans/tiny,
-/turf/simulated/floor/pod/dark,
-/area/ruin/powered)
 "v" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood,
@@ -127,6 +121,14 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"W" = (
+/obj/machinery/door/airlock/survival_pod/glass{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/tracks/mapped,
+/obj/structure/fans/tiny,
+/turf/simulated/floor/pod/dark,
+/area/ruin/powered)
 
 (1,1,1) = {"
 a
@@ -188,7 +190,7 @@ d
 g
 l
 q
-t
+W
 v
 b
 b

--- a/_maps/map_files/RandomRuins/SpaceRuins/abandoned_engi_sat.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/abandoned_engi_sat.dmm
@@ -281,15 +281,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/abandoned_engi_sat)
-"iO" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/external/glass{
-	name = "Engineering Dock Airlock";
-	id_tag = "engineering_away"
+"hW" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Construction Area";
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/abandoned_engi_sat)
+"ir" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/turf/simulated/floor/plasteel,
 /area/ruin/space/abandoned_engi_sat)
 "iV" = (
 /obj/effect/mapping_helpers/turfs/rust/maybe,
@@ -423,6 +429,17 @@
 	icon_state = "4-8"
 	},
 /turf/template_noop,
+/area/ruin/space/abandoned_engi_sat)
+"lH" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external/glass{
+	name = "Engineering Dock Airlock";
+	id_tag = "engineering_away";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/turf/simulated/floor/plating,
 /area/ruin/space/abandoned_engi_sat)
 "lQ" = (
 /obj/machinery/driver_button{
@@ -773,12 +790,6 @@
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
 /area/ruin/space/abandoned_engi_sat)
-"yj" = (
-/obj/machinery/door/airlock{
-	name = "Restroom"
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/space/abandoned_engi_sat)
 "yq" = (
 /obj/item/shard{
 	icon_state = "small";
@@ -812,6 +823,14 @@
 "yJ" = (
 /obj/structure/lattice,
 /turf/template_noop,
+/area/ruin/space/abandoned_engi_sat)
+"yL" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/turf/simulated/floor/plating,
 /area/ruin/space/abandoned_engi_sat)
 "zb" = (
 /obj/item/radio/intercom{
@@ -987,13 +1006,6 @@
 /mob/living/basic/mining/hivelord/space,
 /turf/simulated/floor/carpet/airless,
 /area/ruin/space/abandoned_engi_sat)
-"FQ" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Construction Area"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/space/abandoned_engi_sat)
 "Gg" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -1059,6 +1071,13 @@
 	amount = 50
 	},
 /obj/item/flashlight/flare,
+/turf/simulated/floor/plasteel,
+/area/ruin/space/abandoned_engi_sat)
+"Ix" = (
+/obj/machinery/door/airlock{
+	name = "Restroom";
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/abandoned_engi_sat)
 "Iz" = (
@@ -1345,13 +1364,6 @@
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/abandoned_engi_sat)
-"Vn" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/turf/simulated/floor/plating,
-/area/ruin/space/abandoned_engi_sat)
 "Vt" = (
 /obj/item/stack/rods{
 	icon_state = "rods-1"
@@ -1402,6 +1414,13 @@
 /mob/living/basic/mining/hivelord/space,
 /turf/simulated/floor/plating,
 /area/ruin/space/abandoned_engi_sat)
+"Xz" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/abandoned_engi_sat)
 "XP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -1422,11 +1441,6 @@
 /obj/structure/marker_beacon/dock_marker,
 /turf/template_noop,
 /area/space/nearstation)
-"YE" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/space/abandoned_engi_sat)
 "YG" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -1857,7 +1871,7 @@ hR
 Sa
 si
 et
-yj
+Ix
 Tw
 Tw
 HK
@@ -2021,7 +2035,7 @@ Gg
 wl
 kZ
 Tw
-YE
+Xz
 jG
 Xq
 XP
@@ -2030,15 +2044,15 @@ fA
 fA
 fA
 Ud
-Vn
+yL
 gC
 zb
 fA
 SI
-iO
+lH
 et
 yE
-iO
+lH
 LP
 "}
 (17,1,1) = {"
@@ -2064,7 +2078,7 @@ XP
 es
 et
 kd
-Kj
+ir
 QK
 bE
 CY
@@ -2321,7 +2335,7 @@ LP
 qu
 sY
 Tw
-FQ
+hW
 fA
 fA
 fA

--- a/_maps/map_files/RandomRuins/SpaceRuins/abandoned_sec_shuttle.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/abandoned_sec_shuttle.dmm
@@ -53,6 +53,15 @@
 	},
 /turf/simulated/floor/plasteel/dark/airless,
 /area/ruin/space/sec_shuttle)
+"k" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/specops,
+/obj/machinery/door/airlock/external{
+	id_tag = "s_docking_airlock";
+	name = "Shuttle Hatch";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark/airless,
+/area/ruin/space/sec_shuttle)
 "m" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood,
@@ -254,7 +263,7 @@ z
 z
 z
 z
-c
+k
 H
 H
 w

--- a/_maps/map_files/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -170,16 +170,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass,
 /area/ruin/space/unpowered)
-"aD" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/highsecurity{
-	name = "Bio Containment"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/research,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/space/unpowered)
 "aE" = (
 /obj/machinery/shieldwallgen{
 	activated = 1;
@@ -562,10 +552,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall/r_wall,
 /area/ruin/space/unpowered)
-"bG" = (
-/obj/machinery/door/airlock/external,
-/turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
 "bH" = (
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/plating,
@@ -667,6 +653,23 @@
 /obj/structure/alien/weeds,
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/unpowered)
+"UD" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/space/unpowered)
+"Wk" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "Bio Containment";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/research,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/unpowered)
 
 (1,1,1) = {"
 aa
@@ -744,14 +747,14 @@ ah
 ap
 ai
 ai
-aD
+Wk
 aL
 aR
 aL
 aL
 aR
 aL
-aD
+Wk
 bv
 bv
 bJ
@@ -891,9 +894,9 @@ ay
 ay
 aH
 ay
-bG
+UD
 bL
-bG
+UD
 aa
 aa
 aa
@@ -914,9 +917,9 @@ ay
 ay
 bq
 ay
-bG
+UD
 bM
-bG
+UD
 aa
 aa
 aa
@@ -1043,14 +1046,14 @@ an
 aq
 au
 am
-aD
+Wk
 aL
 ba
 aL
 aL
 ba
 aL
-aD
+Wk
 bD
 Qh
 ov

--- a/_maps/map_files/RandomRuins/SpaceRuins/alien_cache_site.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/alien_cache_site.dmm
@@ -29,11 +29,6 @@
 /obj/item/weldingtool/largetank,
 /turf/simulated/floor/plating/abductor,
 /area/ruin/space/powered/alien_cache_site)
-"fA" = (
-/obj/structure/fans/tiny/invisible,
-/obj/machinery/door/airlock/abductor/secure,
-/turf/simulated/floor/plating/abductor,
-/area/ruin/space/powered/alien_cache_site)
 "gf" = (
 /obj/effect/spawner/random/glowstick,
 /obj/structure/table/abductor,
@@ -115,6 +110,13 @@
 "Ha" = (
 /turf/simulated/wall/indestructible/abductor,
 /area/ruin/space/powered/alien_cache_site/cache_room)
+"IP" = (
+/obj/structure/fans/tiny/invisible,
+/obj/machinery/door/airlock/abductor/secure{
+	dir = 4
+	},
+/turf/simulated/floor/plating/abductor,
+/area/ruin/space/powered/alien_cache_site)
 "JC" = (
 /obj/structure/curtain/open,
 /turf/simulated/floor/plating/abductor,
@@ -125,13 +127,15 @@
 	desc = "Effectively impervious to conventional methods of destruction. It looks like someone tried to break it, but failed"
 	},
 /area/ruin/space/powered/alien_cache_site)
-"TW" = (
-/turf/simulated/wall/mineral/wood,
-/area/ruin/space/powered/alien_cache_site)
-"Yg" = (
-/obj/machinery/door/airlock/abductor,
+"PB" = (
+/obj/machinery/door/airlock/abductor{
+	dir = 4
+	},
 /obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/plating/abductor,
+/area/ruin/space/powered/alien_cache_site)
+"TW" = (
+/turf/simulated/wall/mineral/wood,
 /area/ruin/space/powered/alien_cache_site)
 "YA" = (
 /obj/effect/spawner/random/engineering/toolbox,
@@ -664,7 +668,7 @@ et
 et
 et
 et
-fA
+IP
 wy
 wy
 wy
@@ -674,7 +678,7 @@ wy
 wy
 kY
 wy
-Yg
+PB
 mQ
 mQ
 mQ

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroid4.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroid4.dmm
@@ -44,18 +44,19 @@
 /obj/structure/shuttle/engine/propulsion/burst,
 /turf/simulated/wall/mineral/titanium,
 /area/ruin/space/unpowered)
-"m" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Escape Pod Airlock"
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/ruin/space/unpowered)
 "p" = (
 /obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
 "Q" = (
 /turf/simulated/mineral/random/low_chance/space,
+/area/ruin/space/unpowered)
+"Y" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod Airlock";
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium/blue,
 /area/ruin/space/unpowered)
 "Z" = (
 /obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
@@ -344,7 +345,7 @@ e
 h
 j
 k
-m
+Y
 a
 a
 "}

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroid8.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroid8.dmm
@@ -19,14 +19,6 @@
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/ruin/space/unpowered)
-"f" = (
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock";
-	name = "Escape Pod Hatch"
-	},
-/obj/effect/mapping_helpers/turfs/damage,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/ruin/space/unpowered)
 "l" = (
 /turf/simulated/mineral,
 /area/ruin/space/unpowered)
@@ -95,6 +87,15 @@
 /obj/structure/computerframe,
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plating,
+/area/ruin/space/unpowered)
+"P" = (
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock";
+	name = "Escape Pod Hatch";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/turfs/damage,
+/turf/simulated/floor/mineral/titanium/blue,
 /area/ruin/space/unpowered)
 "R" = (
 /turf/simulated/floor/plating/asteroid/airless,
@@ -322,7 +323,7 @@ l
 O
 D
 c
-f
+P
 R
 R
 R

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroidmine_drakehounds.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroidmine_drakehounds.dmm
@@ -22,14 +22,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/drakehound_mine/hallway_south)
-"aB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/command/glass,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/airless,
-/area/ruin/drakehound_mine/bridge)
 "bh" = (
 /obj/machinery/light{
 	dir = 8
@@ -116,13 +108,6 @@
 "dE" = (
 /turf/simulated/floor/plasteel,
 /area/ruin/drakehound_mine/hallway_north)
-"dM" = (
-/obj/machinery/door/airlock/survival_pod{
-	locked = 1
-	},
-/obj/machinery/door/poddoor,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/drakehound_mine/ship)
 "dS" = (
 /turf/simulated/floor/plasteel,
 /area/ruin/drakehound_mine/hallway_south)
@@ -418,10 +403,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/drakehound_mine/bar)
-"kN" = (
-/obj/machinery/door/airlock/command/glass,
-/turf/simulated/floor/plasteel,
-/area/ruin/drakehound_mine/bridge)
 "kQ" = (
 /obj/machinery/light{
 	dir = 4
@@ -472,6 +453,13 @@
 	},
 /turf/space,
 /area/ruin/drakehound_mine/solars)
+"lY" = (
+/obj/machinery/door/airlock/maintenance/external{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/plating,
+/area/ruin/drakehound_mine/hallway_south)
 "mh" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
@@ -678,6 +666,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/drakehound_mine/bar)
+"rb" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/drakehound_mine/hallway_north)
 "re" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel/dark,
@@ -758,11 +752,6 @@
 	},
 /turf/space,
 /area/ruin/drakehound_mine/solars)
-"th" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/ruin/drakehound_mine/hallway_south)
 "ti" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
@@ -995,6 +984,19 @@
 	},
 /turf/space,
 /area/ruin/drakehound_mine/solars)
+"BM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/multi_tile/glass,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/drakehound_mine/arrivals)
 "BV" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -1082,13 +1084,6 @@
 "DV" = (
 /turf/simulated/mineral/ancient,
 /area/ruin/drakehound_mine/hallway_north)
-"DZ" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/drakehound_mine/hallway_south)
 "Ef" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -1164,11 +1159,16 @@
 /obj/machinery/power/smes/engineering,
 /turf/simulated/floor/plasteel,
 /area/ruin/drakehound_mine/hallway_south)
-"FZ" = (
-/obj/machinery/door/airlock/maintenance/external,
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plating,
-/area/ruin/drakehound_mine/hallway_south)
+"Gs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/command/glass{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/airless,
+/area/ruin/drakehound_mine/bridge)
 "GE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1275,6 +1275,22 @@
 "Kx" = (
 /turf/simulated/wall/mineral/titanium/survival/pod,
 /area/ruin/drakehound_mine/ship)
+"Lj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/drakehound_mine/hallway_south)
+"Lk" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/drakehound_mine/hallway_south)
 "Lm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1356,10 +1372,6 @@
 "NT" = (
 /turf/simulated/floor/pod/dark,
 /area/ruin/drakehound_mine/ship)
-"Oa" = (
-/obj/machinery/door/airlock/multi_tile/glass,
-/turf/simulated/floor/plasteel,
-/area/ruin/drakehound_mine/hallway_north)
 "Oh" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -1385,11 +1397,6 @@
 /obj/item/flashlight/lantern,
 /turf/simulated/floor/plating/asteroid,
 /area/ruin/space/unpowered)
-"OS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/multi_tile/glass,
-/turf/simulated/floor/plasteel,
-/area/ruin/drakehound_mine/hallway_south)
 "Pm" = (
 /turf/simulated/mineral/random/space,
 /area/ruin/drakehound_mine/bar)
@@ -1455,6 +1462,14 @@
 /obj/structure/foamedmetal,
 /turf/simulated/floor/plating/asteroid,
 /area/ruin/space/unpowered)
+"QO" = (
+/obj/machinery/door/airlock/survival_pod{
+	locked = 1;
+	dir = 4
+	},
+/obj/machinery/door/poddoor,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/drakehound_mine/ship)
 "Ro" = (
 /turf/simulated/floor/plating/asteroid,
 /area/ruin/space/unpowered)
@@ -1495,21 +1510,6 @@
 	},
 /turf/simulated/floor/mineral/plastitanium,
 /area/ruin/drakehound_mine/ship)
-"Tf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/drakehound_mine/arrivals)
 "Tk" = (
 /turf/simulated/mineral/ancient,
 /area/ruin/drakehound_mine/hallway_south)
@@ -1539,6 +1539,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/drakehound_mine/mechbay)
+"TS" = (
+/obj/machinery/door/airlock/command/glass{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/drakehound_mine/bridge)
 "TZ" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
@@ -1705,6 +1711,13 @@
 /obj/effect/spawner/random/blood,
 /turf/simulated/floor/plasteel,
 /area/ruin/drakehound_mine/bar)
+"Zg" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/ruin/drakehound_mine/hallway_south)
 "Zx" = (
 /obj/structure/rack,
 /obj/item/pickaxe/gold,
@@ -2334,7 +2347,7 @@ fV
 mr
 ee
 ii
-FZ
+lY
 Ro
 Ro
 Ro
@@ -2396,7 +2409,7 @@ vo
 mr
 ii
 ii
-FZ
+lY
 Ro
 Ro
 Ro
@@ -2505,14 +2518,14 @@ jg
 rw
 rw
 FK
-Oa
+rb
 rf
 Cq
 dE
 dE
 dE
 rw
-OS
+Lj
 gG
 XX
 Qx
@@ -2827,7 +2840,7 @@ wl
 mE
 mG
 NP
-kN
+TS
 az
 dS
 tV
@@ -2889,7 +2902,7 @@ mE
 EO
 mE
 qV
-aB
+Gs
 Xd
 ii
 tV
@@ -3151,7 +3164,7 @@ FB
 mr
 lw
 Ot
-th
+Zg
 cb
 dl
 PF
@@ -3272,7 +3285,7 @@ rI
 FB
 FQ
 fX
-DZ
+Lk
 TH
 mC
 mr
@@ -3336,7 +3349,7 @@ FB
 ga
 FB
 uU
-Tf
+BM
 ZC
 Oh
 DA
@@ -3564,7 +3577,7 @@ Xf
 Xf
 oK
 Ss
-dM
+QO
 jJ
 kr
 Kx
@@ -3572,7 +3585,7 @@ Zx
 Kx
 kr
 VB
-dM
+QO
 Ss
 Ss
 Ss

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroidmine_pirates.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroidmine_pirates.dmm
@@ -50,11 +50,6 @@
 	},
 /turf/simulated/floor/plating/asteroid,
 /area/ruin/space/unpowered)
-"m" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/ruin/space/powered)
 "n" = (
 /turf/simulated/mineral/random/low_chance/space,
 /area/ruin/space/unpowered)
@@ -237,6 +232,13 @@
 /area/ruin/space/unpowered)
 "X" = (
 /obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/ruin/space/powered)
+"Z" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/powered)
 
@@ -733,7 +735,7 @@ X
 j
 x
 P
-m
+Z
 o
 p
 n

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroidmine_skullakin.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroidmine_skullakin.dmm
@@ -183,18 +183,6 @@
 "dy" = (
 /turf/simulated/floor/plasteel,
 /area/ruin/skullakin_mine/mining)
-"dz" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/ruin/skullakin_mine/temple)
 "dD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -218,6 +206,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/ruin/skullakin_mine/temple)
+"et" = (
+/obj/machinery/door/airlock/multi_tile/glass,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/multi_tile/impassable{
+	dir = 4;
+	id_tag = "skullakin_mine_depths_lockdown"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/engine,
+/area/ruin/skullakin_mine/cafeteria)
 "ey" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/cable{
@@ -243,34 +249,6 @@
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/skullakin_mine/mission_control)
-"eT" = (
-/obj/machinery/door/airlock/multi_tile,
-/obj/machinery/door/poddoor/multi_tile/impassable{
-	id_tag = "skullakin_mine_depths_lockdown"
-	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/engine,
-/area/ruin/skullakin_mine/mining)
-"eV" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/multi_tile/impassable{
-	dir = 4;
-	id_tag = "skullakin_mine_intermediate_lockdown"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/engine,
-/area/ruin/skullakin_mine/overseer)
 "eX" = (
 /obj/machinery/light{
 	dir = 1
@@ -335,25 +313,6 @@
 /obj/machinery/economy/vending/wallmed/directional/south,
 /turf/simulated/floor/mineral/plastitanium,
 /area/ruin/skullakin_mine/arrivals)
-"gr" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/multi_tile/impassable{
-	dir = 4;
-	id_tag = "skullakin_mine_intermediate_lockdown"
-	},
-/turf/simulated/floor/engine,
-/area/ruin/skullakin_mine/cafeteria)
 "gt" = (
 /obj/machinery/power/apc/off_station/empty_charge/directional/east,
 /obj/structure/cable,
@@ -400,6 +359,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/ruin/skullakin_mine/cafeteria)
+"ha" = (
+/obj/machinery/door/airlock/multi_tile/glass,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/multi_tile/impassable{
+	dir = 4;
+	id_tag = "skullakin_mine_intermediate_lockdown"
+	},
+/turf/simulated/floor/engine,
+/area/ruin/skullakin_mine/cafeteria)
 "hc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
@@ -436,6 +412,14 @@
 /obj/structure/spider/stickyweb,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/skullakin_mine/mission_control)
+"hk" = (
+/obj/machinery/door/airlock/security{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/mineral/plastitanium,
+/area/ruin/skullakin_mine/arrivals)
 "hn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -459,6 +443,21 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin)
 "hF" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/engine,
+/area/ruin/skullakin_mine/cafeteria)
+"hQ" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/poddoor/multi_tile/impassable{
+	id_tag = "skullakin_mine_intermediate_lockdown"
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/engine,
 /area/ruin/skullakin_mine/cafeteria)
@@ -695,6 +694,16 @@
 "nw" = (
 /turf/simulated/floor/plasteel,
 /area/ruin/skullakin_mine/cafeteria)
+"nC" = (
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/plating{
+	desc = "<br>There is some old writing on this floor. You are barely able to read out a few lines from a tangled scribble.<br><br>In a chamber a great mirror lies, cut away it solemn cries. Travel bold as thou might, piercing vastness as a kite.<br><br>HONK!<br>";
+	name = "Old Note #6"
+	},
+/area/ruin/skullakin_mine/arrivals)
 "nD" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plasteel/dark,
@@ -763,26 +772,6 @@
 /obj/effect/decal/cleanable/glass/plasma,
 /turf/simulated/floor/plasteel,
 /area/ruin/skullakin_mine/arrivals)
-"pB" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/multi_tile/impassable{
-	dir = 4;
-	id_tag = "skullakin_mine_depths_lockdown"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/engine,
-/area/ruin/skullakin_mine/cafeteria)
 "pI" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/cable{
@@ -919,25 +908,6 @@
 /obj/effect/spawner/random/cobweb/right/frequent,
 /turf/simulated/floor/plasteel,
 /area/ruin/skullakin_mine/mission_control)
-"rH" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/multi_tile/impassable{
-	dir = 4;
-	id_tag = "skullakin_mine_depths_lockdown"
-	},
-/turf/simulated/floor/engine,
-/area/ruin/skullakin_mine/mission_control)
 "rV" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -1009,22 +979,6 @@
 /obj/effect/spawner/airlock/w_to_e,
 /turf/simulated/wall,
 /area/ruin/skullakin_mine/arrivals)
-"tC" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/engine,
-/area/ruin/skullakin_mine/mission_control)
 "tD" = (
 /obj/structure/spider/stickyweb,
 /turf/simulated/floor/mineral/plasma,
@@ -1128,18 +1082,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/skullakin_mine/mission_control)
-"vW" = (
-/obj/machinery/door/poddoor/multi_tile/impassable{
-	id_tag = "skullakin_mine_intermediate_lockdown"
-	},
-/obj/machinery/door/airlock/multi_tile/glass,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/engine,
-/area/ruin/skullakin_mine/temple)
 "wb" = (
 /obj/effect/gibspawner/generic,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1230,6 +1172,20 @@
 	},
 /turf/simulated/floor/carpet/royalblack,
 /area/ruin/skullakin_mine/temple)
+"yi" = (
+/obj/machinery/door/airlock/multi_tile/glass,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/engine,
+/area/ruin/skullakin_mine/mining)
 "yn" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -1256,6 +1212,20 @@
 	name = "Old Note #6"
 	},
 /area/ruin/skullakin_mine/cafeteria)
+"yQ" = (
+/obj/machinery/door/poddoor/multi_tile/impassable{
+	id_tag = "skullakin_mine_intermediate_lockdown"
+	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/engine,
+/area/ruin/skullakin_mine/temple)
 "yT" = (
 /obj/structure/ore_box,
 /turf/simulated/floor/plasteel,
@@ -1492,6 +1462,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/mineral/plastitanium,
 /area/ruin/skullakin_mine/temple)
+"CH" = (
+/obj/machinery/door/airlock/engineering{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/engine,
+/area/ruin/skullakin_mine/temple)
 "CN" = (
 /turf/space,
 /area/space)
@@ -1611,12 +1591,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/skullakin_mine/cafeteria)
-"Gw" = (
-/obj/machinery/door/airlock/security,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/mineral/plastitanium,
-/area/ruin/skullakin_mine/arrivals)
 "GA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -1679,6 +1653,20 @@
 	name = "Old Note #6"
 	},
 /area/ruin/skullakin_mine/arrivals)
+"HZ" = (
+/obj/machinery/door/airlock/multi_tile/glass,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/engine,
+/area/ruin/skullakin_mine/mission_control)
 "Ia" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1732,6 +1720,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/engine,
 /area/ruin/skullakin_mine/mining)
+"IB" = (
+/obj/machinery/door/airlock/multi_tile/glass,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/ruin/skullakin_mine/temple)
 "IC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1912,6 +1910,16 @@
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plasteel,
 /area/ruin/skullakin_mine/temple)
+"LV" = (
+/obj/machinery/door/airlock/multi_tile{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/multi_tile/impassable{
+	id_tag = "skullakin_mine_depths_lockdown"
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/engine,
+/area/ruin/skullakin_mine/mining)
 "MK" = (
 /obj/structure/table/glass,
 /obj/effect/spawner/random/plushies,
@@ -1925,6 +1933,24 @@
 /obj/machinery/economy/vending/minedrobe,
 /turf/simulated/floor/plasteel,
 /area/ruin/skullakin_mine/mining)
+"Nd" = (
+/obj/machinery/door/airlock/multi_tile/glass,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/multi_tile/impassable{
+	dir = 4;
+	id_tag = "skullakin_mine_intermediate_lockdown"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/engine,
+/area/ruin/skullakin_mine/overseer)
 "Nj" = (
 /obj/effect/decal/cleanable/glass/plasma,
 /obj/effect/decal/cleanable/dirt,
@@ -1979,22 +2005,6 @@
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plasteel,
 /area/ruin/skullakin_mine/arrivals)
-"Oo" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/engine,
-/area/ruin/skullakin_mine/mining)
 "Ov" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -2076,14 +2086,6 @@
 /obj/machinery/economy/vending/coffee,
 /turf/simulated/floor/plasteel,
 /area/ruin/skullakin_mine/cafeteria)
-"PQ" = (
-/obj/machinery/door/airlock/engineering,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/engine,
-/area/ruin/skullakin_mine/temple)
 "Qk" = (
 /turf/simulated/floor/mineral/plasma,
 /area/ruin/skullakin_mine/temple)
@@ -2096,6 +2098,23 @@
 /obj/structure/lattice,
 /turf/space,
 /area/ruin/skullakin_mine/solars)
+"QO" = (
+/obj/machinery/door/airlock/multi_tile/glass,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/multi_tile/impassable{
+	dir = 4;
+	id_tag = "skullakin_mine_depths_lockdown"
+	},
+/turf/simulated/floor/engine,
+/area/ruin/skullakin_mine/mission_control)
 "QV" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -2120,19 +2139,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/ruin/skullakin_mine/mining)
-"Rn" = (
-/obj/machinery/door/airlock/multi_tile/glass,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/poddoor/multi_tile/impassable{
-	id_tag = "skullakin_mine_intermediate_lockdown"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/engine,
-/area/ruin/skullakin_mine/cafeteria)
 "Rs" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/mineral/plastitanium,
@@ -2505,14 +2511,6 @@
 /obj/structure/spider/stickyweb,
 /turf/simulated/floor/plasteel,
 /area/ruin/skullakin_mine/mining)
-"XB" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plating{
-	desc = "<br>There is some old writing on this floor. You are barely able to read out a few lines from a tangled scribble.<br><br>In a chamber a great mirror lies, cut away it solemn cries. Travel bold as thou might, piercing vastness as a kite.<br><br>HONK!<br>";
-	name = "Old Note #6"
-	},
-/area/ruin/skullakin_mine/arrivals)
 "XI" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -3084,7 +3082,7 @@ gc
 AD
 dG
 lC
-eT
+LV
 zH
 zf
 zf
@@ -3266,7 +3264,7 @@ Ho
 Ho
 Ho
 kx
-Oo
+yi
 Ho
 Ho
 Ho
@@ -3548,7 +3546,7 @@ rf
 rf
 zy
 eZ
-tC
+HZ
 zy
 zy
 zy
@@ -3833,7 +3831,7 @@ zy
 zy
 zy
 eZ
-rH
+QO
 zy
 zy
 zy
@@ -3852,7 +3850,7 @@ sR
 Sb
 eX
 uM
-XB
+nC
 CN
 CN
 CN
@@ -3899,7 +3897,7 @@ Ol
 Sb
 Za
 uM
-XB
+nC
 CN
 CN
 CN
@@ -4115,7 +4113,7 @@ AP
 AP
 AP
 Wd
-pB
+et
 AP
 AP
 CN
@@ -4222,7 +4220,7 @@ jo
 jy
 Za
 VR
-Gw
+hk
 wG
 gi
 Sb
@@ -4268,7 +4266,7 @@ mt
 mt
 mt
 Ta
-dz
+IB
 mt
 mt
 jo
@@ -4352,13 +4350,13 @@ nD
 HG
 HG
 ff
-Rn
+hQ
 Xi
 Fg
 IN
 xN
 hf
-vW
+yQ
 LK
 Cr
 ZX
@@ -4599,7 +4597,7 @@ xG
 SC
 pR
 TT
-PQ
+CH
 Uw
 sk
 Pq
@@ -4629,7 +4627,7 @@ cz
 Ft
 AP
 hF
-gr
+ha
 AP
 pd
 pd
@@ -4911,7 +4909,7 @@ mT
 mT
 mT
 IW
-eV
+Nd
 mT
 mT
 mT

--- a/_maps/map_files/RandomRuins/SpaceRuins/blowntcommsat.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/blowntcommsat.dmm
@@ -403,8 +403,10 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/tcommsat)
-"Av" = (
-/obj/machinery/door/airlock/external,
+"AA" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/tcommsat)
 "AV" = (
@@ -419,12 +421,6 @@
 "BD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/tcommsat)
-"Cq" = (
-/obj/machinery/door/airlock/hatch/syndicate{
-	locked = 1
-	},
-/turf/simulated/floor/plating/airless,
 /area/ruin/space/tcommsat)
 "CC" = (
 /obj/structure/window/reinforced{
@@ -482,6 +478,12 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
+/area/ruin/space/tcommsat)
+"GT" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
 /area/ruin/space/tcommsat)
 "GV" = (
 /obj/structure/door_assembly/door_assembly_hatch,
@@ -597,6 +599,13 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
+"NS" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	locked = 1;
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/tcommsat)
 "Or" = (
 /obj/machinery/door/airlock/hatch,
 /turf/simulated/floor/plating/airless,
@@ -1287,7 +1296,7 @@ kx
 ot
 nk
 sb
-Cq
+NS
 Sp
 Wc
 jk
@@ -1452,7 +1461,7 @@ wO
 KH
 Ac
 rc
-Cq
+NS
 Wc
 Wc
 Wc
@@ -1461,7 +1470,7 @@ Is
 Sp
 Wc
 Wc
-Or
+AA
 Pn
 FK
 al
@@ -2030,14 +2039,14 @@ my
 fI
 rc
 rc
-Or
+AA
 eu
 BD
 mL
 mL
 mL
 Yt
-Av
+GT
 Ua
 Vf
 nX
@@ -2228,7 +2237,7 @@ Go
 yM
 Wc
 Wc
-Cq
+NS
 UC
 rc
 rc
@@ -2572,7 +2581,7 @@ wO
 HW
 fh
 rc
-Cq
+NS
 ii
 Is
 gg

--- a/_maps/map_files/RandomRuins/SpaceRuins/casino.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/casino.dmm
@@ -80,10 +80,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/ruin/space/powered/casino/kitchen)
-"bJ" = (
-/obj/machinery/door/airlock,
-/turf/simulated/floor/plasteel/freezer,
-/area/ruin/space/powered/casino/hall)
 "bR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -431,6 +427,12 @@
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/powered/casino/arrivals)
+"lc" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ruin/space/powered/casino/floor)
 "lj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -500,10 +502,6 @@
 /obj/structure/table/wood/poker,
 /turf/simulated/floor/carpet/black,
 /area/ruin/space/powered/casino/floor)
-"mP" = (
-/obj/machinery/door/airlock/multi_tile/glass,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/space/powered/casino/arrivals)
 "mW" = (
 /obj/effect/mapping_helpers/turfs/rust/maybe,
 /turf/simulated/wall,
@@ -643,6 +641,12 @@
 /obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
 /turf/simulated/floor/plating,
 /area/ruin/space/powered/casino/maints)
+"ri" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ruin/space/powered/casino/maints)
 "rp" = (
 /obj/machinery/economy/vending/dinnerware,
 /turf/simulated/floor/plating,
@@ -651,6 +655,12 @@
 /obj/machinery/door/airlock/hatch,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/ruin/space/powered/casino/docked_ships)
+"rM" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/powered/casino/arrivals)
 "sx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -917,10 +927,6 @@
 "zX" = (
 /turf/simulated/floor/mineral/plastitanium,
 /area/ruin/space/powered/casino/security)
-"An" = (
-/obj/machinery/door/airlock,
-/turf/simulated/floor/plating,
-/area/ruin/space/powered/casino/maints)
 "Aw" = (
 /obj/effect/spawner/airlock,
 /turf/simulated/wall,
@@ -1022,10 +1028,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/powered/casino/arrivals)
-"Dy" = (
-/obj/machinery/door/airlock,
-/turf/simulated/floor/plating,
-/area/ruin/space/powered/casino/floor)
 "DJ" = (
 /obj/effect/spawner/random/dirt/maybe,
 /obj/effect/spawner/random/pool/casino_mob,
@@ -1082,11 +1084,6 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/ruin/space/powered/casino/kitchen)
-"EZ" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/spawner/random/dirt/maybe,
-/turf/simulated/floor/plating,
-/area/ruin/space/powered/casino/maints)
 "Fk" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -1167,6 +1164,16 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/powered/casino/arrivals)
+"HI" = (
+/obj/machinery/door/airlock/security{
+	name = "Evidence Storage";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/ruin/space/powered/casino/security)
 "Is" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -1207,15 +1214,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/powered/casino/teleporter)
-"JW" = (
-/obj/machinery/door/airlock/security{
-	name = "Evidence Storage"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/mineral/plastitanium,
-/area/ruin/space/powered/casino/security)
 "Ky" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/beer{
@@ -1258,6 +1256,12 @@
 "LK" = (
 /turf/simulated/wall,
 /area/ruin/space/powered/casino/arrivals)
+"Mm" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ruin/space/powered/casino/kitchen)
 "Mt" = (
 /turf/simulated/wall/mineral/plastitanium,
 /area/ruin/space/powered/casino/docked_ships)
@@ -1345,6 +1349,12 @@
 	icon_state = "showroomfloor"
 	},
 /area/ruin/space/powered/casino/kitchen)
+"Pr" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/ruin/space/powered/casino/hall)
 "Pz" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -1398,10 +1408,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/powered/casino/engine)
-"Ri" = (
-/obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/plating,
-/area/ruin/space/powered/casino/kitchen)
 "Ro" = (
 /obj/machinery/light{
 	dir = 8
@@ -1738,6 +1744,19 @@
 "Zr" = (
 /obj/structure/coatrack,
 /obj/item/storage/bag/garment,
+/turf/simulated/floor/plating,
+/area/ruin/space/powered/casino/maints)
+"Zs" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ruin/space/powered/casino/arrivals)
+"ZH" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/spawner/random/dirt/maybe,
 /turf/simulated/floor/plating,
 /area/ruin/space/powered/casino/maints)
 "ZJ" = (
@@ -2275,7 +2294,7 @@ Uy
 ky
 dd
 dd
-EZ
+ZH
 DJ
 dd
 dd
@@ -2328,7 +2347,7 @@ rp
 TO
 in
 PG
-Ri
+Mm
 lS
 lS
 TW
@@ -2416,7 +2435,7 @@ aC
 aC
 ZM
 oP
-An
+ri
 IS
 sO
 UW
@@ -2620,15 +2639,15 @@ wg
 "}
 (20,1,1) = {"
 wg
-xw
+Zs
 Dv
 Yy
 DR
 jt
-mP
+rM
 cc
 cc
-mP
+rM
 cc
 wq
 SX
@@ -2665,7 +2684,7 @@ wg
 "}
 (21,1,1) = {"
 wg
-xw
+Zs
 wD
 jK
 zg
@@ -2870,7 +2889,7 @@ zX
 jh
 qe
 Hq
-bJ
+Pr
 cy
 qe
 gQ
@@ -2960,7 +2979,7 @@ zX
 iw
 qe
 wn
-bJ
+Pr
 cy
 qe
 xD
@@ -2999,7 +3018,7 @@ xq
 VI
 VI
 OU
-JW
+HI
 bR
 bR
 hi
@@ -3052,7 +3071,7 @@ KV
 jz
 du
 no
-Dy
+lc
 Th
 Th
 aW

--- a/_maps/map_files/RandomRuins/SpaceRuins/clockwork_monastery.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/clockwork_monastery.dmm
@@ -55,12 +55,6 @@
 /obj/machinery/sleeper/clockwork,
 /turf/simulated/floor/clockwork,
 /area/ruin/space/clockwork_monastery)
-"eS" = (
-/obj/machinery/door/airlock/clockwork{
-	name = "Inner Narthex"
-	},
-/turf/simulated/floor/clockwork,
-/area/ruin/space/clockwork_monastery)
 "gV" = (
 /turf/template_noop,
 /area/template_noop)
@@ -69,12 +63,6 @@
 /obj/item/bedsheet/clockwork,
 /obj/machinery/light/clockwork{
 	dir = 4
-	},
-/turf/simulated/floor/clockwork,
-/area/ruin/space/clockwork_monastery)
-"hV" = (
-/obj/machinery/door/airlock/clockwork/glass{
-	name = "Feretory"
 	},
 /turf/simulated/floor/clockwork,
 /area/ruin/space/clockwork_monastery)
@@ -122,14 +110,15 @@
 	},
 /turf/simulated/floor/clockwork,
 /area/ruin/space/clockwork_monastery)
-"mn" = (
-/obj/structure/table/reinforced/brass,
+"mk" = (
+/obj/machinery/door/airlock/clockwork{
+	name = "Chapel";
+	dir = 4
+	},
 /turf/simulated/floor/clockwork,
 /area/ruin/space/clockwork_monastery)
-"oc" = (
-/obj/machinery/door/airlock/clockwork{
-	name = "Rotunda"
-	},
+"mn" = (
+/obj/structure/table/reinforced/brass,
 /turf/simulated/floor/clockwork,
 /area/ruin/space/clockwork_monastery)
 "of" = (
@@ -140,6 +129,13 @@
 "ow" = (
 /turf/simulated/floor/plating/asteroid/basalt,
 /area/ruin/unpowered)
+"oS" = (
+/obj/machinery/door/airlock/clockwork/glass{
+	name = "Feretory";
+	dir = 4
+	},
+/turf/simulated/floor/clockwork,
+/area/ruin/space/clockwork_monastery)
 "oW" = (
 /turf/simulated/wall/clockwork,
 /area/ruin/space/clockwork_monastery)
@@ -237,12 +233,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/lava/plasma,
-/area/ruin/space/clockwork_monastery)
-"xv" = (
-/obj/machinery/door/airlock/clockwork/glass{
-	name = "Workshop"
-	},
-/turf/simulated/floor/clockwork,
 /area/ruin/space/clockwork_monastery)
 "yn" = (
 /obj/structure/table/reinforced/brass,
@@ -399,13 +389,6 @@
 	},
 /turf/simulated/floor/clockwork,
 /area/ruin/space/clockwork_monastery)
-"HF" = (
-/obj/machinery/door/airlock/clockwork{
-	name = "Outer Narthex"
-	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/clockwork,
-/area/ruin/space/clockwork_monastery)
 "Ib" = (
 /obj/structure/chair/brass{
 	dir = 1
@@ -501,6 +484,27 @@
 /obj/item/clockwork/component/belligerent_eye/lens_gem,
 /turf/simulated/floor/clockwork,
 /area/ruin/space/clockwork_monastery)
+"Of" = (
+/obj/machinery/door/airlock/clockwork/glass{
+	name = "Workshop";
+	dir = 4
+	},
+/turf/simulated/floor/clockwork,
+/area/ruin/space/clockwork_monastery)
+"Pc" = (
+/obj/machinery/door/airlock/clockwork{
+	name = "Rotunda";
+	dir = 4
+	},
+/turf/simulated/floor/clockwork,
+/area/ruin/space/clockwork_monastery)
+"PJ" = (
+/obj/machinery/door/airlock/clockwork{
+	name = "Inner Narthex";
+	dir = 4
+	},
+/turf/simulated/floor/clockwork,
+/area/ruin/space/clockwork_monastery)
 "Rv" = (
 /obj/machinery/light/clockwork{
 	dir = 8
@@ -530,6 +534,14 @@
 /obj/item/clockwork/component/hierophant_ansible/obelisk,
 /turf/simulated/floor/clockwork,
 /area/ruin/space/clockwork_monastery)
+"Sv" = (
+/obj/machinery/door/airlock/clockwork{
+	name = "Outer Narthex";
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/clockwork,
+/area/ruin/space/clockwork_monastery)
 "Vh" = (
 /obj/effect/turf_decal/woodsiding{
 	dir = 9
@@ -551,12 +563,6 @@
 /area/ruin/space/clockwork_monastery)
 "WR" = (
 /mob/living/simple_animal/hostile/clockwork_construct/clockwork_marauder/hostile,
-/turf/simulated/floor/clockwork,
-/area/ruin/space/clockwork_monastery)
-"Xk" = (
-/obj/machinery/door/airlock/clockwork{
-	name = "Chapel"
-	},
 /turf/simulated/floor/clockwork,
 /area/ruin/space/clockwork_monastery)
 "Xw" = (
@@ -1399,7 +1405,7 @@ rJ
 rJ
 rJ
 rJ
-hV
+oS
 rJ
 rJ
 MU
@@ -2076,7 +2082,7 @@ kC
 kC
 kC
 Xw
-HF
+Sv
 rJ
 rJ
 rJ
@@ -2087,7 +2093,7 @@ rJ
 rJ
 rJ
 rJ
-eS
+PJ
 rJ
 bg
 bg
@@ -2095,7 +2101,7 @@ bg
 bg
 bg
 rJ
-oc
+Pc
 rJ
 rJ
 rJ
@@ -2111,7 +2117,7 @@ rJ
 rJ
 rJ
 rJ
-Xk
+mk
 bg
 bg
 bg
@@ -2146,7 +2152,7 @@ Ht
 kC
 kC
 Xw
-HF
+Sv
 rJ
 rJ
 rJ
@@ -2157,7 +2163,7 @@ rJ
 rJ
 rJ
 rJ
-eS
+PJ
 rJ
 bg
 bg
@@ -2165,7 +2171,7 @@ bg
 bg
 bg
 rJ
-oc
+Pc
 rJ
 rJ
 rJ
@@ -2181,7 +2187,7 @@ rJ
 rJ
 rJ
 rJ
-Xk
+mk
 bg
 bg
 bg
@@ -2869,7 +2875,7 @@ rJ
 rJ
 rJ
 rJ
-xv
+Of
 rJ
 Jx
 yn

--- a/_maps/map_files/RandomRuins/SpaceRuins/clownmime.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/clownmime.dmm
@@ -19,11 +19,6 @@
 /obj/effect/mapping_helpers/turfs/burn,
 /turf/simulated/floor/plating,
 /area/ruin/space/clown_mime_ruin)
-"cz" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/structure/fans/tiny,
-/turf/simulated/floor/plating,
-/area/ruin/space/clown_mime_ruin)
 "cB" = (
 /obj/effect/spawner/random/blood/often,
 /obj/effect/mapping_helpers/turfs/burn,
@@ -82,6 +77,13 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/mineral/titanium,
+/area/ruin/space/clown_mime_ruin)
+"gq" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay";
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium,
 /area/ruin/space/clown_mime_ruin)
 "gE" = (
 /obj/item/grenade/bananade,
@@ -166,10 +168,6 @@
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/clown_mime_ruin)
-"kv" = (
-/obj/machinery/door/airlock/external/glass,
-/turf/simulated/floor/mineral/tranquillite,
-/area/ruin/space/powered)
 "kQ" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge"
@@ -204,6 +202,12 @@
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/cap,
 /turf/simulated/floor/plating/airless,
+/area/ruin/space/clown_mime_ruin)
+"nc" = (
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/ruin/space/clown_mime_ruin)
 "nF" = (
 /obj/structure/shuttle/engine/heater{
@@ -361,10 +365,6 @@
 /obj/effect/spawner/random/blood/often,
 /turf/simulated/floor/plating,
 /area/ruin/space/clown_mime_ruin)
-"sZ" = (
-/obj/machinery/door/airlock/external/glass,
-/turf/simulated/floor/plating,
-/area/ruin/space/clown_mime_ruin)
 "tg" = (
 /obj/item/flag/mime,
 /turf/simulated/floor/mineral/tranquillite,
@@ -505,10 +505,6 @@
 	},
 /turf/simulated/floor/mineral/plastitanium,
 /area/ruin/space/clown_mime_ruin)
-"Au" = (
-/obj/machinery/door/airlock/external/glass,
-/turf/simulated/floor/mineral/bananium,
-/area/ruin/space/powered)
 "Ax" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -700,6 +696,13 @@
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/ruin/space/clown_mime_ruin)
+"Mf" = (
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/plating,
+/area/ruin/space/clown_mime_ruin)
 "MF" = (
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/clown_mime_ruin)
@@ -745,6 +748,12 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/mineral/titanium,
 /area/ruin/space/clown_mime_ruin)
+"QG" = (
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/bananium,
+/area/ruin/space/powered)
 "QS" = (
 /obj/machinery/computer/nonfunctional{
 	dir = 4
@@ -768,6 +777,12 @@
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plating,
 /area/ruin/space/clown_mime_ruin)
+"SV" = (
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/tranquillite,
+/area/ruin/space/powered)
 "TC" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /obj/effect/mapping_helpers/turfs/burn,
@@ -828,12 +843,6 @@
 /obj/effect/mapping_helpers/turfs/burn,
 /obj/effect/spawner/random/blood/often,
 /turf/simulated/floor/mineral/titanium,
-/area/ruin/space/clown_mime_ruin)
-"Xi" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Bay"
-	},
-/turf/simulated/floor/mineral/plastitanium,
 /area/ruin/space/clown_mime_ruin)
 "Xq" = (
 /turf/simulated/wall/mineral/titanium,
@@ -1147,7 +1156,7 @@ lS
 nX
 pj
 Gx
-kv
+SV
 xB
 xB
 Oz
@@ -1201,10 +1210,10 @@ Xq
 Bb
 Bb
 ub
-Xi
+gq
 vC
 gS
-Xi
+gq
 tz
 VH
 Gx
@@ -1231,10 +1240,10 @@ tN
 tN
 Bb
 Vh
-Xi
+gq
 gS
 gS
-Xi
+gq
 qc
 VL
 DZ
@@ -1258,7 +1267,7 @@ bz
 UC
 UC
 UC
-Au
+QG
 Bb
 GS
 BW
@@ -1407,18 +1416,18 @@ qh
 qh
 qh
 qh
-cz
+Mf
 qJ
 wb
-sZ
+nc
 Ht
 Cs
 OK
 gS
-sZ
+nc
 wb
 qE
-cz
+Mf
 qh
 qh
 qh
@@ -1437,18 +1446,18 @@ qh
 qh
 qh
 qh
-cz
+Mf
 ri
 IR
-sZ
+nc
 gS
 OK
 gS
 Cs
-sZ
+nc
 me
 qE
-cz
+Mf
 qh
 qh
 qh

--- a/_maps/map_files/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -766,14 +766,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/ruin/space/deepstorage)
-"ct" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/fans/tiny,
-/turf/simulated/floor/catwalk,
-/area/ruin/space/deepstorage)
 "cA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/blob/normal/deepstorage,
@@ -1378,14 +1370,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/deepstorage)
-"hW" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "DS_Tram"
-	},
-/turf/simulated/floor/plating,
-/area/ruin/space/deepstorage)
 "hY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced{
@@ -1690,6 +1674,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/deepstorage)
+"kn" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/obj/structure/railing/cap{
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
+/area/ruin/space/deepstorage)
 "ko" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/decal/cleanable/dirt,
@@ -1778,6 +1772,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/engine/airless,
 /area/ruin/space/unpowered)
+"kQ" = (
+/obj/machinery/door/airlock/freezer{
+	locked = 1;
+	name = "Medical Storage";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/ruin/space/deepstorage)
 "kR" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -1913,14 +1915,6 @@
 	},
 /turf/simulated/floor/chasm/space_ruin/airless,
 /area/ruin/space/powered)
-"mc" = (
-/obj/structure/barricade/wooden/crude{
-	layer = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
-/obj/machinery/door/airlock/centcom,
-/turf/simulated/floor/catwalk,
-/area/ruin/space/deepstorage)
 "mf" = (
 /obj/effect/spawner/window/plastitanium,
 /obj/machinery/door/poddoor/shutters,
@@ -1928,6 +1922,18 @@
 /area/ruin/space/deepstorage)
 "mg" = (
 /turf/simulated/mineral/ancient,
+/area/ruin/space/deepstorage)
+"mj" = (
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
+/obj/machinery/door/airlock/vault{
+	name = "Auxiliary Power Room";
+	dir = 4
+	},
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "DS_Engineering"
+	},
+/turf/simulated/floor/catwalk,
 /area/ruin/space/deepstorage)
 "mu" = (
 /obj/structure/railing,
@@ -1942,12 +1948,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/chasm/space_ruin,
-/area/ruin/space/deepstorage)
-"mE" = (
-/obj/machinery/door/airlock/hatch,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
 /area/ruin/space/deepstorage)
 "mF" = (
 /obj/machinery/optable,
@@ -2128,6 +2128,17 @@
 /obj/item/salvage/ruin/carp,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/deepstorage)
+"nK" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/multi_tile/impassable/triple{
+	id_tag = "DS_BossStorage";
+	name = "warehouse blast doors"
+	},
+/turf/simulated/floor/catwalk,
+/area/ruin/space/deepstorage)
 "nM" = (
 /obj/item/kirbyplants/medium/medium6,
 /obj/effect/decal/cleanable/dirt,
@@ -2152,6 +2163,16 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/blob/normal/deepstorage,
 /turf/simulated/floor/plasteel/white,
+/area/ruin/space/deepstorage)
+"nP" = (
+/obj/structure/barricade/wooden/crude{
+	layer = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
+/obj/machinery/door/airlock/centcom{
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
 /area/ruin/space/deepstorage)
 "nQ" = (
 /obj/structure/table/glass,
@@ -2255,12 +2276,6 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lowpressure,
 /area/ruin/space/deepstorage)
-"oN" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/firedoor,
-/obj/structure/railing,
-/turf/simulated/floor/catwalk,
-/area/ruin/space/deepstorage)
 "oO" = (
 /obj/item/reagent_containers/drinks/oilcan{
 	pixel_y = 4
@@ -2360,20 +2375,6 @@
 /obj/structure/railing,
 /turf/simulated/floor/plating/asteroid/basalt/airless,
 /area/ruin/space/unpowered)
-"pz" = (
-/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
-/obj/machinery/door/airlock/command/glass{
-	name = "Floor Administrator's Office"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "DScmoffice"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "DScmoffice1"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/space/deepstorage)
 "pJ" = (
 /obj/structure/reagent_dispensers/oil,
 /turf/simulated/floor/plasteel{
@@ -2392,6 +2393,16 @@
 /area/ruin/space/unpowered)
 "pQ" = (
 /obj/effect/spawner/window/shuttle,
+/turf/simulated/floor/plating,
+/area/ruin/space/deepstorage)
+"pS" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "DS_Tram"
+	},
 /turf/simulated/floor/plating,
 /area/ruin/space/deepstorage)
 "pV" = (
@@ -2434,6 +2445,14 @@
 	},
 /turf/simulated/floor/engine/airless,
 /area/ruin/space/unpowered)
+"qe" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/railing,
+/turf/simulated/floor/catwalk,
+/area/ruin/space/deepstorage)
 "qm" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -2579,15 +2598,6 @@
 /obj/structure/table,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/deepstorage)
-"rK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
-/obj/machinery/door/airlock/hatch,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "podfloor"
-	},
-/area/ruin/space/deepstorage)
 "rM" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -2644,6 +2654,16 @@
 /area/ruin/space/deepstorage)
 "sk" = (
 /turf/simulated/wall/indestructible/rock,
+/area/ruin/space/deepstorage)
+"sl" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/catwalk,
 /area/ruin/space/deepstorage)
 "sv" = (
 /obj/structure/railing{
@@ -2996,6 +3016,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/deepstorage)
+"uP" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/deepstorage)
 "uV" = (
 /obj/structure/railing{
 	dir = 8
@@ -3232,14 +3259,12 @@
 	},
 /turf/simulated/wall/indestructible/riveted,
 /area/ruin/space/deepstorage)
-"wH" = (
+"wK" = (
 /obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
-/obj/machinery/door/airlock/hatch,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "DS_Quartermaster"
+/obj/machinery/door/airlock/centcom{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel/dark,
+/turf/simulated/floor/catwalk,
 /area/ruin/space/deepstorage)
 "wV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3406,14 +3431,6 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/catwalk,
 /area/ruin/space/deepstorage)
-"yl" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/firedoor,
-/obj/structure/railing/cap{
-	dir = 8
-	},
-/turf/simulated/floor/catwalk,
-/area/ruin/space/deepstorage)
 "ym" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -3423,14 +3440,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/ruin/space/deepstorage)
-"yp" = (
-/obj/machinery/door/firedoor,
-/obj/structure/fans/tiny,
-/obj/structure/railing{
-	dir = 9
-	},
-/turf/simulated/floor/catwalk,
 /area/ruin/space/deepstorage)
 "yt" = (
 /obj/structure/railing/cap{
@@ -3531,6 +3540,31 @@
 /obj/item/defibrillator/loaded,
 /turf/simulated/floor/plasteel/white,
 /area/ruin/space/deepstorage)
+"ze" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
+/obj/machinery/door/airlock/command/glass{
+	name = "Floor Administrator's Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "DScmoffice"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "DScmoffice1"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/deepstorage)
+"zf" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/simulated/floor/catwalk,
+/area/ruin/space/deepstorage)
 "zg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/mineral/titanium,
@@ -3614,14 +3648,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/ruin/space/deepstorage)
-"zD" = (
-/obj/structure/barricade/wooden/crude{
-	layer = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
-/obj/machinery/door/airlock/hatch,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/space/deepstorage)
 "zG" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light/small{
@@ -3659,6 +3685,17 @@
 "zN" = (
 /obj/item/paper/fluff/ruins/deepstorage/log2,
 /turf/simulated/floor/plasteel,
+/area/ruin/space/deepstorage)
+"zP" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "DS_Quartermaster"
+	},
+/turf/simulated/floor/plasteel/dark,
 /area/ruin/space/deepstorage)
 "zX" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -3730,17 +3767,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/catwalk/airless,
-/area/ruin/space/deepstorage)
-"As" = (
-/obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
-/obj/machinery/door/airlock/vault{
-	name = "Auxiliary Power Room"
-	},
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "DS_Engineering"
-	},
-/turf/simulated/floor/catwalk,
 /area/ruin/space/deepstorage)
 "Av" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3877,6 +3903,12 @@
 /obj/item/flashlight/lantern,
 /obj/item/flashlight/lantern,
 /turf/simulated/floor/catwalk,
+/area/ruin/space/deepstorage)
+"Bl" = (
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
 /area/ruin/space/deepstorage)
 "Bm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4029,14 +4061,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/ruin/space/deepstorage)
-"Cm" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/firedoor,
-/obj/structure/railing/cap{
-	dir = 6
-	},
-/turf/simulated/floor/catwalk,
-/area/ruin/space/deepstorage)
 "Cn" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/structure/rack,
@@ -4188,13 +4212,6 @@
 /obj/item/reagent_containers/iv_bag/salglu,
 /turf/simulated/floor/catwalk,
 /area/ruin/space/deepstorage)
-"Dq" = (
-/obj/machinery/door/airlock/freezer{
-	locked = 1;
-	name = "Medical Storage"
-	},
-/turf/simulated/floor/plasteel/white,
-/area/ruin/space/deepstorage)
 "Dr" = (
 /obj/effect/turf_decal/box,
 /obj/effect/decal/cleanable/dirt,
@@ -4318,6 +4335,16 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/ruin/space/deepstorage)
+"El" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/catwalk,
+/area/ruin/space/deepstorage)
 "Ep" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4366,6 +4393,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/nonfunctional,
 /turf/simulated/floor/plasteel/dark,
+/area/ruin/space/deepstorage)
+"EC" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
 /area/ruin/space/deepstorage)
 "EI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4423,6 +4458,16 @@
 	dir = 1
 	},
 /area/ruin/space/deepstorage)
+"Fh" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
+/obj/machinery/door/airlock/highsecurity{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "DS_Storage"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/deepstorage)
 "Fk" = (
 /turf/simulated/floor/chasm/space_ruin,
 /area/ruin/space/deepstorage)
@@ -4479,6 +4524,16 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lowpressure,
+/area/ruin/space/deepstorage)
+"FO" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/railing/cap{
+	dir = 8
+	},
+/turf/simulated/floor/catwalk,
 /area/ruin/space/deepstorage)
 "FS" = (
 /obj/effect/turf_decal/stripes/line{
@@ -4739,10 +4794,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/deepstorage)
-"IN" = (
-/obj/machinery/door/airlock/glass,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/space/deepstorage)
 "IP" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -4857,14 +4908,6 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/deepstorage)
-"JV" = (
-/obj/machinery/door/firedoor,
-/obj/structure/fans/tiny,
-/obj/structure/railing/cap{
-	dir = 9
-	},
-/turf/simulated/floor/catwalk,
-/area/ruin/space/deepstorage)
 "JW" = (
 /obj/machinery/door/poddoor/preopen,
 /obj/machinery/door/airlock/virology/glass{
@@ -4978,6 +5021,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/mineral/titanium/blue,
+/area/ruin/space/deepstorage)
+"KF" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
+/obj/machinery/door/airlock/highsecurity{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
 /area/ruin/space/deepstorage)
 "KI" = (
 /obj/structure/railing/cap{
@@ -5094,15 +5144,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/deepstorage)
-"LJ" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/multi_tile/impassable/triple{
-	id_tag = "DS_BossStorage";
-	name = "warehouse blast doors"
-	},
-/turf/simulated/floor/catwalk,
-/area/ruin/space/deepstorage)
 "LK" = (
 /obj/effect/spawner/window/reinforced/polarized/grilled{
 	id = "DScmoffice"
@@ -5195,6 +5236,24 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
+/area/ruin/space/deepstorage)
+"Ms" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
+/area/ruin/space/deepstorage)
+"MI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "podfloor"
+	},
 /area/ruin/space/deepstorage)
 "MR" = (
 /obj/structure/rack,
@@ -5363,6 +5422,16 @@
 "Ol" = (
 /obj/structure/blob/normal/deepstorage,
 /turf/simulated/floor/plating/asteroid/basalt/lowpressure,
+/area/ruin/space/deepstorage)
+"On" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "podfloor"
+	},
 /area/ruin/space/deepstorage)
 "Oo" = (
 /obj/item/trash/chips,
@@ -5806,6 +5875,16 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/deepstorage)
+"Sb" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/railing/cap{
+	dir = 6
+	},
+/turf/simulated/floor/catwalk,
+/area/ruin/space/deepstorage)
 "Sc" = (
 /obj/item/kirbyplants/large/plant8,
 /turf/simulated/floor/plasteel/dark,
@@ -5817,6 +5896,16 @@
 "Sh" = (
 /obj/structure/table,
 /obj/item/salvage/ruin/brick,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/deepstorage)
+"Sk" = (
+/obj/structure/barricade/wooden/crude{
+	layer = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/deepstorage)
 "Sl" = (
@@ -5851,8 +5940,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/deepstorage)
-"SC" = (
-/obj/machinery/door/airlock,
+"SH" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -5925,11 +6016,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/ruin/space/deepstorage)
-"To" = (
-/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
-/obj/machinery/door/airlock/centcom,
-/turf/simulated/floor/catwalk,
-/area/ruin/space/deepstorage)
 "Tq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tiles/dark/side,
@@ -5996,6 +6082,16 @@
 "TY" = (
 /obj/machinery/porta_turret/syndicate/assault_pod,
 /turf/simulated/floor/plasteel/dark/airless,
+/area/ruin/space/deepstorage)
+"TZ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/obj/structure/railing/cap{
+	dir = 9
+	},
+/turf/simulated/floor/catwalk,
 /area/ruin/space/deepstorage)
 "Ud" = (
 /obj/structure/railing/cap,
@@ -6544,14 +6640,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/deepstorage)
-"Yb" = (
-/obj/machinery/door/firedoor,
-/obj/structure/fans/tiny,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/catwalk,
-/area/ruin/space/deepstorage)
 "Yc" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/tile/disco_light/thirty,
@@ -6606,14 +6694,6 @@
 	amount = 50;
 	pixel_x = -2;
 	pixel_y = -2
-	},
-/turf/simulated/floor/catwalk,
-/area/ruin/space/deepstorage)
-"Yz" = (
-/obj/machinery/door/firedoor,
-/obj/structure/fans/tiny,
-/obj/structure/railing/cap{
-	dir = 4
 	},
 /turf/simulated/floor/catwalk,
 /area/ruin/space/deepstorage)
@@ -8144,7 +8224,7 @@ Bf
 Zf
 Bf
 Zf
-pz
+ze
 bP
 bP
 wh
@@ -8500,7 +8580,7 @@ BE
 BE
 Ik
 No
-LJ
+nK
 FN
 eB
 nR
@@ -8571,7 +8651,7 @@ BE
 ri
 Ik
 No
-na
+Ms
 FN
 eB
 eB
@@ -8642,7 +8722,7 @@ yQ
 BE
 Ik
 No
-na
+Ms
 FN
 eB
 eB
@@ -9127,7 +9207,7 @@ jB
 nG
 VH
 tT
-Dq
+kQ
 QR
 ht
 eh
@@ -9846,7 +9926,7 @@ Mn
 bU
 dd
 bP
-oN
+qe
 Fk
 pQ
 pQ
@@ -9854,7 +9934,7 @@ EJ
 pQ
 pQ
 Fk
-yp
+zf
 uV
 Dm
 UA
@@ -9917,7 +9997,7 @@ lt
 bU
 bU
 bP
-oN
+qe
 Fk
 UF
 Yr
@@ -9925,7 +10005,7 @@ uf
 QN
 UF
 Fk
-Yb
+El
 wh
 aQ
 cY
@@ -9988,7 +10068,7 @@ zj
 tr
 bU
 wh
-oN
+qe
 DK
 UF
 KE
@@ -9996,7 +10076,7 @@ zg
 vS
 UF
 ol
-Yb
+El
 mN
 Ew
 cY
@@ -10059,15 +10139,15 @@ Fk
 Qx
 bU
 wh
-yl
+FO
 Gl
-hW
+pS
 Qy
 uf
 Qy
-hW
+pS
 Gl
-JV
+TZ
 bP
 bU
 JR
@@ -10130,15 +10210,15 @@ Fk
 Qx
 aQ
 wh
-Cm
+Sb
 Gl
-hW
+pS
 mA
 uf
 mA
-hW
+pS
 Gl
-Yz
+kn
 wh
 bU
 ts
@@ -10201,7 +10281,7 @@ Fk
 Qx
 aQ
 wh
-oN
+qe
 DK
 UF
 KD
@@ -10209,7 +10289,7 @@ uf
 ZI
 UF
 ol
-Yb
+El
 CT
 bU
 ts
@@ -10272,7 +10352,7 @@ Fk
 WJ
 aQ
 wh
-oN
+qe
 Fk
 UF
 CB
@@ -10280,7 +10360,7 @@ zg
 qZ
 UF
 Fk
-Yb
+El
 wh
 bU
 Uu
@@ -10343,7 +10423,7 @@ Fk
 lt
 bU
 bP
-oN
+qe
 Fk
 pQ
 pQ
@@ -10351,7 +10431,7 @@ GU
 pQ
 pQ
 Fk
-Yb
+El
 mN
 bU
 tk
@@ -10414,7 +10494,7 @@ Fk
 Mn
 vo
 Rl
-oN
+qe
 Fk
 Fk
 pQ
@@ -10422,7 +10502,7 @@ pQ
 pQ
 Fk
 Fk
-Yb
+El
 wh
 bU
 MW
@@ -10493,7 +10573,7 @@ jB
 jB
 jB
 jB
-ct
+sl
 wh
 bc
 Wn
@@ -10726,7 +10806,7 @@ vt
 kR
 WB
 iq
-As
+mj
 bM
 aW
 aj
@@ -10767,7 +10847,7 @@ Bm
 jB
 ih
 bP
-zD
+Sk
 Ei
 Rw
 BH
@@ -10835,7 +10915,7 @@ tc
 Vv
 bl
 QL
-IN
+Bl
 wh
 mP
 jB
@@ -11199,14 +11279,14 @@ RQ
 ch
 vG
 wh
-wH
+zP
 wh
 bU
 IJ
 jB
 XH
 JH
-rK
+MI
 bP
 bc
 IJ
@@ -11281,7 +11361,7 @@ jB
 cU
 vL
 bP
-Hx
+uP
 wh
 bU
 RB
@@ -11294,7 +11374,7 @@ Zy
 bU
 Zy
 wh
-Hx
+uP
 dO
 TE
 bl
@@ -11399,7 +11479,7 @@ ab
 ab
 jB
 Kx
-SC
+EC
 xZ
 tu
 jB
@@ -11445,13 +11525,13 @@ rP
 uV
 uV
 yZ
-To
+wK
 bc
 al
 wh
 al
 bU
-To
+wK
 wh
 bP
 wh
@@ -11473,7 +11553,7 @@ jB
 jB
 VS
 tu
-mE
+SH
 qF
 wh
 IJ
@@ -11541,7 +11621,7 @@ ab
 ab
 jB
 Kg
-SC
+EC
 tu
 fD
 jB
@@ -11578,7 +11658,7 @@ jB
 wh
 bU
 wh
-Hx
+uP
 UR
 UR
 UR
@@ -11587,13 +11667,13 @@ lb
 bP
 bU
 wh
-mc
+nP
 aQ
 iJ
 mN
 iJ
 bU
-To
+wK
 bP
 wh
 wh
@@ -11683,7 +11763,7 @@ ab
 ab
 jB
 zG
-SC
+EC
 xZ
 Uv
 jB
@@ -11757,7 +11837,7 @@ jB
 jB
 xZ
 tu
-mE
+SH
 wh
 CT
 jB
@@ -11774,7 +11854,7 @@ bU
 Lq
 bU
 wh
-TK
+Fh
 aK
 Lq
 aK
@@ -11791,7 +11871,7 @@ Lq
 Lq
 bU
 bP
-Hx
+uP
 TE
 bl
 JK
@@ -12058,7 +12138,7 @@ bP
 jB
 fN
 ew
-ZW
+On
 wh
 bU
 Wo
@@ -12653,11 +12733,11 @@ jB
 jB
 uo
 bP
-aR
+KF
 wh
 Rl
 bP
-aR
+KF
 Rx
 Lo
 WY

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict2.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict2.dmm
@@ -92,6 +92,12 @@
 /obj/item/salvage/ruin/tablet,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/powered)
+"B" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ruin/space/powered)
 
 (1,1,1) = {"
 a
@@ -288,7 +294,7 @@ c
 e
 e
 e
-c
+B
 i
 i
 i
@@ -296,7 +302,7 @@ n
 i
 i
 i
-c
+B
 e
 e
 e

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict4.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict4.dmm
@@ -113,10 +113,6 @@
 /obj/effect/mob_spawn/human/corpse/random_species/doctor,
 /turf/simulated/floor/mineral/titanium/airless,
 /area/ruin/space/unpowered)
-"B" = (
-/obj/machinery/door/airlock/titanium/glass,
-/turf/simulated/floor/mineral/titanium/airless,
-/area/ruin/space/unpowered)
 "C" = (
 /obj/effect/spawner/random/trash,
 /obj/effect/mapping_helpers/turfs/damage,
@@ -144,6 +140,12 @@
 "H" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/food_or_drink/dinner,
+/turf/simulated/floor/mineral/titanium/airless,
+/area/ruin/space/unpowered)
+"I" = (
+/obj/machinery/door/airlock/titanium/glass{
+	dir = 4
+	},
 /turf/simulated/floor/mineral/titanium/airless,
 /area/ruin/space/unpowered)
 "K" = (
@@ -1195,7 +1197,7 @@ b
 b
 b
 d
-B
+I
 x
 t
 h

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict5.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict5.dmm
@@ -226,6 +226,13 @@
 "Dt" = (
 /turf/simulated/mineral/random/high_chance/space,
 /area/ruin/space/unpowered)
+"Ed" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/ruin/space/unpowered)
 "Gx" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel,
@@ -258,6 +265,14 @@
 /obj/structure/closet/cabinet,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/unpowered)
+"LF" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/structure/barricade/wooden/crude,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/ruin/space/unpowered)
 "LZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
@@ -270,12 +285,6 @@
 "Oc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
-"Oj" = (
-/obj/machinery/door/airlock/external,
-/obj/structure/barricade/wooden/crude,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/unpowered)
 "Pq" = (
@@ -349,11 +358,6 @@
 /area/ruin/space/unpowered)
 "ZP" = (
 /obj/structure/table_frame,
-/turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
-"ZZ" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/unpowered)
 
@@ -1343,10 +1347,10 @@ zN
 Pq
 kO
 vE
-Oj
+LF
 vE
 vE
-ZZ
+Ed
 Nv
 WA
 WA

--- a/_maps/map_files/RandomRuins/SpaceRuins/dj.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/dj.dmm
@@ -582,14 +582,6 @@
 /obj/machinery/sleeper,
 /turf/simulated/floor/carpet/grimey,
 /area/ruin/space/djstation)
-"bE" = (
-/obj/machinery/door/airlock{
-	name = "Restroom"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/ruin/space/djstation)
 "bF" = (
 /obj/effect/spawner/window/shuttle,
 /obj/structure/cable,
@@ -609,17 +601,6 @@
 /obj/machinery/power/tracker,
 /turf/template_noop,
 /area/ruin/space/djstation/solars)
-"bI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering"
-	},
-/turf/simulated/floor/plasteel/fakestairs{
-	dir = 1
-	},
-/area/ruin/space/djstation)
 "bJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -760,6 +741,15 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
+/area/ruin/space/djstation)
+"ib" = (
+/obj/machinery/door/airlock{
+	name = "Restroom";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
 /area/ruin/space/djstation)
 "mL" = (
 /obj/machinery/light/small{
@@ -918,6 +908,18 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel/dark,
+/area/ruin/space/djstation)
+"Ic" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/fakestairs{
+	dir = 1
+	},
 /area/ruin/space/djstation)
 "Mj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -1596,7 +1598,7 @@ aS
 ba
 bx
 bm
-bE
+ib
 aY
 bQ
 aS
@@ -1791,7 +1793,7 @@ ah
 bn
 UP
 uf
-bI
+Ic
 bj
 aU
 bp

--- a/_maps/map_files/RandomRuins/SpaceRuins/engineering_vessel.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/engineering_vessel.dmm
@@ -48,6 +48,15 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/unpowered)
+"i" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/unpowered)
 "k" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -136,12 +145,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
-"z" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge"
-	},
-/turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
 "A" = (
 /obj/machinery/computer/nonfunctional{
 	dir = 1
@@ -160,9 +163,6 @@
 "E" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
-"F" = (
-/turf/simulated/wall/mineral/plastitanium,
 /area/ruin/space/unpowered)
 "H" = (
 /turf/simulated/floor/plasteel/dark,
@@ -253,6 +253,13 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/unpowered)
+"T" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/ruin/space/unpowered)
 "U" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -286,13 +293,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/unpowered)
-"Y" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/public/glass,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/space/unpowered)
 "Z" = (
 /obj/structure/shelf,
 /obj/effect/spawner/random/bluespace_tap/clothes_rare,
@@ -321,7 +321,7 @@ P
 (2,1,1) = {"
 P
 C
-F
+C
 r
 N
 C
@@ -354,10 +354,10 @@ K
 f
 H
 W
-F
+C
 C
 o
-F
+C
 U
 m
 a
@@ -369,10 +369,10 @@ C
 S
 H
 X
-Y
+i
 c
 b
-z
+T
 p
 E
 A
@@ -384,10 +384,10 @@ K
 g
 H
 I
-F
+C
 C
 d
-F
+C
 q
 p
 A
@@ -411,7 +411,7 @@ a
 (8,1,1) = {"
 P
 C
-F
+C
 v
 L
 C
@@ -429,7 +429,7 @@ P
 C
 a
 a
-F
+C
 C
 a
 C

--- a/_maps/map_files/RandomRuins/SpaceRuins/freighter.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/freighter.dmm
@@ -6,6 +6,13 @@
 /obj/item/reagent_containers/spray/cleaner/advanced,
 /turf/simulated/floor/mineral/plastitanium,
 /area/ruin/space/powered)
+"cU" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/pod/dark,
+/area/ruin/space/powered)
 "dN" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /obj/machinery/disco,
@@ -60,10 +67,6 @@
 "iq" = (
 /obj/structure/fans/tiny,
 /turf/simulated/floor/mineral/plastitanium,
-/area/ruin/space/powered)
-"iP" = (
-/obj/machinery/door/airlock/medical,
-/turf/simulated/floor/plasteel,
 /area/ruin/space/powered)
 "jM" = (
 /obj/machinery/door/poddoor/multi_tile/impassable/triple{
@@ -155,6 +158,12 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel/dark,
+/area/ruin/space/powered)
+"nj" = (
+/obj/machinery/door/airlock/medical{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
 /area/ruin/space/powered)
 "nq" = (
 /obj/structure/closet/crate,
@@ -465,12 +474,6 @@
 /obj/item/toy/plushie/nianplushie,
 /turf/simulated/floor/wood,
 /area/ruin/space/powered)
-"Je" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/space/powered)
 "Jw" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal/fifty{
@@ -713,6 +716,10 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/powered)
+"ZH" = (
+/obj/machinery/door/airlock/multi_tile/glass,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/powered)
 
 (1,1,1) = {"
 Kh
@@ -801,7 +808,7 @@ LW
 lx
 xB
 lx
-WF
+cU
 Kh
 Kh
 Kh
@@ -1046,7 +1053,7 @@ LW
 LW
 LW
 La
-Je
+ZH
 LW
 LW
 LW
@@ -1061,7 +1068,7 @@ Kh
 LW
 MX
 zV
-iP
+nj
 xJ
 xJ
 Br
@@ -1160,7 +1167,7 @@ LW
 LW
 LW
 La
-Je
+ZH
 LW
 LW
 LW

--- a/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
@@ -1,4 +1,11 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aQ" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	name = "Telecommunications";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/syndicate_listening_station)
 "aW" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -75,6 +82,17 @@
 	icon_state = "asteroidplating"
 	},
 /area/ruin/space/syndicate_listening_station/asteroid)
+"hI" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	name = "Engineering";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/syndicate_listening_station)
 "hQ" = (
 /obj/structure/sink/directional/east,
 /obj/structure/mirror{
@@ -154,6 +172,13 @@
 "qC" = (
 /obj/item/flag/syndi,
 /turf/simulated/floor/plasteel/dark,
+/area/ruin/space/syndicate_listening_station)
+"qD" = (
+/obj/machinery/door/airlock/silver{
+	name = "Bathroom";
+	dir = 4
+	},
+/turf/simulated/floor/mineral/silver,
 /area/ruin/space/syndicate_listening_station)
 "qW" = (
 /obj/structure/cable/yellow{
@@ -269,18 +294,6 @@
 /obj/item/stock_parts/cell/high,
 /turf/simulated/floor/plating,
 /area/ruin/space/syndicate_listening_station)
-"wj" = (
-/obj/machinery/door/airlock/hatch/syndicate{
-	name = "Telecommunications"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/space/syndicate_listening_station)
-"wr" = (
-/obj/machinery/door/airlock/hatch/syndicate{
-	name = "Cabin"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/space/syndicate_listening_station)
 "wF" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -295,6 +308,13 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/syndicate_listening_station/asteroid)
+"xG" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	name = "Cabin";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/syndicate_listening_station)
 "xK" = (
 /obj/structure/bed,
 /obj/item/bedsheet/syndie,
@@ -551,12 +571,6 @@
 /obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
 /turf/simulated/floor/wood,
 /area/ruin/space/syndicate_listening_station)
-"RN" = (
-/obj/machinery/door/airlock/silver{
-	name = "Bathroom"
-	},
-/turf/simulated/floor/mineral/silver,
-/area/ruin/space/syndicate_listening_station)
 "Sq" = (
 /obj/structure/table/glass/reinforced/plastitanium,
 /obj/item/food/soup/chicken_noodle_soup,
@@ -600,16 +614,6 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/syndicate_listening_station)
-"UM" = (
-/obj/machinery/door/airlock/hatch/syndicate{
-	name = "Engineering"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel/dark,
 /area/ruin/space/syndicate_listening_station)
 "UT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1328,7 +1332,7 @@ bU
 kJ
 Fx
 Lj
-wr
+xG
 le
 le
 kJ
@@ -1454,13 +1458,13 @@ UC
 tF
 tF
 Bt
-UM
+hI
 yv
 yv
 yv
 dS
 le
-wj
+aQ
 le
 Go
 Vn
@@ -1582,7 +1586,7 @@ yn
 kJ
 mn
 Nd
-RN
+qD
 le
 le
 le

--- a/_maps/map_files/RandomRuins/SpaceRuins/meatpackers.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/meatpackers.dmm
@@ -46,13 +46,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/engine,
 /area/ruin/unpowered/bmp_ship/delta)
-"am" = (
-/obj/machinery/door/airlock/silver{
-	locked = 1
-	},
-/obj/effect/mapping_helpers/turfs/burn,
-/turf/simulated/floor/plating/airless,
-/area/ruin/unpowered/bmp_ship/delta)
 "an" = (
 /obj/structure/bed/roller,
 /turf/simulated/floor/plating/airless,
@@ -360,10 +353,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/bmp_ship/delta)
-"bE" = (
-/obj/machinery/door/airlock/silver,
-/turf/simulated/floor/carpet,
-/area/ruin/unpowered/bmp_ship/fore)
 "bF" = (
 /turf/simulated/wall/mineral/titanium,
 /area/ruin/unpowered/bmp_ship/midship)
@@ -1410,17 +1399,6 @@
 /obj/item/kitchen/knife,
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/bmp_ship/aft)
-"fl" = (
-/obj/machinery/door/airlock/titanium,
-/turf/simulated/floor/carpet,
-/area/ruin/unpowered/bmp_ship/fore)
-"fm" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/titanium,
-/turf/simulated/floor/carpet,
-/area/ruin/unpowered/bmp_ship/fore)
 "fn" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -1658,28 +1636,6 @@
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/bmp_ship/midship)
-"gc" = (
-/obj/machinery/door/airlock/silver{
-	locked = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered/bmp_ship/aft)
-"gd" = (
-/obj/machinery/door/airlock/silver{
-	locked = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered/bmp_ship/aft)
-"ge" = (
-/obj/machinery/door/airlock/titanium,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered/bmp_ship/aft)
 "gf" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/head/helmet/space/syndicate/green/dark,
@@ -1690,13 +1646,6 @@
 /obj/structure/mecha_wreckage/ripley,
 /turf/simulated/floor/plating/airless,
 /area/ruin/powered)
-"gh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/silver,
-/turf/simulated/floor/plating/airless,
-/area/ruin/unpowered/bmp_ship/fore)
 "gi" = (
 /turf/simulated/mineral/random/space,
 /area/ruin/unpowered/bmp_ship/midship)
@@ -2064,6 +2013,15 @@
 /obj/item/salvage/ruin/pirate,
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/bmp_ship/midship)
+"rQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/titanium{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/ruin/unpowered/bmp_ship/fore)
 "uK" = (
 /mob/living/basic/pirate,
 /obj/effect/turf_decal/tiles/jobs/bar/checker,
@@ -2072,6 +2030,15 @@
 "uT" = (
 /turf/simulated/mineral/random/high_chance/space,
 /area/ruin/powered)
+"xB" = (
+/obj/machinery/door/airlock/titanium{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered/bmp_ship/aft)
 "BC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2080,6 +2047,12 @@
 /obj/effect/turf_decal/tiles/jobs/bar/checker,
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered/bmp_ship/midship)
+"Df" = (
+/obj/machinery/door/airlock/titanium{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/ruin/unpowered/bmp_ship/fore)
 "Ht" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -2095,12 +2068,52 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/bmp_ship/delta)
+"IO" = (
+/obj/machinery/door/airlock/silver{
+	locked = 1;
+	dir = 4
+	},
+/obj/effect/mapping_helpers/turfs/burn,
+/turf/simulated/floor/plating/airless,
+/area/ruin/unpowered/bmp_ship/delta)
+"Kd" = (
+/obj/machinery/door/airlock/silver{
+	locked = 1;
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered/bmp_ship/aft)
 "PE" = (
 /obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/bmp_ship/aft)
 "PP" = (
 /obj/structure/computerframe{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/ruin/unpowered/bmp_ship/fore)
+"Ql" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/silver{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/ruin/unpowered/bmp_ship/fore)
+"Qt" = (
+/obj/machinery/door/airlock/silver{
+	locked = 1;
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/unpowered/bmp_ship/aft)
+"RW" = (
+/obj/machinery/door/airlock/silver{
 	dir = 4
 	},
 /turf/simulated/floor/carpet,
@@ -2715,7 +2728,7 @@ ek
 ds
 ds
 ds
-fl
+Df
 fA
 fN
 fA
@@ -2768,7 +2781,7 @@ ds
 eB
 el
 el
-fm
+rQ
 fC
 fB
 fY
@@ -2810,7 +2823,7 @@ aD
 aQ
 bi
 bh
-fl
+Df
 ds
 ds
 ds
@@ -2916,7 +2929,7 @@ aD
 aR
 bj
 bk
-bE
+RW
 ds
 ds
 cG
@@ -2931,7 +2944,7 @@ aD
 fF
 fQ
 fQ
-gh
+Ql
 gq
 gL
 fA
@@ -4467,7 +4480,7 @@ ew
 ft
 eX
 cv
-gc
+Qt
 cC
 dG
 cC
@@ -4606,7 +4619,7 @@ ad
 ad
 aj
 aj
-am
+IO
 aB
 aj
 aj
@@ -4626,14 +4639,14 @@ fk
 fv
 fJ
 dD
-gd
+Kd
 cB
 gE
 gS
 gZ
 gR
 cC
-gc
+Qt
 dG
 dG
 cl
@@ -4891,7 +4904,7 @@ cB
 cB
 cB
 eA
-ge
+xB
 cB
 gG
 cC

--- a/_maps/map_files/RandomRuins/SpaceRuins/mechtransport.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/mechtransport.dmm
@@ -12,13 +12,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/mech_transport)
-"aW" = (
-/obj/machinery/door/airlock/hatch,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/ruin/space/mech_transport)
 "aZ" = (
 /obj/effect/spawner/random/loot_crate,
 /obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
@@ -141,17 +134,19 @@
 /obj/item/chair,
 /turf/simulated/floor/mineral/plastitanium/red/airless,
 /area/ruin/space/mech_transport)
-"ma" = (
-/obj/machinery/door/airlock/hatch,
+"mn" = (
+/turf/template_noop,
+/area/template_noop)
+"mV" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "mechtransport_lockdown";
 	name = "lockdown blast door"
 	},
-/turf/simulated/floor/mineral/plastitanium,
+/turf/simulated/floor/plasteel/dark,
 /area/ruin/space/mech_transport)
-"mn" = (
-/turf/template_noop,
-/area/template_noop)
 "nO" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -346,14 +341,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/mech_transport)
-"yR" = (
-/obj/machinery/door/airlock/hatch,
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "mechtransport_lockdown";
-	name = "lockdown blast door"
-	},
-/turf/simulated/floor/plasteel/dark,
 /area/ruin/space/mech_transport)
 "zy" = (
 /obj/effect/decal/remains/human,
@@ -573,6 +560,16 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/mech_transport)
+"Ox" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "mechtransport_lockdown";
+	name = "lockdown blast door"
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/ruin/space/mech_transport)
 "OQ" = (
 /obj/effect/turf_decal/delivery/partial{
 	dir = 8
@@ -667,6 +664,15 @@
 	amount = 15
 	},
 /turf/simulated/floor/plasteel/dark,
+/area/ruin/space/mech_transport)
+"UX" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
 /area/ruin/space/mech_transport)
 "Vj" = (
 /obj/structure/shuttle/engine/heater,
@@ -1209,7 +1215,7 @@ VS
 VS
 RY
 VS
-yR
+mV
 Kz
 Lq
 HK
@@ -1297,7 +1303,7 @@ VS
 VS
 VS
 VS
-ma
+Ox
 uu
 QC
 HT
@@ -1391,7 +1397,7 @@ pJ
 VS
 zM
 VS
-aW
+UX
 aq
 gk
 sY

--- a/_maps/map_files/RandomRuins/SpaceRuins/moonoutpost19.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/moonoutpost19.dmm
@@ -398,10 +398,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/ruin/space/moonbase19)
-"bb" = (
-/obj/machinery/door/airlock/multi_tile/glass,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/space/moonbase19)
 "bd" = (
 /obj/structure/sign/nosmoking{
 	pixel_x = 32
@@ -523,10 +519,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/moonbase19)
-"bx" = (
-/obj/machinery/door/airlock/external/glass,
-/turf/simulated/floor/mineral/titanium,
-/area/ruin/space/powered)
 "bz" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -802,14 +794,6 @@
 /obj/effect/turf_decal/tiles/white/side,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/moonbase19)
-"cx" = (
-/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
-/obj/machinery/door/airlock/security/glass,
-/obj/structure/barricade/wooden/crude{
-	layer = 4
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/space/moonbase19)
 "cy" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/cobweb2,
@@ -858,15 +842,6 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/turfs/damage,
-/turf/simulated/floor/plating,
-/area/ruin/space/moonbase19)
-"cF" = (
-/obj/structure/barricade/wooden/crude{
-	layer = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
-/obj/machinery/door/airlock/maintenance_hatch,
 /turf/simulated/floor/plating,
 /area/ruin/space/moonbase19)
 "cI" = (
@@ -992,12 +967,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/mineral/titanium,
 /area/ruin/space/powered)
-"di" = (
-/obj/machinery/door/airlock/centcom,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/ruin/space/moonbase19)
 "dj" = (
 /obj/structure/closet/crate,
 /turf/simulated/floor/mineral/titanium,
@@ -1034,6 +1003,16 @@
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel/white,
+/area/ruin/space/moonbase19)
+"dr" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/highsecurity{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "awayscilock1"
+	},
+/turf/simulated/floor/plasteel/dark,
 /area/ruin/space/moonbase19)
 "ds" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1301,12 +1280,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/moonbase19)
-"el" = (
-/obj/machinery/door/airlock,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
 /area/ruin/space/moonbase19)
 "em" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1598,11 +1571,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/moonbase19)
-"fn" = (
-/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
-/obj/machinery/door/airlock/centcom,
-/turf/simulated/floor/plasteel,
-/area/ruin/space/moonbase19)
 "fp" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1740,16 +1708,6 @@
 	dir = 4
 	},
 /obj/structure/closet/l3closet/general,
-/turf/simulated/floor/catwalk,
-/area/ruin/space/moonbase19)
-"fQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
-/obj/machinery/door/airlock/centcom{
-	name = "Cafeteria"
-	},
 /turf/simulated/floor/catwalk,
 /area/ruin/space/moonbase19)
 "fR" = (
@@ -2027,6 +1985,16 @@
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/catwalk,
 /area/ruin/space/moonbase19)
+"gI" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4
+	},
+/obj/structure/barricade/wooden{
+	layer = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/ruin/space/moonbase19)
 "gJ" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
 /obj/structure/railing,
@@ -2097,14 +2065,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/moonbase19)
-"gW" = (
-/obj/effect/mapping_helpers/turfs/damage,
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock";
-	name = "Escape Pod Hatch"
-	},
-/turf/simulated/floor/mineral/titanium/airless,
 /area/ruin/space/moonbase19)
 "gX" = (
 /obj/structure/rack,
@@ -2385,10 +2345,6 @@
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid5"
 	},
-/area/ruin/space/moonbase19)
-"hK" = (
-/obj/machinery/door/airlock/external/glass,
-/turf/simulated/floor/catwalk,
 /area/ruin/space/moonbase19)
 "hL" = (
 /turf/simulated/floor/plasteel{
@@ -2852,17 +2808,6 @@
 /obj/structure/window/full/basic,
 /turf/simulated/floor/grass,
 /area/ruin/space/moonbase19)
-"iZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Workshop"
-	},
-/turf/simulated/floor/catwalk,
-/area/ruin/space/moonbase19)
 "ja" = (
 /obj/machinery/economy/arcade/claw,
 /turf/simulated/floor/plasteel/dark,
@@ -2942,13 +2887,6 @@
 	},
 /obj/structure/filingcabinet,
 /turf/simulated/floor/plasteel/dark,
-/area/ruin/space/moonbase19)
-"jn" = (
-/obj/machinery/door/airlock/centcom,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
 /area/ruin/space/moonbase19)
 "jo" = (
 /obj/structure/closet/cabinet,
@@ -3091,6 +3029,16 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
+/area/ruin/space/moonbase19)
+"jN" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engine Room";
+	dir = 4
+	},
+/obj/machinery/door/firedoor/closed{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
 /area/ruin/space/moonbase19)
 "jP" = (
 /obj/structure/railing,
@@ -3246,17 +3194,6 @@
 	},
 /obj/effect/turf_decal/tiles/dark/corner,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/moonbase19)
-"kh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "awayscilock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
-/obj/machinery/door/airlock/centcom{
-	name = "Research Division"
-	},
-/turf/simulated/floor/catwalk,
 /area/ruin/space/moonbase19)
 "ki" = (
 /obj/machinery/door/airlock/external,
@@ -3541,6 +3478,12 @@
 "lz" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel/dark,
+/area/ruin/space/moonbase19)
+"lA" = (
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
 /area/ruin/space/moonbase19)
 "lC" = (
 /obj/item/food/beans,
@@ -3857,6 +3800,18 @@
 /obj/machinery/atmospherics/air_sensor,
 /turf/simulated/floor/engine,
 /area/ruin/space/moonbase19)
+"mL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "awayscilock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/centcom{
+	name = "Research Division";
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
+/area/ruin/space/moonbase19)
 "mM" = (
 /obj/machinery/floodlight,
 /obj/effect/turf_decal/yellow_siding{
@@ -4146,6 +4101,17 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
+/area/ruin/space/moonbase19)
+"nT" = (
+/obj/structure/barricade/wooden/crude{
+	layer = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/ruin/space/moonbase19)
 "nV" = (
 /obj/effect/turf_decal/stripes/line{
@@ -4640,16 +4606,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/moonbase19)
-"pV" = (
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "awayscilock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
-/obj/machinery/door/airlock/centcom{
-	name = "Research Division"
-	},
-/turf/simulated/floor/catwalk,
-/area/ruin/space/moonbase19)
 "pW" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
@@ -5097,6 +5053,18 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/ruin/space/moonbase19)
+"rO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Workshop";
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
+/area/ruin/space/moonbase19)
 "rP" = (
 /obj/structure/flora/ash/rock/style_random,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -5133,16 +5101,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/turf_decal/tiles/dark/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/space/moonbase19)
-"rV" = (
-/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
-/obj/machinery/door/airlock{
-	name = "Dorms"
-	},
-/obj/effect/turf_decal/tiles/department/virology/side{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
@@ -5295,15 +5253,22 @@
 /obj/effect/mapping_helpers/turfs/rust,
 /turf/simulated/wall/indestructible/riveted,
 /area/ruin/space/moonbase19)
+"sI" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/command/glass{
+	name = "Senior Researcher's Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "mo19rdoffice"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/moonbase19)
 "sK" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/moonbase19)
-"sL" = (
-/obj/machinery/door/airlock/external/glass,
-/turf/simulated/floor/plating/asteroid/ancient,
 /area/ruin/space/moonbase19)
 "sR" = (
 /obj/structure/chair/sofa/bench/left,
@@ -5325,6 +5290,19 @@
 /area/ruin/space/moonbase19)
 "sZ" = (
 /obj/structure/chair/office/dark,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/moonbase19)
+"ta" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/command/glass{
+	name = "Senior Researcher's Office";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "mo19rdoffice"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/moonbase19)
 "tc" = (
@@ -5370,6 +5348,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/catwalk,
+/area/ruin/space/moonbase19)
+"ti" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
 /area/ruin/space/moonbase19)
 "tj" = (
 /obj/structure/railing/cap,
@@ -5743,6 +5729,12 @@
 /obj/effect/spawner/random/pool/spaceloot/moonoutpost19/vault3,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/moonbase19)
+"vj" = (
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/turf/simulated/floor/plating/asteroid/ancient,
+/area/ruin/space/moonbase19)
 "vm" = (
 /obj/machinery/atmospherics/portable/canister/air,
 /turf/simulated/floor/plasteel/dark,
@@ -5991,13 +5983,6 @@
 /obj/structure/table,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/moonbase19)
-"wP" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engine Room"
-	},
-/obj/machinery/door/firedoor/closed,
-/turf/simulated/floor/plating/airless,
-/area/ruin/space/moonbase19)
 "wQ" = (
 /obj/structure/railing{
 	dir = 4
@@ -6147,6 +6132,12 @@
 /obj/structure/closet/crate/can,
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plasteel,
+/area/ruin/space/moonbase19)
+"xy" = (
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/ruin/space/moonbase19)
 "xz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6718,16 +6709,6 @@
 /obj/machinery/economy/vending/coffee,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/moonbase19)
-"Af" = (
-/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
-/obj/machinery/door/airlock/command/glass{
-	name = "Senior Researcher's Office"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "mo19rdoffice"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/space/moonbase19)
 "Aj" = (
 /mob/living/basic/alien/sentinel,
 /turf/simulated/floor/plasteel,
@@ -7138,6 +7119,13 @@
 /obj/structure/chair,
 /turf/simulated/floor/catwalk,
 /area/ruin/space/moonbase19)
+"BN" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ruin/space/moonbase19)
 "BO" = (
 /obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/engineering/glass{
@@ -7159,6 +7147,17 @@
 	dir = 9
 	},
 /turf/simulated/floor/catwalk,
+/area/ruin/space/moonbase19)
+"BS" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "awayscilock"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/ruin/space/moonbase19)
 "BY" = (
 /obj/structure/railing{
@@ -7200,6 +7199,13 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel/white,
+/area/ruin/space/moonbase19)
+"Cq" = (
+/obj/structure/lattice,
+/obj/machinery/door/firedoor/closed{
+	dir = 4
+	},
+/turf/template_noop,
 /area/ruin/space/moonbase19)
 "Cr" = (
 /obj/structure/cable{
@@ -7271,6 +7277,14 @@
 /obj/structure/mopbucket/full,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/moonbase19)
+"CA" = (
+/obj/machinery/door/airlock/centcom{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/ruin/space/moonbase19)
 "CB" = (
 /obj/machinery/economy/vending/coffee,
 /obj/effect/decal/cleanable/dirt,
@@ -7313,6 +7327,17 @@
 	},
 /obj/effect/decal/cleanable/blood/tracks/mapped,
 /turf/simulated/floor/plasteel,
+/area/ruin/space/moonbase19)
+"CK" = (
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "awayscilock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/centcom{
+	name = "Research Division";
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
 /area/ruin/space/moonbase19)
 "CL" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -7471,12 +7496,6 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/moonbase19)
-"Dt" = (
-/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
-/obj/machinery/door/airlock/medical/glass,
-/obj/effect/decal/cleanable/blood/tracks/mapped,
-/turf/simulated/floor/plasteel/dark,
 /area/ruin/space/moonbase19)
 "Dw" = (
 /obj/structure/closet/crate,
@@ -7736,6 +7755,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/moonbase19)
+"EM" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/tracks/mapped,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/moonbase19)
 "EN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/greenglow,
@@ -7765,6 +7792,19 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/yellow_siding,
+/turf/simulated/floor/plasteel,
+/area/ruin/space/moonbase19)
+"ES" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock{
+	name = "Dorms";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/virology/side{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/moonbase19)
 "ET" = (
@@ -8168,6 +8208,14 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
+/area/ruin/space/moonbase19)
+"GM" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/security{
+	name = "Security Checkpoint";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
 /area/ruin/space/moonbase19)
 "GP" = (
 /obj/machinery/computer/nonfunctional,
@@ -8606,6 +8654,15 @@
 "IW" = (
 /turf/simulated/floor/engine/vacuum,
 /area/space/nearstation)
+"IY" = (
+/obj/effect/mapping_helpers/turfs/damage,
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock";
+	name = "Escape Pod Hatch";
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium/airless,
+/area/ruin/space/moonbase19)
 "IZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8871,6 +8928,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/moonbase19)
+"Kl" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/ruin/space/moonbase19)
 "Km" = (
 /obj/structure/railing{
 	dir = 6
@@ -8917,6 +8981,12 @@
 /area/ruin/space/moonbase19)
 "Kx" = (
 /obj/structure/closet/toolcloset,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/moonbase19)
+"Kz" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/moonbase19)
 "KC" = (
@@ -9096,6 +9166,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/moonbase19)
+"Lm" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock{
+	name = "Dorms";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/virology/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/space/moonbase19)
 "Ln" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -9106,6 +9187,13 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel/dark,
+/area/ruin/space/moonbase19)
+"Lr" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/centcom{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
 /area/ruin/space/moonbase19)
 "Lw" = (
 /obj/structure/railing{
@@ -9799,6 +9887,15 @@
 	},
 /turf/simulated/floor/catwalk,
 /area/ruin/space/moonbase19)
+"OB" = (
+/obj/machinery/door/airlock/centcom{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/ruin/space/moonbase19)
 "OD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10012,13 +10109,12 @@
 	temperature = 273.15
 	},
 /area/ruin/space/moonbase19)
-"PF" = (
-/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
-/obj/machinery/door/airlock/security{
-	name = "Security Checkpoint"
+"PG" = (
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/space/moonbase19)
+/turf/simulated/floor/mineral/titanium,
+/area/ruin/space/powered)
 "PK" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -10111,6 +10207,14 @@
 	dir = 10
 	},
 /turf/simulated/floor/catwalk,
+/area/ruin/space/moonbase19)
+"Qd" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/ruin/space/moonbase19)
 "Qe" = (
 /obj/structure/railing/cap{
@@ -10688,6 +10792,16 @@
 	icon_state = "asteroidplating"
 	},
 /area/ruin/space/moonbase19)
+"SQ" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/structure/barricade/wooden/crude{
+	layer = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/moonbase19)
 "ST" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10751,18 +10865,6 @@
 "Th" = (
 /obj/structure/sign/public/restroom,
 /turf/simulated/wall/r_wall,
-/area/ruin/space/moonbase19)
-"Ti" = (
-/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
-/obj/machinery/door/airlock/command/glass{
-	name = "Senior Researcher's Office"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "mo19rdoffice"
-	},
-/turf/simulated/floor/plasteel/dark,
 /area/ruin/space/moonbase19)
 "Tm" = (
 /obj/structure/railing/cap{
@@ -10952,18 +11054,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/moonbase19)
-"Ue" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
-/obj/machinery/door/airlock{
-	name = "Dorms"
-	},
-/obj/effect/turf_decal/tiles/department/virology/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/space/moonbase19)
 "Ug" = (
 /obj/structure/chair,
 /obj/machinery/light/small{
@@ -11046,6 +11136,14 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/moonbase19)
+"Uy" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Workshop";
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
+/area/ruin/space/moonbase19)
 "Uz" = (
 /obj/structure/barricade/wooden/crude{
 	layer = 4
@@ -11121,10 +11219,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/moonbase19)
-"UO" = (
-/obj/structure/lattice,
-/obj/machinery/door/firedoor/closed,
-/turf/template_noop,
+"UL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/centcom{
+	name = "Cafeteria";
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
 /area/ruin/space/moonbase19)
 "UQ" = (
 /obj/structure/railing/corner{
@@ -11374,15 +11478,6 @@
 /area/ruin/space/moonbase19)
 "Wd" = (
 /obj/effect/spawner/window/reinforced/grilled,
-/turf/simulated/floor/plating,
-/area/ruin/space/moonbase19)
-"We" = (
-/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "awayscilock"
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/moonbase19)
 "Wg" = (
@@ -11957,6 +12052,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/moonbase19)
+"YH" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/centcom{
+	name = "Cafeteria";
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
+/area/ruin/space/moonbase19)
 "YJ" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel,
@@ -11981,13 +12084,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/moonbase19)
-"YM" = (
-/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Workshop"
-	},
-/turf/simulated/floor/catwalk,
 /area/ruin/space/moonbase19)
 "YQ" = (
 /obj/structure/railing{
@@ -12041,12 +12137,6 @@
 /obj/structure/holosign/barrier/engineering,
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plating,
-/area/ruin/space/moonbase19)
-"Zb" = (
-/obj/machinery/door/airlock/external/glass{
-	locked = 1
-	},
-/turf/simulated/floor/catwalk,
 /area/ruin/space/moonbase19)
 "Zf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12128,6 +12218,13 @@
 /obj/item/storage/secure/briefcase,
 /turf/simulated/floor/carpet/royalblue,
 /area/ruin/space/moonbase19)
+"Zs" = (
+/obj/machinery/door/airlock/external/glass{
+	locked = 1;
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
+/area/ruin/space/moonbase19)
 "Zu" = (
 /obj/machinery/computer/nonfunctional,
 /obj/structure/window/reinforced{
@@ -12182,10 +12279,6 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/moonbase19)
-"ZE" = (
-/obj/machinery/door/airlock/external/glass,
-/turf/simulated/floor/plating,
-/area/ruin/space/moonbase19)
 "ZI" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/structure/table,
@@ -12224,14 +12317,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/engine,
-/area/ruin/space/moonbase19)
-"ZP" = (
-/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
-/obj/machinery/door/airlock/medical/glass,
-/obj/structure/barricade/wooden{
-	layer = 4
-	},
-/turf/simulated/floor/plasteel/white,
 /area/ruin/space/moonbase19)
 "ZR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12552,7 +12637,7 @@ ag
 La
 rl
 wc
-Dt
+EM
 Oc
 ZA
 TS
@@ -12617,7 +12702,7 @@ Wd
 Am
 Ci
 vz
-cF
+nT
 QQ
 tX
 tX
@@ -12888,7 +12973,7 @@ tX
 ag
 yb
 hE
-nw
+Kl
 nW
 rE
 cC
@@ -12959,7 +13044,7 @@ Sk
 kw
 Ix
 iC
-rV
+Lm
 aA
 KR
 IM
@@ -12985,7 +13070,7 @@ qD
 fi
 hp
 gr
-cx
+SQ
 cX
 vn
 wd
@@ -13081,7 +13166,7 @@ kZ
 IJ
 oX
 oT
-Ue
+ES
 My
 bZ
 WZ
@@ -13296,7 +13381,7 @@ dH
 dp
 HY
 ep
-rZ
+BN
 jb
 tX
 tX
@@ -13351,7 +13436,7 @@ ig
 Qn
 Sm
 Xd
-ZP
+gI
 QW
 oo
 Oe
@@ -13452,7 +13537,7 @@ Bg
 Bg
 cm
 cm
-rZ
+BN
 dY
 Sb
 FC
@@ -13559,7 +13644,7 @@ cm
 Gy
 bP
 bP
-Mx
+Qd
 Yh
 aA
 ak
@@ -13696,7 +13781,7 @@ yy
 cM
 Bg
 Bg
-YM
+Uy
 tV
 ak
 lY
@@ -13744,7 +13829,7 @@ Xl
 WX
 ON
 ny
-wP
+jN
 Za
 Ur
 nK
@@ -13805,7 +13890,7 @@ Xl
 ON
 Wg
 ON
-UO
+Cq
 Za
 Sz
 ag
@@ -13818,7 +13903,7 @@ Bx
 ed
 ci
 ci
-iZ
+rO
 Pj
 CW
 lY
@@ -13866,7 +13951,7 @@ wl
 ON
 RA
 MT
-UO
+Cq
 GD
 Fc
 Dz
@@ -14017,7 +14102,7 @@ te
 yx
 Ev
 Ev
-fQ
+UL
 td
 bZ
 da
@@ -14047,7 +14132,7 @@ Sp
 cm
 PB
 bP
-Mx
+Qd
 ak
 aA
 aA
@@ -14078,7 +14163,7 @@ fr
 aK
 Hx
 aK
-qx
+YH
 Ak
 gl
 dz
@@ -14208,7 +14293,7 @@ Mt
 OD
 lX
 TZ
-bb
+Kz
 OM
 ia
 ax
@@ -14477,11 +14562,11 @@ dO
 Pt
 Pr
 Pr
-Af
+sI
 UH
 cX
 QS
-PF
+GM
 NS
 aA
 ca
@@ -14505,7 +14590,7 @@ Qy
 LJ
 ak
 ak
-fn
+Lr
 ak
 ak
 Jv
@@ -14513,7 +14598,7 @@ iW
 iW
 aA
 qo
-rZ
+BN
 cm
 bP
 kb
@@ -14599,11 +14684,11 @@ yQ
 uw
 nh
 lP
-Ti
+ta
 Rl
 sj
 EF
-PF
+GM
 ak
 Wb
 NF
@@ -14758,7 +14843,7 @@ IN
 tm
 cp
 cm
-rZ
+BN
 cm
 cm
 bP
@@ -14908,7 +14993,7 @@ ah
 yX
 MJ
 Rc
-Ct
+dr
 aq
 aq
 yE
@@ -14916,13 +15001,13 @@ Zh
 Lf
 la
 ak
-kh
+mL
 ve
 ve
 qr
 fp
 fp
-pV
+CK
 aA
 xf
 hk
@@ -15030,7 +15115,7 @@ Hd
 ky
 aA
 NM
-Ct
+dr
 OT
 Uv
 rk
@@ -15038,13 +15123,13 @@ Ct
 Ao
 Qk
 aA
-pV
+CK
 fr
 fr
 Hx
 aK
 aK
-kh
+mL
 ak
 xO
 hl
@@ -15185,7 +15270,7 @@ fM
 fM
 Sb
 Sb
-jn
+OB
 eM
 Yl
 eO
@@ -15307,7 +15392,7 @@ kk
 Wo
 kk
 Ph
-di
+CA
 dK
 NJ
 zL
@@ -15408,7 +15493,7 @@ tX
 tX
 zT
 ad
-sL
+vj
 db
 ie
 rG
@@ -15430,7 +15515,7 @@ af
 tX
 ag
 aD
-el
+ti
 eA
 af
 jb
@@ -15453,7 +15538,7 @@ jE
 bP
 cm
 bP
-We
+BS
 Mg
 Hj
 xl
@@ -15524,7 +15609,7 @@ rY
 EV
 ag
 PL
-ZE
+xy
 ad
 fV
 hG
@@ -15552,7 +15637,7 @@ tX
 tX
 ag
 Yu
-el
+ti
 PK
 ag
 pK
@@ -16084,8 +16169,8 @@ iL
 fX
 gC
 cr
-gW
-hK
+IY
+lA
 QP
 cm
 aA
@@ -16268,10 +16353,10 @@ ad
 hG
 ad
 ad
-Zb
+Zs
 Da
 iv
-bx
+PG
 aU
 aU
 hu
@@ -16451,7 +16536,7 @@ ad
 dA
 iM
 ad
-Zb
+Zs
 Da
 iv
 dg

--- a/_maps/map_files/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/oldstation.dmm
@@ -199,15 +199,6 @@
 /obj/structure/toilet/directional/north,
 /turf/simulated/floor/plasteel/white,
 /area/ruin/ancientstation)
-"aK" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Prototype Laboratory"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/ruins/theta,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/white/side,
-/turf/simulated/floor/plasteel,
-/area/ruin/ancientstation/thetacorridor)
 "aL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -382,11 +373,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/ruin/ancientstation)
-"bn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/highsecurity,
-/turf/simulated/floor/plating,
-/area/ruin/ancientstation/hivebot)
 "bo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/airless,
@@ -437,27 +423,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation/sec)
-"bv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/science{
-	name = "Artificial Program Core Room"
-	},
-/turf/simulated/floor/plating,
-/area/ruin/ancientstation/hivebot)
-"bw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/science{
-	name = "Artificial Program Core Room"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/ruin/ancientstation/hivebot)
 "bx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -651,14 +616,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/ancientstation)
-"ch" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
 /area/ruin/ancientstation)
 "ci" = (
 /obj/effect/decal/cleanable/dirt,
@@ -944,19 +901,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/ancientstation/atmo)
-"dc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/poddoor{
-	id_tag = "prototype_vault_antechamber";
-	name = "Theta prototype lab blast door"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/white,
-/area/ruin/ancientstation/proto)
 "dd" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/off_station/empty_charge/directional/east,
@@ -1523,13 +1467,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation)
-"eN" = (
-/obj/machinery/door/firedoor,
-/mob/living/basic/hivebot,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/ruin/ancientstation/thetacorridor)
 "eO" = (
 /obj/structure/lattice,
 /obj/item/solar_assembly,
@@ -1632,16 +1569,6 @@
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/official/nanotrasen_logo/directional/north,
-/turf/simulated/floor/plasteel,
-/area/ruin/ancientstation)
-"ff" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/public/glass{
-	name = "Charlie Station Cryogenics Room"
-	},
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation)
 "fg" = (
@@ -1790,13 +1717,6 @@
 /obj/effect/turf_decal/tiles/department/security,
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation/comm)
-"fB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/ruin/ancientstation)
 "fC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1864,16 +1784,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel/airless,
 /area/ruin/ancientstation/betanorth)
-"fK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge Staff Cryopods"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/ruin/ancientstation/comm)
 "fL" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -2102,6 +2012,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation/engi)
+"gq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/ancientstation/rnd)
 "gr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2322,11 +2242,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation/thetacorridor)
-"gU" = (
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/ruin/ancientstation/thetacorridor)
 "gV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2495,7 +2410,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/general_air_control/large_tank_control{
 	name = "Mixed Air Supply Control";
-	autolink_sensors = list("air_sensor"="Tank");
+	autolink_sensors = list("air_sensor" = "Tank");
 	outlet_autolink_ids = list("theta_air_out");
 	inlet_injector_autolink_ids = list("theta_air_in");
 	dir = 8
@@ -2619,17 +2534,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation/engi)
-"hH" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tiles/department/engineering/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/ancientstation)
 "hI" = (
 /obj/effect/decal/cleanable/vomit,
 /obj/effect/decal/cleanable/dirt,
@@ -2655,11 +2559,6 @@
 /obj/effect/turf_decal/tiles/department/science,
 /turf/simulated/floor/plasteel/white,
 /area/ruin/ancientstation/comm)
-"hO" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/ruin/ancientstation)
 "hP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/chem_heater,
@@ -2872,15 +2771,6 @@
 "in" = (
 /turf/simulated/floor/plating/airless,
 /area/ruin/ancientstation/atmo)
-"io" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/ancientstation/rnd)
 "ir" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -2926,12 +2816,6 @@
 /obj/machinery/door/airlock/science,
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation/thetacorridor)
-"ix" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research,
-/turf/simulated/floor/plasteel,
-/area/ruin/ancientstation/rnd)
 "iy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
@@ -2986,19 +2870,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ruin/ancientstation/engi)
-"iH" = (
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor/closed,
-/turf/simulated/floor/plasteel/airless,
-/area/ruin/ancientstation/atmo)
 "iJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -3152,12 +3023,6 @@
 /obj/structure/particle_accelerator/particle_emitter/center,
 /turf/simulated/floor/plating,
 /area/ruin/ancientstation/thetacorridor)
-"jn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/white,
-/area/ruin/ancientstation)
 "jo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/large/dead,
@@ -3228,11 +3093,6 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/ancientstation/thetacorridor)
-"jx" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
 /area/ruin/ancientstation/thetacorridor)
 "jy" = (
 /obj/machinery/atmospherics/meter,
@@ -3594,13 +3454,6 @@
 /mob/living/basic/hivebot/strong,
 /turf/simulated/floor/plasteel/white,
 /area/ruin/ancientstation/rnd)
-"kM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/basic/hivebot,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/ruin/ancientstation/thetacorridor)
 "kN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -3611,13 +3464,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation)
-"kO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/mob/living/basic/hivebot,
-/turf/simulated/floor/plasteel,
-/area/ruin/ancientstation/thetacorridor)
 "kP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3729,16 +3575,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation/sec)
-"le" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/ruin/ancientstation/comm)
 "lf" = (
 /turf/simulated/floor/engine/vacuum,
 /area/ruin/ancientstation/atmo)
@@ -3754,6 +3590,18 @@
 /obj/effect/spawner/random/cobweb/right/frequent,
 /turf/simulated/floor/plating,
 /area/ruin/ancientstation/thetacorridor)
+"lk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/ruin/ancientstation/rnd)
 "ll" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4174,6 +4022,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation)
+"nM" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Prototype Laboratory";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/theta,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/white/side,
+/turf/simulated/floor/plasteel,
+/area/ruin/ancientstation/thetacorridor)
 "nZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4245,16 +4105,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation/sec)
-"oV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/ancientstation)
 "oY" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/public/cryo,
@@ -4369,14 +4219,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation/comm)
-"qm" = (
-/obj/machinery/door/poddoor{
-	id_tag = "prototype_vault_antechamber";
-	name = "Theta prototype lab blast door"
+"qr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/closed{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/white,
-/area/ruin/ancientstation/proto)
+/turf/simulated/floor/plasteel/airless,
+/area/ruin/ancientstation/betanorth)
 "qu" = (
 /obj/effect/mapping_helpers/turfs/rust,
 /obj/effect/spawner/random/fungus/maybe,
@@ -4395,6 +4244,15 @@
 	},
 /turf/template_noop,
 /area/space/nearstation)
+"qx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/ruin/ancientstation)
 "qz" = (
 /turf/simulated/wall/indestructible/riveted,
 /area/ruin/ancientstation/proto)
@@ -4441,14 +4299,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ruin/ancientstation/hydroponics)
-"ro" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/ruin/ancientstation/hydroponics)
 "rx" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/basic/hivebot,
@@ -4465,6 +4315,13 @@
 	dir = 10
 	},
 /obj/effect/spawner/random/cobweb/right/frequent,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/ruin/ancientstation)
+"rE" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/ancientstation)
@@ -4493,15 +4350,6 @@
 /obj/structure/cable/yellow,
 /turf/template_noop,
 /area/space/nearstation)
-"rU" = (
-/obj/machinery/door/poddoor/multi_tile/impassable{
-	name = "prototype vault blast doors";
-	desc = "A heavy duty blast door that opens mechanically. It was hermetically sealed when the crew went into cryostasis.";
-	id_tag = "prototype_vault"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/engine,
-/area/ruin/ancientstation/powered)
 "rX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -4551,6 +4399,17 @@
 /obj/structure/girder/reinforced,
 /turf/simulated/floor/plating/airless,
 /area/ruin/ancientstation/atmo)
+"su" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/science{
+	name = "Artificial Program Core Room";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ruin/ancientstation/hivebot)
 "sx" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4593,6 +4452,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation)
+"sX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/highsecurity{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ruin/ancientstation/hivebot)
 "sY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -4612,6 +4478,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation/thetacorridor)
+"tm" = (
+/obj/machinery/door/poddoor{
+	id_tag = "prototype_vault_antechamber";
+	name = "Theta prototype lab blast door"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/ruin/ancientstation/proto)
 "ts" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/showcase/machinery/oldpod,
@@ -4684,6 +4560,19 @@
 	},
 /turf/simulated/floor/engine,
 /area/ruin/ancientstation/proto)
+"uh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/ancientstation/rnd)
 "uk" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -4691,6 +4580,19 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/ruin/ancientstation)
+"uo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/public/glass{
+	name = "Charlie Station Cryogenics Room";
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation)
 "ut" = (
@@ -4709,6 +4611,19 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/tank/internals/emergency_oxygen,
+/turf/simulated/floor/plasteel,
+/area/ruin/ancientstation/comm)
+"uD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge Staff Cryopods";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation/comm)
 "uQ" = (
@@ -4821,15 +4736,6 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/ruin/ancientstation/kitchen)
-"vN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/ruin/ancientstation)
 "vY" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4854,11 +4760,6 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel/airless,
-/area/ruin/ancientstation/betanorth)
-"wi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/closed,
 /turf/simulated/floor/plasteel/airless,
 /area/ruin/ancientstation/betanorth)
 "wm" = (
@@ -4951,6 +4852,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation)
+"xM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/ancientstation/comm)
 "xP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -5015,6 +4929,16 @@
 /obj/machinery/light,
 /turf/simulated/floor/plasteel/white,
 /area/ruin/ancientstation/proto)
+"yA" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tiles/department/engineering/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/ancientstation)
 "yB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/mob_spawn/human/alive/old/eng,
@@ -5047,6 +4971,15 @@
 /obj/structure/sign/poster/official/science/directional/east,
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation/thetacorridor)
+"zo" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/mob/living/basic/hivebot,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/ruin/ancientstation/thetacorridor)
 "zp" = (
 /obj/structure/table,
 /obj/machinery/cooking/grill,
@@ -5071,6 +5004,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation/betanorth)
+"zG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/poddoor{
+	id_tag = "prototype_vault_antechamber";
+	name = "Theta prototype lab blast door"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/ruin/ancientstation/proto)
 "zJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5101,6 +5049,20 @@
 /obj/structure/sign/poster/official/nanomichi_ad/directional/east,
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation/betanorth)
+"zS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/basic/hivebot,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/ruin/ancientstation/thetacorridor)
 "zT" = (
 /obj/structure/table,
 /obj/item/tank/internals/oxygen,
@@ -5125,6 +5087,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation)
+"Aj" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/ruin/ancientstation/thetacorridor)
 "Ak" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -5132,6 +5101,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation)
+"Al" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Prototype Laboratory";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/ruins/theta,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/white/side,
+/turf/simulated/floor/plasteel,
+/area/ruin/ancientstation/thetacorridor)
 "Ax" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -5168,16 +5154,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/ruin/ancientstation/proto)
-"AO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/closed,
-/turf/simulated/floor/plasteel/airless,
-/area/ruin/ancientstation/betanorth)
 "AP" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -5191,20 +5167,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation/sec)
-"AV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/highsecurity{
-	name = "Prototype Laboratory"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/ruins/theta,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/white/side,
-/turf/simulated/floor/plasteel,
-/area/ruin/ancientstation/thetacorridor)
 "AY" = (
 /obj/machinery/door/poddoor{
 	id_tag = "ancient"
@@ -5241,6 +5203,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/ruin/ancientstation/sec)
+"Bj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/ancientstation)
 "Bk" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -5325,6 +5299,15 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/ruin/ancientstation/thetacorridor)
+"BZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/mob/living/basic/hivebot,
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation/thetacorridor)
 "Cb" = (
@@ -5464,6 +5447,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation/thetacorridor)
+"Dd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/science{
+	name = "Artificial Program Core Room";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/ruin/ancientstation/hivebot)
 "De" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/pod,
@@ -5510,6 +5509,23 @@
 /obj/item/kirbyplants/large/dead,
 /turf/simulated/floor/plasteel/airless,
 /area/ruin/ancientstation/atmo)
+"Dy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/ancientstation/thetacorridor)
+"DE" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/ruin/ancientstation)
 "DG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -5561,6 +5577,17 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/ancientstation/betanorth)
+"Eq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/ruin/ancientstation)
 "Es" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/flag/nt,
@@ -5686,16 +5713,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/white,
 /area/ruin/ancientstation)
-"Gi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+"Gb" = (
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/ancientstation/thetacorridor)
+/area/ruin/ancientstation)
 "Gq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
@@ -5767,6 +5791,19 @@
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall,
 /area/ruin/ancientstation/betanorth)
+"HF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tiles/department/engineering/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/ancientstation)
 "HO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5946,6 +5983,12 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/ruin/ancientstation/proto)
+"Ju" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/ruin/ancientstation/powered)
 "Jz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/secure/oldstation/security,
@@ -5970,6 +6013,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation/comm)
+"JK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/ruin/ancientstation/hydroponics)
 "JO" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -5977,6 +6030,13 @@
 /obj/machinery/hydroponics/soil,
 /turf/simulated/floor/grass,
 /area/ruin/ancientstation/hydroponics)
+"JP" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/ruin/ancientstation/thetacorridor)
 "JV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -5985,6 +6045,15 @@
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/ruin/ancientstation/betanorth)
+"Kb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/basic/hivebot,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/ancientstation/thetacorridor)
 "Kf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash,
@@ -6002,10 +6071,6 @@
 /obj/effect/turf_decal/tiles/department/virology/side,
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation/hydroponics)
-"Ku" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/turf/simulated/floor/plating,
-/area/ruin/ancientstation/thetacorridor)
 "KA" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -6029,6 +6094,22 @@
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall,
 /area/ruin/ancientstation/hivebot)
+"KX" = (
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/closed{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/airless,
+/area/ruin/ancientstation/atmo)
 "Ld" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel/white,
@@ -6152,14 +6233,6 @@
 	},
 /turf/template_noop,
 /area/space/nearstation)
-"LR" = (
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tiles/department/engineering/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/ancientstation)
 "LZ" = (
 /obj/effect/mapping_helpers/turfs/rust,
 /obj/structure/sign/public/cryo,
@@ -6241,6 +6314,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation)
+"Nd" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/ruin/ancientstation/betanorth)
 "Nh" = (
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plasteel/white,
@@ -6354,6 +6437,12 @@
 /obj/effect/spawner/random/fungus/probably,
 /turf/simulated/wall,
 /area/ruin/ancientstation/hivebot)
+"OH" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ruin/ancientstation/thetacorridor)
 "ON" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/janitorialcart{
@@ -6413,6 +6502,18 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/ancientstation/atmo)
+"Pu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/ruin/ancientstation/thetacorridor)
 "Pz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6457,14 +6558,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/machinery/recharger,
-/turf/simulated/floor/plasteel,
-/area/ruin/ancientstation/rnd)
-"PM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation/rnd)
 "PO" = (
@@ -6568,6 +6661,16 @@
 /obj/effect/turf_decal/tiles/department/science,
 /turf/simulated/floor/plasteel/white,
 /area/ruin/ancientstation/comm)
+"Rl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/ruin/ancientstation)
 "Ru" = (
 /mob/living/basic/hivebot,
 /obj/effect/decal/cleanable/dirt,
@@ -6719,6 +6822,17 @@
 /obj/effect/turf_decal/tiles/department/chemistry,
 /turf/simulated/floor/plasteel/white,
 /area/ruin/ancientstation/comm)
+"SQ" = (
+/obj/machinery/door/poddoor/multi_tile/impassable{
+	name = "prototype vault blast doors";
+	desc = "A heavy duty blast door that opens mechanically. It was hermetically sealed when the crew went into cryostasis.";
+	id_tag = "prototype_vault"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/ruin/ancientstation/powered)
 "SR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -6996,18 +7110,6 @@
 /obj/structure/transit_tube/horizontal,
 /turf/template_noop,
 /area/space/nearstation)
-"VV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/basic/hivebot,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/ruin/ancientstation/thetacorridor)
 "Wc" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /obj/effect/decal/cleanable/generic,
@@ -7110,14 +7212,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation/betanorth)
-"XB" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/ruin/ancientstation/betanorth)
 "XM" = (
 /obj/structure/table/reinforced,
 /obj/item/paper/fluff/ruins/oldstation/protogun,
@@ -7190,10 +7284,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation/thetacorridor)
-"Yu" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/engine,
-/area/ruin/ancientstation/powered)
+"Yw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/closed{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/airless,
+/area/ruin/ancientstation/betanorth)
 "YH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7462,7 +7564,7 @@ aa
 sp
 jQ
 db
-iH
+KX
 PX
 jL
 lr
@@ -7538,7 +7640,7 @@ gV
 gV
 gV
 gV
-XB
+Nd
 id
 xZ
 Bp
@@ -7546,7 +7648,7 @@ ek
 QP
 bY
 bY
-AO
+Yw
 fs
 uQ
 aa
@@ -7594,7 +7696,7 @@ cT
 UA
 Qi
 Qi
-wi
+qr
 be
 fr
 aa
@@ -8938,11 +9040,11 @@ pO
 nw
 ca
 hC
-hH
+HF
 ca
 VA
 bC
-LR
+yA
 lp
 Tw
 KC
@@ -8978,7 +9080,7 @@ Zr
 aL
 aL
 aL
-ch
+DE
 cd
 cy
 uk
@@ -8986,11 +9088,11 @@ cb
 tT
 cb
 ZT
-fB
+qx
 jG
 op
 MI
-oV
+Bj
 kl
 ck
 nh
@@ -8998,7 +9100,7 @@ kl
 iJ
 Yk
 ga
-vN
+Eq
 jy
 jN
 ya
@@ -9262,11 +9364,11 @@ ut
 Cx
 eL
 eL
-le
+xM
 dv
 al
 dv
-fK
+uD
 fv
 sI
 cB
@@ -9274,7 +9376,7 @@ da
 dw
 hD
 FQ
-ro
+JK
 fO
 gs
 gt
@@ -9286,7 +9388,7 @@ ia
 ha
 kN
 fv
-ff
+uo
 jH
 yt
 yB
@@ -9551,10 +9653,10 @@ aa
 az
 aI
 aP
-jn
+Rl
 Cb
 bl
-jn
+Rl
 bC
 bC
 cE
@@ -9562,11 +9664,11 @@ bJ
 iy
 fv
 jH
-fB
+qx
 gM
 gu
 jq
-fB
+qx
 jH
 CA
 Cv
@@ -9574,7 +9676,7 @@ jH
 kF
 sI
 bC
-hO
+rE
 bg
 bg
 bg
@@ -9610,11 +9712,11 @@ lN
 bx
 bC
 bC
-eM
+Gb
 bC
 dy
 bC
-eM
+Gb
 dW
 bC
 IQ
@@ -10377,12 +10479,12 @@ rX
 es
 BX
 bO
-kM
+Kb
 bO
 rx
 qN
 fq
-gU
+Aj
 fq
 fq
 hg
@@ -10425,12 +10527,12 @@ RR
 iV
 cY
 if
-VV
+zS
 jr
 ih
 xj
 am
-Gi
+Pu
 iV
 iV
 LB
@@ -10438,7 +10540,7 @@ aU
 gh
 ta
 fq
-jx
+JP
 bS
 bS
 Lr
@@ -10585,12 +10687,12 @@ gT
 jF
 qz
 UW
-rU
+SQ
 sm
 jC
 ZR
 dh
-rU
+SQ
 tY
 qz
 Et
@@ -10633,12 +10735,12 @@ fq
 jF
 qz
 jU
-Yu
+Ju
 jT
 ZR
 ZR
 Ld
-Yu
+Ju
 Sh
 qz
 Et
@@ -10656,7 +10758,7 @@ ah
 ai
 co
 ds
-bn
+sX
 Bb
 cM
 lW
@@ -10704,12 +10806,12 @@ aj
 ah
 ap
 ap
-bn
+sX
 Bb
-bw
+Dd
 dm
 lw
-io
+uh
 nz
 dG
 eh
@@ -10723,13 +10825,13 @@ hi
 hx
 gf
 ii
-ix
+gq
 hv
 fq
-aK
+nM
 Nh
 UE
-qm
+tm
 ZR
 nI
 LG
@@ -10754,10 +10856,10 @@ ac
 ac
 ac
 Bb
-bv
+su
 bO
 dX
-ix
+gq
 dG
 dG
 lb
@@ -10771,13 +10873,13 @@ jA
 LE
 IL
 is
-PM
+lk
 CN
 qj
-AV
+Al
 ps
 Vj
-dc
+zG
 DK
 gb
 LG
@@ -10873,12 +10975,12 @@ lh
 jF
 qz
 jW
-rU
+SQ
 jT
 ZR
 ZR
 Ld
-rU
+SQ
 qZ
 qz
 Et
@@ -10921,12 +11023,12 @@ fq
 jF
 qz
 jX
-Yu
+Ju
 ng
 Jo
 Dg
 Jt
-Yu
+Ju
 XM
 qz
 Et
@@ -11049,12 +11151,12 @@ Ys
 dq
 hj
 bO
-eN
+zo
 jt
 Ru
 fq
 OW
-gU
+Aj
 Ru
 fq
 lK
@@ -11062,7 +11164,7 @@ im
 BM
 jw
 fq
-Ku
+OH
 Xq
 bS
 uR
@@ -11097,12 +11199,12 @@ Lj
 gj
 aM
 bO
-kO
+BZ
 bO
 kS
 fq
 kS
-gT
+Dy
 kS
 fq
 hE

--- a/_maps/map_files/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/onehalf.dmm
@@ -84,13 +84,6 @@
 "ap" = (
 /turf/simulated/floor/plasteel,
 /area/ruin/space/onehalf/dorms_med)
-"aq" = (
-/obj/machinery/door/airlock/external,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/ruin/space/onehalf/drone_bay)
 "ar" = (
 /turf/simulated/wall,
 /area/ruin/space/onehalf/drone_bay)
@@ -328,17 +321,6 @@
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/onehalf/hallway)
-"aV" = (
-/obj/machinery/door/airlock/medical/glass,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/white,
-/area/ruin/space/onehalf/dorms_med)
-"aW" = (
-/obj/machinery/door/airlock,
-/turf/simulated/floor/plasteel,
-/area/ruin/space/onehalf/dorms_med)
 "aX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1129,6 +1111,12 @@
 /mob/living/basic/carp,
 /turf/template_noop,
 /area/space/nearstation)
+"tW" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/space/onehalf/dorms_med)
 "xr" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -1156,6 +1144,24 @@
 /obj/machinery/power/apc/off_station/directional/north,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/onehalf/abandonedbridge)
+"TO" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/ruin/space/onehalf/drone_bay)
+"Yf" = (
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/ruin/space/onehalf/dorms_med)
 
 (1,1,1) = {"
 aa
@@ -1340,7 +1346,7 @@ ag
 am
 am
 aK
-aV
+Yf
 bg
 bx
 bN
@@ -1428,7 +1434,7 @@ ah
 ap
 ap
 ap
-aW
+tW
 bh
 bv
 aI
@@ -1491,9 +1497,9 @@ aa
 aa
 ad
 ai
-aq
+TO
 aD
-aq
+TO
 aX
 bm
 bn

--- a/_maps/map_files/RandomRuins/SpaceRuins/rocky_motel.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/rocky_motel.dmm
@@ -110,14 +110,6 @@
 /obj/effect/turf_decal/tiles/dark/side,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/rocky_motel)
-"if" = (
-/obj/machinery/door/airlock{
-	id_tag = "toilet_unitb";
-	name = "Unit B"
-	},
-/obj/effect/mapping_helpers/turfs/damage,
-/turf/simulated/floor/wood,
-/area/ruin/space/rocky_motel)
 "iT" = (
 /obj/machinery/power/solar,
 /obj/structure/cable{
@@ -158,6 +150,15 @@
 /obj/item/clothing/under/pants/blackjeans,
 /obj/item/clothing/suit/sovietcoat,
 /turf/simulated/floor/carpet/black,
+/area/ruin/space/rocky_motel)
+"mk" = (
+/obj/machinery/door/airlock{
+	id_tag = "toilet_unitb";
+	name = "Unit B";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/turfs/damage,
+/turf/simulated/floor/wood,
 /area/ruin/space/rocky_motel)
 "mO" = (
 /obj/structure/cable{
@@ -222,6 +223,13 @@
 /obj/structure/dresser,
 /turf/simulated/floor/carpet/royalblack,
 /area/ruin/space/rocky_motel)
+"re" = (
+/obj/effect/mapping_helpers/turfs/damage,
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/ruin/space/rocky_motel)
 "sQ" = (
 /turf/simulated/floor/plasteel,
 /area/ruin/space/rocky_motel)
@@ -234,6 +242,16 @@
 	},
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/rocky_motel/asteroid)
+"tb" = (
+/obj/machinery/door/airlock{
+	id_tag = "toilet_unitb";
+	name = "Unit B";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/ruin/space/rocky_motel)
 "tq" = (
 /obj/structure/sign/poster/random/directional/west,
 /turf/simulated/floor/carpet/royalblack,
@@ -385,6 +403,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/rocky_motel)
+"Hg" = (
+/obj/machinery/door/airlock/titanium{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/ruin/space/rocky_motel/asteroid)
 "Hp" = (
 /obj/machinery/power/solar_control/autostart,
 /obj/structure/cable{
@@ -470,11 +494,6 @@
 	icon_state = "solarpanel"
 	},
 /area/ruin/space/rocky_motel/asteroid)
-"KJ" = (
-/obj/effect/mapping_helpers/turfs/damage,
-/obj/machinery/door/airlock,
-/turf/simulated/floor/wood,
-/area/ruin/space/rocky_motel)
 "LE" = (
 /obj/machinery/suit_storage_unit/standard_unit{
 	storage_type = /obj/item/tank/internals/oxygen
@@ -652,15 +671,6 @@
 	},
 /turf/simulated/wall,
 /area/ruin/space/rocky_motel)
-"Wa" = (
-/obj/machinery/door/airlock{
-	id_tag = "toilet_unitb";
-	name = "Unit B"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/ruin/space/rocky_motel)
 "Wn" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -733,10 +743,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/ruin/space/rocky_motel)
-"Zd" = (
-/obj/machinery/door/airlock/titanium,
-/turf/simulated/floor/mineral/titanium,
-/area/ruin/space/rocky_motel/asteroid)
 "Ze" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/atmospherics/portable/canister/air,
@@ -997,7 +1003,7 @@ vV
 WD
 WD
 WD
-Wa
+tb
 YM
 cT
 MT
@@ -1098,11 +1104,11 @@ MT
 Ha
 RC
 AG
-KJ
+re
 ib
 ib
 Cq
-if
+mk
 LF
 LF
 LF
@@ -1238,7 +1244,7 @@ Ya
 Aa
 aY
 aY
-Zd
+Hg
 au
 au
 Ya

--- a/_maps/map_files/RandomRuins/SpaceRuins/sieged_lab.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/sieged_lab.dmm
@@ -1,4 +1,13 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aj" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/space/sieged_lab)
 "aW" = (
 /obj/structure/extinguisher_cabinet/empty{
 	pixel_x = 28
@@ -78,6 +87,16 @@
 /obj/effect/turf_decal/tiles/department/engineering/side,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/sieged_lab)
+"fI" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Power Room";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/side{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/space/sieged_lab)
 "fV" = (
 /obj/effect/spawner/themed_mess/dirty,
 /turf/simulated/floor/plasteel,
@@ -111,13 +130,6 @@
 /obj/structure/engineeringcart,
 /obj/effect/turf_decal/tiles/department/engineering/side{
 	dir = 6
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/space/sieged_lab)
-"jD" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/turf_decal/tiles/neutral/side{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/sieged_lab)
@@ -192,10 +204,6 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/ruin/space/sieged_lab)
-"mM" = (
-/obj/machinery/door/airlock,
-/turf/simulated/floor/wood,
-/area/ruin/space/sieged_lab)
 "mU" = (
 /obj/structure/sign/poster/official/build/directional/north,
 /obj/effect/turf_decal/tiles/department/engineering/side{
@@ -224,6 +232,12 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/sieged_lab)
+"ok" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/ruin/space/sieged_lab)
 "oI" = (
 /obj/structure/sign/directions/security{
 	dir = 8
@@ -246,12 +260,32 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/sieged_lab)
+"pB" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/effect/turf_decal/tiles/neutral/side{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/space/sieged_lab)
 "pT" = (
 /obj/effect/map_effect/marker_helper/mapmanip/submap/edge{
 	dir = 8
 	},
 /obj/effect/turf_decal/tiles/neutral/side{
 	dir = 6
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/space/sieged_lab)
+"pU" = (
+/obj/machinery/door/airlock/security{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/sieged_lab)
@@ -318,29 +352,9 @@
 	},
 /turf/template_noop,
 /area/template_noop)
-"rV" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/turf_decal/tiles/neutral/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/space/sieged_lab)
 "rW" = (
 /obj/structure/sign/directions/security,
 /turf/simulated/wall,
-/area/ruin/space/sieged_lab)
-"sj" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Power Room"
-	},
-/obj/effect/turf_decal/tiles/neutral/side{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/space/sieged_lab)
-"sS" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/turf/simulated/floor/plating,
 /area/ruin/space/sieged_lab)
 "tc" = (
 /obj/item/chair/stool,
@@ -470,17 +484,6 @@
 /obj/effect/map_effect/marker/mapmanip/submap/insert/ruin/sieged_lab/vert_hallway,
 /turf/simulated/floor/plating,
 /area/ruin/space/sieged_lab)
-"xV" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/obj/machinery/door/poddoor/multi_tile/impassable{
-	id_tag = "SL_EndRoom"
-	},
-/obj/effect/turf_decal/tiles/neutral/side{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/space/sieged_lab)
 "yn" = (
 /obj/effect/decal/cleanable/blood/tracks/mapped{
 	dir = 6
@@ -539,6 +542,28 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/sieged_lab)
+"Am" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/machinery/door/poddoor/multi_tile/impassable{
+	id_tag = "SL_EndRoom"
+	},
+/obj/effect/turf_decal/tiles/neutral/side{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/space/sieged_lab)
+"Ar" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/space/sieged_lab)
 "AB" = (
 /obj/structure/noticeboard,
 /obj/item/paper/sieged_lab_research_paper,
@@ -569,14 +594,6 @@
 	},
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/space/sieged_lab)
-"BT" = (
-/obj/machinery/door/airlock/security,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/sieged_lab)
@@ -624,6 +641,16 @@
 "DC" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
+/area/ruin/space/sieged_lab)
+"DN" = (
+/obj/machinery/door/airlock/security{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
 /area/ruin/space/sieged_lab)
 "DW" = (
 /obj/effect/turf_decal/tiles/neutral/side{
@@ -720,14 +747,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/sieged_lab)
-"JK" = (
-/obj/machinery/door/airlock/security,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/space/sieged_lab)
 "KE" = (
 /obj/docking_port/stationary/whiteship{
 	dir = 8;
@@ -754,13 +773,6 @@
 "KZ" = (
 /obj/effect/spawner/random/trash,
 /obj/effect/turf_decal/tiles/department/engineering/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/space/sieged_lab)
-"La" = (
-/obj/machinery/door/airlock/multi_tile/glass,
-/obj/effect/turf_decal/tiles/neutral/side{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -912,14 +924,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/sieged_lab)
-"Uq" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/obj/effect/turf_decal/tiles/neutral/side{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/space/sieged_lab)
 "UB" = (
 /obj/effect/turf_decal/tiles/neutral/side{
 	dir = 4
@@ -990,6 +994,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/sieged_lab)
+"Ye" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ruin/space/sieged_lab)
 "Yk" = (
 /obj/effect/map_effect/marker_helper/mapmanip/submap/edge{
 	color = "#ff7f00"
@@ -1003,6 +1013,15 @@
 /obj/effect/map_effect/marker/mapmanip/submap/insert/ruin/sieged_lab/horiz_hallway,
 /obj/effect/turf_decal/tiles/neutral/side{
 	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/space/sieged_lab)
+"YI" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/side{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/sieged_lab)
@@ -2199,7 +2218,7 @@ rW
 Gh
 Gh
 Gh
-JK
+pU
 mq
 yO
 SP
@@ -2317,7 +2336,7 @@ ZK
 Gh
 Gh
 Gh
-BT
+DN
 OI
 Hk
 SP
@@ -2414,7 +2433,7 @@ bx
 UB
 UB
 UB
-jD
+aj
 AI
 tn
 UB
@@ -2473,7 +2492,7 @@ lx
 DW
 eA
 xr
-rV
+Ar
 AC
 DW
 xr
@@ -2501,11 +2520,11 @@ SP
 VQ
 tn
 Tn
-La
+YI
 ff
 US
 UB
-La
+YI
 pu
 qr
 ut
@@ -3132,7 +3151,7 @@ xr
 Gh
 Gh
 Gh
-sj
+fI
 Tt
 KZ
 jC
@@ -3198,7 +3217,7 @@ ZK
 ZK
 tZ
 tZ
-mM
+ok
 ql
 ql
 le
@@ -3323,7 +3342,7 @@ oZ
 oZ
 oZ
 xS
-sS
+Ye
 tZ
 Wo
 ZK
@@ -3382,7 +3401,7 @@ oZ
 oZ
 oZ
 oZ
-sS
+Ye
 tZ
 kc
 ZK
@@ -3478,7 +3497,7 @@ Gh
 Gh
 Gh
 Gh
-xV
+Am
 oZ
 oZ
 oZ
@@ -3537,7 +3556,7 @@ jL
 Gh
 Gh
 Gh
-Uq
+pB
 oZ
 oZ
 oZ

--- a/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
@@ -110,12 +110,6 @@
 /obj/structure/shuttle/engine/propulsion/burst,
 /turf/simulated/wall/mineral/titanium,
 /area/ruin/space/powered)
-"aB" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Escape Pod Airlock"
-	},
-/turf/simulated/floor/mineral/titanium/blue/airless,
-/area/ruin/space/powered)
 "aD" = (
 /turf/template_noop,
 /area/space/nearstation)
@@ -207,13 +201,6 @@
 /obj/effect/spawner/random/cobweb/left/rare,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/powered/bar)
-"aX" = (
-/obj/machinery/door/airlock/multi_tile/glass,
-/obj/effect/turf_decal/tiles/dark/side{
-	dir = 10
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/space/powered/bar)
 "aY" = (
 /obj/item/clothing/neck/stethoscope,
 /obj/item/stack/medical/bruise_pack/advanced,
@@ -227,16 +214,6 @@
 /obj/structure/lattice,
 /turf/template_noop,
 /area/space/nearstation)
-"ba" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/tiles/dark/side{
-	dir = 10
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/space/powered/bar)
 "bb" = (
 /obj/machinery/door/poddoor,
 /turf/simulated/floor/plasteel,
@@ -385,6 +362,13 @@
 /obj/structure/lattice,
 /turf/template_noop,
 /area/space/nearstation)
+"hr" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Bathroom";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/powered/bar)
 "iM" = (
 /obj/effect/decal/cleanable/glass,
 /turf/simulated/floor/plasteel/dark,
@@ -450,6 +434,14 @@
 "oJ" = (
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/space/nearstation)
+"oK" = (
+/obj/machinery/door/airlock{
+	name = "Bar Storage";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
+/turf/simulated/floor/wood,
+/area/ruin/space/powered/bar)
 "pb" = (
 /obj/item/stack/tile/plasteel,
 /obj/machinery/door_control{
@@ -549,6 +541,15 @@
 /obj/structure/mopbucket/full,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/powered/bar)
+"xt" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/dark/side{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/space/powered/bar)
 "xZ" = (
 /obj/item/beacon,
 /turf/simulated/floor/plasteel/dark,
@@ -587,12 +588,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/powered/bar)
-"Ad" = (
-/obj/machinery/door/airlock{
-	name = "Unisex Bathroom"
-	},
-/turf/simulated/floor/plasteel/dark,
 /area/ruin/space/powered/bar)
 "AX" = (
 /obj/effect/turf_decal/tiles/dark/corner{
@@ -653,6 +648,14 @@
 /obj/machinery/economy/vending/coffee,
 /obj/effect/turf_decal/tiles/dark/side{
 	dir = 6
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/space/powered/bar)
+"Fo" = (
+/obj/machinery/door/airlock/multi_tile/glass,
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/tiles/dark/side{
+	dir = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/powered/bar)
@@ -802,6 +805,13 @@
 "Ow" = (
 /obj/item/stack/ore/glass/basalt,
 /turf/simulated/floor/plating/asteroid/ancient,
+/area/ruin/space/powered)
+"Oy" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod Airlock";
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium/blue/airless,
 /area/ruin/space/powered)
 "Pr" = (
 /obj/structure/chair/stool,
@@ -1417,7 +1427,7 @@ JK
 ak
 Cx
 ax
-aB
+Oy
 JK
 JK
 JK
@@ -1689,7 +1699,7 @@ JK
 ak
 ax
 ax
-aB
+Oy
 JK
 JK
 bj
@@ -1697,7 +1707,7 @@ JK
 ak
 ax
 ax
-aB
+Oy
 JK
 JK
 JK
@@ -1962,7 +1972,7 @@ am
 am
 aQ
 fg
-ba
+Fo
 aQ
 am
 am
@@ -2343,7 +2353,7 @@ aO
 aO
 aO
 AX
-aX
+xt
 bg
 bF
 bk
@@ -2444,7 +2454,7 @@ av
 as
 bc
 as
-ay
+oK
 cE
 aT
 zC
@@ -2564,7 +2574,7 @@ bk
 xZ
 qZ
 bk
-Ad
+hr
 bk
 bN
 am
@@ -2660,7 +2670,7 @@ am
 LB
 as
 as
-ay
+oK
 bk
 bk
 bk

--- a/_maps/map_files/RandomRuins/SpaceRuins/submaps/asteroid8_submap.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/submaps/asteroid8_submap.dmm
@@ -66,6 +66,15 @@
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
+"p" = (
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock";
+	name = "Escape Pod Hatch";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/turfs/damage,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/ruin/space/unpowered)
 "r" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /obj/effect/decal/cleanable/glass,
@@ -149,14 +158,6 @@
 /obj/effect/map_effect/marker/mapmanip/submap/extract/space_ruin/asteroid8,
 /turf/simulated/floor/engine,
 /area/ruin/space/unpowered)
-"N" = (
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock";
-	name = "Escape Pod Hatch"
-	},
-/obj/effect/mapping_helpers/turfs/damage,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/ruin/space/unpowered)
 "P" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /obj/effect/decal/cleanable/glass,
@@ -232,7 +233,7 @@ h
 o
 w
 t
-N
+p
 h
 h
 "}

--- a/_maps/map_files/RandomRuins/SpaceRuins/submaps/rocky_motel_submap.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/submaps/rocky_motel_submap.dmm
@@ -311,11 +311,6 @@
 /obj/effect/decal/cleanable/molten_object/large,
 /turf/simulated/floor/carpet/royalblack,
 /area/template_noop)
-"Hc" = (
-/obj/machinery/door/airlock/hatch/syndicate,
-/obj/effect/mapping_helpers/turfs/damage,
-/turf/simulated/floor/wood,
-/area/template_noop)
 "Ir" = (
 /obj/structure/chair{
 	dir = 4
@@ -392,14 +387,16 @@
 /obj/structure/closet/syndicate,
 /turf/simulated/floor/mineral/plastitanium,
 /area/template_noop)
-"Qy" = (
-/turf/simulated/wall/indestructible/syndicate,
-/area/template_noop)
-"Rg" = (
-/obj/machinery/door/airlock/hatch/syndicate,
+"Oh" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
+/area/template_noop)
+"Qy" = (
+/turf/simulated/wall/indestructible/syndicate,
 /area/template_noop)
 "RW" = (
 /turf/simulated/floor/plating/asteroid/airless,
@@ -450,9 +447,22 @@
 /obj/effect/mapping_helpers/turfs/burn,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/template_noop)
+"Xr" = (
+/obj/machinery/door/airlock/titanium{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/template_noop)
 "Yw" = (
 /obj/structure/machine_frame,
 /turf/space,
+/area/template_noop)
+"YB" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/turfs/damage,
+/turf/simulated/floor/wood,
 /area/template_noop)
 "Zy" = (
 /obj/machinery/atmospherics/unary/portables_connector,
@@ -1157,7 +1167,7 @@ hB
 mJ
 mJ
 mJ
-Rg
+Oh
 DF
 DF
 fZ
@@ -1226,11 +1236,11 @@ fZ
 Ga
 LT
 rK
-Hc
+YB
 DF
 DF
 DF
-Hc
+YB
 DF
 DF
 DF
@@ -1326,7 +1336,7 @@ DF
 iy
 kT
 kT
-lB
+Xr
 DF
 DF
 DF

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndicatedruglab.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndicatedruglab.dmm
@@ -178,6 +178,14 @@
 /obj/structure/nest/carppuppy,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/syndicate_druglab/asteroid)
+"uz" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/survival_pod{
+	name = "Syndicate Drug Lab";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ruin/space/syndicate_druglab)
 "uC" = (
 /obj/structure/beebox/unwrenched,
 /turf/simulated/floor/pod/dark,
@@ -282,13 +290,6 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/ruin/space/syndicate_druglab)
-"FE" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/survival_pod{
-	name = "Syndicate Drug Lab"
-	},
-/turf/simulated/floor/plating,
-/area/ruin/space/syndicate_druglab)
 "Gm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -323,6 +324,14 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
+/area/ruin/space/syndicate_druglab)
+"JN" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/survival_pod{
+	name = "Syndicate Drug Lab";
+	dir = 4
+	},
+/turf/simulated/floor/pod/dark,
 /area/ruin/space/syndicate_druglab)
 "JP" = (
 /obj/structure/table,
@@ -388,13 +397,6 @@
 "RS" = (
 /turf/template_noop,
 /area/template_noop)
-"SG" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/survival_pod{
-	name = "Syndicate Drug Lab"
-	},
-/turf/simulated/floor/pod/dark,
-/area/ruin/space/syndicate_druglab)
 "Tz" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -1046,9 +1048,9 @@ BD
 st
 os
 gU
-SG
+JN
 wD
-FE
+uz
 Pl
 II
 gI

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
@@ -78,6 +78,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered/syndicate_space_base/storage)
+"aw" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	name = "Custodial Closet";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/unpowered/syndicate_space_base/arrivals)
 "ax" = (
 /obj/structure/chair{
 	dir = 1
@@ -90,6 +102,16 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_space_base/arrivals)
+"ay" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
+/turf/simulated/floor/plating,
+/area/ruin/unpowered/syndicate_space_base/atmos)
 "az" = (
 /turf/simulated/wall/mineral/plastitanium,
 /area/ruin/unpowered/syndicate_space_base/dormitories)
@@ -339,6 +361,20 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_space_base/main)
+"cv" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/unpowered/syndicate_space_base/dormitories)
 "cw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -548,6 +584,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/ruin/unpowered/syndicate_space_base/service)
+"dI" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/unpowered/syndicate_space_base/virology)
 "dK" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -595,17 +637,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_space_base/dormitories)
-"dW" = (
-/obj/machinery/door/airlock/hatch/syndicate,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_space_base/storage)
 "dX" = (
 /obj/machinery/atmospherics/portable/canister/carbon_dioxide,
 /obj/effect/turf_decal/delivery/green/hollow,
@@ -844,16 +875,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_space_base/main)
-"ft" = (
-/obj/machinery/door/airlock/hatch/syndicate,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_space_base/dormitories)
 "fv" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -1162,6 +1183,15 @@
 /obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_space_base/toxlaunch)
+"gY" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/unpowered/syndicate_space_base/main)
 "hc" = (
 /obj/machinery/light{
 	dir = 8
@@ -1254,6 +1284,17 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_space_base/arrivals)
+"hD" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/unpowered/syndicate_space_base/atmos)
 "hI" = (
 /obj/machinery/camera{
 	c_tag = "Syndicate Base Cave East 4";
@@ -1310,15 +1351,6 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/ruin/unpowered/syndicate_space_base/service)
-"hV" = (
-/obj/machinery/door/airlock/hatch/syndicate{
-	name = "Custodial Closet"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_space_base/arrivals)
 "hY" = (
 /obj/structure/closet/bombcloset,
 /turf/simulated/floor/plasteel/dark,
@@ -1506,6 +1538,18 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_space_base/main)
+"iL" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/unpowered/syndicate_space_base/main)
 "iM" = (
 /obj/machinery/atmospherics/refill_station/oxygen,
 /turf/simulated/floor/plating,
@@ -1604,6 +1648,18 @@
 /obj/structure/chair/stool/bar,
 /turf/simulated/floor/carpet/grimey,
 /area/ruin/unpowered/syndicate_space_base/service)
+"js" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/unpowered/syndicate_space_base/dormitories)
 "jH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1862,12 +1918,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/ruin/unpowered/syndicate_space_base/arrivals)
-"lw" = (
-/obj/machinery/door/airlock/hatch/syndicate,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
-/turf/simulated/floor/plating,
-/area/ruin/unpowered/syndicate_space_base/atmos)
 "lD" = (
 /obj/machinery/conveyor/east{
 	id = "syndiegarbage"
@@ -1943,16 +1993,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_space_base/telecomms)
-"mi" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_space_base/main)
 "mk" = (
 /obj/effect/turf_decal/woodsiding{
 	dir = 1
@@ -2029,6 +2069,18 @@
 	},
 /turf/simulated/floor/engine,
 /area/ruin/unpowered/syndicate_space_base/testlab)
+"mN" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/unpowered/syndicate_space_base/chemistry)
 "mO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -2054,14 +2106,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_space_base/main)
-"mQ" = (
-/obj/machinery/door/airlock/hatch/syndicate,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_space_base/storage)
 "mR" = (
 /obj/machinery/sleeper/syndie{
 	dir = 4
@@ -2343,15 +2387,6 @@
 /obj/effect/turf_decal/delivery/green/hollow,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_space_base/toxlaunch)
-"og" = (
-/obj/machinery/door/airlock/hatch/syndicate{
-	name = "Recycling"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_space_base/arrivals)
 "ol" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2721,6 +2756,18 @@
 /obj/structure/chair,
 /turf/simulated/floor/redgrid,
 /area/ruin/unpowered/syndicate_space_base/telecomms)
+"qQ" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/unpowered/syndicate_space_base/main)
 "qR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2800,6 +2847,18 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_space_base/arrivals)
+"rm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/unpowered/syndicate_space_base/main)
 "rn" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3852,6 +3911,12 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/ruin/unpowered/syndicate_space_base/service)
+"xA" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/unpowered/syndicate_space_base/main)
 "xB" = (
 /obj/structure/sign/security/armory,
 /turf/simulated/wall/mineral/plastitanium,
@@ -4148,17 +4213,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_space_base/arrivals)
-"zL" = (
-/obj/machinery/door/airlock/hatch/syndicate,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_space_base/medbay)
 "zO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -4430,15 +4484,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_space_base/main)
-"Bw" = (
-/obj/machinery/door/airlock/hatch/syndicate{
-	name = "Teleporter Room"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_space_base/arrivals)
 "Bx" = (
 /obj/machinery/door/airlock/hatch/syndicate,
 /obj/machinery/door/firedoor,
@@ -4485,18 +4530,6 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/ruin/unpowered/syndicate_space_base/service)
-"BK" = (
-/obj/machinery/door/airlock/hatch/syndicate,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_space_base/medbay)
 "BL" = (
 /obj/structure/table,
 /obj/machinery/cooking/grill,
@@ -4556,13 +4589,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_space_base/arrivals)
-"Cg" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_space_base/main)
 "Cl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4626,6 +4652,18 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_space_base/dormitories)
+"CP" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/unpowered/syndicate_space_base/storage)
 "CQ" = (
 /obj/structure/sign/service/kitchen,
 /turf/simulated/wall/mineral/plastitanium,
@@ -4678,6 +4716,21 @@
 /obj/structure/sign/poster/contraband/syndicate_recruitment/directional/north,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_space_base/arrivals)
+"Df" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/unpowered/syndicate_space_base/telecomms)
 "Dg" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/transparent/glass/reinforced,
@@ -5079,22 +5132,18 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/engineering)
-"Fp" = (
-/obj/machinery/door/airlock/hatch/syndicate,
-/obj/machinery/door/firedoor,
+"Fr" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	name = "Recycling";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
 /turf/simulated/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_space_base/toxlaunch)
-"Fv" = (
-/obj/machinery/door/airlock/hatch/syndicate,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_space_base/dormitories)
+/area/ruin/unpowered/syndicate_space_base/arrivals)
 "Fw" = (
 /obj/machinery/biogenerator,
 /obj/structure/window/reinforced,
@@ -5215,6 +5264,22 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_space_base/main)
+"Gn" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/unpowered/syndicate_space_base/medbay)
 "Go" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -5354,18 +5419,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/ruin/unpowered/syndicate_space_base/service)
-"Hi" = (
-/obj/machinery/door/airlock/hatch/syndicate,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_space_base/toxlaunch)
 "Hm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -5536,16 +5589,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/ruin/unpowered/syndicate_space_base/testlab)
-"Is" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_space_base/main)
 "Iv" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plating,
@@ -5820,6 +5863,21 @@
 	},
 /turf/simulated/floor/wood,
 /area/ruin/unpowered/syndicate_space_base/service)
+"JQ" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/unpowered/syndicate_space_base/storage)
 "JR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -5898,6 +5956,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_space_base/toxlaunch)
+"KE" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/unpowered/syndicate_space_base/main)
 "KG" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -5925,10 +5993,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/ruin/unpowered/syndicate_space_base/cave)
-"KO" = (
-/obj/machinery/door/airlock/hatch/syndicate,
-/turf/simulated/floor/plating,
-/area/ruin/unpowered/syndicate_space_base/virology)
 "KR" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
@@ -6026,6 +6090,21 @@
 	},
 /turf/simulated/floor/engine/air,
 /area/ruin/unpowered/syndicate_space_base/atmos)
+"Ly" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/unpowered/syndicate_space_base/medbay)
 "LC" = (
 /obj/structure/sign/public/arcade,
 /turf/simulated/wall/mineral/plastitanium,
@@ -6118,14 +6197,6 @@
 /obj/effect/turf_decal/tiles/department/engineering/side,
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered/syndicate_space_base/atmos)
-"Mk" = (
-/obj/machinery/door/airlock/hatch/syndicate,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_space_base/chemistry)
 "Ml" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/engine,
@@ -6249,6 +6320,12 @@
 /obj/machinery/computer/arcade/battle,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_space_base/arrivals)
+"Nc" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ruin/unpowered/syndicate_space_base/virology)
 "Nf" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -6304,6 +6381,35 @@
 	},
 /turf/simulated/floor/engine,
 /area/ruin/unpowered/syndicate_space_base/toxtest)
+"Nx" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/unpowered/syndicate_space_base/control)
+"NG" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/unpowered/syndicate_space_base/toxlaunch)
 "NH" = (
 /obj/structure/sign/science/chemistry_sci,
 /turf/simulated/wall/mineral/plastitanium,
@@ -6859,14 +6965,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/ruin/unpowered/syndicate_space_base/arrivals)
-"RW" = (
-/obj/machinery/door/airlock/hatch/syndicate,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_space_base/main)
 "RX" = (
 /turf/simulated/wall/mineral/plastitanium,
 /area/ruin/unpowered/syndicate_space_base/main)
@@ -7045,15 +7143,6 @@
 /obj/effect/turf_decal/tiles/department/virology/side,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_space_base/genetics)
-"ST" = (
-/obj/machinery/door/airlock/hatch/syndicate,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_space_base/control)
 "SV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7210,6 +7299,18 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/box/beakers,
 /obj/item/storage/box/foam_grenades,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/unpowered/syndicate_space_base/toxlaunch)
+"Ua" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_space_base/toxlaunch)
 "Uc" = (
@@ -7394,6 +7495,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered/syndicate_space_base/storage)
+"Vk" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/transparent/glass/reinforced,
+/area/ruin/unpowered/syndicate_space_base/service)
 "Vl" = (
 /turf/simulated/wall/indestructible/syndicate,
 /area/ruin/unpowered/syndicate_space_base/toxtest)
@@ -7772,13 +7879,6 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/ruin/unpowered/syndicate_space_base/service)
-"Xt" = (
-/obj/machinery/door/airlock/hatch/syndicate,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_space_base/atmos)
 "Xv" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7902,17 +8002,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/atmos)
-"Yu" = (
-/obj/machinery/door/airlock/hatch/syndicate,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_space_base/telecomms)
 "Yw" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -7921,6 +8010,22 @@
 /obj/effect/turf_decal/tiles/department/science/side,
 /turf/simulated/floor/plasteel/white,
 /area/ruin/unpowered/syndicate_space_base/chemistry)
+"Yz" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/unpowered/syndicate_space_base/virology)
 "YF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -7974,6 +8079,18 @@
 	},
 /turf/simulated/floor/grass,
 /area/ruin/unpowered/syndicate_space_base/service)
+"YT" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	name = "Teleporter Room";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/unpowered/syndicate_space_base/arrivals)
 "YU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -8005,10 +8122,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/ruin/unpowered/syndicate_space_base/chemistry)
-"YY" = (
-/obj/machinery/door/airlock/hatch/syndicate,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_space_base/virology)
 "Zb" = (
 /obj/structure/rack,
 /obj/item/rpd{
@@ -8096,18 +8209,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_space_base/arrivals)
-"ZK" = (
-/obj/machinery/door/airlock/hatch/syndicate,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/autoname/syndie_base,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_space_base/virology)
 "ZQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9057,7 +9158,7 @@ xn
 nf
 hi
 QN
-Bw
+YT
 zH
 zH
 Xo
@@ -9068,7 +9169,7 @@ wE
 Cl
 Cl
 Zg
-hV
+aw
 zH
 Wf
 Pu
@@ -9506,7 +9607,7 @@ wJ
 xn
 vR
 Ic
-og
+Fr
 xD
 yc
 Og
@@ -9787,14 +9888,14 @@ Mf
 Mf
 AD
 Mf
-Lj
+KE
 iX
 mO
 Qr
 Qa
 fq
 ZB
-Cg
+gY
 on
 QD
 hN
@@ -9802,7 +9903,7 @@ kF
 fP
 Pb
 sR
-mi
+iL
 fP
 fP
 BC
@@ -9818,7 +9919,7 @@ xc
 zz
 fP
 uN
-Is
+rm
 fP
 On
 ZU
@@ -9860,14 +9961,14 @@ Mf
 AD
 Mf
 AD
-Lj
+KE
 am
 LN
 am
 ZQ
 xZ
 Bi
-Gi
+xA
 GA
 sc
 xS
@@ -9875,7 +9976,7 @@ In
 am
 am
 Mw
-Gi
+xA
 yb
 am
 cK
@@ -9891,7 +9992,7 @@ am
 tW
 cK
 Fe
-Gi
+xA
 am
 hL
 YQ
@@ -10046,7 +10147,7 @@ ml
 Gg
 Xh
 up
-Fp
+Ua
 lG
 lG
 eT
@@ -10240,7 +10341,7 @@ Uv
 Dy
 am
 up
-Mk
+mN
 Xn
 JF
 it
@@ -10248,7 +10349,7 @@ eg
 Yj
 zn
 IS
-Mk
+mN
 tB
 YF
 Gg
@@ -10338,7 +10439,7 @@ rF
 Oq
 fA
 wn
-Hi
+NG
 jH
 FP
 qB
@@ -10401,14 +10502,14 @@ Gg
 Pn
 rt
 rt
-lw
+ay
 Eb
 zl
 zl
 sF
 AB
 Od
-Xt
+hD
 sU
 pp
 hs
@@ -10529,7 +10630,7 @@ oM
 oM
 oM
 oM
-Dg
+Vk
 am
 Mw
 IJ
@@ -10602,7 +10703,7 @@ oM
 oM
 oM
 oM
-Dg
+Vk
 am
 iK
 IJ
@@ -10751,7 +10852,7 @@ ig
 Dy
 AQ
 Xf
-zL
+Ly
 NU
 SV
 UT
@@ -10759,7 +10860,7 @@ SV
 MN
 vu
 Gt
-BK
+Gn
 fP
 FM
 fR
@@ -10908,7 +11009,7 @@ RS
 ai
 am
 Jr
-Yu
+Df
 zt
 qJ
 IY
@@ -11189,7 +11290,7 @@ Dy
 Xh
 am
 Mw
-Gi
+xA
 Kw
 am
 am
@@ -11262,7 +11363,7 @@ fP
 fP
 fP
 YU
-mi
+iL
 fP
 fP
 no
@@ -11276,7 +11377,7 @@ Rf
 lo
 ls
 vN
-ST
+Nx
 dG
 Jy
 Ai
@@ -11485,17 +11586,17 @@ vp
 am
 GA
 cu
-ZK
+Yz
 DV
 Sq
 kD
-KO
+Nc
 Wm
 wA
 PL
 sV
 TK
-RW
+qQ
 qf
 kE
 kE
@@ -11546,7 +11647,7 @@ VZ
 az
 ZV
 up
-mQ
+CP
 xo
 xo
 xo
@@ -11554,7 +11655,7 @@ US
 uh
 xo
 xo
-mQ
+CP
 tB
 tB
 Md
@@ -11635,7 +11736,7 @@ PL
 jX
 rb
 Ge
-YY
+dI
 Wm
 wA
 PL
@@ -11834,11 +11935,11 @@ er
 ol
 rq
 zs
-ft
+cv
 Ha
 Ha
 QG
-dW
+JQ
 Ty
 JV
 xa
@@ -11846,7 +11947,7 @@ Ty
 cw
 Ty
 Ty
-dW
+JQ
 lo
 lo
 vi
@@ -11907,7 +12008,7 @@ cY
 bY
 qV
 Bf
-Fv
+js
 Fa
 Fa
 Gs

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndiecakesfactory.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndiecakesfactory.dmm
@@ -491,12 +491,6 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/ruin/space/syndicakefactory)
-"vR" = (
-/obj/machinery/door/airlock/hatch/syndicate{
-	name = "SC-Eridani"
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/space/syndicakefactory)
 "wd" = (
 /obj/structure/table/glass/reinforced/plastitanium,
 /obj/item/kitchen/knife/butcher,
@@ -566,6 +560,13 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
+/area/ruin/space/syndicakefactory)
+"yW" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	name = "SC-Eridani";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
 /area/ruin/space/syndicakefactory)
 "zc" = (
 /obj/structure/table/glass/reinforced/plastitanium,
@@ -823,6 +824,12 @@
 /obj/effect/decal/cleanable/flour,
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
+/area/ruin/space/syndicakefactory)
+"KE" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
 /area/ruin/space/syndicakefactory)
 "KS" = (
 /obj/machinery/door/poddoor{
@@ -1925,7 +1932,7 @@ Ii
 xO
 xO
 xO
-vR
+yW
 LN
 hF
 LN
@@ -1933,7 +1940,7 @@ hF
 zt
 Hy
 lZ
-Hy
+KE
 pd
 "}
 (21,1,1) = {"

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndiedepot.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndiedepot.dmm
@@ -394,22 +394,6 @@
 /obj/machinery/economy/vending/syndisnack,
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_depot/core)
-"bH" = (
-/obj/machinery/door/airlock/silver,
-/turf/simulated/floor/plasteel/dark,
-/area/syndicate_depot/core)
-"bI" = (
-/obj/machinery/door/poddoor{
-	id_tag = "syndi_depot_rear";
-	name = "Sealed Doors";
-	protected = 0
-	},
-/obj/effect/mapping_helpers/airlock/access/all/syndicate,
-/obj/machinery/door/airlock/external{
-	id_tag = "sst_away"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/syndicate_depot/outer)
 "bJ" = (
 /obj/effect/spawner/random/syndicate/trapped_documents,
 /turf/simulated/floor/plasteel/dark,
@@ -870,17 +854,37 @@
 /obj/structure/sign/poster/contraband/lusty_xenomorph/directional/north,
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_depot/core)
+"rv" = (
+/obj/machinery/door/airlock/silver{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/syndicate_depot/core)
 "rJ" = (
 /obj/structure/sign/poster/contraband/tools/directional/south,
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_depot/core)
-"tE" = (
-/obj/structure/sign/poster/contraband/syndicate_recruitment/directional/east,
+"tu" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_depot/core)
-"uH" = (
-/obj/machinery/door/airlock/silver,
+"tB" = (
+/obj/machinery/door/poddoor{
+	id_tag = "syndi_depot_rear";
+	name = "Sealed Doors";
+	protected = 0
+	},
 /obj/effect/mapping_helpers/airlock/access/all/syndicate,
+/obj/machinery/door/airlock/external{
+	id_tag = "sst_away";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/syndicate_depot/outer)
+"tE" = (
+/obj/structure/sign/poster/contraband/syndicate_recruitment/directional/east,
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_depot/core)
 "BU" = (
@@ -924,6 +928,13 @@
 /area/syndicate_depot/core)
 "VS" = (
 /obj/structure/sign/poster/official/obey/directional/north,
+/turf/simulated/floor/plasteel/dark,
+/area/syndicate_depot/core)
+"YZ" = (
+/obj/machinery/door/airlock/silver{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_depot/core)
 "ZV" = (
@@ -2634,7 +2645,7 @@ aE
 aD
 aD
 aD
-aF
+tu
 aD
 aD
 aQ
@@ -2745,7 +2756,7 @@ bS
 cd
 cq
 cq
-bH
+rv
 aD
 cW
 aD
@@ -2791,7 +2802,7 @@ at
 aQ
 aD
 aD
-uH
+YZ
 bS
 ce
 cr
@@ -3148,7 +3159,7 @@ bf
 bl
 aj
 aj
-bI
+tB
 bT
 cg
 af

--- a/_maps/map_files/RandomRuins/SpaceRuins/telecomns_returns.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/telecomns_returns.dmm
@@ -153,6 +153,21 @@
 	},
 /turf/simulated/floor/catwalk/airless,
 /area/space/nearstation/no_teleport)
+"dh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/machinery/door/airlock/hatch{
+	name = "Telecoms Satellite";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/space/telecomms/tele)
 "dn" = (
 /obj/machinery/computer/nonfunctional{
 	dir = 4
@@ -366,18 +381,6 @@
 /obj/machinery/light_switch{
 	pixel_y = -28
 	},
-/turf/simulated/floor/plasteel,
-/area/ruin/space/telecomms/tele)
-"gJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/machinery/door/airlock/hatch{
-	name = "Telecoms Satellite"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/telecomms/tele)
 "gR" = (
@@ -831,6 +834,24 @@
 	},
 /turf/simulated/floor/plasteel/full,
 /area/ruin/space/telecomms/foyer)
+"pp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/machinery/door/airlock/hatch{
+	name = "Telecoms Satellite";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "dvorak";
+	id_tag = "dvorak"
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/space/telecomms/foyer)
 "pE" = (
 /obj/effect/spawner/random/cobweb/left/frequent,
 /obj/effect/spawner/random/cobweb/right/frequent,
@@ -865,6 +886,22 @@
 	temperature = 80
 	},
 /area/ruin/space/telecomms/chamber)
+"qm" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/machinery/door/airlock/hatch{
+	name = "Telecoms Lounge";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	id = "dvorak";
+	id_tag = "dvorak"
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/space/telecomms/computer)
 "qn" = (
 /obj/machinery/porta_turret/ai_turret/disable{
 	check_synth = 1;
@@ -1343,6 +1380,17 @@
 	},
 /turf/simulated/floor/catwalk,
 /area/ruin/space/telecomms/powercontrol)
+"wQ" = (
+/obj/structure/fans/tiny/invisible,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Core Access";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/telecomms/chamber)
 "wW" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -1408,19 +1456,6 @@
 "xG" = (
 /obj/structure/chair/office/dark{
 	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/space/telecomms/computer)
-"xL" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/machinery/door/airlock/hatch{
-	name = "Telecoms Lounge"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor{
-	id = "dvorak";
-	id_tag = "dvorak"
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/telecomms/computer)
@@ -2511,21 +2546,6 @@
 "PQ" = (
 /turf/simulated/wall/r_wall,
 /area/ruin/space/telecomms/tele)
-"PU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/machinery/door/airlock/hatch{
-	name = "Telecoms Satellite"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "dvorak";
-	id_tag = "dvorak"
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/space/telecomms/foyer)
 "PZ" = (
 /turf/template_noop,
 /area/space/no_teleport)
@@ -3097,14 +3117,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/telecomms/computer)
-"Zj" = (
-/obj/structure/fans/tiny/invisible,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Core Access"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/space/telecomms/chamber)
 "Zl" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -6200,10 +6212,10 @@ zG
 Dr
 ph
 UE
-PU
+pp
 Sn
 cH
-gJ
+dh
 IE
 IE
 vZ
@@ -6510,7 +6522,7 @@ ux
 ux
 Zu
 ME
-Zj
+wQ
 EM
 il
 Af
@@ -6914,7 +6926,7 @@ Pl
 Pl
 Kc
 RB
-xL
+qm
 YF
 nL
 nL

--- a/_maps/map_files/RandomRuins/SpaceRuins/turretedoutpost.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/turretedoutpost.dmm
@@ -167,6 +167,16 @@
 /obj/machinery/light,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/turreted_outpost)
+"rh" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/turreted_outpost)
 "rL" = (
 /obj/structure/rack,
 /obj/structure/cable{
@@ -559,14 +569,6 @@
 /obj/structure/foamedmetal,
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/turreted_outpost/vault)
-"TD" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/space/turreted_outpost)
 "TV" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -1044,7 +1046,7 @@ qa
 Oc
 xB
 TV
-TD
+rh
 Hb
 Hb
 Hb

--- a/_maps/map_files/RandomRuins/SpaceRuins/unathi_skiff.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/unathi_skiff.dmm
@@ -1,11 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"aZ" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/space/unathi_breacher/engineering)
 "bF" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -274,6 +267,14 @@
 /obj/machinery/suit_storage_unit,
 /turf/simulated/floor/plasteel/airless,
 /area/ruin/space/unathi_breacher/engineering)
+"vK" = (
+/obj/machinery/door/poddoor,
+/obj/machinery/door/airlock/survival_pod{
+	locked = 1;
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/unathi_breacher/dorms)
 "vY" = (
 /obj/effect/turf_decal/stripes/red/corner{
 	dir = 1
@@ -291,13 +292,6 @@
 /obj/item/stack/sheet/mineral/plastitanium,
 /turf/template_noop,
 /area/template_noop)
-"yi" = (
-/obj/machinery/door/poddoor,
-/obj/machinery/door/airlock/survival_pod{
-	locked = 1
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/space/unathi_breacher/bar)
 "yx" = (
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/ruin/space/unathi_breacher/bridge)
@@ -483,6 +477,14 @@
 /obj/structure/window/full/shuttle/survival_pod/tinted,
 /turf/simulated/floor/plating,
 /area/ruin/space/unathi_breacher/bar)
+"NQ" = (
+/obj/machinery/door/poddoor,
+/obj/machinery/door/airlock/survival_pod{
+	locked = 1;
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/unathi_breacher/bar)
 "NT" = (
 /turf/simulated/wall/mineral/titanium/survival/pod,
 /area/ruin/space/unathi_breacher/engineering)
@@ -557,6 +559,15 @@
 /mob/living/basic/drakehound_breacher,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/unathi_breacher/dorms)
+"Rl" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/unathi_breacher/engineering)
 "RI" = (
 /obj/item/stack/rods,
 /obj/structure/table_frame,
@@ -617,13 +628,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/unathi_breacher/bar)
-"Xq" = (
-/obj/machinery/door/poddoor,
-/obj/machinery/door/airlock/survival_pod{
-	locked = 1
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/space/unathi_breacher/dorms)
 "XA" = (
 /obj/item/toy/plushie/lizardplushie,
 /obj/structure/table,
@@ -816,11 +820,11 @@ Zl
 hB
 CZ
 iF
-aZ
+Rl
 fN
 yy
 kf
-aZ
+Rl
 dK
 mH
 mH
@@ -863,7 +867,7 @@ Gb
 "}
 (13,1,1) = {"
 Gb
-Xq
+vK
 li
 CZ
 LX
@@ -875,7 +879,7 @@ GR
 Wu
 mH
 pZ
-yi
+NQ
 Gb
 "}
 (14,1,1) = {"

--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
@@ -50,9 +50,6 @@
 "al" = (
 /turf/simulated/wall/indestructible/titanium/soviet,
 /area/ruin/space/derelict/bridge)
-"am" = (
-/turf/simulated/wall/indestructible/titanium/soviet,
-/area/ruin/space/derelict/bridge)
 "an" = (
 /obj/effect/spawner/window/shuttle,
 /obj/machinery/door/poddoor/shutters{
@@ -461,12 +458,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/derelict/bridge)
-"bm" = (
-/turf/simulated/wall/indestructible/titanium/soviet,
-/area/ruin/space/derelict/crew_quarters)
-"bn" = (
-/turf/simulated/wall/indestructible/titanium/soviet,
-/area/ruin/space/derelict/arrival)
 "bo" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -850,12 +841,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/derelict/arrival)
-"cq" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Command Wing"
-	},
-/turf/simulated/floor/wood,
-/area/ruin/space/derelict/bridge)
 "cr" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/drinks/drinkingglass/shotglass,
@@ -954,20 +939,6 @@
 /obj/structure/sign/poster/contraband/communist_state/directional/north,
 /turf/simulated/floor/wood,
 /area/ruin/space/derelict/bridge)
-"cF" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "ruslockcom";
-	layer = 3;
-	name = "Bridge Lockdown"
-	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Command Wing"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/space/derelict/bridge)
 "cG" = (
 /obj/structure/closet/crate/can,
 /obj/effect/spawner/random/maintenance,
@@ -986,15 +957,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/derelict/bridge)
-"cI" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Bathroom"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/ruin/space/derelict/crew_quarters)
 "cJ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1017,14 +979,15 @@
 /obj/structure/sign/mech,
 /turf/simulated/wall/indestructible/titanium/soviet,
 /area/ruin/space/derelict/arrival)
-"cN" = (
-/obj/machinery/door/airlock/hatch{
-	desc = "A sturdy armoury door. If you listen closely, you can barely make out a soviet marching tune coming from the other side of the door.";
-	name = "Armoury"
+"cM" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Eastern Annex";
+	dir = 4
 	},
-/obj/effect/decal/cleanable/blood/tracks/mapped,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/space/derelict/arrival)
+/turf/simulated/floor/plasteel{
+	icon_state = "stage_stairs"
+	},
+/area/ruin/space/derelict/crew_quarters)
 "cO" = (
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower/directional/west,
@@ -1375,12 +1338,6 @@
 /obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plating,
 /area/ruin/space/derelict/crew_quarters)
-"dI" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Dormitories"
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/space/derelict/crew_quarters)
 "dJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -1475,26 +1432,23 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/derelict/arrival)
+"dV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/titanium{
+	name = "Central Annex";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/ruin/space/derelict/hallway/primary)
 "dW" = (
 /turf/simulated/wall/indestructible/titanium/soviet,
 /area/ruin/space/derelict/hallway/primary)
 "dX" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall/indestructible/titanium/soviet,
-/area/ruin/space/derelict/hallway/primary)
-"dY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "ruslock";
-	layer = 3;
-	name = "Central Annex Lockdown"
-	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Command Wing"
-	},
-/turf/simulated/floor/plasteel/dark,
 /area/ruin/space/derelict/hallway/primary)
 "dZ" = (
 /obj/structure/closet/crate/can,
@@ -1539,9 +1493,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/derelict/arrival)
-"eg" = (
-/turf/simulated/wall/indestructible/titanium/soviet,
-/area/ruin/space/derelict/hallway/primary)
 "eh" = (
 /obj/machinery/light/spot{
 	dir = 1
@@ -1569,12 +1520,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/derelict/hallway/primary)
-"ek" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Dormitories"
-	},
-/turf/simulated/floor/wood,
-/area/ruin/space/derelict/crew_quarters)
 "el" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -1749,20 +1694,6 @@
 /obj/item/trash/spentcasing/bullet/medium,
 /turf/simulated/floor/wood,
 /area/ruin/space/derelict/crew_quarters)
-"eJ" = (
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "ruslocksec";
-	layer = 2.9;
-	name = "Security Wing Lockdown"
-	},
-/obj/machinery/door/airlock/multi_tile/glass{
-	name = "Security Wing"
-	},
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/space/derelict/arrival)
 "eK" = (
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "ruslocksec";
@@ -2823,21 +2754,6 @@
 /obj/structure/sign/security,
 /turf/simulated/wall/indestructible/titanium/soviet,
 /area/ruin/space/derelict/arrival)
-"hu" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Wing"
-	},
-/turf/simulated/floor/plasteel/fakestairs,
-/area/ruin/space/derelict/arrival)
-"hv" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Wing"
-	},
-/turf/simulated/floor/plasteel/fakestairs,
-/area/ruin/space/derelict/arrival)
 "hw" = (
 /obj/structure/sink/directional/west,
 /obj/effect/turf_decal/tiles/department/science/side{
@@ -2902,25 +2818,6 @@
 /obj/effect/turf_decal/tiles/dark/corner,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/derelict/hallway/primary)
-"hE" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Eastern Annex"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "stage_stairs"
-	},
-/area/ruin/space/derelict/crew_quarters)
-"hH" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Eastern Annex"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "stage_stairs"
-	},
-/area/ruin/space/derelict/crew_quarters)
 "hI" = (
 /obj/structure/closet/crate{
 	opened = 1
@@ -3369,37 +3266,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/derelict/arrival)
-"iW" = (
-/obj/machinery/door/airlock/science{
-	name = "Science Wing"
-	},
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "ruslock";
-	layer = 3;
-	name = "Central Annex Lockdown"
-	},
-/obj/effect/turf_decal/tiles/department/science/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/space/derelict/hallway/primary)
-"iX" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/science{
-	name = "Science Wing"
-	},
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "ruslock";
-	layer = 3;
-	name = "Central Annex Lockdown"
-	},
-/obj/effect/turf_decal/tiles/department/science/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/space/derelict/hallway/primary)
 "iY" = (
 /obj/structure/lattice,
 /obj/item/stack/ore/iron,
@@ -3416,31 +3282,6 @@
 "ja" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/ruin/space/derelict/hallway/primary)
-"jb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Wing"
-	},
-/obj/effect/turf_decal/tiles/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/tiles/department/engineering/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/space/derelict/hallway/primary)
-"jc" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Wing"
-	},
-/obj/effect/turf_decal/tiles/department/engineering/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tiles/dark/corner,
-/turf/simulated/floor/plasteel,
 /area/ruin/space/derelict/hallway/primary)
 "jd" = (
 /obj/structure/cable{
@@ -4450,26 +4291,6 @@
 /obj/structure/sign/service/botany,
 /turf/simulated/wall/indestructible/titanium/soviet,
 /area/ruin/space/derelict/hallway/primary)
-"lA" = (
-/obj/machinery/door/airlock/glass{
-	name = "Hydroponics";
-	welded = 1
-	},
-/obj/effect/turf_decal/tiles/department/virology/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/space/derelict/hallway/primary)
-"lB" = (
-/obj/machinery/door/airlock/glass{
-	name = "Hydroponics";
-	welded = 1
-	},
-/obj/effect/turf_decal/tiles/department/virology/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/space/derelict/hallway/primary)
 "lC" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -4486,23 +4307,6 @@
 "lD" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/engine/vacuum,
-/area/ruin/space/derelict/hallway/primary)
-"lE" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Mess Hall"
-	},
-/obj/effect/turf_decal/tiles/jobs/bar/checker,
-/turf/simulated/floor/plasteel,
-/area/ruin/space/derelict/hallway/primary)
-"lF" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Mess Hall"
-	},
-/obj/effect/turf_decal/tiles/jobs/bar/checker,
-/turf/simulated/floor/plasteel,
 /area/ruin/space/derelict/hallway/primary)
 "lG" = (
 /obj/machinery/light/spot{
@@ -4808,30 +4612,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/derelict/crew_quarters)
-"mH" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medical Wing";
-	welded = 1
-	},
-/turf/simulated/floor/plasteel/fakestairs{
-	dir = 1
-	},
-/area/ruin/space/derelict/arrival)
 "mI" = (
 /obj/structure/sign/greencross,
 /turf/simulated/wall/indestructible/titanium/soviet,
-/area/ruin/space/derelict/arrival)
-"mJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medical Wing";
-	welded = 1
-	},
-/turf/simulated/floor/plasteel/fakestairs{
-	dir = 1
-	},
 /area/ruin/space/derelict/arrival)
 "mL" = (
 /obj/effect/mapping_helpers/turfs/damage,
@@ -4867,14 +4650,6 @@
 /obj/effect/turf_decal/tiles/jobs/bar/checker,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/derelict/hallway/primary)
-"mQ" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Eastern Annex"
-	},
-/turf/simulated/floor/plasteel/fakestairs{
-	dir = 1
-	},
-/area/ruin/space/derelict/crew_quarters)
 "mR" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
@@ -5335,6 +5110,21 @@
 /obj/item/stack/tile/plasteel,
 /turf/template_noop,
 /area/ruin/space/derelict/arrival)
+"oo" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "ruslock";
+	layer = 3;
+	name = "Central Annex Lockdown"
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "Command Wing";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/derelict/hallway/primary)
 "op" = (
 /obj/item/stack/ore/iron,
 /obj/effect/turf_decal/tiles/department/virology/side,
@@ -5639,16 +5429,16 @@
 "pk" = (
 /turf/simulated/wall/indestructible/titanium/soviet,
 /area/space/nearstation)
-"pl" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"pm" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medical Wing";
+	welded = 1;
+	dir = 4
 	},
-/obj/machinery/door/airlock/titanium{
-	name = "Central Annex"
+/turf/simulated/floor/plasteel/fakestairs{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/ruin/space/derelict/hallway/primary)
+/area/ruin/space/derelict/arrival)
 "po" = (
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/derelict/arrival)
@@ -6024,15 +5814,6 @@
 "qw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tiles/department/security,
-/turf/simulated/floor/plasteel,
-/area/ruin/space/derelict/arrival)
-"qx" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/titanium{
-	name = "Central Annex"
-	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/derelict/arrival)
 "qy" = (
@@ -6816,6 +6597,13 @@
 /obj/structure/sign/security/armory,
 /turf/simulated/wall/indestructible/titanium/soviet,
 /area/ruin/space/derelict/arrival)
+"uy" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Wing";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/fakestairs,
+/area/ruin/space/derelict/arrival)
 "vm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/flag/ussp,
@@ -6824,6 +6612,28 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/derelict/arrival)
+"wF" = (
+/obj/machinery/door/airlock/glass{
+	name = "Hydroponics";
+	welded = 1;
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/virology/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/space/derelict/hallway/primary)
+"xg" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Mess Hall";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/jobs/bar/checker,
+/turf/simulated/floor/plasteel,
+/area/ruin/space/derelict/hallway/primary)
 "xi" = (
 /obj/effect/spawner/random/fungus/frequent,
 /turf/simulated/wall/indestructible/titanium/soviet,
@@ -6832,6 +6642,14 @@
 /mob/living/basic/giant_spider/hunter,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/derelict/crew_quarters)
+"Be" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Mess Hall";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/jobs/bar/checker,
+/turf/simulated/floor/plasteel,
+/area/ruin/space/derelict/hallway/primary)
 "Bx" = (
 /obj/machinery/door_control{
 	id = "ruslock";
@@ -6844,10 +6662,40 @@
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/wood,
 /area/ruin/space/derelict/crew_quarters)
+"Cf" = (
+/obj/machinery/door/airlock/hatch{
+	locked = 1;
+	name = "Storage Bay";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/space/derelict/crew_quarters)
 "Ci" = (
 /mob/living/basic/pirate/ranged,
 /turf/simulated/floor/plasteel/white/airless,
 /area/ruin/space/derelict/arrival)
+"Cp" = (
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "ruslocksec";
+	layer = 2.9;
+	name = "Security Wing Lockdown"
+	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Security Wing";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/derelict/arrival)
+"CB" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Dormitories";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/ruin/space/derelict/crew_quarters)
 "Ef" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/barsign{
@@ -6859,10 +6707,61 @@
 /obj/structure/sign/securearea,
 /turf/simulated/wall/indestructible/titanium/soviet,
 /area/ruin/space/derelict/arrival)
+"EF" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Bathroom";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/ruin/space/derelict/crew_quarters)
+"FX" = (
+/obj/machinery/door/airlock/science{
+	name = "Science Wing";
+	dir = 4
+	},
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "ruslock";
+	layer = 3;
+	name = "Central Annex Lockdown"
+	},
+/obj/effect/turf_decal/tiles/department/science/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/space/derelict/hallway/primary)
 "HM" = (
 /obj/structure/sign/engineering,
 /turf/simulated/wall/indestructible/titanium/soviet,
 /area/ruin/space/derelict/hallway/primary)
+"IU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Wing";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/tiles/department/engineering/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/space/derelict/hallway/primary)
+"JZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Wing";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/fakestairs,
+/area/ruin/space/derelict/arrival)
 "KH" = (
 /obj/structure/sign/command,
 /turf/simulated/wall/indestructible/titanium/soviet,
@@ -6879,6 +6778,15 @@
 /obj/structure/sign/cargo/dock,
 /turf/simulated/wall/indestructible/titanium/soviet,
 /area/ruin/space/derelict/hallway/primary)
+"Mf" = (
+/obj/machinery/door/airlock/hatch{
+	desc = "A sturdy armoury door. If you listen closely, you can barely make out a soviet marching tune coming from the other side of the door.";
+	name = "Armoury";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/tracks/mapped,
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/derelict/arrival)
 "Mh" = (
 /obj/structure/sign/service/kitchen,
 /turf/simulated/wall/indestructible/titanium/soviet,
@@ -6887,6 +6795,24 @@
 /obj/effect/spawner/random/fungus/frequent,
 /turf/simulated/wall/indestructible/titanium/soviet,
 /area/ruin/space/derelict/crew_quarters)
+"Nu" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/science{
+	name = "Science Wing";
+	dir = 4
+	},
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "ruslock";
+	layer = 3;
+	name = "Central Annex Lockdown"
+	},
+/obj/effect/turf_decal/tiles/department/science/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/space/derelict/hallway/primary)
 "Nv" = (
 /obj/effect/spawner/airlock,
 /turf/simulated/wall/indestructible/titanium/soviet,
@@ -6899,6 +6825,17 @@
 /mob/living/basic/pirate,
 /turf/simulated/floor/plasteel/white/airless,
 /area/ruin/space/derelict/arrival)
+"RB" = (
+/obj/machinery/door/airlock/glass{
+	name = "Hydroponics";
+	welded = 1;
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/virology/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/space/derelict/hallway/primary)
 "Sv" = (
 /obj/item/flag/ussp,
 /obj/effect/turf_decal/tiles/department/security/side{
@@ -6911,9 +6848,50 @@
 /obj/item/trash/spentcasing/bullet,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/derelict/arrival)
+"TF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/titanium{
+	name = "Central Annex";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/space/derelict/arrival)
+"TY" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Wing";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/engineering/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/dark/corner,
+/turf/simulated/floor/plasteel,
+/area/ruin/space/derelict/hallway/primary)
 "UY" = (
 /obj/structure/sign/command/conference,
 /turf/simulated/wall/indestructible/titanium/soviet,
+/area/ruin/space/derelict/bridge)
+"VH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medical Wing";
+	welded = 1;
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/fakestairs{
+	dir = 1
+	},
+/area/ruin/space/derelict/arrival)
+"Wl" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Command Wing";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
 /area/ruin/space/derelict/bridge)
 "Xb" = (
 /obj/structure/sign/cargo/dock{
@@ -6922,6 +6900,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/derelict/arrival)
+"XC" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Eastern Annex";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/fakestairs{
+	dir = 1
+	},
+/area/ruin/space/derelict/crew_quarters)
+"XK" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Dormitories";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/space/derelict/crew_quarters)
 "XQ" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -6947,6 +6941,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/derelict/arrival)
+"YU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Eastern Annex";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "stage_stairs"
+	},
+/area/ruin/space/derelict/crew_quarters)
 "Za" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -6954,6 +6960,21 @@
 /obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/ruin/space/derelict/arrival)
+"ZV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "ruslockcom";
+	layer = 3;
+	name = "Bridge Lockdown"
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "Command Wing";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/space/derelict/bridge)
 
 (1,1,1) = {"
 ac
@@ -7562,14 +7583,14 @@ ac
 ac
 ac
 ac
-bn
-bn
+aW
+aW
 jm
-bn
-bn
+aW
+aW
 lu
-bn
-bn
+aW
+aW
 ac
 ac
 ac
@@ -7656,14 +7677,14 @@ ac
 ac
 ac
 ac
-bn
+aW
 iS
 jn
 jS
 kL
 hY
 lK
-bn
+aW
 ac
 ac
 ac
@@ -7748,17 +7769,17 @@ ac
 ac
 ac
 aW
-bn
-bn
-bn
+aW
+aW
+aW
 iT
 hY
 jT
 kM
 lv
 lL
-bn
-bn
+aW
+aW
 aW
 ac
 ac
@@ -7838,10 +7859,10 @@ ac
 ac
 ac
 aW
-bn
+aW
 xi
-bn
-bn
+aW
+aW
 hI
 hX
 iv
@@ -7853,10 +7874,10 @@ hY
 Xb
 me
 mu
-bn
-bn
-bn
-bn
+aW
+aW
+aW
+aW
 aW
 ac
 ac
@@ -7929,9 +7950,9 @@ ac
 ac
 ac
 aW
-bn
-bn
-bn
+aW
+aW
+aW
 gq
 gK
 ha
@@ -7951,9 +7972,9 @@ ro
 mR
 ni
 nw
-bn
-bn
-bn
+aW
+aW
+aW
 aW
 ac
 ai
@@ -8022,14 +8043,14 @@ ac
 ac
 ac
 aW
-bn
+aW
 ff
 fA
 dL
 gr
 gL
 dn
-hu
+uy
 hK
 hY
 hY
@@ -8041,7 +8062,7 @@ hY
 hY
 hY
 iw
-mH
+pm
 mS
 nj
 mS
@@ -8114,16 +8135,16 @@ ac
 ac
 ac
 aW
-bn
-bn
-bn
+aW
+aW
+aW
 de
 do
 do
 do
 do
 hb
-bn
+aW
 hK
 hY
 ix
@@ -8207,7 +8228,7 @@ ac
 ac
 ac
 aW
-bn
+aW
 ed
 en
 El
@@ -8217,7 +8238,7 @@ fX
 fX
 fX
 fX
-hv
+JZ
 hL
 hZ
 iy
@@ -8229,7 +8250,7 @@ iy
 iy
 iy
 iy
-mJ
+VH
 mT
 mT
 Yi
@@ -8300,18 +8321,18 @@ ac
 ac
 ac
 aW
-bn
+aW
 dU
 do
 do
-eJ
+Cp
 do
 fC
 do
 do
 gM
 hc
-bn
+aW
 hM
 ia
 iz
@@ -8323,7 +8344,7 @@ lx
 iV
 iz
 mx
-bn
+aW
 mU
 nl
 nx
@@ -8393,7 +8414,7 @@ ac
 ac
 ac
 aW
-bn
+aW
 dP
 fX
 fX
@@ -8405,19 +8426,19 @@ fY
 do
 gN
 hd
-bn
-bn
-bn
-bn
-bn
+aW
+aW
+aW
+aW
+aW
 jr
 ka
 kT
 ly
-bn
-bn
-bn
-bn
+aW
+aW
+aW
+aW
 mV
 nm
 mS
@@ -8485,9 +8506,9 @@ ac
 ac
 ac
 aW
-bn
-bn
-bn
+aW
+aW
+aW
 dQ
 do
 do
@@ -8497,23 +8518,23 @@ de
 fE
 fZ
 gs
-bn
-bn
+aW
+aW
 aW
 ac
 ac
 ac
 aW
-bn
+aW
 kb
-bn
-bn
+aW
+aW
 aW
 ac
 ac
 aW
-bn
-bn
+aW
+aW
 ny
 nK
 ob
@@ -8578,7 +8599,7 @@ ac
 ac
 ac
 aW
-bn
+aW
 dm
 dA
 dL
@@ -8586,10 +8607,10 @@ do
 do
 do
 eo
-bn
+aW
 fh
 fF
-bn
+aW
 fG
 aW
 ac
@@ -8671,7 +8692,7 @@ ac
 ac
 ac
 aW
-bn
+aW
 dd
 dn
 do
@@ -8680,8 +8701,8 @@ do
 do
 ee
 ep
-bn
-bn
+aW
+aW
 fG
 aW
 ac
@@ -8764,7 +8785,7 @@ ac
 ac
 ac
 aW
-bn
+aW
 cL
 de
 do
@@ -8774,7 +8795,7 @@ do
 do
 ef
 eq
-bn
+aW
 aW
 ac
 ac
@@ -8857,16 +8878,16 @@ ac
 ac
 ac
 aW
-bn
-bn
-bn
+aW
+aW
+aW
 df
 dp
 dB
 do
 do
 dR
-bn
+aW
 dF
 aW
 ac
@@ -8904,7 +8925,7 @@ mS
 oc
 oS
 qg
-bn
+aW
 aW
 ac
 ac
@@ -8950,16 +8971,16 @@ ac
 ac
 ac
 ac
-bn
+aW
 cl
 cz
-bn
+aW
 de
 dq
 dC
 do
 dR
-bn
+aW
 aW
 ac
 ac
@@ -9044,7 +9065,7 @@ ac
 ac
 ac
 aW
-bn
+aW
 cm
 cA
 tc
@@ -9052,7 +9073,7 @@ cA
 do
 dD
 dM
-bn
+aW
 aW
 ac
 ac
@@ -9137,15 +9158,15 @@ ac
 ac
 ac
 aW
-bn
+aW
 bS
 cn
 cB
-cN
+Mf
 cB
 dr
 dE
-bn
+aW
 aW
 ac
 ac
@@ -9164,7 +9185,7 @@ ac
 dW
 Lk
 kg
-eg
+dW
 dW
 ac
 ac
@@ -9230,7 +9251,7 @@ ac
 ac
 ac
 ac
-bn
+aW
 bF
 bT
 co
@@ -9238,7 +9259,7 @@ cA
 El
 dg
 ds
-bn
+aW
 aW
 ac
 ac
@@ -9253,15 +9274,15 @@ ac
 ac
 ac
 dW
-eg
-eg
-eg
+dW
+dW
+dW
 js
 kh
 kU
-eg
-eg
-eg
+dW
+dW
+dW
 dW
 ac
 ac
@@ -9284,7 +9305,7 @@ Ci
 qC
 mU
 qY
-bn
+aW
 ac
 ac
 ac
@@ -9324,12 +9345,12 @@ ac
 ac
 ac
 aW
-bn
+aW
 bG
 bU
 cp
 cC
-bn
+aW
 dh
 dt
 dF
@@ -9345,8 +9366,8 @@ ac
 ac
 ac
 dW
-eg
-eg
+dW
+dW
 ib
 iA
 et
@@ -9356,7 +9377,7 @@ kV
 lz
 lM
 mg
-eg
+dW
 gy
 ja
 cR
@@ -9370,7 +9391,7 @@ ac
 ac
 ac
 ag
-bn
+aW
 pT
 mU
 mU
@@ -9378,7 +9399,7 @@ mS
 qC
 mS
 qZ
-bn
+aW
 aW
 ac
 ac
@@ -9417,15 +9438,15 @@ ac
 ac
 ac
 al
-am
-am
-am
-am
-am
-am
-am
-am
-am
+al
+al
+al
+al
+al
+al
+al
+al
+al
 al
 ag
 ac
@@ -9438,16 +9459,16 @@ ac
 ac
 dW
 eL
-eg
+dW
 hw
 hN
 eP
 eP
-iW
+FX
 js
 kj
 kW
-lA
+wF
 lN
 lO
 jA
@@ -9465,15 +9486,15 @@ aj
 ac
 ag
 aW
-bn
-bn
+aW
+aW
 qh
 qs
 qD
 qL
-bn
+aW
 ro
-bn
+aW
 aW
 ac
 ac
@@ -9515,10 +9536,10 @@ aX
 bo
 bH
 bK
-am
+al
 cD
 cO
-am
+al
 al
 ag
 ag
@@ -9530,18 +9551,18 @@ ac
 ac
 ac
 dW
-eg
+dW
 gO
 he
 hk
 hk
 hk
 hk
-iX
+Nu
 ju
 fJ
 kX
-lB
+RB
 lO
 mz
 my
@@ -9560,7 +9581,7 @@ ag
 ag
 ag
 aW
-bn
+aW
 qi
 qt
 ka
@@ -9568,7 +9589,7 @@ hY
 ra
 qy
 rw
-bn
+aW
 ac
 ac
 ac
@@ -9609,10 +9630,10 @@ aY
 bp
 bI
 bV
-cq
+Wl
 ba
 cP
-am
+al
 ag
 ag
 ag
@@ -9623,7 +9644,7 @@ ac
 ac
 ac
 dW
-eg
+dW
 gt
 gP
 fk
@@ -9631,11 +9652,11 @@ eP
 eP
 ic
 iB
-eg
+dW
 jv
 eP
 kY
-eg
+dW
 lP
 mj
 mz
@@ -9662,7 +9683,7 @@ iy
 rb
 qM
 rx
-bn
+aW
 aW
 ac
 ac
@@ -9703,10 +9724,10 @@ aZ
 bq
 bJ
 ba
-am
+al
 cE
 cQ
-am
+al
 ac
 ac
 ac
@@ -9716,7 +9737,7 @@ ac
 ac
 ag
 dW
-eg
+dW
 ga
 gu
 gQ
@@ -9725,11 +9746,11 @@ eP
 eP
 id
 iC
-eg
+dW
 jw
 kk
 kZ
-eg
+dW
 lQ
 jA
 lO
@@ -9749,7 +9770,7 @@ ac
 ac
 ac
 aW
-bn
+aW
 qv
 hY
 qM
@@ -9797,9 +9818,9 @@ ba
 br
 bK
 ba
-am
-am
-am
+al
+al
+al
 al
 ac
 ac
@@ -9809,7 +9830,7 @@ ag
 ac
 ag
 dW
-eg
+dW
 fH
 gb
 gv
@@ -9818,13 +9839,13 @@ fJ
 eP
 fK
 ie
-eg
-eg
-eg
+dW
+dW
+dW
 kl
-eg
-eg
-eg
+dW
+dW
+dW
 mk
 mA
 ja
@@ -9910,7 +9931,7 @@ fj
 fJ
 fR
 hx
-eg
+dW
 eL
 dW
 ac
@@ -9918,7 +9939,7 @@ jy
 km
 lb
 ac
-eg
+dW
 ml
 ii
 ii
@@ -9938,14 +9959,14 @@ ac
 ac
 ac
 aW
-bn
+aW
 qF
 hY
 re
 qM
 hY
 qw
-bn
+aW
 aW
 ac
 ac
@@ -9996,7 +10017,7 @@ ac
 ac
 ac
 dW
-eg
+dW
 fi
 eP
 fj
@@ -10040,7 +10061,7 @@ hY
 hY
 qy
 rJ
-bn
+aW
 ac
 ac
 ac
@@ -10073,13 +10094,13 @@ ac
 ac
 ac
 al
-am
-am
-am
+al
+al
+al
 bu
-am
-am
-am
+al
+al
+al
 al
 ac
 ac
@@ -10089,7 +10110,7 @@ ac
 ac
 ac
 ac
-eg
+dW
 eN
 eP
 fj
@@ -10097,7 +10118,7 @@ fJ
 eP
 fK
 hg
-eg
+dW
 dW
 ac
 ac
@@ -10117,7 +10138,7 @@ nN
 jA
 or
 oK
-eg
+dW
 ag
 ac
 ac
@@ -10127,7 +10148,7 @@ ac
 ac
 ac
 aW
-bn
+aW
 qN
 rf
 hY
@@ -10166,7 +10187,7 @@ ac
 ak
 ac
 ac
-am
+al
 at
 aI
 bc
@@ -10183,13 +10204,13 @@ ac
 ac
 ac
 dW
-eg
+dW
 eO
 fj
 fJ
 eP
 gw
-eg
+dW
 eL
 dW
 ag
@@ -10211,7 +10232,7 @@ jA
 lO
 lO
 oL
-eg
+dW
 dW
 ac
 ac
@@ -10276,7 +10297,7 @@ ac
 ac
 ac
 ac
-eg
+dW
 er
 eP
 fk
@@ -10290,9 +10311,9 @@ ac
 ac
 ac
 dW
-eg
+dW
 kn
-eg
+dW
 ii
 ac
 ac
@@ -10306,7 +10327,7 @@ lO
 os
 lO
 oT
-eg
+dW
 ac
 ac
 ac
@@ -10370,20 +10391,20 @@ ac
 ac
 ac
 ac
-eg
+dW
 es
 eP
 fk
 fK
 gd
-eg
+dW
 dW
 ac
 ac
 ag
 ac
 dW
-eg
+dW
 dW
 iE
 ii
@@ -10394,13 +10415,13 @@ mX
 ac
 ac
 dW
-eg
+dW
 nO
 lN
 lN
 lN
 oU
-eg
+dW
 ac
 ac
 ac
@@ -10416,7 +10437,7 @@ hY
 hY
 rk
 rN
-bn
+aW
 ac
 ac
 ac
@@ -10455,8 +10476,8 @@ be
 bw
 bi
 bZ
-am
-am
+al
+al
 ac
 ac
 ac
@@ -10464,19 +10485,19 @@ ac
 ac
 ac
 dW
-eg
+dW
 et
 eQ
 fl
 fL
 Ye
-eg
+dW
 ac
 ac
 ac
 ag
 dW
-eg
+dW
 dW
 iE
 ko
@@ -10488,13 +10509,13 @@ ac
 iq
 ac
 ac
-eg
-eg
-eg
+dW
+dW
+dW
 ot
 oM
 lz
-eg
+dW
 dW
 ac
 ac
@@ -10510,8 +10531,8 @@ rq
 rq
 hY
 rO
-bn
-bn
+aW
+aW
 Nv
 ac
 ac
@@ -10550,7 +10571,7 @@ bw
 bi
 bi
 ct
-am
+al
 cS
 di
 du
@@ -10564,12 +10585,12 @@ eR
 fm
 fM
 gf
-eg
+dW
 ac
 ac
 ac
 ac
-eg
+dW
 dW
 iE
 jz
@@ -10582,21 +10603,21 @@ ac
 ac
 ac
 ac
-eg
+dW
 nP
 of
 of
 of
 oV
 pe
-eg
+dW
 if
 if
 if
 if
 if
 if
-bn
+aW
 qy
 qR
 ri
@@ -10636,7 +10657,7 @@ ac
 ac
 ac
 ac
-am
+al
 ay
 aM
 bf
@@ -10644,14 +10665,14 @@ bx
 bL
 bL
 cu
-cF
+ZV
 cT
 dj
 cT
 cT
 dj
 cT
-dY
+oo
 ei
 ev
 eS
@@ -10683,14 +10704,14 @@ ou
 oN
 oW
 hk
-pl
+dV
 ps
 pB
 hk
 ps
 qb
 hk
-qx
+TF
 qH
 iy
 rj
@@ -10698,8 +10719,8 @@ rs
 rz
 qu
 rQ
-bn
-bn
+aW
+aW
 Nv
 sh
 ac
@@ -10738,7 +10759,7 @@ bi
 bi
 bi
 cv
-am
+al
 cS
 cS
 cS
@@ -10752,7 +10773,7 @@ eT
 fo
 fO
 gh
-eg
+dW
 ac
 ac
 cR
@@ -10765,26 +10786,26 @@ ii
 ld
 iE
 dW
-eg
+dW
 ac
 ac
 ac
 ac
-eg
+dW
 nR
 og
 ov
 of
 oX
 eP
-eg
+dW
 if
 if
 if
 if
 if
 if
-bn
+aW
 qw
 qS
 rk
@@ -10831,8 +10852,8 @@ bg
 bi
 bi
 ca
-am
-am
+al
+al
 ac
 ac
 ac
@@ -10840,13 +10861,13 @@ ac
 ac
 ac
 dW
-eg
+dW
 HM
 eU
 fp
-eg
-eg
-eg
+dW
+dW
+dW
 ac
 ac
 ac
@@ -10858,19 +10879,19 @@ iE
 kp
 iE
 dW
-eg
+dW
 dW
 ac
 ac
 ac
 ac
-eg
-eg
-eg
+dW
+dW
+dW
 ow
 oO
 Mh
-eg
+dW
 dW
 ac
 ac
@@ -10879,7 +10900,7 @@ ac
 ac
 ac
 aW
-bn
+aW
 vm
 hY
 ru
@@ -10887,8 +10908,8 @@ ru
 hY
 rS
 rZ
-bn
-bn
+aW
+aW
 ac
 ac
 jO
@@ -10934,7 +10955,7 @@ ac
 ac
 ac
 ac
-eg
+dW
 ex
 eV
 fq
@@ -10951,20 +10972,20 @@ iZ
 dW
 kq
 dW
-eg
+dW
 dW
 ac
 ac
 ac
 ac
 dW
-eg
+dW
 mo
 lU
 ox
 lU
 oY
-eg
+dW
 ac
 ac
 ac
@@ -10980,7 +11001,7 @@ hY
 hY
 rk
 rT
-bn
+aW
 ac
 ac
 ac
@@ -11028,7 +11049,7 @@ ac
 ac
 ac
 ac
-eg
+dW
 ey
 eW
 fr
@@ -11041,10 +11062,10 @@ ac
 ac
 ak
 ac
-eg
-eg
+dW
+dW
 kr
-eg
+dW
 dW
 ac
 ag
@@ -11058,7 +11079,7 @@ lU
 ox
 lU
 oZ
-eg
+dW
 ac
 ac
 ac
@@ -11106,7 +11127,7 @@ ac
 ac
 ac
 ac
-am
+al
 aD
 aR
 bh
@@ -11151,7 +11172,7 @@ lU
 mZ
 ox
 lS
-eg
+dW
 dW
 ac
 ac
@@ -11201,13 +11222,13 @@ ag
 ac
 ac
 al
-am
-am
+al
+al
 UY
 by
-am
-am
-am
+al
+al
+al
 al
 ac
 ac
@@ -11217,7 +11238,7 @@ ac
 ac
 ac
 ag
-eg
+dW
 eY
 eP
 fs
@@ -11237,7 +11258,7 @@ ac
 ac
 ac
 dW
-eg
+dW
 mY
 lU
 lU
@@ -11245,7 +11266,7 @@ lU
 oh
 oy
 oP
-eg
+dW
 ag
 ac
 ac
@@ -11255,7 +11276,7 @@ ac
 ac
 ac
 aW
-bn
+aW
 qN
 qt
 hY
@@ -11302,7 +11323,7 @@ bi
 bc
 ce
 cw
-am
+al
 ac
 ac
 ac
@@ -11312,7 +11333,7 @@ ac
 ac
 ag
 dW
-eg
+dW
 ft
 eP
 fs
@@ -11356,7 +11377,7 @@ hY
 hY
 qy
 rX
-bn
+aW
 ac
 ac
 ac
@@ -11396,7 +11417,7 @@ bz
 bz
 bz
 cx
-am
+al
 al
 ac
 ac
@@ -11414,7 +11435,7 @@ gB
 fQ
 eP
 hB
-eg
+dW
 eL
 dW
 ac
@@ -11442,14 +11463,14 @@ ac
 ac
 ac
 aW
-bn
+aW
 qt
 hY
 hY
 hY
 hY
 rG
-bn
+aW
 aW
 ac
 ac
@@ -11491,7 +11512,7 @@ bO
 cf
 bi
 cG
-am
+al
 al
 ac
 ac
@@ -11501,7 +11522,7 @@ ag
 ag
 ag
 dW
-eg
+dW
 fS
 gj
 fJ
@@ -11510,13 +11531,13 @@ eP
 eP
 hP
 ij
-eg
-eg
-eg
+dW
+dW
+dW
 kt
-eg
-eg
-eg
+dW
+dW
+dW
 mn
 lU
 lU
@@ -11525,7 +11546,7 @@ no
 np
 nB
 oj
-eg
+dW
 dW
 ag
 ag
@@ -11578,7 +11599,7 @@ ac
 ac
 ac
 al
-am
+al
 bj
 bB
 bP
@@ -11596,8 +11617,8 @@ ag
 ag
 ag
 dW
-eg
-eg
+dW
+dW
 gC
 gT
 hk
@@ -11605,11 +11626,11 @@ hk
 fQ
 eP
 iH
-eg
+dW
 jC
 ku
 le
-eg
+dW
 lR
 mo
 lU
@@ -11629,7 +11650,7 @@ ac
 ac
 ac
 aW
-bn
+aW
 qt
 hY
 hY
@@ -11691,7 +11712,7 @@ ac
 ac
 ac
 dW
-eg
+dW
 gD
 eP
 eP
@@ -11699,11 +11720,11 @@ eP
 fk
 eP
 gA
-eg
+dW
 jD
 fk
 lf
-eg
+dW
 lS
 lU
 mn
@@ -11730,7 +11751,7 @@ hY
 hY
 hY
 rC
-bn
+aW
 aW
 ac
 ac
@@ -11774,7 +11795,7 @@ ch
 bh
 cH
 cW
-am
+al
 al
 ag
 ag
@@ -11786,25 +11807,25 @@ ac
 ac
 ac
 dW
-eg
+dW
 gU
 hl
 hC
 hQ
 hk
 hk
-jb
+IU
 jE
 kv
 lg
-lE
+xg
 lT
 mp
 mp
 mO
 nc
 nr
-eg
+dW
 dW
 ac
 ac
@@ -11816,7 +11837,7 @@ ac
 ag
 ag
 aW
-bn
+aW
 qm
 qz
 jn
@@ -11824,7 +11845,7 @@ hY
 rl
 rv
 rD
-bn
+aW
 ac
 ac
 ac
@@ -11861,15 +11882,15 @@ ac
 ac
 ac
 aV
-bm
-bm
-bm
-bm
-bm
-bm
-bm
-bm
-bm
+aV
+aV
+aV
+aV
+aV
+aV
+aV
+aV
+aV
 aV
 ag
 ac
@@ -11882,16 +11903,16 @@ ac
 ac
 dW
 eL
-eg
+dW
 hD
 hR
 eP
 eP
-jc
+TY
 jF
 fk
 lh
-lF
+Be
 lU
 lU
 mo
@@ -11909,15 +11930,15 @@ ac
 ac
 ag
 aV
-bm
-bm
-bm
-bm
+aV
+aV
+aV
+aV
 qJ
 qW
-bm
-bm
-bm
+aV
+aV
+aV
 aV
 ac
 ac
@@ -11956,11 +11977,11 @@ ac
 ac
 ac
 aV
-bm
+aV
 bR
 ci
 cy
-bm
+aV
 cX
 dk
 dv
@@ -11977,8 +11998,8 @@ ac
 ac
 ac
 dW
-eg
-eg
+dW
+dW
 ik
 iI
 HM
@@ -11988,8 +12009,8 @@ li
 Mh
 lV
 mq
-eg
-eg
+dW
+dW
 dW
 ac
 ac
@@ -12002,7 +12023,7 @@ ac
 ac
 ac
 ag
-bm
+aV
 pU
 qc
 qn
@@ -12010,7 +12031,7 @@ dJ
 py
 pw
 rm
-bm
+aV
 aV
 ac
 ac
@@ -12050,15 +12071,15 @@ ac
 ac
 ac
 ac
-bm
+aV
 bR
 cj
 cj
-cI
+EF
 cY
 db
 dw
-bm
+aV
 aV
 ac
 ac
@@ -12073,15 +12094,15 @@ ac
 ac
 ac
 dW
-eg
-eg
-eg
+dW
+dW
+dW
 jH
 fk
 lj
-eg
-eg
-eg
+dW
+dW
+dW
 dW
 ac
 ac
@@ -12096,7 +12117,7 @@ ac
 ac
 ac
 aV
-bm
+aV
 pV
 qd
 pZ
@@ -12104,7 +12125,7 @@ dJ
 db
 pw
 rm
-bm
+aV
 ac
 ac
 ac
@@ -12145,14 +12166,14 @@ ac
 ac
 ac
 aV
-bm
+aV
 ck
 ck
-bm
+aV
 cZ
 db
 dx
-bm
+aV
 aV
 aV
 ac
@@ -12170,9 +12191,9 @@ ac
 ac
 ac
 dW
-eg
+dW
 kx
-eg
+dW
 dW
 ac
 ac
@@ -12197,7 +12218,7 @@ pZ
 db
 db
 qX
-bm
+aV
 aV
 ac
 ac
@@ -12240,13 +12261,13 @@ ac
 ac
 ac
 aV
-bm
-bm
-bm
+aV
+aV
+aV
 da
 db
 db
-dI
+XK
 db
 aV
 aV
@@ -12290,7 +12311,7 @@ qe
 qo
 db
 qK
-bm
+aV
 aV
 ac
 ac
@@ -12334,13 +12355,13 @@ ac
 ac
 ac
 ac
-bm
+aV
 aV
 cJ
 db
 db
 db
-dI
+XK
 db
 db
 aV
@@ -12375,7 +12396,7 @@ ac
 ac
 ac
 aV
-bm
+aV
 pt
 Ae
 pM
@@ -12434,11 +12455,11 @@ cK
 dc
 dc
 dy
-bm
+aV
 db
 dJ
 dZ
-bm
+aV
 dH
 aV
 ac
@@ -12468,8 +12489,8 @@ ac
 ac
 aV
 dH
-bm
-bm
+aV
+aV
 pu
 pD
 pN
@@ -12524,15 +12545,15 @@ ac
 ac
 ac
 aV
-bm
-bm
-bm
-bm
+aV
+aV
+aV
+aV
 Lb
 db
 db
 ea
-bm
+aV
 eB
 aV
 aV
@@ -12563,7 +12584,7 @@ aV
 aV
 pa
 pf
-bm
+aV
 pv
 pE
 pO
@@ -12619,14 +12640,14 @@ ac
 ac
 ac
 aV
-bm
+aV
 Mi
 dz
 dJ
 db
 db
 eb
-bm
+aV
 eC
 eD
 aV
@@ -12657,7 +12678,7 @@ aV
 db
 db
 db
-qW
+Cf
 pw
 pw
 db
@@ -12714,18 +12735,18 @@ ac
 ac
 ac
 aV
-bm
+aV
 dz
 db
 db
 db
 eb
-ek
+CB
 eD
 fb
 eD
 Bx
-bm
+aV
 dH
 aV
 ac
@@ -12745,13 +12766,13 @@ ac
 ac
 aV
 dH
-bm
+aV
 db
 db
 db
 db
 db
-qW
+Cf
 px
 db
 db
@@ -12809,35 +12830,35 @@ ac
 ac
 ac
 aV
-bm
+aV
 dK
 db
 dJ
 ec
-bm
+aV
 eE
 fc
 fv
 eD
 gl
 gE
-bm
-bm
+aV
+aV
 aV
 ac
 ac
 ac
 aV
-bm
+aV
 kz
-bm
+aV
 aV
 ac
 ac
 ac
 aV
-bm
-bm
+aV
+aV
 nD
 nV
 ok
@@ -12845,7 +12866,7 @@ oB
 ok
 pb
 nV
-bm
+aV
 py
 dJ
 pP
@@ -12907,8 +12928,8 @@ aV
 aV
 dN
 dT
-bm
-bm
+aV
+aV
 eF
 eD
 fw
@@ -12918,18 +12939,18 @@ gF
 eD
 hm
 ge
-bm
-bm
-bm
-bm
+aV
+aV
+aV
+aV
 je
 kA
 lk
-bm
-bm
-bm
-bm
-bm
+aV
+aV
+aV
+aV
+aV
 ne
 ns
 db
@@ -12939,10 +12960,10 @@ db
 db
 db
 oR
-bm
+aV
 pz
 pF
-bm
+aV
 aV
 ac
 ac
@@ -12999,9 +13020,9 @@ ac
 ac
 ac
 aV
-bm
-bm
-bm
+aV
+aV
+aV
 el
 eG
 fd
@@ -13011,7 +13032,7 @@ fd
 fd
 eG
 fd
-hE
+YU
 hS
 im
 iJ
@@ -13023,7 +13044,7 @@ je
 lW
 mr
 mD
-bm
+aV
 nf
 nt
 db
@@ -13033,9 +13054,9 @@ db
 oR
 db
 ph
-bm
+aV
 Mi
-bm
+aV
 aV
 ac
 ac
@@ -13095,7 +13116,7 @@ ac
 ac
 ac
 aV
-bm
+aV
 em
 eH
 eD
@@ -13117,7 +13138,7 @@ je
 lX
 ms
 hT
-mQ
+XC
 db
 db
 dJ
@@ -13127,7 +13148,7 @@ db
 db
 db
 pi
-bm
+aV
 aV
 ac
 ac
@@ -13190,8 +13211,8 @@ ac
 ac
 ac
 aV
-bm
-bm
+aV
+aV
 fe
 fy
 fV
@@ -13211,7 +13232,7 @@ hU
 hU
 hU
 hT
-bm
+aV
 db
 dJ
 db
@@ -13220,7 +13241,7 @@ ol
 ol
 ol
 pc
-bm
+aV
 aV
 ac
 ac
@@ -13293,7 +13314,7 @@ gp
 gH
 gW
 gH
-hH
+cM
 hT
 hU
 iL
@@ -13305,15 +13326,15 @@ eD
 hU
 hU
 hU
-mQ
+XC
 db
 db
 db
 nX
 om
 oC
-bm
-bm
+aV
+aV
 pk
 ac
 ac
@@ -13383,11 +13404,11 @@ ac
 aV
 dH
 dH
-bm
+aV
 gI
 gX
 ho
-bm
+aV
 hV
 io
 iM
@@ -13403,7 +13424,7 @@ Ld
 nh
 nv
 nE
-bm
+aV
 dH
 dH
 aV
@@ -13478,10 +13499,10 @@ ac
 ac
 ac
 aV
-bm
-bm
-bm
-bm
+aV
+aV
+aV
+aV
 hW
 ip
 iN
@@ -13493,10 +13514,10 @@ lG
 lZ
 ms
 mF
-bm
-bm
-bm
-bm
+aV
+aV
+aV
+aV
 aV
 ac
 ac
@@ -13576,7 +13597,7 @@ ac
 ac
 ac
 aV
-bm
+aV
 dH
 dH
 kG
@@ -13586,7 +13607,7 @@ lo
 Oh
 dH
 dH
-bm
+aV
 aV
 ac
 ac
@@ -13673,11 +13694,11 @@ ac
 ac
 ac
 ac
-bm
+aV
 jL
-bm
+aV
 lp
-bm
+aV
 ac
 ag
 ac
@@ -13767,11 +13788,11 @@ ac
 ac
 ac
 ac
-bm
+aV
 lo
-bm
+aV
 lo
-bm
+aV
 ag
 ag
 ac

--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp_tele.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp_tele.dmm
@@ -126,16 +126,6 @@
 /obj/effect/mapping_helpers/turfs/burn,
 /turf/simulated/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/teleporter)
-"od" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "experimental teleporter access"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/closed,
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/space/derelict/teleporter)
 "og" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
@@ -321,6 +311,19 @@
 "Io" = (
 /obj/structure/sign/vacuum,
 /turf/simulated/wall/mineral/titanium,
+/area/ruin/space/derelict/teleporter)
+"Mb" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "experimental teleporter access";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/closed{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
 /area/ruin/space/derelict/teleporter)
 "NU" = (
 /obj/effect/turf_decal/stripes/line{
@@ -512,7 +515,7 @@ Av
 Vu
 Um
 og
-od
+Mb
 pD
 wh
 oy

--- a/_maps/map_files/RandomRuins/SpaceRuins/whiteship.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/whiteship.dmm
@@ -43,6 +43,10 @@
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/abandoned)
+"gq" = (
+/obj/machinery/door/airlock/multi_tile/glass,
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/abandoned)
 "hz" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
@@ -92,18 +96,6 @@
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/abandoned)
-"sm" = (
-/obj/effect/spawner/random/dirt/often,
-/obj/machinery/door/airlock/titanium,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plating,
-/area/shuttle/abandoned)
-"tV" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
-/turf/simulated/floor/mineral/plastitanium,
-/area/shuttle/abandoned)
 "ux" = (
 /turf/simulated/floor/plating,
 /area/shuttle/abandoned)
@@ -122,10 +114,6 @@
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/abandoned)
 "vB" = (
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"wh" = (
-/obj/machinery/door/airlock/titanium/glass,
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/abandoned)
 "wF" = (
@@ -255,11 +243,25 @@
 /obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/plating,
 /area/shuttle/abandoned)
+"Vi" = (
+/obj/effect/spawner/random/dirt/often,
+/obj/machinery/door/airlock/titanium{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/plating,
+/area/shuttle/abandoned)
 "Yr" = (
 /obj/machinery/computer/shuttle/white_ship{
 	dir = 4
 	},
 /turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/abandoned)
+"Yu" = (
+/obj/machinery/door/airlock/titanium/glass{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium,
 /area/shuttle/abandoned)
 
 (1,1,1) = {"
@@ -350,7 +352,7 @@ zO
 zO
 zO
 wF
-tV
+gq
 zO
 zO
 zO
@@ -380,7 +382,7 @@ zM
 zO
 AS
 bE
-wh
+Yu
 vB
 vB
 zO
@@ -508,7 +510,7 @@ zM
 zO
 ri
 cf
-sm
+Vi
 Kd
 vz
 zO

--- a/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
@@ -374,10 +374,6 @@
 	icon_state = "chapel"
 	},
 /area/ruin/space/powered)
-"bv" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/turf/simulated/floor/wood,
-/area/ruin/space/powered)
 "bw" = (
 /obj/item/storage/toolbox/electrical,
 /obj/structure/table,
@@ -486,6 +482,12 @@
 /obj/item/stack/sheet/mineral/plasma,
 /obj/structure/table,
 /turf/simulated/floor/plating,
+/area/ruin/space/powered)
+"xW" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
 /area/ruin/space/powered)
 "EZ" = (
 /obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
@@ -769,7 +771,7 @@ aC
 aC
 aC
 aC
-bv
+xW
 bI
 bK
 bM

--- a/_maps/map_files/RandomRuins/SpaceRuins/wreckedcargoship.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/wreckedcargoship.dmm
@@ -101,10 +101,6 @@
 /obj/effect/turf_decal/tiles/dark/corner,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/wreck_cargoship)
-"eQ" = (
-/obj/machinery/door/airlock/hatch,
-/turf/simulated/floor/pod/light,
-/area/ruin/space/wreck_cargoship)
 "eV" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/tiles/department/engineering/corner{
@@ -153,12 +149,6 @@
 /area/ruin/space/wreck_cargoship)
 "gE" = (
 /turf/simulated/wall/mineral/plastitanium,
-/area/ruin/space/wreck_cargoship)
-"he" = (
-/obj/machinery/door/firedoor/border_only/closed{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
 /area/ruin/space/wreck_cargoship)
 "hh" = (
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -421,13 +411,6 @@
 	dir = 1
 	},
 /area/ruin/space/wreck_cargoship)
-"pv" = (
-/obj/machinery/door/firedoor/border_only/closed{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/turfs/damage,
-/turf/simulated/floor/plating,
-/area/ruin/space/wreck_cargoship)
 "py" = (
 /obj/structure/railing{
 	dir = 1
@@ -439,14 +422,6 @@
 	icon_state = "titanium";
 	dir = 4
 	},
-/area/ruin/space/wreck_cargoship)
-"pz" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/barricade/wooden/crude{
-	layer = 4
-	},
-/obj/machinery/door/airlock/maintenance_hatch,
-/turf/simulated/floor/plasteel,
 /area/ruin/space/wreck_cargoship)
 "pD" = (
 /obj/structure/closet/walllocker/emerglocker/directional/north,
@@ -497,6 +472,12 @@
 "qr" = (
 /obj/structure/largecrate,
 /obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/ruin/space/wreck_cargoship)
+"qT" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/ruin/space/wreck_cargoship)
 "qY" = (
@@ -567,6 +548,12 @@
 /obj/effect/decal/cleanable/molten_object/large,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/wreck_cargoship)
+"tB" = (
+/obj/machinery/door/firedoor/border_only/closed{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ruin/space/wreck_cargoship)
 "tD" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/reagent_dispensers/fueltank,
@@ -607,10 +594,6 @@
 "wp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/pod/light,
-/area/ruin/space/wreck_cargoship)
-"xX" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/turf/simulated/floor/plating,
 /area/ruin/space/wreck_cargoship)
 "yb" = (
 /obj/structure/railing,
@@ -683,6 +666,13 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/wreck_cargoship)
+"Bo" = (
+/obj/machinery/door/firedoor/border_only/closed{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/turfs/damage,
+/turf/simulated/floor/plating,
+/area/ruin/space/wreck_cargoship)
 "Bt" = (
 /obj/structure/rack,
 /obj/item/stack/cable_coil,
@@ -714,9 +704,9 @@
 /obj/effect/decal/cleanable/glass,
 /turf/simulated/floor/plating,
 /area/ruin/space/wreck_cargoship)
-"BP" = (
+"Co" = (
 /obj/machinery/door/firedoor/border_only/closed{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -1040,6 +1030,12 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/ruin/space/wreck_cargoship)
+"PZ" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/turf/simulated/floor/pod/light,
+/area/ruin/space/wreck_cargoship)
 "QH" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/plasma{
@@ -1309,6 +1305,16 @@
 	},
 /obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
 /turf/simulated/floor/plating,
+/area/ruin/space/wreck_cargoship)
+"XR" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/barricade/wooden/crude{
+	layer = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
 /area/ruin/space/wreck_cargoship)
 "XX" = (
 /obj/machinery/light/small,
@@ -1647,7 +1653,7 @@ GR
 lW
 tm
 Ll
-pz
+XR
 yb
 Vb
 gE
@@ -1747,7 +1753,7 @@ ea
 gE
 Xn
 Nf
-xX
+qT
 NI
 NM
 cT
@@ -1755,7 +1761,7 @@ NM
 RM
 qY
 NM
-xX
+qT
 Ih
 pR
 gE
@@ -1831,7 +1837,7 @@ ea
 ea
 DY
 ea
-BP
+Co
 DI
 hD
 Ei
@@ -1852,12 +1858,12 @@ ea
 DY
 VZ
 DY
-pv
+Bo
 BA
 CB
 kP
 Vw
-eQ
+PZ
 wp
 Vs
 oE
@@ -1873,7 +1879,7 @@ DY
 ea
 DY
 DY
-he
+tB
 ET
 mm
 ET

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -176,11 +176,30 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
+"aG" = (
+/obj/machinery/door/airlock/centcom{
+	aiControlDisabled = 1;
+	name = "Assault Pod";
+	req_access = list(150);
+	dir = 4
+	},
+/obj/docking_port/mobile/assault_pod,
+/turf/simulated/floor/plating,
+/area/shuttle/assault_pod)
 "aH" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/permits,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
+"aI" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "syndicate_away";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/jobs/bar/checker,
+/turf/simulated/floor/plasteel,
+/area/syndicate_mothership)
 "aJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -586,6 +605,15 @@
 	},
 /turf/simulated/floor/holofloor,
 /area/holodeck/source_basketball)
+"co" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/shuttles,
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Supply";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/centcom/suppy)
 "cp" = (
 /obj/structure/table/abductor,
 /obj/item/bonegel/alien,
@@ -904,6 +932,21 @@
 	},
 /turf/simulated/floor/holofloor,
 /area/holodeck/source_boxingcourt)
+"dM" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/centcom{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white,
+/area/ghost_bar)
+"dN" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/external_no_weld{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "dO" = (
 /obj/effect/turf_decal/tiles/department/virology/side{
 	dir = 4
@@ -1151,6 +1194,13 @@
 /obj/effect/spawner/window/plastitanium,
 /turf/simulated/floor/plating,
 /area/shuttle/administration)
+"fb" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	req_access = null;
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ghost_bar)
 "fd" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -1164,15 +1214,6 @@
 "fg" = (
 /turf/simulated/wall/indestructible/wood,
 /area/ninja/holding)
-"fk" = (
-/obj/machinery/door/airlock/hatch/syndicate{
-	autoclose = 0;
-	id_tag = "syndijail_door_int";
-	locked = 1;
-	name = "Syndicate Jail Internal Airlock"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/syndicate_mothership/jail)
 "fm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -1310,6 +1351,20 @@
 "fM" = (
 /turf/simulated/floor/plasteel,
 /area/tdome/arena_source)
+"fN" = (
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/commander,
+/obj/machinery/door/airlock/external/glass{
+	name = "Gamma Armory";
+	id_tag = "gamma_away";
+	dir = 4
+	},
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "CCGAMMA";
+	name = "Gamma Security"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/centcom/gamma)
 "fO" = (
 /obj/structure/rack,
 /obj/item/clothing/under/color/red,
@@ -1417,6 +1472,14 @@
 /obj/effect/baseturf_helper/asteroid/snow,
 /turf/simulated/wall/indestructible/rock/snow,
 /area/syndicate_mothership)
+"gf" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Infirmary";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical,
+/turf/simulated/floor/plasteel/white,
+/area/centcom/control)
 "gg" = (
 /obj/structure/showcase,
 /turf/simulated/floor/wood,
@@ -1810,23 +1873,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership)
-"hx" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "s_docking_airlock";
-	name = "Shuttle Hatch"
-	},
-/obj/docking_port/mobile/admin,
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 9;
-	height = 18;
-	id = "admin_away";
-	name = "centcom bay 1";
-	timid = 1;
-	width = 19
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/administration)
 "hy" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/item/kirbyplants/large,
@@ -1996,6 +2042,14 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tdome/tdomeadmin)
+"hU" = (
+/obj/machinery/door/airlock/hatch{
+	desc = "Danger: May contain robustness";
+	name = "Dojo";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/admin)
 "hV" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/sit{
 	dir = 1
@@ -2008,52 +2062,6 @@
 	},
 /turf/simulated/floor/plating/abductor,
 /area/abductor_ship)
-"hX" = (
-/obj/effect/mapping_helpers/airlock/access/all/syndicate,
-/obj/machinery/door/airlock/external{
-	id_tag = "s_docking_airlock";
-	name = "Shuttle Airlock"
-	},
-/obj/machinery/door_control/no_emag{
-	id = "syndicate_elite";
-	name = "Blast Doors";
-	pixel_x = -25;
-	req_access = list(150)
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "syndicate_elite";
-	name = "Front Hull Door";
-	opacity = 0;
-	req_access = list(150)
-	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/plating,
-/area/shuttle/syndicate_elite)
-"hY" = (
-/obj/effect/mapping_helpers/airlock/access/all/syndicate,
-/obj/machinery/door/airlock/external{
-	id_tag = "s_docking_airlock";
-	name = "Shuttle Airlock"
-	},
-/obj/machinery/door_control/no_emag{
-	id = "syndicate_sit_1";
-	name = "Blast Doors";
-	pixel_x = -25;
-	req_access = list(150)
-	},
-/obj/structure/fans/tiny,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "syndicate_sit_1";
-	name = "Front Hull Door";
-	opacity = 0;
-	req_access = list(150)
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/syndicate_sit)
 "ia" = (
 /obj/machinery/cooking/deepfryer/upgraded,
 /obj/effect/turf_decal/tiles/dark/checker,
@@ -2173,12 +2181,6 @@
 /obj/item/reagent_containers/drinks/cans/cola,
 /turf/simulated/floor/plasteel,
 /area/centcom/evac)
-"iw" = (
-/obj/machinery/door/airlock/hatch/syndicate{
-	name = "Shuttle Dock"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/syndicate_mothership)
 "ix" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
@@ -2711,6 +2713,15 @@
 /obj/machinery/pdapainter,
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership)
+"ki" = (
+/obj/machinery/door/airlock/centcom{
+	hackProof = 1;
+	locked = 1;
+	name = "CentCom Auxiliary Announcement Closet (Steve)";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/centcom/control)
 "kj" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -2979,15 +2990,6 @@
 /obj/structure/gunrack,
 /turf/simulated/floor/plasteel/dark,
 /area/ghost_bar)
-"lb" = (
-/obj/machinery/door/airlock/hatch/syndicate{
-	name = "SST Ready Room"
-	},
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "sst_ready"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/syndicate_mothership)
 "le" = (
 /obj/effect/landmark/spawner/syndieprisonwarp,
 /turf/simulated/floor/plasteel/dark,
@@ -3068,15 +3070,6 @@
 /area/shuttle/administration)
 "ls" = (
 /obj/structure/closet/secure_closet/contractor,
-/turf/simulated/floor/plasteel/dark,
-/area/syndicate_mothership/jail)
-"lt" = (
-/obj/machinery/door/airlock/hatch/syndicate{
-	damage_deflection = 75;
-	id_tag = "syndicate_jail";
-	locked = 1;
-	name = "Syndicate Jail"
-	},
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership/jail)
 "lu" = (
@@ -3532,19 +3525,6 @@
 /obj/structure/closet/syndicate/personal,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
-"mJ" = (
-/obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/commander,
-/obj/machinery/door/airlock/external/glass{
-	name = "Gamma Armory";
-	id_tag = "gamma_away"
-	},
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "CCGAMMA";
-	name = "Gamma Security"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/centcom/gamma)
 "mK" = (
 /obj/machinery/computer/shuttle/syndicate/recall,
 /obj/effect/turf_decal/tiles/jobs/bar/checker,
@@ -3796,12 +3776,6 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/plasteel,
 /area/admin)
-"nu" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Clothing Storage"
-	},
-/turf/simulated/floor/plasteel,
-/area/admin)
 "nv" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 10
@@ -3829,12 +3803,6 @@
 /obj/item/crowbar/red,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
-"ny" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Mecha Room"
-	},
-/turf/simulated/floor/plasteel,
-/area/admin)
 "nz" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor/plasteel/freezer,
@@ -4392,6 +4360,19 @@
 /obj/effect/turf_decal/tiles/jobs/bar/checker,
 /turf/simulated/floor/plasteel,
 /area/syndicate_mothership)
+"pA" = (
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/general,
+/obj/machinery/door/airlock/centcom{
+	aiControlDisabled = 1;
+	auto_close_time = 25;
+	hackProof = 1;
+	max_integrity = 3000;
+	name = "Escape Pod Dock";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/centcom/evac)
 "pB" = (
 /obj/docking_port/stationary/gamma_armory/centcomm,
 /turf/space,
@@ -4447,13 +4428,6 @@
 /obj/structure/flora/junglebush/large,
 /turf/simulated/floor/grass/jungle,
 /area/centcom/evac)
-"pK" = (
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/commander,
-/obj/machinery/door/airlock/centcom{
-	name = "Shuttle Control Office"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/centcom/gamma)
 "pL" = (
 /obj/structure/railing,
 /obj/structure/railing{
@@ -4527,12 +4501,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ghost_bar)
-"pY" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Team Storage"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/centcom/specops)
 "pZ" = (
 /obj/machinery/economy/vending/medical,
 /turf/simulated/floor/mineral/titanium,
@@ -5147,11 +5115,6 @@
 /obj/machinery/atmospherics/unary/tank/air,
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/syndicate)
-"rS" = (
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/external_no_weld,
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "rT" = (
 /obj/structure/table/wood/poker,
 /obj/item/reagent_containers/drinks/bottle/cognac,
@@ -5160,14 +5123,6 @@
 "rU" = (
 /turf/simulated/floor/plasteel/dark,
 /area/ghost_bar)
-"rV" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "s_docking_airlock";
-	name = "Shuttle Hatch"
-	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/plating,
-/area/shuttle/administration)
 "rW" = (
 /obj/structure/closet/crate,
 /turf/simulated/floor/mineral/titanium,
@@ -5314,14 +5269,6 @@
 /obj/item/reagent_containers/drinks/bottle/gin,
 /turf/simulated/floor/wood,
 /area/syndicate_mothership)
-"sE" = (
-/obj/effect/mapping_helpers/airlock/access/all/syndicate,
-/obj/machinery/door/airlock/multi_tile/glass{
-	name = "Equipment Room"
-	},
-/obj/effect/turf_decal/tiles/jobs/bar/checker,
-/turf/simulated/floor/plasteel,
-/area/syndicate_mothership)
 "sF" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/drinks/shaker,
@@ -5435,15 +5382,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/syndicate_mothership)
-"tc" = (
-/obj/machinery/door/airlock/centcom{
-	aiControlDisabled = 1;
-	name = "Assault Pod";
-	req_access = list(150)
-	},
-/obj/docking_port/mobile/assault_pod,
-/turf/simulated/floor/plating,
-/area/shuttle/assault_pod)
 "td" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -5605,19 +5543,6 @@
 /obj/effect/landmark/spawner/backrooms,
 /turf/simulated/floor/backrooms_carpet,
 /area/backrooms)
-"tJ" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "ADMINCHEMLOCKDOWN";
-	name = "Security Doors";
-	opacity = 0
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "Chem Lab"
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/admin)
 "tK" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 8
@@ -5951,6 +5876,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/centcom/evac)
+"uQ" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "admin_away";
+	name = "Administration Shuttle";
+	opacity = 0;
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/plasteel/dark,
+/area/centcom/specops)
 "uS" = (
 /obj/effect/spawner/window/plastitanium,
 /turf/simulated/floor/plating,
@@ -5989,16 +5924,6 @@
 /area/syndicate_mothership)
 "vd" = (
 /turf/simulated/floor/carpet/green,
-/area/ghost_bar)
-"ve" = (
-/obj/effect/turf_decal/tiles/department/security/corner,
-/obj/effect/turf_decal/tiles/department/security/corner{
-	dir = 1
-	},
-/obj/machinery/door/airlock/hatch/syndicate{
-	req_access = null
-	},
-/turf/simulated/floor/plasteel/freezer,
 /area/ghost_bar)
 "vf" = (
 /obj/effect/landmark/spawner/trader,
@@ -6054,12 +5979,6 @@
 /obj/structure/chair/sofa/corp,
 /turf/simulated/floor/transparent/glass,
 /area/tdome/tdomeobserve)
-"vr" = (
-/obj/machinery/door/airlock{
-	name = "Toilet"
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/trader_station/sol)
 "vs" = (
 /obj/structure/railing,
 /obj/item/kirbyplants/large,
@@ -6221,6 +6140,30 @@
 /obj/item/kirbyplants/large,
 /turf/simulated/floor/plasteel/dark,
 /area/tdome/tdomeobserve)
+"vS" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
+/obj/machinery/door/airlock/external{
+	id_tag = "s_docking_airlock";
+	name = "Shuttle Airlock";
+	dir = 4
+	},
+/obj/machinery/door_control/no_emag{
+	id = "syndicate_elite";
+	name = "Blast Doors";
+	pixel_x = -25;
+	req_access = list(150)
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "syndicate_elite";
+	name = "Front Hull Door";
+	opacity = 0;
+	req_access = list(150)
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/plating,
+/area/shuttle/syndicate_elite)
 "vT" = (
 /obj/structure/table,
 /obj/structure/window/reinforced,
@@ -6243,6 +6186,16 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/carpet,
 /area/admin)
+"vY" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	name = "SIT Ready Room";
+	dir = 4
+	},
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "sit_ready"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/syndicate_mothership)
 "wa" = (
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 1
@@ -6449,9 +6402,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ghost_bar)
-"wK" = (
-/turf/simulated/wall/mineral/plastitanium,
-/area/shuttle/supply)
 "wM" = (
 /obj/structure/closet/wardrobe/xenos,
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -6578,13 +6528,6 @@
 /obj/structure/toilet/directional/east,
 /turf/simulated/floor/plasteel/freezer,
 /area/trader_station/sol)
-"xb" = (
-/obj/machinery/door/airlock/hatch{
-	desc = "You've heard rumors of the horrors that go on within this lab.";
-	name = "Laboratory (DANGER!)"
-	},
-/turf/simulated/floor/plasteel,
-/area/admin)
 "xc" = (
 /obj/machinery/computer/supplycomp/public,
 /turf/simulated/floor/plasteel,
@@ -6651,9 +6594,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/admin)
+"xm" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ghost_bar)
 "xo" = (
 /turf/simulated/floor/grass/jungle,
 /area/wizard_station)
+"xp" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Briefing Room";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/centcom/specops)
 "xr" = (
 /obj/structure/table,
 /obj/item/card/id/centcom{
@@ -6748,12 +6705,26 @@
 /obj/structure/table/wood/fancy/purple,
 /turf/simulated/floor/carpet,
 /area/admin)
+"xL" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/tdome/tdomeobserve)
 "xM" = (
 /obj/machinery/computer/shuttle/admin{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
+"xN" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Mecha Room";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/admin)
 "xO" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/wizrobe/magusblue,
@@ -7173,6 +7144,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/ghost_bar)
+"zA" = (
+/obj/machinery/door/airlock{
+	name = "Toilet";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/trader_station/sol)
 "zB" = (
 /obj/machinery/cooking/oven/upgraded,
 /obj/effect/turf_decal/tiles/dark/checker,
@@ -7455,6 +7433,16 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/ghost_bar)
+"AC" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	name = "SST Ready Room";
+	dir = 4
+	},
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "sst_ready"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/syndicate_mothership)
 "AE" = (
 /obj/item/paper/monitorkey,
 /obj/machinery/computer/message_monitor{
@@ -7514,21 +7502,8 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/admin)
-"AM" = (
-/obj/machinery/door/airlock/hatch{
-	desc = "Danger: May contain robustness";
-	name = "Dojo"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/admin)
 "AO" = (
 /turf/space,
-/area/admin)
-"AP" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Shuttle Bay"
-	},
-/turf/simulated/floor/plasteel,
 /area/admin)
 "AQ" = (
 /obj/structure/showcase,
@@ -7585,13 +7560,6 @@
 	},
 /turf/simulated/floor/catwalk,
 /area/shuttle/supply)
-"Be" = (
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/shuttles,
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Supply"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/centcom/suppy)
 "Bf" = (
 /obj/item/storage/toolbox/syndicate{
 	desc = "A powerful relic many men worked long and hard to keep safe and away from the forces of evil.";
@@ -7621,6 +7589,18 @@
 /obj/structure/table/wood,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/ghost_bar)
+"Bi" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/commander,
+/obj/machinery/door/airlock/centcom{
+	name = "Administrative Office";
+	dir = 4
+	},
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "specopsoffice";
+	name = "Super Privacy Shutters"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/centcom/specops)
 "Bj" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/carpet/black,
@@ -7750,16 +7730,6 @@
 /obj/effect/turf_decal/tiles/jobs/bar/checker,
 /turf/simulated/floor/plasteel,
 /area/syndicate_mothership)
-"BK" = (
-/obj/effect/turf_decal/tiles/department/medical/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner,
-/obj/machinery/door/airlock/hatch/syndicate{
-	req_access = null
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/ghost_bar)
 "BL" = (
 /obj/effect/turf_decal{
 	dir = 4
@@ -7786,6 +7756,13 @@
 	},
 /turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/supply)
+"BP" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Armory";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/admin)
 "BT" = (
 /obj/effect/landmark/spawner/tdomeobserve,
 /turf/simulated/floor/plasteel/dark,
@@ -7986,6 +7963,14 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel/dark,
 /area/tdome/tdomeadmin)
+"CC" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
+/obj/effect/turf_decal/tiles/jobs/bar/checker,
+/turf/simulated/floor/plasteel,
+/area/syndicate_mothership)
 "CD" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "s_docking_airlock";
@@ -8161,6 +8146,17 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/ghost_bar)
+"Dl" = (
+/obj/machinery/door/airlock/external{
+	aiControlDisabled = 1;
+	hackProof = 1;
+	id_tag = "emergency_away";
+	name = "Arrival Airlock";
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/plasteel,
+/area/centcom/evac)
 "Dm" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -8354,17 +8350,6 @@
 /obj/item/kirbyplants/large,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
-"DV" = (
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/commander,
-/obj/machinery/door/airlock/centcom{
-	name = "Administrative Office"
-	},
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "specopsoffice";
-	name = "Super Privacy Shutters"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/centcom/specops)
 "DW" = (
 /obj/structure/rack,
 /obj/item/katana/energy,
@@ -8376,6 +8361,13 @@
 /obj/item/clothing/shoes/space_ninja,
 /turf/simulated/floor/engine,
 /area/admin)
+"DY" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome Access";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/centcom/control)
 "DZ" = (
 /obj/item/stock_parts/cell/bluespace,
 /obj/item/stock_parts/cell/bluespace,
@@ -8386,16 +8378,6 @@
 /obj/structure/shelf/engineering,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
-"Ea" = (
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/specops,
-/obj/machinery/door/airlock/centcom{
-	name = "Shuttle Control Office"
-	},
-/obj/effect/turf_decal/tiles/department/engineering{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/centcom/suppy)
 "Ec" = (
 /obj/structure/railing,
 /obj/structure/sign/directions/engineering{
@@ -8438,18 +8420,6 @@
 /obj/machinery/economy/vending/snack,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
-"El" = (
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/general,
-/obj/machinery/door/airlock/centcom{
-	aiControlDisabled = 1;
-	auto_close_time = 25;
-	hackProof = 1;
-	max_integrity = 3000;
-	name = "Escape Pod Dock"
-	},
-/turf/simulated/floor/wood,
-/area/centcom/evac)
 "En" = (
 /obj/structure/closet/crate,
 /obj/item/storage/box/donkpockets,
@@ -8687,15 +8657,6 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
-"Fu" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "admin_away";
-	name = "Administration Shuttle";
-	opacity = 0
-	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/plasteel/dark,
-/area/centcom/specops)
 "Fv" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -9016,6 +8977,13 @@
 /obj/structure/chair,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
+"Gs" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Clothing Storage";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/admin)
 "Gt" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -9214,15 +9182,6 @@
 	icon_state = "rampbottom"
 	},
 /area/holodeck/source_theatre)
-"Hr" = (
-/obj/machinery/door/airlock/hatch/syndicate{
-	name = "SIT Ready Room"
-	},
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "sit_ready"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/syndicate_mothership)
 "Hs" = (
 /obj/structure/table,
 /obj/item/storage/lockbox/mindshield,
@@ -9268,6 +9227,41 @@
 /obj/structure/railing,
 /turf/simulated/floor/wood,
 /area/ghost_bar)
+"HB" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "smindicate";
+	name = "Outer Airlock";
+	opacity = 0
+	},
+/obj/machinery/door_control/no_emag{
+	id = "smindicate";
+	name = "External Door Control";
+	pixel_x = -26;
+	pixel_y = 2;
+	req_access = list(150)
+	},
+/obj/docking_port/mobile/nuke_ops,
+/obj/docking_port/stationary{
+	area_type = /area/syndicate_mothership;
+	dheight = 9;
+	dir = 2;
+	dwidth = 5;
+	height = 22;
+	id = "syndicate_away";
+	name = "syndicate base";
+	turf_type = /turf/simulated/floor/plating/asteroid/snow/airless;
+	width = 18
+	},
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "syndishuttle_door_ext";
+	name = "Ship External Airlock";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/syndicate)
 "HC" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor/mineral/titanium,
@@ -9381,12 +9375,6 @@
 /obj/machinery/economy/vending/cigarette,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
-"HZ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/ghost_bar)
 "Ia" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/reedbush,
@@ -9446,12 +9434,26 @@
 	icon_state = "asteroidplating"
 	},
 /area/ghost_bar)
+"Ip" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	name = "Shuttle Dock";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/syndicate_mothership)
 "Iq" = (
 /obj/effect/turf_decal/tiles/department/security/corner{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/gamma)
+"Ir" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Shuttle Bay";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/admin)
 "Is" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ants,
@@ -9492,12 +9494,15 @@
 /obj/structure/railing,
 /turf/simulated/floor/grass,
 /area/centcom/evac)
-"IC" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Thunderdome Access"
+"IB" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "s_docking_airlock";
+	name = "Shuttle Hatch";
+	dir = 4
 	},
-/turf/simulated/floor/plasteel/dark,
-/area/centcom/control)
+/obj/structure/fans/tiny,
+/turf/simulated/floor/plating,
+/area/shuttle/administration)
 "ID" = (
 /obj/effect/turf_decal/tiles/department/command/side{
 	dir = 1
@@ -9600,15 +9605,13 @@
 /obj/machinery/computer/shuttle/ferry,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
-"Jb" = (
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/specops,
-/obj/machinery/door/airlock/external{
-	id_tag = "s_docking_airlock";
-	name = "Shuttle Hatch"
+"Ja" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Team Storage";
+	dir = 4
 	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/plating,
-/area/shuttle/specops)
+/turf/simulated/floor/plasteel/dark,
+/area/centcom/specops)
 "Jd" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4
@@ -9764,6 +9767,15 @@
 /obj/structure/shelf/engineering,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
+"JF" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Equipment Room";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/jobs/bar/checker,
+/turf/simulated/floor/plasteel,
+/area/syndicate_mothership)
 "JG" = (
 /obj/structure/railing,
 /obj/structure/railing{
@@ -9783,12 +9795,6 @@
 /obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/wood,
 /area/ghost_bar)
-"JJ" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Thunderdome"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/tdome/tdomeobserve)
 "JM" = (
 /obj/machinery/computer/shuttle/ferry,
 /obj/effect/turf_decal/tiles/department/security/side{
@@ -9823,6 +9829,15 @@
 /obj/effect/turf_decal/tiles/jobs/bar/checker,
 /turf/simulated/floor/plasteel,
 /area/tdome/tdomeobserve)
+"JR" = (
+/obj/machinery/door/airlock/centcom{
+	aiControlDisabled = 1;
+	name = "Assault Pod";
+	req_access = list(150);
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/assault_pod)
 "JS" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'FOURTH WALL'.";
@@ -10151,9 +10166,6 @@
 "KX" = (
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
-"KY" = (
-/turf/simulated/wall/mineral/plastitanium,
-/area/shuttle/syndicate)
 "KZ" = (
 /obj/machinery/computer/communications{
 	dir = 1
@@ -10247,15 +10259,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet/arcade,
-/area/syndicate_mothership)
-"Lp" = (
-/obj/machinery/door/airlock/hatch/syndicate{
-	autoclose = 0;
-	id_tag = "syndijail_door_ext";
-	locked = 1;
-	name = "Syndicate Jail External Airlock"
-	},
-/turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership)
 "Lq" = (
 /obj/machinery/recharge_station,
@@ -10366,6 +10369,20 @@
 	},
 /turf/simulated/floor/wood,
 /area/ghost_bar)
+"LN" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Teleporter Access";
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "ADMINLOCKDOWN";
+	name = "Security Doors";
+	opacity = 0
+	},
+/turf/simulated/floor/plasteel,
+/area/admin)
 "LQ" = (
 /obj/machinery/door/poddoor/impassable{
 	name = "Heavy Supply";
@@ -10515,14 +10532,6 @@
 /obj/structure/shelf/engineering,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
-"Mz" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/shuttles,
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Supply"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/centcom/suppy)
 "MA" = (
 /obj/machinery/door/airlock/hatch{
 	desc = "Danger: May contain robustness";
@@ -10530,14 +10539,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/ninja/outpost)
-"MD" = (
-/obj/machinery/door/airlock/centcom{
-	hackProof = 1;
-	locked = 1;
-	name = "CentCom Auxiliary Announcement Closet (Steve)"
+"MB" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/specops,
+/obj/machinery/door/airlock/external{
+	id_tag = "s_docking_airlock";
+	name = "Shuttle Hatch";
+	dir = 4
 	},
-/turf/simulated/floor/plasteel/dark,
-/area/centcom/control)
+/obj/structure/fans/tiny,
+/turf/simulated/floor/plating,
+/area/shuttle/specops)
 "ME" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -10645,40 +10656,6 @@
 	icon_state = "asteroid1"
 	},
 /area/holodeck/source_desert)
-"MS" = (
-/obj/effect/mapping_helpers/airlock/access/all/syndicate,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "smindicate";
-	name = "Outer Airlock";
-	opacity = 0
-	},
-/obj/machinery/door_control/no_emag{
-	id = "smindicate";
-	name = "External Door Control";
-	pixel_x = -26;
-	pixel_y = 2;
-	req_access = list(150)
-	},
-/obj/docking_port/mobile/nuke_ops,
-/obj/docking_port/stationary{
-	area_type = /area/syndicate_mothership;
-	dheight = 9;
-	dir = 2;
-	dwidth = 5;
-	height = 22;
-	id = "syndicate_away";
-	name = "syndicate base";
-	turf_type = /turf/simulated/floor/plating/asteroid/snow/airless;
-	width = 18
-	},
-/obj/machinery/door/airlock/external/glass{
-	id_tag = "syndishuttle_door_ext";
-	name = "Ship External Airlock"
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/syndicate)
 "MU" = (
 /obj/machinery/economy/vending/cola/free{
 	name = "\improper Wizbust Softdrinks"
@@ -10712,10 +10689,6 @@
 /area/centcom/evac)
 "MZ" = (
 /obj/structure/closet/wardrobe/grey,
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/ghost_bar)
-"Na" = (
-/obj/machinery/door/airlock/external_no_weld,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/ghost_bar)
 "Nb" = (
@@ -10867,6 +10840,12 @@
 /obj/structure/sink/directional/east,
 /turf/simulated/floor/plasteel/freezer,
 /area/ghost_bar)
+"NE" = (
+/obj/machinery/door/airlock/external_no_weld{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ghost_bar)
 "NH" = (
 /turf/simulated/floor/plasteel/stairs/left{
 	dir = 8
@@ -10892,19 +10871,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/ghost_bar)
-"NO" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Teleporter Access"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "ADMINLOCKDOWN";
-	name = "Security Doors";
-	opacity = 0
-	},
-/turf/simulated/floor/plasteel,
-/area/admin)
 "NP" = (
 /obj/structure/bookcase/random,
 /turf/simulated/floor/plasteel/dark,
@@ -11172,6 +11138,20 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership)
+"OO" = (
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "adminshuttleblast";
+	name = "Blast Doors";
+	req_access = list(101)
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/general,
+/obj/machinery/door/airlock/centcom{
+	id_tag = "adminshuttle";
+	name = "General Access";
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/administration)
 "OP" = (
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/transport)
@@ -11184,19 +11164,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
-"OR" = (
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "adminshuttleblast";
-	name = "Blast Doors";
-	req_access = list(101)
-	},
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/general,
-/obj/machinery/door/airlock/centcom{
-	id_tag = "adminshuttle";
-	name = "General Access"
-	},
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/shuttle/administration)
 "OS" = (
 /obj/effect/turf_decal/tiles/jobs/bar/checker,
 /turf/simulated/floor/plasteel,
@@ -11208,11 +11175,6 @@
 	icon_state = "asteroid2"
 	},
 /area/holodeck/source_desert)
-"OU" = (
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/centcom,
-/turf/simulated/floor/plasteel/freezer,
-/area/ghost_bar)
 "OV" = (
 /obj/item/kirbyplants/large,
 /obj/machinery/door_control/no_emag{
@@ -11234,6 +11196,30 @@
 /obj/machinery/tcomms/relay/cc,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
+"OZ" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
+/obj/machinery/door/airlock/external{
+	id_tag = "s_docking_airlock";
+	name = "Shuttle Airlock";
+	dir = 4
+	},
+/obj/machinery/door_control/no_emag{
+	id = "syndicate_sit_1";
+	name = "Blast Doors";
+	pixel_x = -25;
+	req_access = list(150)
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "syndicate_sit_1";
+	name = "Front Hull Door";
+	opacity = 0;
+	req_access = list(150)
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/syndicate_sit)
 "Pa" = (
 /obj/effect/turf_decal/delivery/white/partial,
 /turf/simulated/floor/plasteel/dark,
@@ -11261,6 +11247,15 @@
 	dir = 1
 	},
 /area/ghost_bar)
+"Pj" = (
+/obj/machinery/door/airlock/hatch/syndicate/command{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "commandcenter"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/syndicate_mothership)
 "Pk" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -11309,12 +11304,26 @@
 	dir = 1
 	},
 /area/ghost_bar)
-"Pr" = (
-/obj/machinery/door/airlock/hatch/syndicate,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate,
-/obj/effect/turf_decal/tiles/jobs/bar/checker,
-/turf/simulated/floor/plasteel,
-/area/syndicate_mothership)
+"Ps" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	autoclose = 0;
+	id_tag = "syndijail_door_int";
+	locked = 1;
+	name = "Syndicate Jail Internal Airlock";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/syndicate_mothership/jail)
+"Pt" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	damage_deflection = 75;
+	id_tag = "syndicate_jail";
+	locked = 1;
+	name = "Syndicate Jail";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/syndicate_mothership/jail)
 "Pu" = (
 /turf/simulated/floor/plasteel/freezer,
 /area/ghost_bar)
@@ -12198,6 +12207,13 @@
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/administration)
+"Sy" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/centcom{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "Sz" = (
 /obj/machinery/door_control/no_emag{
 	id = "CCTELE";
@@ -12222,6 +12238,20 @@
 /obj/structure/sign/nosmoking/alt,
 /turf/simulated/wall/indestructible/riveted,
 /area/ghost_bar)
+"SC" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "ADMINCHEMLOCKDOWN";
+	name = "Security Doors";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "Chem Lab";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/admin)
 "SD" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -12235,6 +12265,17 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
+"SF" = (
+/obj/effect/turf_decal/tiles/department/security/corner,
+/obj/effect/turf_decal/tiles/department/security/corner{
+	dir = 1
+	},
+/obj/machinery/door/airlock/hatch/syndicate{
+	req_access = null;
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "SG" = (
 /obj/machinery/autolathe/upgraded{
 	hacked = 1
@@ -12337,9 +12378,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/ghost_bar)
-"Td" = (
-/turf/simulated/wall/indestructible/syndicate,
 /area/ghost_bar)
 "Te" = (
 /turf/simulated/wall/indestructible/riveted,
@@ -12462,6 +12500,21 @@
 /obj/machinery/computer/camera_advanced/shuttle_docker/ert,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/specops)
+"TB" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/commander,
+/obj/machinery/door/airlock/centcom{
+	name = "Shuttle Control Office";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/centcom/gamma)
+"TD" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Badmin's Bar";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/centcom/evac)
 "TE" = (
 /turf/simulated/floor/wood,
 /area/ninja/outpost)
@@ -12555,14 +12608,6 @@
 "TU" = (
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/evac)
-"TV" = (
-/obj/effect/mapping_helpers/airlock/access/all/syndicate,
-/obj/machinery/door/airlock/external/glass{
-	id_tag = "syndicate_away"
-	},
-/obj/effect/turf_decal/tiles/jobs/bar/checker,
-/turf/simulated/floor/plasteel,
-/area/syndicate_mothership)
 "TW" = (
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 1
@@ -12650,12 +12695,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/centcom/control)
-"Uk" = (
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/centcom,
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white,
-/area/ghost_bar)
 "Ul" = (
 /obj/effect/landmark/newplayer_start,
 /turf/simulated/wall/indestructible/splashscreen,
@@ -12676,6 +12715,16 @@
 /obj/item/lighter,
 /turf/simulated/floor/wood,
 /area/centcom/control)
+"Uo" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	autoclose = 0;
+	id_tag = "syndijail_door_ext";
+	locked = 1;
+	name = "Syndicate Jail External Airlock";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/syndicate_mothership)
 "Up" = (
 /obj/item/caution/proximity_sign,
 /obj/item/caution/proximity_sign,
@@ -12733,20 +12782,18 @@
 /obj/item/storage/lockbox/medal/cc,
 /turf/simulated/floor/carpet,
 /area/centcom/specops)
-"UA" = (
-/obj/machinery/door/airlock/external{
-	aiControlDisabled = 1;
-	hackProof = 1;
-	id_tag = "emergency_away";
-	name = "Arrival Airlock"
-	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/plasteel,
-/area/centcom/evac)
 "UB" = (
 /obj/structure/sign/poster/contraband/syndicate_recruitment/directional/north,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/ghost_bar)
+"UC" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/shuttles,
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Supply";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/centcom/suppy)
 "UD" = (
 /obj/effect/landmark/spawner/antag_extract_warp,
 /obj/effect/turf_decal/delivery/red/hollow,
@@ -12813,6 +12860,24 @@
 /obj/structure/toilet/directional/east,
 /turf/simulated/floor/plasteel/freezer,
 /area/ghost_bar)
+"UT" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "s_docking_airlock";
+	name = "Shuttle Hatch";
+	dir = 4
+	},
+/obj/docking_port/mobile/admin,
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 9;
+	height = 18;
+	id = "admin_away";
+	name = "centcom bay 1";
+	timid = 1;
+	width = 19
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/administration)
 "UU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/secure_data/laptop,
@@ -13003,6 +13068,14 @@
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
+"VE" = (
+/obj/machinery/door/airlock/hatch{
+	desc = "You've heard rumors of the horrors that go on within this lab.";
+	name = "Laboratory (DANGER!)";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/admin)
 "VF" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
@@ -13320,13 +13393,6 @@
 /obj/item/toy/sword,
 /turf/simulated/floor/plasteel,
 /area/centcom/evac)
-"WN" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Infirmary"
-	},
-/obj/effect/turf_decal/tiles/department/medical,
-/turf/simulated/floor/plasteel/white,
-/area/centcom/control)
 "WO" = (
 /obj/structure/table/wood,
 /obj/item/clothing/accessory/medal{
@@ -13390,6 +13456,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/centcom/control)
+"WW" = (
+/obj/effect/turf_decal/tiles/department/medical/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner,
+/obj/machinery/door/airlock/hatch/syndicate{
+	req_access = null;
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "WX" = (
 /obj/item/kirbyplants/large,
 /turf/simulated/floor/transparent/glass/reinforced,
@@ -13458,12 +13535,6 @@
 "Xj" = (
 /turf/simulated/floor/transparent/glass,
 /area/centcom/specops)
-"Xk" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	name = "Badmin's Bar"
-	},
-/turf/simulated/floor/wood,
-/area/centcom/evac)
 "Xl" = (
 /obj/machinery/economy/vending/snack/free,
 /obj/effect/turf_decal/tiles/department/virology/side{
@@ -13714,15 +13785,6 @@
 /obj/machinery/computer/arcade/recruiter,
 /turf/simulated/floor/carpet/arcade,
 /area/syndicate_mothership)
-"Yi" = (
-/turf/simulated/wall/indestructible/syndicate,
-/area/syndicate_mothership)
-"Yj" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Briefing Room"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/centcom/specops)
 "Yk" = (
 /obj/item/storage/box/ids{
 	pixel_x = 3;
@@ -13924,6 +13986,17 @@
 /obj/structure/sign/public/restroom,
 /turf/simulated/wall/indestructible/riveted,
 /area/ghost_bar)
+"YY" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/specops,
+/obj/machinery/door/airlock/centcom{
+	name = "Shuttle Control Office";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/engineering{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/centcom/suppy)
 "YZ" = (
 /obj/machinery/economy/vending/syndisnack,
 /turf/simulated/floor/carpet/black,
@@ -14093,9 +14166,6 @@
 /obj/effect/turf_decal/tiles/department/security/side,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
-"ZG" = (
-/turf/simulated/wall/mineral/plastitanium,
-/area/shuttle/administration)
 "ZH" = (
 /obj/structure/bookcase/random,
 /obj/effect/decal/cleanable/cobweb,
@@ -26957,15 +27027,15 @@ aN
 aN
 aN
 aN
-ZG
+Rv
 jt
 bS
-ZG
+Rv
 aN
-ZG
+Rv
 jt
 bS
-ZG
+Rv
 aN
 aN
 aN
@@ -27213,17 +27283,17 @@ aN
 aN
 aN
 aN
-ZG
-ZG
+Rv
+Rv
 cJ
 cJ
-ZG
-ZG
-ZG
+Rv
+Rv
+Rv
 cJ
 cJ
-ZG
-ZG
+Rv
+Rv
 aN
 aN
 aN
@@ -27468,20 +27538,20 @@ aN
 aN
 aN
 aN
-ZG
-ZG
-ZG
+Rv
+Rv
+Rv
 Km
 ZN
 ZN
 Ek
-ZG
+Rv
 rg
 lr
 lr
 Sx
-ZG
-ZG
+Rv
+Rv
 aN
 aN
 aN
@@ -27725,21 +27795,21 @@ aN
 aN
 aN
 aN
-ZG
+Rv
 dl
 ZN
 zC
 ZN
 ZN
 EN
-ZG
+Rv
 Nw
 lr
 lr
 lr
 rM
-ZG
-ZG
+Rv
+Rv
 aN
 aN
 aN
@@ -27982,21 +28052,21 @@ aN
 aN
 aN
 Db
-ZG
+Rv
 XX
 ZN
 Rz
 Po
 ZN
 YL
-ZG
+Rv
 pq
 lr
 lr
 lr
 lr
 TZ
-ZG
+Rv
 aN
 aN
 aN
@@ -28239,21 +28309,21 @@ aN
 aN
 aN
 aN
-ZG
+Rv
 qY
 ZN
 Mf
 Po
 ZN
 HY
-ZG
+Rv
 km
 lr
 mv
 HC
 lr
 KA
-ZG
+Rv
 aN
 aN
 aN
@@ -28496,21 +28566,21 @@ aN
 aN
 aN
 aN
-ZG
+Rv
 PC
 Gi
 nQ
 Po
 ZN
 ZN
-ZG
+Rv
 Tb
 lr
 lr
 GE
 Hn
 pZ
-ZG
+Rv
 aN
 aN
 aN
@@ -28753,21 +28823,21 @@ XM
 XM
 XM
 XM
-ZG
-ZG
-ZG
-ZG
-ZG
+Rv
+Rv
+Rv
+Rv
+Rv
 Lw
-ZG
-ZG
-ZG
+Rv
+Rv
+Rv
 Us
-ZG
-ZG
-ZG
-ZG
-ZG
+Rv
+Rv
+Rv
+Rv
+Rv
 aN
 aN
 aN
@@ -28994,7 +29064,7 @@ sm
 sm
 YA
 YA
-Jb
+MB
 Rs
 Rs
 Sq
@@ -29009,10 +29079,10 @@ Zr
 xM
 Ra
 Ra
-Fu
-rV
+uQ
+IB
 pU
-OR
+OO
 Ih
 ZN
 ZN
@@ -29024,7 +29094,7 @@ ZN
 ZN
 ZN
 ZN
-ZG
+Rv
 aN
 aN
 aN
@@ -29251,7 +29321,7 @@ Gd
 GR
 uC
 YA
-Jb
+MB
 Rs
 Rs
 Sq
@@ -29266,10 +29336,10 @@ Zr
 sw
 Ra
 Ra
-Fu
-hx
+uQ
+UT
 ZN
-OR
+OO
 ZN
 ZN
 ZN
@@ -29281,7 +29351,7 @@ ZN
 ZN
 ZN
 tG
-ZG
+Rv
 aN
 aN
 aN
@@ -29524,21 +29594,21 @@ AV
 Ra
 Ra
 Lm
-ZG
-ZG
-ZG
+Rv
+Rv
+Rv
 ei
-ZG
-ZG
-ZG
+Rv
+Rv
+Rv
 su
-ZG
-ZG
-ZG
+Rv
+Rv
+Rv
 hE
-ZG
-ZG
-ZG
+Rv
+Rv
+Rv
 aN
 aN
 aN
@@ -29781,21 +29851,21 @@ Gr
 Ra
 Ra
 Zr
-ZG
+Rv
 Qd
 PQ
 ZN
 pD
-ZG
+Rv
 QA
 ZN
 ZN
-ZG
+Rv
 ZN
 ZN
 fE
 Hs
-ZG
+Rv
 aN
 aN
 aN
@@ -30038,21 +30108,21 @@ Gr
 Ra
 Ra
 Zr
-ZG
+Rv
 Nx
 ZN
 ZN
 on
-ZG
+Rv
 Qg
 SE
 SE
-ZG
+Rv
 ZN
 ZN
 ZN
 Mm
-ZG
+Rv
 aN
 aN
 aN
@@ -30295,21 +30365,21 @@ Gr
 Ra
 Ra
 Zr
-ZG
+Rv
 SD
 ZN
 ZN
 Cw
-ZG
+Rv
 GU
 NK
 Tr
-ZG
+Rv
 ZN
 ZN
 ZN
 ZN
-ZG
+Rv
 aN
 aN
 aN
@@ -30552,21 +30622,21 @@ Gr
 Ra
 Ra
 Zr
-ZG
-ZG
+Rv
+Rv
 ft
 ZN
 ZN
-ZG
+Rv
 eX
 eX
 eX
-ZG
+Rv
 qC
 th
 ry
 Rv
-ZG
+Rv
 aN
 aN
 aN
@@ -30787,7 +30857,7 @@ aN
 aN
 aN
 pB
-mJ
+fN
 Hi
 Hi
 Hi
@@ -30810,19 +30880,19 @@ Ra
 Ra
 Zr
 aN
-ZG
+Rv
 Oc
 ZN
 SG
-ZG
+Rv
 aN
 aN
 aN
-ZG
+Rv
 ZN
 ZN
 pr
-ZG
+Rv
 aN
 aN
 aN
@@ -31067,19 +31137,19 @@ Ra
 Ra
 Zr
 aN
-ZG
-ZG
+Rv
+Rv
 Gi
 nH
-ZG
+Rv
 aN
 aN
 aN
-ZG
+Rv
 Px
 DO
-ZG
-ZG
+Rv
+Rv
 aN
 aN
 aN
@@ -31306,7 +31376,7 @@ wa
 Mh
 Hi
 Hi
-pK
+TB
 Rr
 Ra
 Ra
@@ -31325,17 +31395,17 @@ Ra
 Zr
 aN
 aN
-ZG
-ZG
-ZG
-ZG
+Rv
+Rv
+Rv
+Rv
 aN
 aN
 aN
-ZG
-ZG
-ZG
-ZG
+Rv
+Rv
+Rv
+Rv
 aN
 aN
 aN
@@ -33624,7 +33694,7 @@ Zr
 hm
 Ra
 Ra
-Yj
+xp
 Ra
 Ra
 DM
@@ -33632,7 +33702,7 @@ LI
 VF
 Ra
 Ra
-DV
+Bi
 Ra
 Yx
 Yx
@@ -34138,7 +34208,7 @@ Ra
 Ra
 Ra
 Ra
-Yj
+xp
 Ra
 MG
 TP
@@ -34368,17 +34438,17 @@ aN
 aN
 aN
 aN
-wK
-wK
-wK
-wK
+lq
+lq
+lq
+lq
 uS
 uS
 uS
-wK
-wK
-wK
-wK
+lq
+lq
+lq
+lq
 aN
 aN
 Zr
@@ -34625,7 +34695,7 @@ aN
 aN
 aN
 aN
-wK
+lq
 oV
 BL
 BL
@@ -34882,7 +34952,7 @@ aN
 aN
 aN
 aN
-wK
+lq
 Fc
 Fc
 Fc
@@ -35139,7 +35209,7 @@ aN
 aN
 aN
 aN
-wK
+lq
 Bd
 Fc
 Fc
@@ -35396,7 +35466,7 @@ aN
 aN
 aN
 aN
-wK
+lq
 Fc
 Fc
 Fc
@@ -35653,7 +35723,7 @@ aN
 aN
 aN
 aN
-wK
+lq
 SS
 nE
 nE
@@ -35910,17 +35980,17 @@ aN
 aN
 aN
 aN
-wK
-wK
-wK
+lq
+lq
+lq
 Bt
 Bz
-wK
+lq
 CD
 Dx
-wK
-wK
-wK
+lq
+lq
+lq
 aN
 aN
 Zr
@@ -36189,7 +36259,7 @@ Ra
 Ra
 Ra
 Ra
-pY
+Ja
 Ra
 Ra
 Ra
@@ -37235,7 +37305,7 @@ ZT
 vV
 iJ
 iJ
-JJ
+xL
 BT
 Op
 Op
@@ -37717,18 +37787,18 @@ sk
 sk
 sk
 DF
-Ea
+YY
 Fg
 sk
 sk
 DF
-Be
+UC
 sk
 sk
 sk
 sk
 sk
-Mz
+co
 ZC
 ZC
 Qx
@@ -39025,16 +39095,16 @@ Yu
 RE
 ID
 EU
-IC
+DY
 EV
-IC
+DY
 Xb
 Xb
 Xb
 Xb
 Xb
 Xb
-JJ
+xL
 BT
 Op
 If
@@ -40298,7 +40368,7 @@ aN
 YA
 Is
 nT
-MD
+ki
 ZC
 ZC
 QD
@@ -40833,7 +40903,7 @@ ZT
 sT
 Tf
 Tf
-JJ
+xL
 BT
 Op
 Op
@@ -42363,7 +42433,7 @@ ZC
 Wd
 ZC
 TY
-WN
+gf
 Xc
 Zx
 Zx
@@ -42877,7 +42947,7 @@ ZC
 Wd
 ZC
 TY
-WN
+gf
 Xc
 Zx
 Zx
@@ -44693,7 +44763,7 @@ Ny
 Ny
 Ny
 uO
-UA
+Dl
 xR
 aN
 aN
@@ -45201,7 +45271,7 @@ Ng
 Ng
 vh
 Ng
-El
+pA
 Xx
 Ny
 iP
@@ -45721,7 +45791,7 @@ Ny
 Ny
 Ny
 uO
-UA
+Dl
 FC
 aN
 aN
@@ -45958,7 +46028,7 @@ Qc
 Ng
 Ng
 Ng
-Xk
+TD
 XG
 Ny
 Ny
@@ -46749,7 +46819,7 @@ Ny
 Ny
 Ny
 uO
-UA
+Dl
 kC
 aN
 aN
@@ -47257,7 +47327,7 @@ Ng
 Ng
 Ng
 Ng
-El
+pA
 Xx
 Ny
 iP
@@ -47777,7 +47847,7 @@ Ny
 Ny
 Ny
 uO
-UA
+Dl
 vL
 aN
 aN
@@ -51323,7 +51393,7 @@ vG
 tt
 tF
 tF
-vr
+zA
 wf
 if
 vG
@@ -58477,10 +58547,10 @@ uw
 uw
 VK
 uw
-Yi
+Sd
 BZ
 BZ
-Yi
+Sd
 uw
 tV
 uw
@@ -58496,14 +58566,14 @@ uw
 uw
 uw
 iF
-KY
-KY
-KY
-KY
-KY
+tf
+tf
+tf
+tf
+tf
 iF
-KY
-KY
+tf
+tf
 uw
 uw
 uw
@@ -58731,7 +58801,7 @@ uw
 uw
 uw
 uw
-Yi
+Sd
 BZ
 BZ
 Sd
@@ -58747,12 +58817,12 @@ uw
 BG
 uw
 iF
-KY
-KY
-KY
-KY
-KY
-KY
+tf
+tf
+tf
+tf
+tf
+tf
 qG
 KX
 ua
@@ -58988,10 +59058,10 @@ uw
 uw
 uw
 uw
-TV
+aI
 BY
 BY
-TV
+aI
 BY
 BY
 BZ
@@ -59003,13 +59073,13 @@ uw
 uw
 uw
 uw
-KY
+tf
 iX
 iX
 rN
 iX
 iX
-KY
+tf
 qG
 KX
 KX
@@ -59260,13 +59330,13 @@ uw
 uw
 uw
 uw
-KY
+tf
 KX
 KX
 KX
 KX
 KX
-KY
+tf
 ts
 KX
 KX
@@ -59502,35 +59572,35 @@ uw
 uw
 uw
 nV
-TV
+aI
 BY
 BY
-TV
+aI
 BY
 BY
 BZ
 uw
 iF
-KY
-KY
-KY
-KY
+tf
+tf
+tf
+tf
 uw
 uw
-KY
+tf
 KX
 jz
 KX
 KX
 KX
-KY
+tf
 tv
 jz
 KX
 un
 tf
-KY
-KY
+tf
+tf
 nB
 uw
 uw
@@ -59759,7 +59829,7 @@ uw
 uw
 uw
 uw
-Yi
+Sd
 BZ
 BZ
 Sd
@@ -59767,25 +59837,25 @@ BY
 BY
 BZ
 uw
-KY
+tf
 lP
 mk
 mF
-KY
+tf
 nv
 uw
-KY
+tf
 qI
 iI
 rO
 KX
 KX
-KY
+tf
 jv
 KX
 KX
 uo
-KY
+tf
 uw
 uw
 uw
@@ -60028,23 +60098,23 @@ lA
 KX
 KX
 mG
-KY
-KY
-KY
-KY
-KY
-KY
-KY
+tf
+tf
+tf
+tf
+tf
+tf
+tf
 Ys
 Vq
 tf
-KY
+tf
 Ft
 Bk
 tg
-KY
-KY
-KY
+tf
+tf
+tf
 uw
 uw
 uw
@@ -60787,7 +60857,7 @@ uw
 uw
 uw
 uw
-Yi
+Sd
 BZ
 BZ
 Sd
@@ -61044,10 +61114,10 @@ uw
 uw
 uw
 uw
-TV
+aI
 BY
 BY
-TV
+aI
 BY
 BY
 BZ
@@ -61056,23 +61126,23 @@ lA
 lT
 KX
 KX
-KY
-KY
-KY
-KY
-KY
-KY
+tf
+tf
+tf
+tf
+tf
+tf
 rR
 YS
 sG
 tf
-KY
+tf
 Fp
 ue
 tg
-KY
-KY
-KY
+tf
+tf
+tf
 uw
 uw
 uw
@@ -61309,25 +61379,25 @@ BY
 BY
 BZ
 uw
-KY
+tf
 lT
 KR
 mI
-KY
+tf
 nB
 UO
 UO
 UO
-KY
+tf
 yw
 sn
 tO
-KY
+tf
 tx
 KX
 KX
 ur
-KY
+tf
 uw
 uw
 uw
@@ -61558,35 +61628,35 @@ uw
 uw
 uw
 uw
-TV
+aI
 BY
 BY
-TV
+aI
 BY
 BY
 BZ
 uw
 lB
-KY
-KY
-KY
-KY
+tf
+tf
+tf
+tf
 uw
 BZ
 BY
-TV
-MS
+aI
+HB
 xB
 sn
 tO
-KY
+tf
 jx
 jz
 KX
 uu
 tf
-KY
-KY
+tf
+tf
 nv
 uw
 uw
@@ -61815,7 +61885,7 @@ uw
 uw
 uw
 uw
-Yi
+Sd
 BZ
 BZ
 Sd
@@ -61836,7 +61906,7 @@ iT
 yw
 dD
 JV
-KY
+tf
 jy
 KX
 KX
@@ -62090,10 +62160,10 @@ BZ
 BY
 UO
 lB
-KY
-KY
-KY
-KY
+tf
+tf
+tf
+tf
 ty
 jz
 KX
@@ -62176,7 +62246,7 @@ rU
 rU
 rU
 DG
-OU
+Sy
 Pu
 zQ
 Me
@@ -62350,7 +62420,7 @@ uw
 uw
 uw
 uw
-KY
+tf
 tz
 tU
 Ao
@@ -62608,14 +62678,14 @@ uw
 uw
 uw
 lB
-KY
-KY
-KY
-KY
-KY
+tf
+tf
+tf
+tf
+tf
 lB
-KY
-KY
+tf
+tf
 uw
 uw
 uw
@@ -63110,7 +63180,7 @@ BZ
 uw
 uw
 uw
-Yi
+Sd
 BZ
 BZ
 BZ
@@ -63119,7 +63189,7 @@ oG
 Sd
 Sd
 Sd
-Yi
+Sd
 uw
 uw
 uw
@@ -63377,7 +63447,7 @@ qK
 qT
 rZ
 Sd
-Yi
+Sd
 uw
 uw
 uw
@@ -63620,7 +63690,7 @@ uw
 BZ
 BY
 BY
-Pr
+CC
 BY
 BY
 BY
@@ -63961,14 +64031,14 @@ Im
 PW
 Da
 Da
-Na
+NE
 EQ
 rU
 zh
 zh
 rU
 zh
-rS
+dN
 HH
 Jy
 Jy
@@ -64218,14 +64288,14 @@ Im
 Mt
 Da
 Da
-Na
+NE
 EQ
 zh
 zh
 rU
 zh
 rU
-rS
+dN
 HH
 Jy
 cX
@@ -64918,7 +64988,7 @@ BY
 BY
 BY
 BY
-sE
+JF
 sK
 XJ
 XJ
@@ -65425,7 +65495,7 @@ rw
 rw
 Sd
 Sd
-Yi
+Sd
 mT
 Sd
 Sd
@@ -66186,7 +66256,7 @@ uw
 uw
 uw
 uw
-Yi
+Sd
 Sd
 sZ
 sZ
@@ -66418,7 +66488,6 @@ Nd
 Nd
 Nd
 uw
-Yi
 Sd
 Sd
 Sd
@@ -66430,9 +66499,10 @@ Sd
 Sd
 Sd
 Sd
-Yi
+Sd
+Sd
 uw
-Yi
+Sd
 Sd
 Sd
 BZ
@@ -66561,7 +66631,7 @@ cg
 rU
 rU
 rU
-HZ
+xm
 oC
 Me
 ps
@@ -67066,7 +67136,7 @@ es
 es
 es
 es
-Uk
+dM
 Jy
 Jy
 Jy
@@ -67200,10 +67270,10 @@ gD
 gD
 gD
 gD
-hY
+OZ
 Sd
 XJ
-iw
+Ip
 XJ
 XJ
 XJ
@@ -67215,7 +67285,7 @@ XJ
 XJ
 XJ
 XJ
-Hr
+vY
 XJ
 XJ
 Sd
@@ -67306,7 +67376,7 @@ ps
 ps
 ps
 ps
-Td
+Im
 ps
 ps
 Me
@@ -67560,12 +67630,12 @@ aN
 OK
 ps
 ps
-Td
-Td
-Td
-Td
-Td
-Td
+Im
+Im
+Im
+Im
+Im
+Im
 Me
 Me
 SI
@@ -67586,13 +67656,13 @@ Me
 Me
 Me
 Me
-Td
-Td
-Td
-Td
-Td
-Td
-Td
+Im
+Im
+Im
+Im
+Im
+Im
+Im
 ps
 ps
 OK
@@ -67817,39 +67887,39 @@ ps
 ps
 ps
 ps
-Td
+Im
 mS
 Vz
 ZY
 ZY
-Td
-Td
-Td
+Im
+Im
+Im
 rD
-Td
-Td
-Td
-Td
-Td
-Td
-Td
-Td
-Td
-Td
-Td
-Td
-Td
-Td
-Td
-Td
-Td
-Td
+Im
+Im
+Im
+Im
+Im
+Im
+Im
+Im
+Im
+Im
+Im
+Im
+Im
+Im
+Im
+Im
+Im
+Im
 RF
 RF
 PF
 CH
 qz
-Td
+Im
 iW
 ps
 ps
@@ -67960,7 +68030,7 @@ aN
 Nd
 uw
 uw
-Yi
+Sd
 Sd
 Sd
 Sd
@@ -67972,7 +68042,7 @@ hq
 Sd
 Sd
 Sd
-Yi
+Sd
 XJ
 Sd
 Sd
@@ -67997,13 +68067,13 @@ aN
 aN
 Sd
 nO
-oz
+JR
 qo
 qP
 rJ
 sg
 qo
-tc
+aG
 tp
 Sd
 aN
@@ -68074,19 +68144,19 @@ OK
 ps
 ps
 ps
-Td
+Im
 FO
 uf
 uf
 uf
-Td
+Im
 Mq
 vv
 vv
 vv
 vv
 ut
-Td
+Im
 SH
 QS
 Du
@@ -68100,13 +68170,13 @@ Im
 WT
 rU
 rU
-Td
+Im
 KP
 eT
 CW
 WR
 Hw
-Td
+Im
 iW
 iW
 ps
@@ -68329,27 +68399,27 @@ aN
 OK
 OK
 ps
-Td
-Td
-Td
+Im
+Im
+Im
 RK
 RK
 RK
 RK
-Td
+Im
 OC
 Tc
 rU
 RQ
 de
 yt
-Td
+Im
 gC
 gC
 gC
 gC
 gC
-ve
+SF
 rU
 rU
 rU
@@ -68357,13 +68427,13 @@ Im
 WK
 RQ
 rU
-BK
+WW
 CW
 CW
 CW
 ju
 PN
-Td
+Im
 PE
 iW
 iW
@@ -68587,20 +68657,20 @@ OK
 ps
 ps
 ps
-Td
+Im
 ED
 RK
 RK
 RK
 yB
-Td
+Im
 yP
 rU
 rU
 rU
 rU
 kr
-Td
+Im
 sH
 ER
 gC
@@ -68610,7 +68680,7 @@ Im
 tP
 RQ
 rU
-zc
+fb
 rU
 rU
 rU
@@ -68619,8 +68689,8 @@ kH
 Ay
 VW
 Zz
-Td
-Td
+Im
+Im
 tu
 PE
 iW
@@ -68738,7 +68808,7 @@ uw
 uw
 uw
 BG
-Yi
+Sd
 BZ
 BZ
 BZ
@@ -68757,7 +68827,7 @@ Sd
 Sd
 Sd
 Sd
-Yi
+Sd
 XJ
 XJ
 Sd
@@ -68792,7 +68862,7 @@ lZ
 mB
 lZ
 lZ
-nu
+Gs
 lZ
 lZ
 lH
@@ -68844,39 +68914,39 @@ ps
 ps
 ps
 ps
-Td
+Im
 mL
 RK
 RK
 kj
 Iw
-Td
+Im
 is
 nf
 rU
 RQ
 rU
 yW
-Td
+Im
 gC
 gC
 gC
 xw
 aq
-Td
+Im
 aT
 rU
 rU
-Td
+Im
 rU
 rU
 rU
-Td
-Td
-Td
-Td
-Td
-Td
+Im
+Im
+Im
+Im
+Im
+Im
 PE
 PE
 PE
@@ -69052,7 +69122,7 @@ lZ
 lH
 lZ
 lZ
-pt
+BP
 lZ
 lZ
 lZ
@@ -69101,39 +69171,39 @@ OK
 ps
 ps
 ps
-Td
+Im
 zL
 Bx
 RK
 Iw
-Td
-Td
-Td
+Im
+Im
+Im
 wJ
 si
 si
 si
 bL
-Td
+Im
 HE
 hz
 hz
-Td
-Td
-Td
-Td
+Im
+Im
+Im
+Im
 CN
 KQ
-Td
+Im
 tP
 RQ
 rU
-Td
+Im
 la
 rU
 bj
 UD
-Td
+Im
 PE
 PE
 PE
@@ -69259,13 +69329,13 @@ uw
 Sd
 ik
 XJ
-iy
+Pj
 XJ
 XJ
 jn
 jC
 XJ
-iy
+Pj
 XJ
 XJ
 XJ
@@ -69356,41 +69426,41 @@ aN
 OK
 ps
 ps
-Td
-Td
-Td
-Td
+Im
+Im
+Im
+Im
 Md
 EB
-Td
-Td
+Im
+Im
 FI
-Td
-Td
-Td
+Im
+Im
+Im
 TJ
-Td
-Td
-Td
-Td
-Td
-Td
-Td
+Im
+Im
+Im
+Im
+Im
+Im
+Im
 GH
 eu
-Td
-Td
-Td
-Td
+Im
+Im
+Im
+Im
 rU
 rU
 rU
-Td
+Im
 Ca
 rU
 bj
 UD
-Td
+Im
 PE
 PE
 lE
@@ -69613,7 +69683,7 @@ aN
 OK
 ps
 ps
-Td
+Im
 rU
 Th
 rU
@@ -69642,12 +69712,12 @@ rU
 rU
 rU
 rU
-Td
+Im
 Ph
 RQ
 bj
 UD
-Td
+Im
 PE
 PE
 PE
@@ -69766,7 +69836,7 @@ uw
 tV
 uw
 uw
-Yi
+Sd
 BZ
 BZ
 BZ
@@ -69785,7 +69855,7 @@ Sd
 Sd
 Sd
 Sd
-Yi
+Sd
 XJ
 XJ
 Sd
@@ -69870,7 +69940,7 @@ aN
 OK
 ps
 ps
-Td
+Im
 rU
 Th
 RQ
@@ -69899,12 +69969,12 @@ rU
 rU
 RQ
 rU
-zc
+fb
 rU
 rU
 Sv
-Td
-Td
+Im
+Im
 PE
 PE
 VV
@@ -70127,7 +70197,7 @@ ps
 ps
 ps
 ps
-Td
+Im
 rU
 Th
 rU
@@ -70156,11 +70226,11 @@ rU
 rU
 rU
 rU
-Td
+Im
 iA
 UX
 CL
-Td
+Im
 PE
 PE
 PE
@@ -70384,40 +70454,40 @@ aN
 ps
 ps
 ps
-Td
-Td
-Td
+Im
+Im
+Im
 Vd
 XK
 XK
-Td
-Td
-Td
-Td
-Td
-Td
+Im
+Im
+Im
+Im
+Im
+Im
 XK
-Td
-Td
+Im
+Im
 PK
 OS
 OS
-Td
-Td
+Im
+Im
 rU
 rU
 rU
-Td
-Td
+Im
+Im
 NJ
 NJ
 NJ
-Td
-Td
+Im
+Im
 NJ
 NJ
 NJ
-Td
+Im
 fH
 PE
 PE
@@ -70530,7 +70600,7 @@ uw
 uw
 uw
 uw
-Yi
+Sd
 Sd
 Sd
 Sd
@@ -70542,7 +70612,7 @@ hA
 Sd
 Sd
 Sd
-Yi
+Sd
 XJ
 Sd
 Sd
@@ -70568,7 +70638,7 @@ kU
 kU
 kU
 kU
-lt
+Pt
 kU
 kU
 kU
@@ -70624,7 +70694,7 @@ aN
 lH
 lZ
 lZ
-NO
+LN
 lZ
 lZ
 lZ
@@ -70641,7 +70711,7 @@ aN
 ps
 ps
 ps
-Td
+Im
 zH
 bn
 Jy
@@ -70651,7 +70721,7 @@ Jy
 bn
 Jy
 JT
-Td
+Im
 lp
 Jy
 Jy
@@ -70660,11 +70730,11 @@ SW
 OS
 OS
 OS
-Td
+Im
 rU
 rU
 rU
-Td
+Im
 PE
 PE
 PE
@@ -70816,10 +70886,10 @@ kM
 Sd
 XJ
 XJ
-Lp
+Uo
 XJ
 XJ
-fk
+Ps
 kU
 kU
 kU
@@ -70848,7 +70918,7 @@ lZ
 lZ
 lZ
 lZ
-ny
+xN
 lZ
 lZ
 wk
@@ -70898,7 +70968,7 @@ aN
 ps
 ps
 ps
-Td
+Im
 Kt
 Kt
 Kt
@@ -70908,7 +70978,7 @@ Jy
 Jy
 Jy
 yM
-Td
+Im
 Jo
 Jy
 Jy
@@ -71073,10 +71143,10 @@ XJ
 Sd
 XJ
 ys
-Lp
+Uo
 XJ
 Tg
-fk
+Ps
 kU
 kU
 Sc
@@ -71123,7 +71193,7 @@ zG
 zG
 lZ
 lZ
-AP
+Ir
 lZ
 lZ
 lZ
@@ -71155,7 +71225,7 @@ aN
 ps
 ps
 ps
-Td
+Im
 xQ
 wF
 hg
@@ -71165,7 +71235,7 @@ yO
 yO
 Jy
 yO
-Td
+Im
 ef
 zr
 Jy
@@ -71311,11 +71381,11 @@ gJ
 gJ
 gJ
 gJ
-hX
+vS
 ii
 Sd
 XJ
-iw
+Ip
 XJ
 XJ
 XJ
@@ -71327,7 +71397,7 @@ XJ
 XJ
 XJ
 XJ
-lb
+AC
 XJ
 XJ
 Sd
@@ -71380,7 +71450,7 @@ zG
 zG
 lZ
 lZ
-AP
+Ir
 lZ
 lZ
 lZ
@@ -71411,8 +71481,8 @@ aN
 aN
 ps
 ps
-Td
-Td
+Im
+Im
 Zq
 kK
 QW
@@ -71422,7 +71492,7 @@ yO
 yO
 Jy
 yO
-Td
+Im
 to
 Jy
 Jy
@@ -71669,7 +71739,7 @@ aN
 ps
 ps
 ps
-Td
+Im
 NN
 NN
 NN
@@ -71679,7 +71749,7 @@ yO
 yO
 yJ
 yO
-Td
+Im
 mz
 Jy
 Jy
@@ -71926,20 +71996,20 @@ aN
 OK
 ps
 ps
-Td
+Im
 RM
 fQ
 Jy
 Jy
 Jy
 yO
-Td
-Td
-Td
-Td
-Td
-Td
-Td
+Im
+Im
+Im
+Im
+Im
+Im
+Im
 zJ
 OS
 OS
@@ -71949,7 +72019,7 @@ OS
 rU
 RQ
 rU
-Td
+Im
 PE
 PE
 PE
@@ -72072,7 +72142,6 @@ Nd
 Nd
 uw
 uw
-Yi
 Sd
 Sd
 Sd
@@ -72084,7 +72153,8 @@ Sd
 Sd
 Sd
 Sd
-Yi
+Sd
+Sd
 uw
 Sd
 Sd
@@ -72183,14 +72253,14 @@ aN
 OK
 ps
 ps
-Td
-Td
-Td
-Td
+Im
+Im
+Im
+Im
 tr
 Jy
 yO
-Td
+Im
 go
 es
 es
@@ -72206,15 +72276,15 @@ Im
 rU
 rU
 rU
-Td
-Td
+Im
+Im
 NJ
 NJ
 NJ
 NJ
 NJ
-Td
-Td
+Im
+Im
 PE
 lE
 fH
@@ -72443,11 +72513,11 @@ ps
 ps
 ps
 ps
-Td
+Im
 Jy
 Jy
 yO
-Td
+Im
 go
 es
 eV
@@ -72459,11 +72529,11 @@ OS
 Zh
 OS
 gM
-Td
+Im
 rU
 rU
 rU
-Td
+Im
 QY
 Go
 RX
@@ -72471,7 +72541,7 @@ RX
 RX
 Al
 Ni
-Td
+Im
 PE
 PE
 PE
@@ -72700,11 +72770,11 @@ OK
 ps
 ps
 ps
-Td
+Im
 Jy
 Jy
 CV
-Td
+Im
 Dk
 es
 zY
@@ -72716,11 +72786,11 @@ OS
 OS
 OS
 uI
-Td
+Im
 rU
 rU
 rU
-Td
+Im
 qH
 qH
 qH
@@ -72728,7 +72798,7 @@ qH
 qH
 Al
 Ni
-Td
+Im
 iW
 iW
 iW
@@ -72957,11 +73027,11 @@ OK
 ps
 ps
 ps
-Td
+Im
 yO
 yO
 yO
-Td
+Im
 ss
 es
 SX
@@ -72973,11 +73043,11 @@ OS
 OS
 OS
 Fv
-Td
+Im
 rU
 RQ
 rU
-zc
+fb
 rU
 RQ
 rU
@@ -72985,9 +73055,9 @@ rU
 RQ
 qH
 VA
-Td
-Td
-Td
+Im
+Im
+Im
 ps
 ps
 ps
@@ -73166,7 +73236,7 @@ nJ
 oB
 nJ
 nJ
-tJ
+SC
 lZ
 lZ
 lZ
@@ -73178,7 +73248,7 @@ lZ
 lZ
 lZ
 lZ
-AM
+hU
 vK
 vK
 vK
@@ -73213,28 +73283,28 @@ aN
 OK
 OK
 ps
-Td
-Td
-Td
-Td
-Td
-Td
+Im
+Im
+Im
+Im
+Im
+Im
 YP
 es
 Kl
 YP
 es
-Td
-Td
-Td
-Td
+Im
+Im
+Im
+Im
 uG
-Td
-Td
+Im
+Im
 rU
 rU
 rU
-Td
+Im
 bZ
 qH
 qH
@@ -73242,9 +73312,9 @@ qH
 rU
 qH
 YZ
-Td
+Im
 bQ
-Td
+Im
 ps
 ps
 ps
@@ -73475,7 +73545,7 @@ ps
 ps
 ps
 ps
-Td
+Im
 SR
 es
 YP
@@ -73487,23 +73557,23 @@ YP
 Pz
 es
 PZ
-Td
+Im
 rU
 rU
 rU
-Td
+Im
 QK
 yy
 yy
 qH
 rU
 rU
-Td
-Td
-Td
-Td
-Td
-Td
+Im
+Im
+Im
+Im
+Im
+Im
 ps
 OK
 OK
@@ -73732,7 +73802,7 @@ ps
 ps
 ps
 ps
-Td
+Im
 rq
 es
 eV
@@ -73744,11 +73814,11 @@ es
 eV
 es
 wP
-Td
+Im
 Ya
 zc
-Td
-Td
+Im
+Im
 ok
 xG
 yy
@@ -73760,7 +73830,7 @@ EM
 EM
 EM
 EM
-Td
+Im
 ps
 OK
 aN
@@ -73937,13 +74007,13 @@ nJ
 nJ
 nJ
 nJ
-tJ
+SC
 uz
 vm
 qJ
 lZ
 lZ
-xb
+VE
 lZ
 lZ
 lZ
@@ -73989,7 +74059,7 @@ OK
 ps
 ps
 ps
-Td
+Im
 LG
 es
 es
@@ -74001,23 +74071,23 @@ es
 es
 es
 hR
-Td
+Im
 pu
 RQ
 Up
-Td
+Im
 Sr
 Rd
 yy
 qH
 rU
 rU
-zc
+fb
 rU
 rU
 RQ
 TO
-Td
+Im
 ps
 ps
 OK
@@ -74245,36 +74315,36 @@ OK
 ps
 ps
 ps
-Td
-Td
-Td
+Im
+Im
+Im
 Oj
 zj
 fF
 es
 VR
 YP
-Td
-Td
-Td
-Td
-Td
+Im
+Im
+Im
+Im
+Im
 UN
 pX
 Gb
-Td
+Im
 rm
 kW
 kW
 LE
 rU
 hf
-Td
+Im
 UG
 UG
 UG
 UG
-Td
+Im
 ps
 ps
 OK
@@ -74504,34 +74574,34 @@ OK
 ps
 ps
 ps
-Td
-Td
-Td
-Td
-Td
-Td
-Td
-Td
+Im
+Im
+Im
+Im
+Im
+Im
+Im
+Im
 ps
 ps
 ps
-Td
-Td
-Td
-Td
-Td
-Td
-Td
-Td
-Td
-Td
-Td
-Td
-Td
-Td
-Td
-Td
-Td
+Im
+Im
+Im
+Im
+Im
+Im
+Im
+Im
+Im
+Im
+Im
+Im
+Im
+Im
+Im
+Im
+Im
 ps
 ps
 OK
@@ -74764,21 +74834,21 @@ ps
 ps
 ps
 ps
-Td
+Im
 ps
 ps
 ps
-Td
-ps
-ps
-ps
-ps
+Im
 ps
 ps
 ps
 ps
 ps
-Td
+ps
+ps
+ps
+ps
+Im
 ps
 ps
 ps
@@ -75035,7 +75105,7 @@ ps
 ps
 ps
 ps
-Td
+Im
 ps
 ps
 ps

--- a/_maps/map_files/shuttles/admin_admin.dmm
+++ b/_maps/map_files/shuttles/admin_admin.dmm
@@ -2,33 +2,6 @@
 "aa" = (
 /turf/space,
 /area/space)
-"ad" = (
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/general,
-/obj/machinery/door/airlock/external{
-	id_tag = "s_docking_airlock";
-	name = "Shuttle Hatch"
-	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/plating,
-/area/shuttle/administration)
-"ae" = (
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/general,
-/obj/machinery/door/airlock/external{
-	id_tag = "s_docking_airlock";
-	name = "Shuttle Hatch"
-	},
-/obj/docking_port/mobile/admin{
-	dir = 2;
-	dwidth = 8;
-	height = 15;
-	id = "admin";
-	name = "admin";
-	timid = 1;
-	width = 18
-	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/plating,
-/area/shuttle/administration)
 "ag" = (
 /obj/machinery/economy/vending/boozeomat,
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -88,19 +61,6 @@
 "aq" = (
 /obj/machinery/light/spot{
 	dir = 4
-	},
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/shuttle/administration)
-"ar" = (
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "adminshuttleblast";
-	name = "Blast Doors";
-	req_access = list(101)
-	},
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/general,
-/obj/machinery/door/airlock/centcom{
-	id_tag = "adminshuttle";
-	name = "General Access"
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
@@ -493,6 +453,49 @@
 "vg" = (
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/administration)
+"yy" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/general,
+/obj/machinery/door/airlock/external{
+	id_tag = "s_docking_airlock";
+	name = "Shuttle Hatch";
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/plating,
+/area/shuttle/administration)
+"Fr" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/general,
+/obj/machinery/door/airlock/external{
+	id_tag = "s_docking_airlock";
+	name = "Shuttle Hatch";
+	dir = 4
+	},
+/obj/docking_port/mobile/admin{
+	dir = 2;
+	dwidth = 8;
+	height = 15;
+	id = "admin";
+	name = "admin";
+	timid = 1;
+	width = 18
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/plating,
+/area/shuttle/administration)
+"Yl" = (
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "adminshuttleblast";
+	name = "Blast Doors";
+	req_access = list(101)
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/general,
+/obj/machinery/door/airlock/centcom{
+	id_tag = "adminshuttle";
+	name = "General Access";
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/administration)
 
 (1,1,1) = {"
 aa
@@ -655,9 +658,9 @@ aa
 aa
 "}
 (9,1,1) = {"
-ad
+yy
 al
-ar
+Yl
 aA
 am
 am
@@ -675,9 +678,9 @@ aa
 aa
 "}
 (10,1,1) = {"
-ae
+Fr
 am
-ar
+Yl
 am
 am
 am

--- a/_maps/map_files/shuttles/admin_armory.dmm
+++ b/_maps/map_files/shuttles/admin_armory.dmm
@@ -7,6 +7,12 @@
 /obj/item/folder,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
+"at" = (
+/obj/machinery/door/airlock/titanium/glass{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/administration)
 "aI" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -282,6 +288,20 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
+"um" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "asclblast";
+	name = "Blast Door";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/administration)
 "uW" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4
@@ -420,6 +440,22 @@
 /obj/machinery/status_display,
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/administration)
+"zk" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "asclblast";
+	name = "Blast Door";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/administration)
 "AH" = (
 /obj/machinery/light/spot,
 /obj/machinery/porta_turret{
@@ -447,20 +483,6 @@
 	pixel_y = -4
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
-/area/shuttle/administration)
-"Bj" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
-/obj/effect/mapping_helpers/airlock/access/any/security/brig,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "asclblast";
-	name = "Blast Door";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
 /area/shuttle/administration)
 "Bn" = (
 /obj/machinery/door/window/reinforced/normal{
@@ -510,10 +532,6 @@
 /obj/machinery/light/spot,
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/mineral/plastitanium/red,
-/area/shuttle/administration)
-"EQ" = (
-/obj/machinery/door/airlock/titanium/glass,
-/turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/administration)
 "Fd" = (
 /obj/structure/rack,
@@ -573,25 +591,6 @@
 	},
 /obj/item/gun/projectile/shotgun/riot,
 /turf/simulated/floor/mineral/plastitanium/red,
-/area/shuttle/administration)
-"Gx" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/external,
-/obj/docking_port/mobile/admin{
-	dwidth = 9;
-	height = 18;
-	name = "armory";
-	roundstart_move = "cc_bay_1";
-	width = 19
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "asclblast";
-	name = "Blast Door";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
 /area/shuttle/administration)
 "Gy" = (
 /obj/structure/chair{
@@ -792,6 +791,27 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
+"So" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/docking_port/mobile/admin{
+	dwidth = 9;
+	height = 18;
+	name = "armory";
+	roundstart_move = "cc_bay_1";
+	width = 19
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "asclblast";
+	name = "Blast Door";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/administration)
 "TD" = (
 /obj/machinery/door/airlock/command{
 	name = "Command Center"
@@ -844,18 +864,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/administration)
-"UX" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/external,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "asclblast";
-	name = "Blast Door";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
 /area/shuttle/administration)
 "VC" = (
 /obj/machinery/door/airlock/titanium{
@@ -967,7 +975,7 @@ Op
 Kh
 Kh
 Kh
-Bj
+zk
 "}
 (4,1,1) = {"
 vk
@@ -987,7 +995,7 @@ Jt
 Kh
 Kh
 Kh
-Bj
+zk
 "}
 (5,1,1) = {"
 vk
@@ -1070,14 +1078,14 @@ fQ
 NQ
 "}
 (9,1,1) = {"
-UX
+um
 mw
 mw
 mw
 mw
 mw
 mw
-EQ
+at
 mw
 mw
 mw
@@ -1090,14 +1098,14 @@ fQ
 NQ
 "}
 (10,1,1) = {"
-Gx
+So
 mw
 mw
 mw
 mw
 mw
 mw
-EQ
+at
 mw
 mw
 mw

--- a/_maps/map_files/shuttles/admin_hospital.dmm
+++ b/_maps/map_files/shuttles/admin_hospital.dmm
@@ -23,37 +23,6 @@
 	},
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/administration)
-"ai" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/external,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "asclblast";
-	name = "Blast Door";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/administration)
-"aj" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/external,
-/obj/docking_port/mobile/admin{
-	dwidth = 9;
-	height = 18;
-	name = "hospital";
-	roundstart_move = "cc_bay_1";
-	width = 19
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "asclblast";
-	name = "Blast Door";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/administration)
 "ap" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor/mineral/titanium,
@@ -559,6 +528,26 @@
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/administration)
+"fz" = (
+/obj/machinery/door/airlock/titanium/glass{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/administration)
+"hM" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "asclblast";
+	name = "Blast Door";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/administration)
 "ia" = (
 /obj/machinery/camera{
 	dir = 8;
@@ -663,6 +652,27 @@
 	dir = 8
 	},
 /turf/simulated/floor/mineral/titanium,
+/area/shuttle/administration)
+"EU" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/docking_port/mobile/admin{
+	dwidth = 9;
+	height = 18;
+	name = "hospital";
+	roundstart_move = "cc_bay_1";
+	width = 19
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "asclblast";
+	name = "Blast Door";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
 /area/shuttle/administration)
 "Jz" = (
 /obj/machinery/light,
@@ -868,14 +878,14 @@ cr
 ab
 "}
 (9,1,1) = {"
-ai
+hM
 aw
 aw
 aw
 aw
 aw
 aw
-aU
+fz
 aw
 aw
 aw
@@ -888,14 +898,14 @@ bR
 ab
 "}
 (10,1,1) = {"
-aj
+EU
 aw
 aw
 aw
 aw
 aw
 aw
-aU
+fz
 aw
 aw
 aw

--- a/_maps/map_files/shuttles/admin_skipjack.dmm
+++ b/_maps/map_files/shuttles/admin_skipjack.dmm
@@ -12,54 +12,11 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
 /area/shuttle/administration)
-"ad" = (
-/obj/effect/mapping_helpers/airlock/access/all/shuttles/vox,
-/obj/machinery/door/airlock/hatch{
-	id_tag = "voxwest_door_ext";
-	locked = 1
-	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/mineral/plastitanium/red/nitrogen,
-/area/shuttle/administration)
 "ae" = (
 /obj/machinery/computer/shuttle/admin/vox{
 	dir = 4
 	},
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
-/area/shuttle/administration)
-"ai" = (
-/obj/machinery/door/airlock/external,
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "open";
-	id_tag = "voxshutters";
-	name = "Blast Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating/nitrogen,
-/area/shuttle/administration)
-"aj" = (
-/obj/docking_port/mobile/admin{
-	dir = 2;
-	dwidth = 9;
-	height = 18;
-	id = "admin";
-	name = "skipjack";
-	roundstart_move = "cc_bay_1";
-	timid = 1;
-	width = 19
-	},
-/obj/machinery/door/airlock/external,
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "open";
-	id_tag = "voxshutters";
-	name = "Blast Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating/nitrogen,
 /area/shuttle/administration)
 "aq" = (
 /obj/machinery/light{
@@ -125,23 +82,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/airless,
-/area/shuttle/administration)
-"aM" = (
-/obj/effect/mapping_helpers/airlock/access/all/shuttles/vox,
-/obj/machinery/door/airlock/hatch{
-	id_tag = "voxeast_door_ext";
-	locked = 1
-	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/mineral/plastitanium/red/nitrogen,
-/area/shuttle/administration)
-"aN" = (
-/obj/effect/mapping_helpers/airlock/access/all/shuttles/vox,
-/obj/machinery/door/airlock/hatch{
-	id_tag = "voxwest_door_int";
-	locked = 1
-	},
-/turf/simulated/floor/mineral/plastitanium/red/nitrogen,
 /area/shuttle/administration)
 "aP" = (
 /obj/item/broken_bottle,
@@ -328,14 +268,6 @@
 	},
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/administration)
-"co" = (
-/obj/effect/mapping_helpers/airlock/access/all/shuttles/vox,
-/obj/machinery/door/airlock/hatch{
-	id_tag = "voxeast_door_int";
-	locked = 1
-	},
-/turf/simulated/floor/mineral/plastitanium/red/nitrogen,
-/area/shuttle/administration)
 "cp" = (
 /obj/structure/ai_core,
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
@@ -383,6 +315,20 @@
 /obj/item/clothing/mask/breath,
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
 /area/shuttle/administration)
+"pf" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "open";
+	id_tag = "voxshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating/nitrogen,
+/area/shuttle/administration)
 "qa" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -396,6 +342,30 @@
 /obj/machinery/atmospherics/portable/canister/nitrogen,
 /obj/machinery/light,
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
+/area/shuttle/administration)
+"tn" = (
+/obj/docking_port/mobile/admin{
+	dir = 2;
+	dwidth = 9;
+	height = 18;
+	id = "admin";
+	name = "skipjack";
+	roundstart_move = "cc_bay_1";
+	timid = 1;
+	width = 19
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "open";
+	id_tag = "voxshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating/nitrogen,
 /area/shuttle/administration)
 "ue" = (
 /obj/structure/window/reinforced{
@@ -470,6 +440,13 @@
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
 /area/shuttle/administration)
+"Hg" = (
+/obj/effect/mapping_helpers/airlock/access/all/shuttles/vox,
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium/red/nitrogen,
+/area/shuttle/administration)
 "IH" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -499,6 +476,34 @@
 /obj/item/tank/internals/nitrogen,
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
 /area/shuttle/administration)
+"Kl" = (
+/obj/effect/mapping_helpers/airlock/access/all/shuttles/vox,
+/obj/machinery/door/airlock/hatch{
+	id_tag = "voxeast_door_ext";
+	locked = 1;
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/mineral/plastitanium/red/nitrogen,
+/area/shuttle/administration)
+"LP" = (
+/obj/effect/mapping_helpers/airlock/access/all/shuttles/vox,
+/obj/machinery/door/airlock/hatch{
+	id_tag = "voxeast_door_int";
+	locked = 1;
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium/red/nitrogen,
+/area/shuttle/administration)
+"MR" = (
+/obj/effect/mapping_helpers/airlock/access/all/shuttles/vox,
+/obj/machinery/door/airlock/hatch{
+	id_tag = "voxwest_door_int";
+	locked = 1;
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium/red/nitrogen,
+/area/shuttle/administration)
 "MT" = (
 /obj/structure/rack,
 /obj/item/pneumatic_cannon,
@@ -515,6 +520,16 @@
 	},
 /obj/machinery/optable,
 /obj/item/organ/internal/brain,
+/turf/simulated/floor/mineral/plastitanium/red/nitrogen,
+/area/shuttle/administration)
+"UD" = (
+/obj/effect/mapping_helpers/airlock/access/all/shuttles/vox,
+/obj/machinery/door/airlock/hatch{
+	id_tag = "voxwest_door_ext";
+	locked = 1;
+	dir = 4
+	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
 /area/shuttle/administration)
 "Vl" = (
@@ -558,7 +573,7 @@ aa
 av
 jg
 jg
-aN
+MR
 jg
 jg
 jg
@@ -575,7 +590,7 @@ aa
 aa
 "}
 (3,1,1) = {"
-ad
+UD
 aq
 aG
 cg
@@ -695,12 +710,12 @@ ae
 zD
 "}
 (9,1,1) = {"
-ai
+pf
 jg
 jg
 ck
 jg
-bb
+Hg
 jg
 jg
 jg
@@ -708,19 +723,19 @@ jg
 jg
 jg
 jg
-bb
+Hg
 jg
 jg
 wk
 wb
 "}
 (10,1,1) = {"
-aj
+tn
 jg
 bY
 cl
 cu
-bb
+Hg
 jg
 jg
 jg
@@ -728,7 +743,7 @@ jg
 jg
 jg
 jg
-bb
+Hg
 XK
 jg
 bR
@@ -835,7 +850,7 @@ aa
 aa
 "}
 (16,1,1) = {"
-aM
+Kl
 aB
 cf
 cn
@@ -858,7 +873,7 @@ aa
 bO
 jg
 jg
-co
+LP
 jg
 jg
 jg

--- a/_maps/map_files/shuttles/emergency_bar.dmm
+++ b/_maps/map_files/shuttles/emergency_bar.dmm
@@ -38,13 +38,6 @@
 /obj/machinery/light/spot,
 /turf/simulated/floor/wood,
 /area/shuttle/escape)
-"al" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Escape Shuttle Cockpit"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/escape)
 "am" = (
 /obj/item/kirbyplants/large,
 /obj/machinery/light/spot{
@@ -160,13 +153,6 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/shuttle/escape)
-"aJ" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Escape Shuttle Cockpit"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/turf/simulated/floor/mineral/titanium,
 /area/shuttle/escape)
 "aK" = (
 /obj/structure/closet/crate/internals,
@@ -301,14 +287,6 @@
 	},
 /turf/simulated/floor/carpet/royalblack,
 /area/shuttle/escape)
-"bi" = (
-/obj/machinery/door/airlock{
-	name = "Toilet"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/shuttle/escape)
 "bn" = (
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/escape)
@@ -337,30 +315,6 @@
 /obj/item/ashtray/glass,
 /obj/effect/turf_decal/woodsiding,
 /turf/simulated/floor/carpet/royalblack,
-/area/shuttle/escape)
-"bt" = (
-/obj/machinery/door/airlock{
-	name = "Unit 1"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/shuttle/escape)
-"bv" = (
-/obj/machinery/door/airlock{
-	name = "Unit 2"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/shuttle/escape)
-"bw" = (
-/obj/machinery/door/airlock{
-	name = "Unit 3"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
 /area/shuttle/escape)
 "bx" = (
 /obj/machinery/sleeper{
@@ -416,6 +370,15 @@
 "bL" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/plating/airless,
+/area/shuttle/escape)
+"bY" = (
+/obj/machinery/door/airlock{
+	name = "Unit 1";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
 /area/shuttle/escape)
 "cE" = (
 /obj/effect/turf_decal/woodsiding{
@@ -478,6 +441,14 @@
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/escape)
+"lu" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Escape Shuttle Cockpit";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/escape)
 "lA" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
@@ -493,6 +464,13 @@
 	},
 /obj/structure/musician/piano,
 /turf/simulated/floor/carpet/royalblack,
+/area/shuttle/escape)
+"mj" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Escape Shuttle Infirmary";
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "mV" = (
 /obj/structure/chair/wood/wings,
@@ -603,6 +581,14 @@
 /obj/structure/bed/roller,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/escape)
+"vu" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Escape Shuttle Cockpit";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/escape)
 "wk" = (
 /obj/structure/sign/poster/contraband/borg_fancy_2/directional/west,
 /obj/machinery/light/small,
@@ -675,6 +661,15 @@
 /obj/structure/table/wood,
 /obj/effect/turf_decal/woodsiding,
 /turf/simulated/floor/carpet/royalblack,
+/area/shuttle/escape)
+"As" = (
+/obj/machinery/door/airlock{
+	name = "Unit 3";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
 /area/shuttle/escape)
 "AA" = (
 /obj/structure/chair/wood/wings{
@@ -763,6 +758,15 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/escape)
+"EQ" = (
+/obj/machinery/door/airlock{
+	name = "Unit 2";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/shuttle/escape)
 "FK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
@@ -840,6 +844,15 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet/royalblack,
+/area/shuttle/escape)
+"KG" = (
+/obj/machinery/door/airlock{
+	name = "Toilet";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
 /area/shuttle/escape)
 "LD" = (
 /obj/machinery/status_display{
@@ -1071,12 +1084,6 @@
 	},
 /turf/simulated/floor/carpet/orange,
 /area/shuttle/escape)
-"Uq" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Escape Shuttle Infirmary"
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/escape)
 "Uv" = (
 /obj/effect/turf_decal/woodsiding{
 	dir = 10
@@ -1172,7 +1179,7 @@ aA
 ab
 NQ
 bo
-bt
+bY
 ao
 ab
 qr
@@ -1239,10 +1246,10 @@ Dy
 aA
 aA
 aA
-bi
+KG
 bo
 bo
-bv
+EQ
 ao
 ab
 bJ
@@ -1312,7 +1319,7 @@ IJ
 ab
 bo
 bo
-bw
+As
 wk
 ab
 qr
@@ -1362,12 +1369,12 @@ Rt
 zU
 Qy
 an
-aJ
+lu
 br
 br
 br
 br
-al
+vu
 aA
 aA
 aA
@@ -1519,7 +1526,7 @@ Zz
 Ai
 aM
 aA
-Uq
+mj
 bn
 bn
 bn

--- a/_maps/map_files/shuttles/emergency_cherenkov.dmm
+++ b/_maps/map_files/shuttles/emergency_cherenkov.dmm
@@ -284,6 +284,14 @@
 /obj/effect/spawner/window/plastitanium/rad_protect,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
+"iJ" = (
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/machinery/door/airlock/command/glass{
+	name = "Escape Shuttle Cockpit";
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/escape)
 "iO" = (
 /obj/machinery/optable,
 /obj/machinery/light{
@@ -399,15 +407,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine/airless,
-/area/shuttle/escape)
-"mM" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/external/glass,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/purple,
-/turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "mW" = (
 /obj/machinery/atmospherics/supermatter_crystal/shard/engine,
@@ -542,13 +541,6 @@
 	},
 /turf/simulated/floor/pod/dark,
 /area/shuttle/escape)
-"pk" = (
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/obj/machinery/door/airlock/command/glass{
-	name = "Escape Shuttle Cockpit"
-	},
-/turf/simulated/floor/mineral/plastitanium,
-/area/shuttle/escape)
 "pR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -624,6 +616,17 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
+/area/shuttle/escape)
+"us" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/purple,
+/turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "uv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
@@ -886,12 +889,6 @@
 	},
 /turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"CN" = (
-/obj/machinery/door/airlock/survival_pod/glass{
-	name = "Shuttle Airlock"
-	},
-/turf/simulated/floor/mineral/plastitanium,
-/area/shuttle/escape)
 "CP" = (
 /obj/machinery/optable,
 /obj/item/radio/intercom{
@@ -940,11 +937,6 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating/airless,
-/area/shuttle/escape)
-"Dh" = (
-/obj/effect/mapping_helpers/airlock/access/any/security/doors,
-/obj/machinery/door/airlock/command/glass,
-/turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "DA" = (
 /obj/structure/sign/radiation,
@@ -1288,6 +1280,13 @@
 	},
 /turf/simulated/floor/catwalk,
 /area/shuttle/escape)
+"Or" = (
+/obj/machinery/door/airlock/survival_pod/glass{
+	name = "Shuttle Airlock";
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/escape)
 "Os" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -1384,6 +1383,13 @@
 	dir = 1
 	},
 /turf/simulated/floor/catwalk,
+/area/shuttle/escape)
+"RY" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Escape Shuttle Infirmary";
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "So" = (
 /obj/structure/railing/corner{
@@ -1532,12 +1538,6 @@
 	},
 /turf/simulated/floor/pod/dark,
 /area/shuttle/escape)
-"Xs" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Escape Shuttle Infirmary"
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/escape)
 "XM" = (
 /obj/machinery/status_display{
 	pixel_x = -32
@@ -1624,6 +1624,13 @@
 	dir = 8
 	},
 /turf/simulated/floor/pod/dark,
+/area/shuttle/escape)
+"ZX" = (
+/obj/effect/mapping_helpers/airlock/access/any/security/doors,
+/obj/machinery/door/airlock/command/glass{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "ZZ" = (
 /obj/structure/chair/comfy/shuttle{
@@ -1746,7 +1753,7 @@ gy
 ZK
 kJ
 Kb
-CN
+Or
 bV
 bV
 bV
@@ -1989,13 +1996,13 @@ Kb
 Kb
 Kb
 Kb
-pk
+iJ
 Kb
 gy
 NO
 kJ
 Kb
-Dh
+ZX
 Kb
 Yp
 JJ
@@ -2048,7 +2055,7 @@ AT
 yh
 kw
 kw
-mM
+us
 uZ
 uZ
 uI
@@ -2075,13 +2082,13 @@ Kb
 Kb
 Kb
 Kb
-pk
+iJ
 Kb
 mX
 jQ
 Yj
 Kb
-Dh
+ZX
 Kb
 By
 ob
@@ -2299,7 +2306,7 @@ rG
 rG
 rG
 rG
-Xs
+RY
 Kb
 fi
 Wf
@@ -2348,7 +2355,7 @@ mX
 pg
 Yj
 Kb
-CN
+Or
 bV
 bV
 bV

--- a/_maps/map_files/shuttles/emergency_clockwork.dmm
+++ b/_maps/map_files/shuttles/emergency_clockwork.dmm
@@ -213,11 +213,6 @@
 	},
 /turf/simulated/floor/clockwork,
 /area/shuttle/escape)
-"ys" = (
-/obj/machinery/door/airlock/clockwork,
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/turf/simulated/floor/clockwork,
-/area/shuttle/escape)
 "yt" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1;
@@ -502,6 +497,13 @@
 "SY" = (
 /obj/structure/table/reinforced/brass,
 /obj/item/storage/toolbox/mechanical,
+/turf/simulated/floor/clockwork,
+/area/shuttle/escape)
+"Tr" = (
+/obj/machinery/door/airlock/clockwork{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/simulated/floor/clockwork,
 /area/shuttle/escape)
 "Uq" = (
@@ -946,7 +948,7 @@ EC
 bL
 xQ
 FQ
-ys
+Tr
 FQ
 Yd
 Yd
@@ -1020,7 +1022,7 @@ EC
 mg
 xQ
 FQ
-ys
+Tr
 FQ
 Yd
 Yd

--- a/_maps/map_files/shuttles/emergency_clown.dmm
+++ b/_maps/map_files/shuttles/emergency_clown.dmm
@@ -83,10 +83,6 @@
 "aw" = (
 /turf/simulated/floor/noslip,
 /area/shuttle/escape)
-"az" = (
-/obj/machinery/door/airlock/public/glass,
-/turf/simulated/floor/plasteel/white,
-/area/shuttle/escape)
 "aB" = (
 /turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
@@ -213,14 +209,6 @@
 /obj/structure/noticeboard,
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/escape)
-"aW" = (
-/obj/machinery/door/airlock/titanium{
-	aiControlDisabled = 1;
-	hackProof = 1;
-	name = "Shuttle Cargo Hatch"
-	},
-/turf/simulated/floor/plasteel/white,
-/area/shuttle/escape)
 "aY" = (
 /obj/machinery/door/airlock/titanium{
 	aiControlDisabled = 1;
@@ -229,12 +217,6 @@
 	name = "Shuttle Hatch"
 	},
 /turf/simulated/floor/noslip,
-/area/shuttle/escape)
-"bb" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Escape Shuttle Infirmary"
-	},
-/turf/simulated/floor/plasteel/white,
 /area/shuttle/escape)
 "bc" = (
 /obj/machinery/economy/vending/clothing,
@@ -336,14 +318,36 @@
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/plating/airless,
 /area/shuttle/escape)
+"nG" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/shuttle/escape)
 "tH" = (
 /turf/simulated/wall/indestructible/fakeglass/plastitanium,
+/area/shuttle/escape)
+"Ct" = (
+/obj/machinery/door/airlock/titanium{
+	aiControlDisabled = 1;
+	hackProof = 1;
+	name = "Shuttle Cargo Hatch";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
 /area/shuttle/escape)
 "Dr" = (
 /turf/simulated/wall/indestructible/syndicate,
 /area/shuttle/escape)
 "MA" = (
 /turf/simulated/wall/indestructible/titanium,
+/area/shuttle/escape)
+"RA" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Escape Shuttle Infirmary";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
 /area/shuttle/escape)
 "Uo" = (
 /obj/structure/chair/comfy/shuttle{
@@ -449,7 +453,7 @@ aD
 aD
 am
 am
-aW
+Ct
 aw
 aw
 bk
@@ -515,7 +519,7 @@ ai
 am
 am
 am
-az
+nG
 am
 am
 am
@@ -605,7 +609,7 @@ aD
 aD
 am
 am
-bb
+RA
 aw
 aw
 aw

--- a/_maps/map_files/shuttles/emergency_cramped.dmm
+++ b/_maps/map_files/shuttles/emergency_cramped.dmm
@@ -92,9 +92,10 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
-"q" = (
+"p" = (
 /obj/machinery/door/airlock/titanium/glass{
-	name = "Cockpit"
+	name = "Cockpit";
+	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/doors,
 /turf/simulated/floor/plating,
@@ -264,7 +265,7 @@ n
 j
 m
 m
-q
+p
 m
 m
 m

--- a/_maps/map_files/shuttles/emergency_cyb.dmm
+++ b/_maps/map_files/shuttles/emergency_cyb.dmm
@@ -175,13 +175,6 @@
 /obj/machinery/status_display,
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/escape)
-"aF" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Escape Shuttle Cockpit"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/turf/simulated/floor/plasteel/dark,
-/area/shuttle/escape)
 "aG" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/mineral/plastitanium/red/brig,
@@ -399,13 +392,6 @@
 "bB" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/simulated/floor/plasteel,
-/area/shuttle/escape)
-"bC" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Escape Shuttle Cockpit"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)
 "bD" = (
 /obj/docking_port/mobile/emergency{
@@ -818,6 +804,29 @@
 "cH" = (
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/escape)
+"Bf" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Escape Shuttle Cockpit";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/turf/simulated/floor/plasteel/dark,
+/area/shuttle/escape)
+"JT" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Escape Shuttle Infirmary";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/shuttle/escape)
+"Nv" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Escape Shuttle Cockpit";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/turf/simulated/floor/plasteel/dark,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 aa
@@ -1082,12 +1091,12 @@ ao
 an
 an
 an
-aF
+Nv
 an
 an
 an
 an
-bC
+Bf
 bB
 ba
 bR
@@ -1114,12 +1123,12 @@ ao
 an
 an
 an
-aF
+Nv
 an
 an
 an
 an
-bC
+Bf
 bB
 ba
 cr
@@ -1287,7 +1296,7 @@ bT
 bT
 bT
 cg
-cl
+JT
 cp
 cs
 cv
@@ -1319,7 +1328,7 @@ bU
 bU
 bU
 ch
-cl
+JT
 cp
 cs
 cv

--- a/_maps/map_files/shuttles/emergency_dept.dmm
+++ b/_maps/map_files/shuttles/emergency_dept.dmm
@@ -169,14 +169,6 @@
 /obj/machinery/status_display,
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/escape)
-"aE" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Escape Shuttle Cockpit";
-	normalspeed = 0
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/turf/simulated/floor/plasteel/dark,
-/area/shuttle/escape)
 "aF" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -192,13 +184,6 @@
 /area/shuttle/escape)
 "aH" = (
 /turf/simulated/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"aI" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Escape Shuttle Infirmary"
-	},
-/obj/effect/turf_decal/tiles/department/medical/checker,
-/turf/simulated/floor/plasteel/white,
 /area/shuttle/escape)
 "aJ" = (
 /obj/structure/table/reinforced,
@@ -348,14 +333,6 @@
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
-/area/shuttle/escape)
-"bj" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Escape Shuttle Cell";
-	normalspeed = 0
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "bk" = (
 /obj/machinery/door/airlock/mining/glass{
@@ -739,6 +716,14 @@
 /obj/structure/window/full/shuttle,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
+"kg" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Escape Shuttle Infirmary";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/checker,
+/turf/simulated/floor/plasteel/white,
+/area/shuttle/escape)
 "mj" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -760,6 +745,15 @@
 /obj/item/flag/cargo,
 /obj/structure/window/full/shuttle,
 /turf/simulated/floor/plating,
+/area/shuttle/escape)
+"nB" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Escape Shuttle Medical Seating";
+	normalspeed = 0;
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "oe" = (
 /obj/structure/chair/comfy/shuttle{
@@ -798,14 +792,6 @@
 /obj/item/clothing/suit/storage/hazardvest/staff,
 /turf/simulated/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
-"sc" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Escape Shuttle Medical Seating";
-	normalspeed = 0
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/escape)
 "sg" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -835,14 +821,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/mineral/titanium,
-/area/shuttle/escape)
-"tG" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Escape Shuttle Cockpit";
-	normalspeed = 0
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "vv" = (
 /obj/machinery/recharge_station/upgraded,
@@ -956,6 +934,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
+"Em" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Escape Shuttle Cockpit";
+	normalspeed = 0;
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/turf/simulated/floor/plasteel/dark,
+/area/shuttle/escape)
 "EG" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/glasses/science,
@@ -968,6 +955,15 @@
 /obj/effect/turf_decal/tiles/department/science/side,
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
+"Fa" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Escape Shuttle Cell";
+	normalspeed = 0;
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/simulated/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
 "Hg" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -976,6 +972,15 @@
 	dir = 8
 	},
 /turf/simulated/floor/mineral/titanium,
+/area/shuttle/escape)
+"IK" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Escape Shuttle Brig";
+	normalspeed = 0;
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "IN" = (
 /obj/structure/chair/comfy/shuttle{
@@ -1008,12 +1013,13 @@
 	},
 /turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"Lh" = (
+"Li" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Escape Shuttle Cockpit";
-	normalspeed = 0
+	normalspeed = 0;
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
 /turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "Ly" = (
@@ -1030,6 +1036,15 @@
 	dir = 4
 	},
 /turf/simulated/floor/mineral/titanium,
+/area/shuttle/escape)
+"MU" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Escape Shuttle Cockpit";
+	normalspeed = 0;
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "Pj" = (
 /obj/structure/chair/comfy/shuttle{
@@ -1272,7 +1287,7 @@ ac
 aH
 aH
 aH
-bj
+Fa
 aH
 aH
 aH
@@ -1370,7 +1385,7 @@ aJ
 aH
 aH
 aH
-aW
+IK
 re
 re
 re
@@ -1401,7 +1416,7 @@ UN
 aG
 aH
 aH
-aW
+IK
 re
 SQ
 Hg
@@ -1458,12 +1473,12 @@ ah
 ao
 sk
 Qr
-Lh
+MU
 Qr
 Qr
 Qr
 Qr
-tG
+Li
 re
 re
 re
@@ -1489,12 +1504,12 @@ ai
 ao
 sk
 Qr
-aE
+Em
 Qr
 Qr
 Qr
 Qr
-tG
+Li
 re
 re
 re
@@ -1556,7 +1571,7 @@ bm
 cp
 cp
 cp
-aI
+kg
 re
 Sw
 BN
@@ -1587,7 +1602,7 @@ bm
 fz
 fz
 cp
-aI
+kg
 re
 re
 re
@@ -1675,7 +1690,7 @@ ac
 fz
 fz
 fz
-sc
+nB
 fz
 fz
 fz

--- a/_maps/map_files/shuttles/emergency_jungle.dmm
+++ b/_maps/map_files/shuttles/emergency_jungle.dmm
@@ -121,13 +121,6 @@
 /obj/machinery/status_display,
 /turf/simulated/wall/mineral/wood,
 /area/shuttle/escape)
-"aF" = (
-/obj/machinery/door/airlock/wood/glass{
-	name = "Escape Shuttle Cockpit"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/turf/simulated/floor/grass,
-/area/shuttle/escape)
 "aG" = (
 /obj/structure/table/wood,
 /obj/item/storage/firstaid/regular,
@@ -829,6 +822,14 @@
 	},
 /turf/simulated/floor/grass,
 /area/shuttle/escape)
+"PX" = (
+/obj/machinery/door/airlock/wood/glass{
+	name = "Escape Shuttle Cockpit";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/turf/simulated/floor/grass,
+/area/shuttle/escape)
 "Rr" = (
 /obj/structure/flora/junglebush,
 /obj/machinery/light/small{
@@ -1114,7 +1115,7 @@ ah
 mC
 SO
 cu
-aF
+PX
 cv
 bM
 ia
@@ -1145,7 +1146,7 @@ ai
 mC
 IH
 cv
-aF
+PX
 SO
 cu
 bM

--- a/_maps/map_files/shuttles/emergency_lance.dmm
+++ b/_maps/map_files/shuttles/emergency_lance.dmm
@@ -61,11 +61,6 @@
 /obj/effect/turf_decal/tiles/department/command/corner,
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)
-"dq" = (
-/obj/machinery/door/airlock/highsecurity,
-/obj/effect/turf_decal/tiles/department/command,
-/turf/simulated/floor/plasteel/dark,
-/area/shuttle/escape)
 "dP" = (
 /obj/structure/shuttle/engine/propulsion/burst/right,
 /turf/simulated/floor/plating/airless,
@@ -193,6 +188,13 @@
 	id_tag = "s_docking_airlock"
 	},
 /obj/structure/fans/tiny/invisible,
+/turf/simulated/floor/plasteel/dark,
+/area/shuttle/escape)
+"hy" = (
+/obj/structure/fans/tiny/invisible,
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)
 "ii" = (
@@ -361,6 +363,23 @@
 "qk" = (
 /obj/structure/marker_beacon/dock_marker,
 /turf/simulated/floor/catwalk,
+/area/shuttle/escape)
+"qm" = (
+/obj/docking_port/mobile/emergency{
+	height = 50;
+	width = 19;
+	timid = 1;
+	dir = 2;
+	lance_docking = 1;
+	shuttle_speed_factor = 1.5;
+	port_direction = 1
+	},
+/obj/machinery/door/airlock/external{
+	id_tag = "s_docking_airlock";
+	dir = 4
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)
 "qS" = (
 /obj/machinery/optable,
@@ -582,22 +601,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)
-"yD" = (
-/obj/docking_port/mobile/emergency{
-	height = 50;
-	width = 19;
-	timid = 1;
-	dir = 2;
-	lance_docking = 1;
-	shuttle_speed_factor = 1.5;
-	port_direction = 1
-	},
-/obj/machinery/door/airlock/external{
-	id_tag = "s_docking_airlock"
-	},
-/obj/structure/fans/tiny/invisible,
-/turf/simulated/floor/plasteel/dark,
-/area/shuttle/escape)
 "yM" = (
 /obj/machinery/computer/crew{
 	dir = 4
@@ -809,6 +812,14 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/escape)
+"IZ" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "s_docking_airlock";
+	dir = 4
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/simulated/floor/plasteel/dark,
+/area/shuttle/escape)
 "Jb" = (
 /obj/machinery/light/small,
 /obj/machinery/computer/operating{
@@ -978,6 +989,13 @@
 	specialfunctions = 4
 	},
 /turf/simulated/floor/mineral/silver,
+/area/shuttle/escape)
+"Qq" = (
+/obj/machinery/door/airlock/highsecurity{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/command,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)
 "Qs" = (
 /obj/effect/turf_decal/tiles/department/engineering{
@@ -1588,7 +1606,7 @@ lH
 lH
 jr
 YC
-dq
+Qq
 WU
 Jd
 Iu
@@ -1601,7 +1619,7 @@ IN
 dP
 "}
 (10,1,1) = {"
-yD
+qm
 Wq
 Wq
 AK
@@ -1611,7 +1629,7 @@ Wq
 Wq
 Wq
 Wq
-dq
+Qq
 UY
 UY
 UY
@@ -1619,7 +1637,7 @@ UY
 xj
 UY
 UY
-dq
+Qq
 WU
 UY
 If
@@ -1627,11 +1645,11 @@ Bx
 bV
 UY
 WU
-dq
+Qq
 UY
 UY
 UY
-dq
+Qq
 WU
 UY
 UY
@@ -1692,7 +1710,7 @@ HL
 Iu
 EV
 kg
-dq
+Qq
 WU
 yg
 lH
@@ -2000,9 +2018,9 @@ cn
 Qs
 Qs
 pV
-gS
+hy
 Wo
-hv
+IZ
 ul
 ul
 ul

--- a/_maps/map_files/shuttles/emergency_meta.dmm
+++ b/_maps/map_files/shuttles/emergency_meta.dmm
@@ -9,24 +9,9 @@
 /obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
-"ag" = (
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock";
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/simulated/floor/plating,
-/area/shuttle/escape)
 "ah" = (
 /obj/structure/sign/nosmoking/alt,
 /turf/simulated/wall/mineral/titanium,
-/area/shuttle/escape)
-"ai" = (
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock";
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/simulated/floor/plating,
 /area/shuttle/escape)
 "am" = (
 /turf/simulated/wall/mineral/plastitanium,
@@ -363,20 +348,6 @@
 /obj/machinery/economy/vending/wallmed/directional/south,
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/escape)
-"bh" = (
-/obj/machinery/door/airlock/command{
-	name = "Emergency Recovery Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"bj" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/turf/simulated/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
 "bl" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Escape Shuttle Infirmary"
@@ -386,12 +357,6 @@
 "bm" = (
 /obj/structure/sign/lifestar,
 /turf/simulated/wall/mineral/titanium,
-/area/shuttle/escape)
-"bn" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Cargo Bay Airlock"
-	},
-/turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "bo" = (
 /obj/structure/chair/comfy/shuttle{
@@ -737,7 +702,7 @@
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
-"ci" = (
+"ln" = (
 /obj/docking_port/mobile/emergency{
 	dir = 2;
 	dwidth = 5;
@@ -748,14 +713,61 @@
 	},
 /obj/machinery/door/airlock/titanium{
 	id_tag = "s_docking_airlock";
-	name = "Emergency Shuttle Airlock"
+	name = "Emergency Shuttle Airlock";
+	dir = 4
 	},
 /turf/simulated/floor/plating,
+/area/shuttle/escape)
+"so" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Cargo Bay Airlock";
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"vt" = (
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock";
+	name = "Emergency Shuttle Airlock";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/simulated/floor/plating,
+/area/shuttle/escape)
+"AG" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/turf/simulated/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"EO" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Escape Shuttle Infirmary";
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "FM" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/economy/vending/wallmed/directional/west,
 /turf/simulated/floor/mineral/titanium,
+/area/shuttle/escape)
+"Kv" = (
+/obj/machinery/door/airlock/external{
+	name = "Emergency Recovery Airlock";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/escape)
+"Mh" = (
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock";
+	name = "Emergency Shuttle Airlock";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/shuttle/escape)
 "Rk" = (
 /turf/simulated/floor/mineral/plastitanium/red/brig,
@@ -769,6 +781,14 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/mineral/titanium,
+/area/shuttle/escape)
+"UK" = (
+/obj/machinery/door/airlock/command{
+	name = "Emergency Recovery Airlock";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -849,7 +869,7 @@ bp
 bp
 bp
 bp
-bq
+Kv
 "}
 (6,1,1) = {"
 ac
@@ -865,7 +885,7 @@ bq
 ab
 bp
 bp
-bq
+Kv
 "}
 (7,1,1) = {"
 ac
@@ -876,7 +896,7 @@ au
 au
 au
 au
-bh
+UK
 br
 ab
 bJ
@@ -924,7 +944,7 @@ au
 au
 au
 au
-bj
+AG
 Rk
 Rk
 Rk
@@ -948,7 +968,7 @@ bS
 ac
 "}
 (12,1,1) = {"
-ai
+Mh
 au
 au
 aM
@@ -980,7 +1000,7 @@ ab
 ab
 "}
 (14,1,1) = {"
-ai
+Mh
 au
 au
 aL
@@ -1020,7 +1040,7 @@ au
 au
 au
 au
-bl
+EO
 au
 au
 au
@@ -1076,7 +1096,7 @@ bZ
 ab
 "}
 (20,1,1) = {"
-ci
+ln
 au
 au
 aM
@@ -1108,7 +1128,7 @@ cb
 ac
 "}
 (22,1,1) = {"
-ag
+vt
 au
 au
 au
@@ -1116,7 +1136,7 @@ au
 au
 au
 au
-bn
+so
 bA
 bp
 bp
@@ -1132,7 +1152,7 @@ au
 au
 au
 au
-bn
+so
 bA
 bp
 bp

--- a/_maps/map_files/shuttles/emergency_mil.dmm
+++ b/_maps/map_files/shuttles/emergency_mil.dmm
@@ -69,13 +69,6 @@
 /obj/machinery/computer/robotics,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"aD" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Escape Shuttle Cockpit"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/escape)
 "aF" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/mineral/plastitanium/red/brig,
@@ -243,31 +236,9 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/shuttle/escape)
-"bc" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Escape Shuttle Cell"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/turf/simulated/floor/plating,
-/area/shuttle/escape)
 "bd" = (
 /obj/structure/noticeboard,
 /turf/simulated/wall/mineral/titanium,
-/area/shuttle/escape)
-"bf" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Escape Shuttle Cockpit"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/turf/simulated/floor/plating,
-/area/shuttle/escape)
-"bg" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "ShuttleMedbay";
-	name = "Shuttle Medbay"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/turf/simulated/floor/plating,
 /area/shuttle/escape)
 "bh" = (
 /obj/docking_port/mobile/emergency{
@@ -373,6 +344,39 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/escape)
+"iJ" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "ShuttleMedbay";
+	name = "Shuttle Medbay";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/turf/simulated/floor/plating,
+/area/shuttle/escape)
+"oH" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Escape Shuttle Cockpit";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"oN" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Escape Shuttle Cockpit";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/turf/simulated/floor/plating,
+/area/shuttle/escape)
+"LF" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Escape Shuttle Cell";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/turf/simulated/floor/plating,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 aa
@@ -437,7 +441,7 @@ aG
 aO
 aO
 aO
-bc
+LF
 aI
 aI
 aI
@@ -536,12 +540,12 @@ ag
 am
 at
 at
-aD
+oH
 aI
 aI
 aI
 aI
-bf
+oN
 aI
 aI
 aI
@@ -645,7 +649,7 @@ aL
 aS
 aS
 ba
-bg
+iJ
 aI
 aI
 aI

--- a/_maps/map_files/shuttles/emergency_narnar.dmm
+++ b/_maps/map_files/shuttles/emergency_narnar.dmm
@@ -280,6 +280,13 @@
 	},
 /turf/simulated/floor/engine/cult,
 /area/shuttle/escape)
+"dy" = (
+/obj/machinery/door/airlock/cult/glass/friendly{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/turf/simulated/floor/engine/cult,
+/area/shuttle/escape)
 "dG" = (
 /obj/effect/rune/empower,
 /turf/simulated/floor/engine/cult,
@@ -467,11 +474,6 @@
 /obj/item/melee/cultblade/dagger,
 /turf/simulated/floor/engine/cult,
 /area/shuttle/escape)
-"Fa" = (
-/obj/machinery/door/airlock/cult/glass/friendly,
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/turf/simulated/floor/engine/cult,
-/area/shuttle/escape)
 "Gi" = (
 /obj/structure/table/reinforced/cult/no_metal,
 /obj/item/reagent_containers/iv_bag/blood/o_minus,
@@ -498,6 +500,12 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
+	},
+/turf/simulated/floor/engine/cult,
+/area/shuttle/escape)
+"Hz" = (
+/obj/machinery/door/airlock/cult/glass/friendly{
+	dir = 4
 	},
 /turf/simulated/floor/engine/cult,
 /area/shuttle/escape)
@@ -546,6 +554,13 @@
 "Mb" = (
 /obj/structure/table/reinforced/cult/no_metal,
 /obj/item/tome,
+/turf/simulated/floor/engine/cult,
+/area/shuttle/escape)
+"MF" = (
+/obj/machinery/door/airlock/cult/glass/friendly{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/doors,
 /turf/simulated/floor/engine/cult,
 /area/shuttle/escape)
 "MR" = (
@@ -733,7 +748,7 @@ aj
 aj
 aj
 aj
-aa
+Hz
 aj
 aj
 aj
@@ -896,13 +911,13 @@ aj
 az
 aj
 af
-Fa
+dy
 aj
 aj
 LV
 aj
 aj
-OM
+MF
 aj
 aj
 ah

--- a/_maps/map_files/shuttles/emergency_old.dmm
+++ b/_maps/map_files/shuttles/emergency_old.dmm
@@ -86,13 +86,6 @@
 /obj/machinery/light/spot,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"ay" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Escape Shuttle Cockpit"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/escape)
 "aA" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -173,20 +166,6 @@
 	pixel_y = -30
 	},
 /obj/machinery/light/spot,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"aT" = (
-/obj/machinery/door/airlock/titanium{
-	aiControlDisabled = 1;
-	hackProof = 1;
-	name = "Shuttle Cargo Hatch"
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"aV" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Escape Shuttle Infirmary"
-	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "aW" = (
@@ -271,6 +250,22 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/doors,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
+"dm" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Escape Shuttle Infirmary";
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"dZ" = (
+/obj/machinery/door/airlock/titanium{
+	aiControlDisabled = 1;
+	hackProof = 1;
+	name = "Shuttle Cargo Hatch";
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/escape)
 "ev" = (
 /obj/machinery/sleeper{
 	dir = 1;
@@ -321,6 +316,14 @@
 /obj/machinery/economy/vending/wallmed/directional/east,
 /obj/structure/bed/roller,
 /turf/simulated/floor/mineral/titanium,
+/area/shuttle/escape)
+"uB" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Escape Shuttle Cockpit";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "xo" = (
 /obj/machinery/recharge_station,
@@ -431,7 +434,7 @@ aC
 aC
 an
 an
-aT
+dZ
 DZ
 DZ
 xo
@@ -497,7 +500,7 @@ ai
 an
 an
 an
-ay
+uB
 an
 an
 an
@@ -587,7 +590,7 @@ aA
 aA
 an
 an
-aV
+dm
 aI
 aI
 aI

--- a/_maps/map_files/shuttles/emergency_raven.dmm
+++ b/_maps/map_files/shuttles/emergency_raven.dmm
@@ -358,13 +358,6 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"bx" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Cockpit"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/turf/simulated/floor/plasteel/dark,
-/area/shuttle/escape)
 "by" = (
 /obj/structure/closet/crate/freezer/iv_storage,
 /obj/effect/turf_decal/tiles/department/medical/side{
@@ -438,12 +431,6 @@
 "bS" = (
 /obj/structure/sign/lifestar,
 /turf/simulated/wall/mineral/plastitanium,
-/area/shuttle/escape)
-"bT" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Escape Shuttle Infirmary"
-	},
-/turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)
 "bU" = (
 /obj/structure/closet/emcloset,
@@ -717,12 +704,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)
-"da" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Seating"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/shuttle/escape)
 "db" = (
 /obj/structure/closet/crate/medical,
 /obj/item/healthanalyzer{
@@ -740,13 +721,6 @@
 "dd" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel/dark,
-/area/shuttle/escape)
-"de" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Seating"
-	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)
 "df" = (
@@ -880,14 +854,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
-"dA" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Emergency Shuttle Engineering"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/turf/simulated/floor/plating,
-/area/shuttle/escape)
 "dB" = (
 /obj/structure/sign/engineering,
 /turf/simulated/wall/mineral/plastitanium,
@@ -1007,6 +973,13 @@
 "hu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/shuttle/escape)
+"it" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Escape Shuttle Infirmary";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
@@ -1137,6 +1110,14 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)
+"uL" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Cockpit";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/turf/simulated/floor/plasteel/dark,
+/area/shuttle/escape)
 "uM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/spot,
@@ -1186,6 +1167,14 @@
 "yY" = (
 /obj/effect/turf_decal/tiles/department/command/side{
 	dir = 9
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/shuttle/escape)
+"zc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Seating";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)
@@ -1263,11 +1252,28 @@
 /obj/effect/turf_decal/raven/nine,
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)
+"Fh" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Holding Area";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/turf/simulated/floor/plasteel/dark,
+/area/shuttle/escape)
 "Ge" = (
 /obj/effect/turf_decal/tiles/department/command/side{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel/dark,
+/area/shuttle/escape)
+"GJ" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Emergency Shuttle Engineering";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/turf/simulated/floor/plating,
 /area/shuttle/escape)
 "GL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1304,6 +1310,13 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)
+"IQ" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Seating";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/shuttle/escape)
 "Jx" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -1329,14 +1342,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel/white,
-/area/shuttle/escape)
-"Kk" = (
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/machinery/door/airlock/engineering{
-	name = "Emergency Shuttle Engineering"
-	},
-/turf/simulated/floor/plating,
 /area/shuttle/escape)
 "Ls" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1452,6 +1457,15 @@
 "Xd" = (
 /obj/effect/turf_decal/raven/seven,
 /turf/simulated/floor/plasteel/dark,
+/area/shuttle/escape)
+"XE" = (
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/machinery/door/airlock/engineering{
+	name = "Emergency Shuttle Engineering";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/shuttle/escape)
 "YX" = (
 /obj/effect/turf_decal/raven/six,
@@ -1664,7 +1678,7 @@ aY
 aY
 aY
 bE
-bk
+Fh
 Ia
 Jx
 Jx
@@ -1674,11 +1688,11 @@ Jx
 ak
 ak
 ak
-da
+IQ
 dh
 ak
 ak
-dA
+GJ
 dE
 dE
 Nd
@@ -1795,10 +1809,10 @@ Ge
 Xd
 NQ
 ph
-bx
+uL
 bc
 bl
-bx
+uL
 BW
 ak
 ak
@@ -1863,10 +1877,10 @@ Ge
 Db
 YX
 ml
-bx
+uL
 bc
 bn
-bx
+uL
 lC
 ac
 ak
@@ -2004,7 +2018,7 @@ bf
 bf
 bf
 US
-bT
+it
 ss
 Rw
 Rw
@@ -2014,11 +2028,11 @@ Rw
 ak
 ak
 ak
-de
+zc
 dn
 ak
 ak
-Kk
+XE
 dE
 dE
 NK

--- a/_maps/map_files/shuttles/trader/trader_glint.dmm
+++ b/_maps/map_files/shuttles/trader/trader_glint.dmm
@@ -9,6 +9,13 @@
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/pod/dark,
 /area/shuttle/trade/sol)
+"ck" = (
+/obj/machinery/door/airlock/survival_pod/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
 "cH" = (
 /obj/structure/shelf,
 /obj/effect/turf_decal/siding/end{
@@ -168,6 +175,14 @@
 	},
 /turf/simulated/floor/pod/dark,
 /area/shuttle/trade/sol)
+"vX" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/survival_pod/glass{
+	id_tag = "s_docking_airlock";
+	dir = 4
+	},
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
 "wB" = (
 /obj/structure/shelf,
 /obj/effect/turf_decal/siding/end{
@@ -220,13 +235,6 @@
 /obj/structure/closet,
 /obj/effect/spawner/random/traders/engineering,
 /turf/simulated/floor/mineral/plastitanium,
-/area/shuttle/trade/sol)
-"Bd" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/survival_pod/glass{
-	id_tag = "s_docking_airlock"
-	},
-/turf/simulated/floor/pod/dark,
 /area/shuttle/trade/sol)
 "BY" = (
 /turf/template_noop,
@@ -375,11 +383,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/pod/dark,
 /area/shuttle/trade/sol)
-"Pu" = (
-/obj/machinery/door/airlock/survival_pod/glass,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/shuttle/trade/sol)
 "Qi" = (
 /obj/effect/spawner/window/shuttle/survival_pod,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -424,20 +427,6 @@
 "Ze" = (
 /turf/simulated/wall/mineral/titanium/survival,
 /area/shuttle/trade/sol)
-"Zm" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/survival_pod/glass{
-	id_tag = "s_docking_airlock"
-	},
-/obj/docking_port/mobile/trader{
-	height = 18;
-	width = 14;
-	dwidth = 7;
-	preferred_direction = 1;
-	dir = 2
-	},
-/turf/simulated/floor/pod/dark,
-/area/shuttle/trade/sol)
 "ZH" = (
 /obj/effect/turf_decal/siding{
 	dir = 5
@@ -448,6 +437,21 @@
 "ZP" = (
 /obj/item/flag/species/unathi,
 /turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
+"ZW" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/survival_pod/glass{
+	id_tag = "s_docking_airlock";
+	dir = 4
+	},
+/obj/docking_port/mobile/trader{
+	height = 18;
+	width = 14;
+	dwidth = 7;
+	preferred_direction = 1;
+	dir = 2
+	},
+/turf/simulated/floor/pod/dark,
 /area/shuttle/trade/sol)
 
 (1,1,1) = {"
@@ -498,7 +502,7 @@ Ze
 iO
 Lw
 uV
-Pu
+ck
 li
 li
 li
@@ -543,7 +547,7 @@ Lv
 li
 li
 IX
-Pu
+ck
 li
 Gr
 li
@@ -571,7 +575,7 @@ FX
 Ze
 "}
 (7,1,1) = {"
-Zm
+ZW
 mK
 iO
 iO
@@ -591,7 +595,7 @@ FX
 BY
 "}
 (8,1,1) = {"
-Bd
+vX
 mK
 iO
 iO
@@ -643,7 +647,7 @@ Et
 li
 li
 yR
-Pu
+ck
 li
 hv
 li
@@ -678,7 +682,7 @@ Ze
 iO
 tt
 oh
-Pu
+ck
 li
 li
 li

--- a/_maps/map_files/shuttles/trader/trader_guild.dmm
+++ b/_maps/map_files/shuttles/trader/trader_guild.dmm
@@ -35,6 +35,14 @@
 "bl" = (
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/trade/sol)
+"ci" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
 "dh" = (
 /obj/effect/turf_decal/woodsiding{
 	dir = 5
@@ -427,13 +435,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/shuttle/trade/sol)
-"zF" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/titanium/glass{
-	id_tag = "s_docking_airlock"
-	},
-/turf/simulated/floor/wood,
-/area/shuttle/trade/sol)
 "AX" = (
 /obj/effect/turf_decal/woodsiding{
 	dir = 8
@@ -452,6 +453,22 @@
 	dir = 5
 	},
 /turf/simulated/floor/carpet/royalblack,
+/area/shuttle/trade/sol)
+"BL" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock";
+	dir = 4
+	},
+/obj/docking_port/mobile/trader{
+	height = 20;
+	width = 16;
+	dwidth = 8;
+	preferred_direction = 1;
+	dir = 1;
+	port_direction = 8
+	},
+/turf/simulated/floor/wood,
 /area/shuttle/trade/sol)
 "Cq" = (
 /obj/machinery/light/small{
@@ -591,30 +608,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/shuttle/trade/sol)
-"Kz" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/titanium/glass{
-	id_tag = "s_docking_airlock"
-	},
-/obj/docking_port/mobile/trader{
-	height = 20;
-	width = 16;
-	dwidth = 8;
-	preferred_direction = 1;
-	dir = 1;
-	port_direction = 8
-	},
-/turf/simulated/floor/wood,
-/area/shuttle/trade/sol)
 "ME" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/traders/minerals,
 /turf/simulated/floor/carpet/royalblue,
-/area/shuttle/trade/sol)
-"Oi" = (
-/obj/machinery/door/airlock/titanium,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/wood,
 /area/shuttle/trade/sol)
 "Pm" = (
 /obj/structure/shuttle/engine/heater,
@@ -625,6 +622,13 @@
 /area/shuttle/trade/sol)
 "PM" = (
 /obj/machinery/economy/atm/directional/east,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"QG" = (
+/obj/machinery/door/airlock/titanium{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
 /turf/simulated/floor/wood,
 /area/shuttle/trade/sol)
 "SR" = (
@@ -745,6 +749,13 @@
 	},
 /turf/simulated/floor/carpet/purple,
 /area/shuttle/trade/sol)
+"ZW" = (
+/obj/machinery/door/airlock/titanium/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
 
 (1,1,1) = {"
 sI
@@ -816,7 +827,7 @@ sI
 Tk
 Hh
 hs
-Oi
+QG
 Hi
 ab
 Tf
@@ -824,7 +835,7 @@ bl
 pK
 Hi
 Hi
-mT
+ZW
 sp
 xH
 qR
@@ -886,7 +897,7 @@ nR
 hy
 AX
 mk
-mT
+ZW
 Hi
 rr
 Be
@@ -920,7 +931,7 @@ eS
 hO
 lz
 Hi
-zF
+ci
 "}
 (9,1,1) = {"
 sI
@@ -942,7 +953,7 @@ eS
 hO
 lz
 Hi
-Kz
+BL
 "}
 (10,1,1) = {"
 sI
@@ -952,7 +963,7 @@ nR
 BJ
 xS
 ea
-mT
+ZW
 Hi
 jC
 mP
@@ -1014,7 +1025,7 @@ bl
 Tk
 kA
 hs
-Oi
+QG
 Hi
 ab
 Tf
@@ -1022,7 +1033,7 @@ bl
 pK
 Hi
 Hi
-mT
+ZW
 ly
 pF
 eD

--- a/_maps/map_files/shuttles/trader/trader_skip.dmm
+++ b/_maps/map_files/shuttles/trader/trader_skip.dmm
@@ -41,20 +41,6 @@
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/trade/sol)
-"ek" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/survival_pod/glass{
-	id_tag = "s_docking_airlock"
-	},
-/obj/docking_port/mobile/trader{
-	height = 18;
-	width = 14;
-	dwidth = 7;
-	preferred_direction = 1;
-	dir = 2
-	},
-/turf/simulated/floor/pod/dark,
-/area/shuttle/trade/sol)
 "gg" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plating,
@@ -110,11 +96,6 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/trade/sol)
-"mT" = (
-/obj/machinery/door/airlock/titanium/glass,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/shuttle/trade/sol)
 "nh" = (
 /obj/effect/spawner/random/traders/large_item,
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -158,11 +139,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
-"qk" = (
-/obj/machinery/door/airlock/titanium/glass,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/plating,
-/area/shuttle/trade/sol)
 "rj" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/traders/civilian,
@@ -195,6 +171,14 @@
 	},
 /turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/trade/sol)
+"um" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/survival_pod/glass{
+	id_tag = "s_docking_airlock";
+	dir = 4
+	},
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
 "uE" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/traders/donksoft,
@@ -213,16 +197,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/mineral/plastitanium,
-/area/shuttle/trade/sol)
-"xb" = (
-/obj/machinery/door/airlock/survival_pod/glass,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/shuttle/trade/sol)
-"yv" = (
-/obj/machinery/door/airlock/survival_pod/glass,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/pod/dark,
 /area/shuttle/trade/sol)
 "yH" = (
 /obj/effect/turf_decal/siding{
@@ -310,6 +284,13 @@
 "Ht" = (
 /turf/simulated/wall/mineral/titanium/survival/pod,
 /area/shuttle/trade/sol)
+"IO" = (
+/obj/machinery/door/airlock/survival_pod/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
 "Jo" = (
 /obj/machinery/economy/atm/directional/north,
 /turf/simulated/floor/pod/dark,
@@ -341,6 +322,13 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"Kq" = (
+/obj/machinery/door/airlock/titanium/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
 "KJ" = (
 /obj/structure/bed,
@@ -374,6 +362,13 @@
 	},
 /obj/effect/landmark/spawner/tradergearminor,
 /turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"Nh" = (
+/obj/machinery/door/airlock/titanium/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/trade/sol)
 "Nt" = (
 /obj/structure/extinguisher_cabinet{
@@ -410,6 +405,13 @@
 /obj/machinery/computer/shuttle/trade/sol,
 /turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/trade/sol)
+"Qy" = (
+/obj/machinery/door/airlock/survival_pod/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/pod/dark,
+/area/shuttle/trade/sol)
 "QI" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -428,6 +430,21 @@
 /area/shuttle/trade/sol)
 "Sg" = (
 /turf/simulated/floor/mineral/plastitanium,
+/area/shuttle/trade/sol)
+"SA" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/survival_pod/glass{
+	id_tag = "s_docking_airlock";
+	dir = 4
+	},
+/obj/docking_port/mobile/trader{
+	height = 18;
+	width = 14;
+	dwidth = 7;
+	preferred_direction = 1;
+	dir = 2
+	},
+/turf/simulated/floor/pod/dark,
 /area/shuttle/trade/sol)
 "SE" = (
 /obj/effect/turf_decal/siding{
@@ -449,13 +466,6 @@
 "VX" = (
 /obj/machinery/door/airlock/survival_pod,
 /obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/pod/dark,
-/area/shuttle/trade/sol)
-"WG" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/survival_pod/glass{
-	id_tag = "s_docking_airlock"
-	},
 /turf/simulated/floor/pod/dark,
 /area/shuttle/trade/sol)
 "YG" = (
@@ -517,7 +527,7 @@ aE
 aE
 VF
 cl
-qk
+Kq
 VF
 FB
 FB
@@ -563,7 +573,7 @@ FB
 uE
 gg
 Nt
-mT
+Nh
 RI
 gg
 yV
@@ -591,7 +601,7 @@ Ht
 Le
 "}
 (7,1,1) = {"
-ek
+SA
 yM
 AY
 gg
@@ -611,7 +621,7 @@ Ht
 zQ
 "}
 (8,1,1) = {"
-WG
+um
 yM
 AY
 gg
@@ -663,7 +673,7 @@ Sg
 KP
 yV
 kS
-xb
+IO
 yV
 AP
 yV
@@ -698,7 +708,7 @@ Ht
 AY
 Bd
 CH
-yv
+Qy
 yV
 yV
 yV

--- a/_maps/map_files/shuttles/trader/trader_skrell.dmm
+++ b/_maps/map_files/shuttles/trader/trader_skrell.dmm
@@ -39,11 +39,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass/jungle/no_creep,
 /area/shuttle/trade/sol)
-"fR" = (
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/obj/machinery/door/airlock/titanium/glass,
-/turf/simulated/floor/wood,
-/area/shuttle/trade/sol)
 "fZ" = (
 /obj/structure/flora/junglebush/large,
 /turf/simulated/floor/grass/jungle/no_creep,
@@ -53,6 +48,13 @@
 /obj/item/bedsheet/blue,
 /obj/effect/turf_decal/woodsiding{
 	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
+"ht" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/obj/machinery/door/airlock/titanium/glass{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/shuttle/trade/sol)
@@ -110,6 +112,22 @@
 /obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
+"rN" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock";
+	dir = 4
+	},
+/obj/docking_port/mobile/trader{
+	height = 21;
+	width = 18;
+	dwidth = 9;
+	preferred_direction = 1;
+	dir = 1;
+	port_direction = 8
+	},
+/turf/simulated/floor/wood,
+/area/shuttle/trade/sol)
 "se" = (
 /obj/item/flag/species/skrell,
 /obj/machinery/light/spot,
@@ -131,6 +149,13 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"vz" = (
+/obj/machinery/door/airlock/titanium/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/wood,
 /area/shuttle/trade/sol)
 "vQ" = (
 /obj/machinery/light/spot,
@@ -302,11 +327,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/shuttle/trade/sol)
-"KW" = (
-/obj/machinery/door/airlock/titanium/glass,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/wood,
-/area/shuttle/trade/sol)
 "Ln" = (
 /turf/template_noop,
 /area/template_noop)
@@ -335,13 +355,6 @@
 "Ot" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/plating/airless,
-/area/shuttle/trade/sol)
-"Pa" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/titanium/glass{
-	id_tag = "s_docking_airlock"
-	},
-/turf/simulated/floor/wood,
 /area/shuttle/trade/sol)
 "QN" = (
 /obj/machinery/computer/shuttle/trade/sol,
@@ -386,18 +399,11 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/trade/sol)
-"Un" = (
+"UJ" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/titanium/glass{
-	id_tag = "s_docking_airlock"
-	},
-/obj/docking_port/mobile/trader{
-	height = 21;
-	width = 18;
-	dwidth = 9;
-	preferred_direction = 1;
-	dir = 1;
-	port_direction = 8
+	id_tag = "s_docking_airlock";
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/shuttle/trade/sol)
@@ -495,7 +501,7 @@ Tm
 Tm
 Tm
 Tm
-fR
+ht
 Os
 FM
 lf
@@ -522,7 +528,7 @@ rF
 Os
 Os
 Os
-KW
+vz
 Os
 Os
 sV
@@ -643,7 +649,7 @@ Os
 Os
 Os
 Os
-Pa
+UJ
 "}
 (10,1,1) = {"
 Ln
@@ -666,7 +672,7 @@ Os
 Os
 Os
 Os
-Un
+rN
 "}
 (11,1,1) = {"
 Ln
@@ -775,7 +781,7 @@ rF
 Os
 Os
 Os
-KW
+vz
 Os
 Os
 Ue
@@ -794,7 +800,7 @@ Zd
 Tm
 Tm
 Tm
-fR
+ht
 Os
 zY
 JM

--- a/_maps/map_files/shuttles/trader/trader_sol.dmm
+++ b/_maps/map_files/shuttles/trader/trader_sol.dmm
@@ -120,6 +120,22 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
+"gL" = (
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock";
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/obj/docking_port/mobile/trader{
+	height = 16;
+	width = 14;
+	dwidth = 7;
+	preferred_direction = 1;
+	dir = 1;
+	port_direction = 8
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/shuttle/trade/sol)
 "hi" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -206,6 +222,13 @@
 /obj/effect/turf_decal/tiles/department/command/side,
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
+"yb" = (
+/obj/machinery/door/airlock/titanium/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/plasteel/dark,
+/area/shuttle/trade/sol)
 "zp" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/traders/engineering,
@@ -225,8 +248,13 @@
 "CH" = (
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
-"Fb" = (
-/turf/simulated/wall/mineral/titanium,
+"DG" = (
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock";
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "Fe" = (
 /obj/structure/bed,
@@ -258,13 +286,6 @@
 /obj/effect/turf_decal/tiles/department/command/side{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel/dark,
-/area/shuttle/trade/sol)
-"Gk" = (
-/obj/machinery/door/airlock/titanium/glass{
-	id_tag = "s_docking_airlock"
-	},
-/obj/structure/fans/tiny,
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "GM" = (
@@ -360,11 +381,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
-"No" = (
-/obj/machinery/door/airlock/titanium/glass,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/plasteel/dark,
-/area/shuttle/trade/sol)
 "NG" = (
 /obj/structure/extinguisher_cabinet{
 	name = "south bump";
@@ -401,21 +417,6 @@
 	},
 /obj/effect/turf_decal/tiles/department/command/side{
 	dir = 8
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/shuttle/trade/sol)
-"Pw" = (
-/obj/machinery/door/airlock/titanium/glass{
-	id_tag = "s_docking_airlock"
-	},
-/obj/structure/fans/tiny,
-/obj/docking_port/mobile/trader{
-	height = 16;
-	width = 14;
-	dwidth = 7;
-	preferred_direction = 1;
-	dir = 1;
-	port_direction = 8
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
@@ -548,11 +549,11 @@ Xi
 Xi
 Xi
 hM
-Fb
-Fb
-Fb
-Fb
-Fb
+hM
+hM
+hM
+hM
+hM
 hi
 fZ
 Xi
@@ -564,13 +565,13 @@ Xi
 Xi
 Xi
 hM
-Fb
-Fb
+hM
+hM
 QN
 Pa
 OE
 LH
-Fb
+hM
 fW
 fZ
 Xi
@@ -580,15 +581,15 @@ Xi
 Xi
 Xi
 hM
-Fb
-Fb
-Fb
+hM
+hM
+hM
 dN
 Wy
 CH
 CH
 CH
-No
+yb
 XX
 fW
 fZ
@@ -597,16 +598,16 @@ Xi
 (4,1,1) = {"
 Xi
 Xi
-Fb
+hM
 Zi
 Yn
-Fb
+hM
 GM
 CH
 aM
 CH
 NG
-Fb
+hM
 VT
 CH
 Lg
@@ -615,28 +616,28 @@ fZ
 (5,1,1) = {"
 Xi
 hM
-Fb
+hM
 Fe
 Mn
-Fb
+hM
 OT
 CH
 CH
 CH
 Jc
-Fb
-Fb
+hM
+hM
 zV
-Fb
-Fb
+hM
+hM
 "}
 (6,1,1) = {"
 uF
 uF
-Fb
-Fb
+hM
+hM
 WB
-Fb
+hM
 fe
 CH
 CH
@@ -646,7 +647,7 @@ Yy
 uk
 CH
 IX
-Fb
+hM
 "}
 (7,1,1) = {"
 uF
@@ -654,7 +655,7 @@ df
 FZ
 OE
 CH
-No
+yb
 CH
 CH
 Hb
@@ -664,7 +665,7 @@ kr
 gA
 CH
 Of
-Gk
+DG
 "}
 (8,1,1) = {"
 uF
@@ -672,7 +673,7 @@ Rp
 gq
 Zx
 CH
-No
+yb
 CH
 CH
 Hb
@@ -682,15 +683,15 @@ kr
 gA
 CH
 Of
-Pw
+gL
 "}
 (9,1,1) = {"
 uF
 uF
-Fb
-Fb
+hM
+hM
 WB
-Fb
+hM
 fe
 CH
 CH
@@ -700,39 +701,39 @@ Yy
 eI
 CH
 lh
-Fb
+hM
 "}
 (10,1,1) = {"
 Xi
 hM
-Fb
+hM
 Fe
 Mn
-Fb
+hM
 fL
 CH
 CH
 CH
 lO
-Fb
-Fb
+hM
+hM
 PU
-Fb
-Fb
+hM
+hM
 "}
 (11,1,1) = {"
 Xi
 Xi
-Fb
+hM
 ID
 Qw
-Fb
+hM
 iW
 CH
 pd
 CH
 NG
-Fb
+hM
 RX
 CH
 Lg
@@ -742,15 +743,15 @@ fZ
 Xi
 Xi
 hM
-Fb
-Fb
-Fb
+hM
+hM
+hM
 zp
 cM
 CH
 CH
 CH
-No
+yb
 XX
 IG
 fZ
@@ -762,13 +763,13 @@ Xi
 Xi
 Xi
 hM
-Fb
-Fb
+hM
+hM
 fc
 Zy
 Zx
 SA
-Fb
+hM
 IG
 fZ
 Xi
@@ -782,11 +783,11 @@ Xi
 Xi
 Xi
 hM
-Fb
-Fb
-Fb
-Fb
-Fb
+hM
+hM
+hM
+hM
+hM
 hi
 fZ
 Xi

--- a/_maps/map_files/shuttles/trader/trader_stead.dmm
+++ b/_maps/map_files/shuttles/trader/trader_stead.dmm
@@ -26,6 +26,13 @@
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/trade/sol)
+"eJ" = (
+/obj/machinery/door/airlock/titanium/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/titanium/yellow,
+/area/shuttle/trade/sol)
 "eM" = (
 /obj/effect/spawner/random/traders/vehicle,
 /turf/simulated/floor/mineral/titanium,
@@ -42,28 +49,6 @@
 "hE" = (
 /obj/item/flag/species/vulp,
 /turf/simulated/floor/mineral/titanium,
-/area/shuttle/trade/sol)
-"il" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/titanium/glass{
-	id_tag = "s_docking_airlock"
-	},
-/obj/docking_port/mobile/trader{
-	height = 17;
-	width = 16;
-	dwidth = 8;
-	preferred_direction = 1;
-	dir = 1;
-	port_direction = 8
-	},
-/turf/simulated/floor/mineral/titanium{
-	color = "#63D335"
-	},
-/area/shuttle/trade/sol)
-"iC" = (
-/obj/machinery/door/airlock/titanium/glass,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/trade/sol)
 "iV" = (
 /turf/template_noop,
@@ -82,6 +67,16 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"jR" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock";
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium{
+	color = "#63D335"
+	},
 /area/shuttle/trade/sol)
 "kM" = (
 /turf/simulated/floor/mineral/titanium/blue,
@@ -211,15 +206,6 @@
 /obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
-"Dx" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/titanium/glass{
-	id_tag = "s_docking_airlock"
-	},
-/turf/simulated/floor/mineral/titanium{
-	color = "#63D335"
-	},
-/area/shuttle/trade/sol)
 "Fx" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -260,11 +246,6 @@
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/trade/sol)
-"Ht" = (
-/obj/machinery/door/airlock/titanium/glass,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/mineral/titanium/yellow,
-/area/shuttle/trade/sol)
 "HT" = (
 /obj/structure/table/wood,
 /obj/item/stack/wrapping_paper,
@@ -283,6 +264,13 @@
 /turf/simulated/floor/mineral/titanium{
 	color = "#63D335"
 	},
+/area/shuttle/trade/sol)
+"Jg" = (
+/obj/machinery/door/airlock/titanium/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/trade/sol)
 "Ji" = (
 /obj/machinery/light/spot{
@@ -442,6 +430,24 @@
 /obj/effect/spawner/random/traders/donksoft,
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/trade/sol)
+"YH" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock";
+	dir = 4
+	},
+/obj/docking_port/mobile/trader{
+	height = 17;
+	width = 16;
+	dwidth = 8;
+	preferred_direction = 1;
+	dir = 1;
+	port_direction = 8
+	},
+/turf/simulated/floor/mineral/titanium{
+	color = "#63D335"
+	},
+/area/shuttle/trade/sol)
 
 (1,1,1) = {"
 iV
@@ -512,7 +518,7 @@ Aj
 Aj
 MK
 Ro
-Ht
+eJ
 rb
 rb
 ut
@@ -562,7 +568,7 @@ Dq
 kM
 Ji
 kM
-iC
+Jg
 MK
 MK
 MK
@@ -593,7 +599,7 @@ bT
 Na
 Na
 Na
-Dx
+jR
 "}
 (9,1,1) = {"
 Dq
@@ -612,14 +618,14 @@ bT
 Na
 Na
 Na
-il
+YH
 "}
 (10,1,1) = {"
 Dq
 kM
 bW
 kM
-iC
+Jg
 MK
 MK
 MK
@@ -683,7 +689,7 @@ Aj
 Aj
 MK
 bP
-Ht
+eJ
 rb
 rb
 ut

--- a/_maps/map_files/shuttles/trader/trader_syndicate.dmm
+++ b/_maps/map_files/shuttles/trader/trader_syndicate.dmm
@@ -4,6 +4,21 @@
 /obj/item/toy/figure/crew/syndie,
 /turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/trade/sol)
+"bu" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/hatch{
+	id_tag = "s_docking_airlock";
+	dir = 4
+	},
+/obj/docking_port/mobile/trader{
+	height = 21;
+	width = 14;
+	dwidth = 7;
+	preferred_direction = 1;
+	dir = 2
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
 "bZ" = (
 /turf/template_noop,
 /area/template_noop)
@@ -157,6 +172,14 @@
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/trade/sol)
+"lB" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/hatch{
+	id_tag = "s_docking_airlock";
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
 "nc" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/plastitanium{
@@ -167,20 +190,6 @@
 "nY" = (
 /obj/machinery/light/spot,
 /obj/machinery/economy/atm/directional/east,
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/shuttle/trade/sol)
-"oZ" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/hatch{
-	id_tag = "s_docking_airlock"
-	},
-/obj/docking_port/mobile/trader{
-	height = 21;
-	width = 14;
-	dwidth = 7;
-	preferred_direction = 1;
-	dir = 2
-	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/trade/sol)
 "ps" = (
@@ -236,13 +245,6 @@
 	},
 /turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/trade/sol)
-"uK" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/hatch{
-	id_tag = "s_docking_airlock"
-	},
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/shuttle/trade/sol)
 "vM" = (
 /obj/machinery/computer/shuttle/trade/sol,
 /obj/effect/turf_decal/woodsiding{
@@ -292,11 +294,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/mineral/plastitanium,
-/area/shuttle/trade/sol)
-"ye" = (
-/obj/machinery/door/airlock/hatch,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/trade/sol)
 "yH" = (
 /obj/effect/turf_decal/woodsiding{
@@ -481,6 +478,13 @@
 /obj/item/scalpel,
 /turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/trade/sol)
+"Qp" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/trade/sol)
 "RQ" = (
 /obj/structure/shelf,
 /obj/effect/turf_decal/siding{
@@ -591,7 +595,7 @@ LQ
 eK
 iA
 kM
-ye
+Qp
 kc
 SY
 LQ
@@ -678,7 +682,7 @@ nc
 Jn
 "}
 (7,1,1) = {"
-oZ
+bu
 jy
 kc
 kc
@@ -689,7 +693,7 @@ kc
 kc
 kc
 Zu
-ye
+Qp
 kc
 kc
 kc
@@ -701,7 +705,7 @@ LQ
 LQ
 "}
 (8,1,1) = {"
-uK
+lB
 jy
 kc
 kc
@@ -712,7 +716,7 @@ kc
 kc
 kc
 Zu
-ye
+Qp
 kc
 kc
 kc
@@ -798,7 +802,7 @@ LQ
 eK
 DB
 kM
-ye
+Qp
 kc
 hF
 LQ

--- a/_maps/map_files/shuttles/trader/trader_synth.dmm
+++ b/_maps/map_files/shuttles/trader/trader_synth.dmm
@@ -26,13 +26,6 @@
 /obj/effect/turf_decal/box,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/trade/sol)
-"e" = (
-/obj/machinery/door/airlock/titanium/glass{
-	id_tag = "s_docking_airlock"
-	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/trade/sol)
 "f" = (
 /obj/structure/extinguisher_cabinet{
 	name = "west bump";
@@ -130,11 +123,6 @@
 /obj/item/toy/plushie/ipcplushie,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/trade/sol)
-"u" = (
-/obj/machinery/door/airlock/titanium/glass,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/trade/sol)
 "v" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/traders/science,
@@ -175,6 +163,14 @@
 /obj/machinery/light/spot,
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/trade/sol)
+"B" = (
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock";
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/trade/sol)
 "C" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/traders/security,
@@ -209,6 +205,13 @@
 "H" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/plating/airless,
+/area/shuttle/trade/sol)
+"I" = (
+/obj/machinery/door/airlock/titanium/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/trade/sol)
 "J" = (
 /obj/effect/spawner/random/traders/vehicle,
@@ -303,20 +306,6 @@
 /obj/structure/sign/securearea,
 /turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
-"O" = (
-/obj/machinery/door/airlock/titanium/glass{
-	id_tag = "s_docking_airlock"
-	},
-/obj/structure/fans/tiny,
-/obj/docking_port/mobile/trader{
-	height = 12;
-	width = 12;
-	dwidth = 6;
-	preferred_direction = 1;
-	dir = 2
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/trade/sol)
 "P" = (
 /obj/item/flag/species/machine,
 /turf/simulated/floor/mineral/titanium/blue,
@@ -335,6 +324,21 @@
 /obj/structure/closet,
 /obj/effect/spawner/random/traders/civilian,
 /turf/simulated/floor/mineral/titanium,
+/area/shuttle/trade/sol)
+"V" = (
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock";
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/obj/docking_port/mobile/trader{
+	height = 12;
+	width = 12;
+	dwidth = 6;
+	preferred_direction = 1;
+	dir = 2
+	},
+/turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/trade/sol)
 "W" = (
 /obj/effect/spawner/window/shuttle,
@@ -377,7 +381,7 @@ W
 P
 R
 G
-u
+I
 f
 E
 i
@@ -429,7 +433,7 @@ K
 H
 "}
 (6,1,1) = {"
-O
+V
 Y
 R
 S
@@ -443,7 +447,7 @@ K
 H
 "}
 (7,1,1) = {"
-e
+B
 Y
 R
 S
@@ -503,7 +507,7 @@ W
 P
 R
 G
-u
+I
 l
 E
 q

--- a/_maps/map_files/shuttles/trader/trader_techno.dmm
+++ b/_maps/map_files/shuttles/trader/trader_techno.dmm
@@ -12,6 +12,13 @@
 /obj/item/toy/plushie/abductor/agent,
 /turf/simulated/floor/mineral/abductor,
 /area/shuttle/trade/sol)
+"d" = (
+/obj/machinery/door/airlock/abductor{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
 "e" = (
 /obj/machinery/light/spot{
 	dir = 8
@@ -59,6 +66,20 @@
 	pixel_x = 10;
 	req_access = list(160);
 	pixel_y = 24
+	},
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
+"k" = (
+/obj/machinery/door/airlock/abductor{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/obj/docking_port/mobile/trader{
+	height = 16;
+	width = 16;
+	dwidth = 8;
+	preferred_direction = 1;
+	dir = 2
 	},
 /turf/simulated/floor/mineral/abductor,
 /area/shuttle/trade/sol)
@@ -127,11 +148,6 @@
 /obj/effect/spawner/random/traders/vehicle,
 /turf/simulated/floor/mineral/abductor,
 /area/shuttle/trade/sol)
-"x" = (
-/obj/machinery/door/airlock/abductor,
-/obj/structure/fans/tiny,
-/turf/simulated/floor/mineral/abductor,
-/area/shuttle/trade/sol)
 "y" = (
 /obj/machinery/door/airlock/abductor{
 	security_level = 6;
@@ -184,18 +200,6 @@
 /obj/machinery/flasher{
 	id = "trader_flash";
 	pixel_x = 28
-	},
-/turf/simulated/floor/mineral/abductor,
-/area/shuttle/trade/sol)
-"F" = (
-/obj/machinery/door/airlock/abductor,
-/obj/structure/fans/tiny,
-/obj/docking_port/mobile/trader{
-	height = 16;
-	width = 16;
-	dwidth = 8;
-	preferred_direction = 1;
-	dir = 2
 	},
 /turf/simulated/floor/mineral/abductor,
 /area/shuttle/trade/sol)
@@ -306,6 +310,13 @@
 /obj/structure/shelf/science,
 /turf/simulated/floor/mineral/abductor,
 /area/shuttle/trade/sol)
+"Z" = (
+/obj/machinery/door/airlock/abductor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/mineral/abductor,
+/area/shuttle/trade/sol)
 
 (1,1,1) = {"
 M
@@ -368,7 +379,7 @@ C
 q
 K
 q
-v
+Z
 q
 q
 q
@@ -427,14 +438,14 @@ P
 q
 q
 q
-v
+Z
 z
 q
 q
 C
 "}
 (8,1,1) = {"
-F
+k
 q
 q
 q
@@ -452,7 +463,7 @@ q
 C
 "}
 (9,1,1) = {"
-x
+d
 q
 q
 q
@@ -481,7 +492,7 @@ P
 q
 q
 q
-v
+Z
 K
 q
 q
@@ -530,7 +541,7 @@ C
 q
 z
 q
-v
+Z
 q
 q
 q

--- a/_maps/map_files/shuttles/trader/trader_ussp.dmm
+++ b/_maps/map_files/shuttles/trader/trader_ussp.dmm
@@ -94,16 +94,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/shuttle/trade/sol)
-"gK" = (
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/shuttle/trade/sol)
-"gR" = (
+"gH" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/titanium/glass{
-	id_tag = "s_docking_airlock"
+	id_tag = "s_docking_airlock";
+	dir = 4
 	},
 /obj/docking_port/mobile/trader{
 	height = 19;
@@ -114,15 +109,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/shuttle/trade/sol)
-"hc" = (
-/turf/simulated/wall/mineral/titanium,
-/area/shuttle/trade/sol)
-"iv" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/titanium/glass{
-	id_tag = "s_docking_airlock"
+"gK" = (
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
+/area/shuttle/trade/sol)
+"hc" = (
+/turf/simulated/wall/mineral/titanium,
 /area/shuttle/trade/sol)
 "jb" = (
 /obj/machinery/flasher_button{
@@ -340,6 +334,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
+"Bm" = (
+/obj/machinery/door/airlock/titanium/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/plasteel,
+/area/shuttle/trade/sol)
 "Bt" = (
 /obj/machinery/economy/atm/directional/east,
 /obj/effect/turf_decal/tiles/department/security/side{
@@ -497,6 +498,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
 /turf/simulated/floor/plasteel,
 /area/shuttle/trade/sol)
+"NN" = (
+/obj/machinery/door/airlock/titanium/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
 "NU" = (
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 9
@@ -522,6 +530,14 @@
 	security_level = 6
 	},
 /obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/plasteel,
+/area/shuttle/trade/sol)
+"OP" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock";
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/shuttle/trade/sol)
 "Pq" = (
@@ -560,11 +576,6 @@
 /obj/item/flag/ussp,
 /obj/effect/turf_decal/box/red,
 /obj/effect/turf_decal/tiles/department/security/side,
-/turf/simulated/floor/plasteel,
-/area/shuttle/trade/sol)
-"RE" = (
-/obj/machinery/door/airlock/titanium/glass,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
 /turf/simulated/floor/plasteel,
 /area/shuttle/trade/sol)
 "RG" = (
@@ -610,11 +621,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/shuttle/trade/sol)
-"YV" = (
-/obj/machinery/door/airlock/titanium/glass,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
 
 (1,1,1) = {"
@@ -665,7 +671,7 @@ EK
 Go
 KF
 Ao
-YV
+NN
 Dj
 ah
 ah
@@ -713,7 +719,7 @@ kd
 xC
 bE
 ah
-RE
+Bm
 ah
 ah
 uM
@@ -744,7 +750,7 @@ Mv
 oM
 "}
 (7,1,1) = {"
-gR
+gH
 yx
 ah
 ah
@@ -765,7 +771,7 @@ Mv
 oM
 "}
 (8,1,1) = {"
-iv
+OP
 RR
 ah
 ah
@@ -818,7 +824,7 @@ jo
 xC
 NU
 ah
-RE
+Bm
 ah
 ah
 rw
@@ -854,7 +860,7 @@ EK
 Go
 Ao
 KF
-YV
+NN
 Dj
 ah
 ah

--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -57,17 +57,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat/atmos)
-"aaA" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/white,
-/area/station/maintenance/starboard)
 "aaQ" = (
 /obj/docking_port/stationary/whiteship{
 	dir = 8;
@@ -235,14 +224,6 @@
 /obj/item/target/syndicate,
 /turf/simulated/floor/plasteel,
 /area/station/security/range)
-"acD" = (
-/obj/machinery/door/airlock{
-	name = "Toilet"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/security/main)
 "acE" = (
 /obj/structure/sink/directional/west,
 /obj/structure/mirror{
@@ -421,14 +402,6 @@
 "ado" = (
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"adp" = (
-/obj/machinery/door/airlock{
-	name = "Bathroom"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/security/main)
 "ads" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -1043,40 +1016,6 @@
 "afO" = (
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
-"afT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel,
-/area/station/security/prisonershuttle)
-"afV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel,
-/area/station/security/prisonershuttle)
 "afX" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating/airless,
@@ -1329,28 +1268,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/command/office/hos)
-"ahu" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	id_tag = "viro_door_int";
-	locked = 1;
-	name = "Virology Lab Internal Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/access_button{
-	autolink_id = "viro_btn_int";
-	name = "Virology Lab Access Button";
-	pixel_x = -24;
-	req_access = list(39)
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/virology)
 "ahz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -2613,26 +2530,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
-"alP" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tiles/department/security/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison/cell_block/a)
-"alQ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/tiles/department/security/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison/cell_block/a)
 "alS" = (
 /obj/structure/closet/secure_closet/evidence,
 /obj/machinery/light/small{
@@ -4887,22 +4784,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/evidence)
-"atr" = (
-/obj/machinery/door/airlock{
-	id_tag = "secmaintdorm1";
-	name = "Room 1"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
-"ats" = (
-/obj/machinery/door/airlock{
-	id_tag = "secmaintdorm2";
-	name = "Room 2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
 "att" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -4940,16 +4821,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
-"atA" = (
-/obj/machinery/door/airlock{
-	name = "Prison Showers"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/security/permabrig)
 "atC" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tiles/department/security/corner{
@@ -5006,22 +4877,6 @@
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonershuttle)
-"atO" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prison Forestry"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
 "atU" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/machinery/door/poddoor/preopen{
@@ -6609,15 +6464,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
-"azJ" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/security/lobby)
 "azK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6661,14 +6507,6 @@
 /obj/effect/turf_decal/tiles/department/security/corner,
 /turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/a)
-"azP" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tiles/department/security/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/security/lobby)
 "azQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6682,14 +6520,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison/cell_block/a)
-"azR" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/security/corner{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/east,
-/turf/simulated/floor/plasteel,
-/area/station/security/lobby)
 "azS" = (
 /obj/structure/chair/stool/bar{
 	dir = 4
@@ -7142,16 +6972,6 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
-"aBv" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "aBw" = (
@@ -8384,6 +8204,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore)
+"aFz" = (
+/obj/machinery/door/airlock/maintenance{
+	electrified_until = -1;
+	locked = 1;
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "aFA" = (
 /obj/structure/chair{
 	dir = 8
@@ -8553,18 +8385,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
-"aGc" = (
-/obj/structure/mineral_door/wood{
-	name = "Abandoned Bar"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/station/maintenance/abandonedbar)
 "aGd" = (
 /obj/effect/spawner/random/fungus/frequent,
 /obj/effect/mapping_helpers/turfs/rust,
@@ -10552,17 +10372,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/electrical/fore_starboard)
-"aNt" = (
-/obj/docking_port/mobile/pod{
-	id = "pod1";
-	name = "escape pod 1"
-	},
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock";
-	name = "Escape Pod Hatch"
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/pod_1)
 "aNu" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10609,17 +10418,6 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
-"aNy" = (
-/obj/docking_port/mobile/pod{
-	id = "pod2";
-	name = "escape pod 2"
-	},
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock";
-	name = "Escape Pod Hatch"
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/pod_2)
 "aNB" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -10704,17 +10502,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
-"aNR" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fsmaint)
 "aNT" = (
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /obj/structure/sign/security{
@@ -11009,18 +10796,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/station/public/arcade)
-"aPg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/multi_tile/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/carpet/arcade,
-/area/station/public/arcade)
 "aPi" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
@@ -11167,14 +10942,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore)
-"aPK" = (
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "maint3";
-	name = "Blast Door"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "aPL" = (
 /obj/effect/turf_decal/tiles/department/virology,
 /turf/simulated/floor/plasteel/white,
@@ -11216,13 +10983,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
-"aPZ" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Escape Pod 1 Airlock";
-	id_tag = "emergency_home"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/north)
 "aQa" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -11579,6 +11339,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
+"aRq" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Security Maintenance";
+	security_level = 1;
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "aRr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11982,18 +11758,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/ne)
-"aTe" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "maint3";
-	name = "Blast Door"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "aTg" = (
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
@@ -12060,14 +11824,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
-"aTt" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/north)
 "aTu" = (
 /turf/simulated/wall,
 /area/station/hallway/secondary/garden)
@@ -12174,39 +11930,6 @@
 /obj/machinery/alarm/directional/north,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/vault)
-"aTL" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/white/corner,
-/turf/simulated/floor/plasteel,
-/area/station/medical/reception)
-"aTM" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/medical/reception)
-"aTN" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id_tag = "paramedic";
-	name = "Paramedic Garage"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door_control{
-	id = "paramedic";
-	name = "Garage Door Control";
-	pixel_x = -24;
-	req_access = list(66)
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/medical/paramedic)
 "aTP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/turf_decal/stripes/line{
@@ -12324,13 +12047,6 @@
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"aUc" = (
-/obj/machinery/door/poddoor{
-	id_tag = "maint2"
-	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "aUd" = (
@@ -12634,23 +12350,20 @@
 /obj/effect/spawner/random/fungus/frequent,
 /turf/simulated/wall,
 /area/station/maintenance/electrical/fore_starboard)
+"aUZ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/medical/cryo)
 "aVc" = (
 /turf/simulated/wall,
 /area/station/security/checkpoint/secondary)
 "aVe" = (
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/garden)
-"aVh" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/public/storage/tools)
 "aVi" = (
 /turf/simulated/wall,
 /area/station/public/storage/tools)
@@ -12876,13 +12589,6 @@
 	},
 /turf/simulated/floor/catwalk/black,
 /area/station/ai_monitored/storage/eva)
-"aVQ" = (
-/obj/machinery/door/poddoor{
-	id_tag = "maint1"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "aVR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/turf_decal/stripes/line{
@@ -13235,14 +12941,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/public/dorms)
-"aWZ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/public/toilet/unisex)
 "aXb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -13905,16 +13603,6 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
-"aZx" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/medical/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore)
 "aZy" = (
 /mob/living/simple_animal/hostile/retaliate/carp/koi{
 	name = "Jeremy"
@@ -14228,26 +13916,6 @@
 /obj/structure/sign/command/eva,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
-"baE" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore)
-"baF" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/medical/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore)
 "baH" = (
 /obj/machinery/atmospherics/refill_station/oxygen,
 /turf/simulated/floor/plasteel/white,
@@ -14469,17 +14137,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
-"bbF" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/poddoor{
-	id_tag = "maint2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "bbG" = (
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plating,
@@ -15384,32 +15041,9 @@
 /obj/effect/landmark/spawner/nukedisc_respawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint2)
-"beO" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/primary/port/east)
 "beP" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/station/hallway/secondary/garden)
-"beQ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/garden)
 "beR" = (
 /obj/effect/spawner/window/reinforced,
@@ -15692,17 +15326,6 @@
 /obj/machinery/hydroponics/soil,
 /turf/simulated/floor/grass,
 /area/station/service/hydroponics)
-"bfK" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/poddoor{
-	id_tag = "maint1"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "bfL" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/plantbgone{
@@ -16360,15 +15983,6 @@
 /obj/machinery/chem_master,
 /turf/simulated/floor/plasteel,
 /area/station/service/hydroponics)
-"bhT" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/storage/tools)
 "bhU" = (
 /obj/structure/window/reinforced,
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -17137,10 +16751,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/nw)
-"bkx" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/public/locker)
 "bky" = (
 /obj/machinery/light,
 /obj/structure/sign/electricshock{
@@ -19020,16 +18630,6 @@
 	icon_state = "chapel"
 	},
 /area/station/service/chapel)
-"bqh" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/public/locker)
 "bqi" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/utensil/fork,
@@ -19968,6 +19568,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/station/service/bar)
+"bty" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/department/command/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/medical/surgery/observation)
 "btA" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -20470,6 +20084,20 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/public/vacant_office)
+"buZ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/multi_tile/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "bva" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
@@ -20887,20 +20515,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
-"bwL" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "mechbay_outer";
-	name = "Mech Bay Public Shutter"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/science/robotics/chargebay)
 "bwM" = (
 /obj/structure/chair/office/dark,
 /turf/simulated/floor/wood,
@@ -20988,19 +20602,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/sorting)
-"bxi" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tiles/department/cargo/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/nw)
-"bxk" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/medical/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/nw)
 "bxl" = (
 /turf/simulated/wall,
 /area/station/command/meeting_room)
@@ -21285,21 +20886,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/service/library)
-"bza" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/ne)
-"bzb" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/ne)
 "bzc" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -21518,20 +21104,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/maintenance/apmaint)
-"bzQ" = (
-/obj/machinery/door/airlock{
-	name = "Unisex Restrooms"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/public/toilet/lockerroom)
 "bzT" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
@@ -21545,6 +21117,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
+"bzY" = (
+/obj/machinery/door/airlock{
+	id_tag = "secmaintdorm2";
+	name = "Room 2";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "bzZ" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -21653,13 +21236,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/west)
-"bAv" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Diner"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/service/bar)
 "bAy" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tiles/department/medical/side,
@@ -22047,13 +21623,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
-"bCt" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/nw)
 "bCu" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -22439,15 +22008,6 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
 /area/station/supply/sorting)
-"bEg" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/ne)
 "bEi" = (
 /obj/structure/closet/crate/medical,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -22463,16 +22023,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/west)
-"bEl" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel,
-/area/station/service/chapel)
-"bEn" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/se)
 "bEp" = (
 /turf/simulated/wall,
 /area/station/medical/reception)
@@ -22503,13 +22053,6 @@
 "bEu" = (
 /turf/simulated/wall,
 /area/station/medical/morgue)
-"bEw" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/medical/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/se)
 "bEx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -22923,6 +22466,14 @@
 "bGr" = (
 /turf/simulated/wall/r_wall,
 /area/station/science/robotics/chargebay)
+"bGu" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tiles/department/science/corner,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/hallway)
 "bGv" = (
 /obj/machinery/alarm/directional/east,
 /obj/effect/turf_decal/tiles/white/side{
@@ -23714,6 +23265,21 @@
 /obj/structure/cable,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/west)
+"bJe" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/north)
 "bJf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23893,15 +23459,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/station/service/bar)
-"bJT" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/se)
 "bJU" = (
 /obj/machinery/door/airlock{
 	id_tag = "toilet_unit1";
@@ -23915,16 +23472,6 @@
 /obj/effect/turf_decal/tiles/white/side{
 	dir = 6
 	},
-/turf/simulated/floor/plasteel,
-/area/station/medical/reception)
-"bJY" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/white/side,
 /turf/simulated/floor/plasteel,
 /area/station/medical/reception)
 "bJZ" = (
@@ -24499,16 +24046,6 @@
 "bMG" = (
 /turf/simulated/wall/r_wall,
 /area/station/command/office/hop)
-"bMJ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/cargo/corner{
-	dir = 8
-	},
-/obj/structure/sign/cargo{
-	pixel_x = -32
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/sw)
 "bML" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25368,16 +24905,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
-"bQn" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/sw)
 "bQo" = (
 /turf/simulated/wall,
 /area/station/command/office/hop)
@@ -25526,25 +25053,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
-"bRh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Engineering";
-	name = "Engineering Security Doors"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/equipmentstorage)
 "bRj" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -26502,6 +26010,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
+"bVb" = (
+/obj/machinery/door/airlock{
+	name = "Prison Showers";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/security/permabrig)
 "bVr" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -26802,26 +26323,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/cmo)
-"bWC" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tiles/department/medical/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/medbay2)
-"bWF" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/department/medical/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/medbay2)
 "bWH" = (
 /turf/simulated/floor/plasteel/fakestairs/left,
 /area/station/hallway/primary/central/ne)
@@ -27249,14 +26750,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
-"bYC" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/medical/cryo)
 "bYD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -27443,12 +26936,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/cmo)
-"bZv" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/medical/cryo)
 "bZw" = (
 /obj/machinery/photocopier,
 /obj/machinery/alarm/directional/east,
@@ -28515,10 +28002,6 @@
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
-"cdI" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/sw)
 "cdJ" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -28771,6 +28254,22 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/sleeper)
+"ceI" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/disposal)
 "ceJ" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -29512,21 +29011,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/ntrep)
-"chI" = (
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Coldroom Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
 "chJ" = (
 /obj/item/kirbyplants/large,
 /obj/structure/sign/poster/official/random/directional/south,
@@ -29734,14 +29218,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
-"ciN" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/engineering/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/north)
 "ciP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -30039,10 +29515,6 @@
 /obj/structure/sign/explosives,
 /turf/simulated/wall/r_wall,
 /area/station/science/toxins/test)
-"ckc" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/carpet/arcade,
-/area/station/public/arcade)
 "ckk" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -30419,17 +29891,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/station/command/office/ntrep)
-"clO" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/engineering/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/north)
 "clR" = (
 /obj/machinery/requests_console/directional/west,
 /turf/simulated/floor/wood,
@@ -30695,6 +30156,20 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
+"cmU" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "E.V.A.";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/eva,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/ai_monitored/storage/eva)
 "cmV" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
@@ -31601,9 +31076,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
-"cqY" = (
-/turf/simulated/wall/indestructible/titanium,
-/area/shuttle/arrival/station)
 "cra" = (
 /obj/structure/extinguisher_cabinet{
 	name = "north bump";
@@ -31862,14 +31334,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tiles/department/engineering/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/north)
-"crX" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/engineering/corner{
-	dir = 8
-	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/north)
 "crY" = (
@@ -32286,15 +31750,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
-"ctt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/north)
 "ctu" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -32544,11 +31999,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
-"cuu" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/engineering/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/north)
 "cuv" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -33871,16 +33321,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/incinerator)
-"czN" = (
-/obj/machinery/door/airlock,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/public/storage/emergency/port)
 "czO" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/turf_decal/tiles/department/command,
@@ -34316,14 +33756,6 @@
 /obj/effect/turf_decal/tiles/dark/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/south)
-"cBB" = (
-/obj/machinery/door/firedoor,
-/obj/structure/sign/poster/official/random/directional/west,
-/obj/effect/turf_decal/tiles/department/science/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/science/hallway)
 "cBC" = (
 /obj/structure/table,
 /obj/item/electropack,
@@ -34479,6 +33911,17 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/maintenance/incinerator)
+"cCy" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint)
 "cCz" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
@@ -34756,15 +34199,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
-"cDC" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/science/hallway)
 "cDD" = (
 /obj/structure/table,
 /obj/item/healthanalyzer/advanced,
@@ -35100,26 +34534,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
-"cEU" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/classic/normal{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id_tag = "kitchenhall";
-	name = "Kitchen Shutters";
-	dir = 2
-	},
-/obj/structure/table/reinforced,
-/obj/effect/mapping_helpers/airlock/windoor/autoname{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
-	dir = 1
-	},
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/kitchen)
 "cEV" = (
 /obj/machinery/light{
 	dir = 4
@@ -35313,17 +34727,6 @@
 /obj/effect/turf_decal/tiles/department/science,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/misc_lab)
-"cFX" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "cFY" = (
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 4
@@ -36112,19 +35515,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/misc_lab)
-"cIM" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	name = "Equipment Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/security/storage)
 "cIT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -36616,6 +36006,31 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
+"cKW" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	location = "Hydroponics"
+	},
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/window/classic/normal{
+	dir = 1;
+	name = "Botany Delivery"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/hydroponics{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint2)
 "cKX" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -37850,6 +37265,18 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/distribution)
+"cQd" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/freezer{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/station/service/kitchen)
 "cQe" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -40455,20 +39882,6 @@
 "dbb" = (
 /turf/simulated/floor/engine/plasma,
 /area/station/engineering/atmos)
-"dbc" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/department/medical,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/reception)
 "dbd" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -41982,16 +41395,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/engine/reactor)
-"dhw" = (
-/obj/machinery/door/airlock,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/public/toilet/unisex)
 "dhy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -42145,17 +41548,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/catwalk/black,
 /area/station/turret_protected/aisat/interior)
-"dil" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/station/public/storage/office)
 "dim" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -42379,25 +41771,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/north)
-"djf" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/neutral/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
-"djg" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/neutral/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
 "djh" = (
 /obj/machinery/firealarm/directional/north,
 /obj/structure/table/reinforced,
@@ -42979,6 +42352,14 @@
 	},
 /turf/simulated/floor/catwalk/black,
 /area/station/aisat/service)
+"dlm" = (
+/obj/effect/map_effect/dynamic_airlock/door/interior,
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/obj/machinery/access_button/offset/west,
+/turf/simulated/floor/plating,
+/area/station/engineering/hardsuitstorage)
 "dln" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/wall/r_wall,
@@ -43048,6 +42429,18 @@
 /obj/machinery/bottler,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
+"dlJ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Bay Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/cargo_bay,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/port)
 "dlK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -43681,17 +43074,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage)
-"dor" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage)
 "dos" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -44143,27 +43525,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/ai)
-"drs" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/command/bridge)
 "drt" = (
 /obj/structure/table/reinforced,
 /obj/item/folder{
@@ -44662,6 +44023,28 @@
 	},
 /turf/simulated/floor/indestructible/titanium/blue,
 /area/shuttle/arrival/station)
+"dtV" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/window/classic/reversed{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/autoname{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id_tag = "kitchenhall";
+	name = "Kitchen Shutters";
+	dir = 2
+	},
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/kitchen)
 "dtY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -44724,6 +44107,22 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
+"dwz" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/obj/machinery/door/airlock/engineering/glass{
+	autoclose = 0;
+	id_tag = "engsm_door_int";
+	locked = 1;
+	name = "Reactor Interior Access";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/control)
 "dwF" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -44748,6 +44147,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
+"dxj" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "mechbay_outer";
+	name = "Mech Bay Public Shutter"
+	},
+/obj/machinery/door_control{
+	id = "mechbay_outer";
+	name = "Outer Mech Bay Shutters Control";
+	pixel_x = 24;
+	req_access = list(29)
+	},
+/turf/simulated/floor/plasteel,
+/area/station/science/robotics/chargebay)
 "dxl" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/structure/disposalpipe/segment,
@@ -44771,20 +44188,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
-"dxQ" = (
-/obj/machinery/door/airlock/public/glass{
-	autoclose = 0;
-	heat_proof = 1;
-	id_tag = "turbine_door_int";
-	name = "Turbine Interior Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/engine,
-/area/station/maintenance/turbine)
 "dxU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -44956,20 +44359,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"dDY" = (
-/obj/machinery/door/airlock/mining{
-	name = "Expedition Headquarters"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/supply/expedition,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel,
-/area/station/supply/expedition)
 "dEb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/food/meat/slab,
@@ -45050,6 +44439,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"dFo" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Escape Pod 2 Airlock";
+	id_tag = "emergency_home";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/north)
 "dFE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
@@ -45078,14 +44475,6 @@
 /obj/effect/turf_decal/tiles/department/security/side,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
-"dGd" = (
-/obj/machinery/door/airlock/external/glass{
-	id_tag = "trader_home";
-	name = "Port Bay 4 Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/secondary/entry/north)
 "dGn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tiles/department/medical/side{
@@ -45093,6 +44482,20 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
+"dGo" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/asmaint2)
 "dGp" = (
 /obj/machinery/status_display/supply_display,
 /turf/simulated/wall,
@@ -45128,30 +44531,6 @@
 /obj/effect/turf_decal/tiles/department/science,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
-"dGS" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	id_tag = "rdofficedoor";
-	name = "Research Director's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/rd,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "rd"
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/command/office/rd)
 "dGW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -45183,6 +44562,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
+"dHj" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/holosign/surgery{
+	id = "surgery2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tiles/department/command,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Operating Theatre 2";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Surgery 2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/medical/surgery/secondary)
 "dHw" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -45203,6 +44606,20 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
+"dHC" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "maint3";
+	name = "Blast Door"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "dHH" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -45509,6 +44926,16 @@
 /obj/effect/spawner/random/oil/maybe,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"dMR" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "dMT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -45569,6 +44996,18 @@
 /obj/effect/turf_decal/delivery/white/hollow,
 /turf/simulated/floor/plasteel,
 /area/station/medical/storage)
+"dOR" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "dPe" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -45589,6 +45028,16 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
+"dQl" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/port)
 "dQC" = (
 /obj/machinery/light{
 	dir = 1
@@ -45611,6 +45060,16 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/ai_upload)
+"dQF" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Diner";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/service/bar)
 "dQM" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -45782,18 +45241,22 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/meeting_room)
-"dUS" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Escape Shuttle Cell"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/tiles/department/security/side{
+"dUZ" = (
+/obj/machinery/door/airlock/engineering/glass{
+	autoclose = 0;
+	id_tag = "engsm_door_ext";
+	locked = 1;
+	name = "Reactor Exterior Access";
 	dir = 4
 	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/secondary/exit)
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/control)
 "dVA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -45823,6 +45286,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/lobby)
+"dVP" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/engineering/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/north)
 "dVQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -45856,18 +45330,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/assembly_line)
-"dWF" = (
-/obj/machinery/door/airlock/command{
-	id_tag = "cmoofficedoor";
-	name = "CMO's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/command,
-/turf/simulated/floor/plasteel/dark,
-/area/station/command/office/cmo)
 "dWT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -45878,17 +45340,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/aft2)
-"dXf" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/science/tox_storage,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/research/glass{
-	name = "Toxins Storage"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/science/storage)
 "dXm" = (
 /obj/structure/chair/stool{
 	dir = 4
@@ -46017,18 +45468,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"dZF" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Engineering";
-	name = "Engineering Security Doors"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/equipmentstorage)
 "dZN" = (
 /obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/tiles/department/medical/side{
@@ -46058,6 +45497,13 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"eao" = (
+/obj/machinery/door/airlock/titanium/glass{
+	dir = 4
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/simulated/floor/indestructible/titanium,
+/area/shuttle/arrival/station)
 "eay" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -46545,6 +45991,18 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint2)
+"ehU" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/public/toilet/unisex)
 "eil" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -46622,35 +46080,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/rnd)
-"eiP" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Internal Medbay Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/station/maintenance/aft)
-"eiT" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Turbine Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/turbine)
 "ejc" = (
 /obj/machinery/economy/vending/snack,
 /obj/effect/turf_decal/tiles/white/corner{
@@ -46800,20 +46229,6 @@
 /obj/effect/turf_decal/tiles/dark/corner,
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
-"emZ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Chemistry Lab"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/chemistry)
 "enz" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -46880,6 +46295,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/east)
+"epQ" = (
+/obj/machinery/door/airlock/medical{
+	name = "Operating Theatre Storage";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/station/medical/surgery)
 "epT" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
@@ -46904,6 +46337,15 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
+"eqo" = (
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "admin_home";
+	name = "Port Bay 1 Airlock";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/secondary/entry/south)
 "eqs" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/atmospherics/portable/canister/nitrogen,
@@ -46919,6 +46361,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
+"eqE" = (
+/obj/machinery/door/airlock/command{
+	id_tag = "cmoofficedoor";
+	name = "CMO's Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/command,
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/office/cmo)
 "eqN" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -47043,19 +46500,28 @@
 /obj/structure/closet,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
-"euX" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+"evd" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/command/glass{
+	name = "AI Core";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/robotics)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/turret_protected/ai)
 "evo" = (
 /obj/item/radio/intercom{
 	name = "north bump";
@@ -47099,25 +46565,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/aisat/hall)
-"evX" = (
-/obj/machinery/door/firedoor,
+"ewx" = (
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
-/obj/effect/spawner/window/reinforced/grilled,
-/turf/simulated/floor/plating,
-/area/station/command/bridge)
-"ewu" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering"
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/command{
+	name = "Head of Security";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/hos,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/controlroom)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/office/hos)
 "exh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tiles/dark/side{
@@ -47244,6 +46708,23 @@
 /obj/item/seeds/banana,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"ezH" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/service/hydroponics)
 "eAb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -47311,22 +46792,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
-"eAY" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fpmaint)
-"eBd" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry)
 "eBy" = (
 /obj/structure/chair/stool{
 	dir = 4
@@ -47355,6 +46820,18 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/public/dorms)
+"eDu" = (
+/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "MiniSat Maintenance";
+	dir = 4
+	},
+/turf/simulated/floor/catwalk/black,
+/area/station/aisat/hall)
 "eDx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash,
@@ -47417,25 +46894,16 @@
 /obj/effect/turf_decal/tiles/department/virology,
 /turf/simulated/floor/plasteel/white,
 /area/station/public/sleep)
+"eEv" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/se)
 "eEy" = (
 /obj/effect/spawner/airlock/long,
 /turf/simulated/wall,
 /area/station/maintenance/apmaint)
-"eEA" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Psych Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "psychoffice"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/station/medical/psych)
 "eER" = (
 /obj/machinery/economy/vending/cigarette,
 /obj/effect/turf_decal/tiles/department/science/side{
@@ -47541,29 +47009,6 @@
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/apmaint)
-"eHw" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	sort_type_txt = "8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "BrigRight";
-	name = "Brig Foyer Right Entrance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
 "eHX" = (
 /obj/structure/table,
 /obj/item/taperecorder,
@@ -47610,13 +47055,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison/cell_block/a)
-"eIN" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/random/maintenance,
-/obj/item/eftpos/register,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
 "eJr" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/barricade/wooden,
@@ -47641,6 +47079,19 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/command/office/captain/bedroom)
+"eJJ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	name = "Surgery Room";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/robotics)
 "eJZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -47712,6 +47163,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/morgue)
+"eLS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/captain,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/command{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/station/command/office/captain)
 "eLY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -47812,6 +47275,19 @@
 /obj/machinery/requests_console/directional/west,
 /turf/simulated/floor/wood,
 /area/station/medical/psych)
+"eNU" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tiles/department/science/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/science/hallway)
 "eNV" = (
 /obj/machinery/camera{
 	c_tag = "Aft Port Solar Access";
@@ -47883,13 +47359,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
-"ePc" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Escape Pod 4 Airlock";
-	id_tag = "emergency_home"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage)
 "ePp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -47924,6 +47393,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
+"ePL" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "ePN" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -48080,6 +47559,19 @@
 /obj/effect/turf_decal/tiles/department/security/side,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
+"eTF" = (
+/obj/item/restraints/legcuffs/beartrap{
+	armed = 1
+	},
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "eTQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
@@ -48194,24 +47686,6 @@
 /obj/effect/turf_decal/tiles/department/science/side,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/rnd)
-"eXG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/warden)
 "eXW" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -48232,18 +47706,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/aft)
-"eYG" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Morgue Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/asmaint2)
 "eYK" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -48266,22 +47728,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
-"eYY" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "mechbay_outer";
-	name = "Mech Bay Public Shutter"
-	},
-/obj/machinery/door_control{
-	id = "mechbay_outer";
-	name = "Outer Mech Bay Shutters Control";
-	pixel_x = 24;
-	req_access = list(29)
-	},
-/turf/simulated/floor/plasteel,
-/area/station/science/robotics/chargebay)
 "eZu" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 1;
@@ -48425,14 +47871,6 @@
 /obj/item/latexballon,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
-"fcM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/barrier/possibly_welded_airlock,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel/white,
-/area/station/maintenance/asmaint)
 "fcQ" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -48440,12 +47878,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
-"fdn" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fpmaint2)
 "fdo" = (
 /obj/machinery/newscaster/security_unit/directional/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -48466,6 +47898,20 @@
 /obj/effect/turf_decal/woodsiding,
 /turf/simulated/floor/grass/jungle/no_creep,
 /area/station/command/bridge)
+"fdH" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "fdK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -48703,20 +48149,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/processing)
-"fiB" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/classic/reversed{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/autoname/desk{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/hydroponics{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/service/hydroponics)
 "fjd" = (
 /obj/structure/chair/sofa/corp/left,
 /turf/simulated/floor/plasteel,
@@ -48743,6 +48175,21 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/break_room)
+"fjw" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore)
 "fjx" = (
 /obj/structure/closet/secure_closet/research_reagents,
 /turf/simulated/floor/engine,
@@ -48769,6 +48216,19 @@
 /obj/machinery/atmospherics/binary/valve/open,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
+"fkj" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/service/janitor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/service/janitor)
 "fkk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -48797,15 +48257,36 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/north)
+"fkz" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/command/side{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/simulated/floor/plasteel/dark,
+/area/station/medical/surgery/observation)
+"fly" = (
+/obj/effect/mapping_helpers/airlock/access/any/command/hop,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/command{
+	name = "Head of Personnel Office";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/command/office/hop)
 "flB" = (
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall,
 /area/station/supply/expedition)
-"flN" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/science/lobby)
 "fmd" = (
 /obj/effect/landmark/spawner/nukedisc_respawn,
 /turf/simulated/floor/plating,
@@ -49146,16 +48627,19 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
-"fsv" = (
-/obj/machinery/door/airlock/engineering,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
-/obj/structure/cable{
+"fsm" = (
+/obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/poddoor{
+	id_tag = "maint2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/electrical/fore_starboard)
+/area/station/maintenance/fsmaint)
 "fsQ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -49166,20 +48650,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
-"fsW" = (
-/obj/machinery/door/airlock/public/glass{
-	autoclose = 0;
-	heat_proof = 1;
-	id_tag = "turbine_door_ext";
-	name = "Turbine Exterior Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/engine,
-/area/station/maintenance/turbine)
 "ftm" = (
 /obj/machinery/hydroponics/constructable{
 	desc = "These are connected with an irrigation tube. You see a little pipe connecting the trays.";
@@ -49229,6 +48699,33 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
+"fup" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "rdofficedoor";
+	name = "Research Director's Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/rd,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "rd"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/command/office/rd)
 "fuw" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
@@ -49367,7 +48864,7 @@
 /obj/machinery/computer/general_air_control{
 	dir = 4;
 	name = "Tank Monitor";
-	autolink_sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous Oxide","waste_sensor"="Gas Mix Tank")
+	autolink_sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous Oxide", "waste_sensor" = "Gas Mix Tank")
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/control)
@@ -49417,19 +48914,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"fxR" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+"fyJ" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/station/service/hydroponics)
+/area/station/maintenance/apmaint)
 "fyQ" = (
 /obj/structure/table,
 /obj/item/stack/medical/bruise_pack/advanced,
@@ -49512,6 +49013,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/lounge)
+"fzV" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/engineering/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/north)
 "fzY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
@@ -49739,18 +49247,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
-"fDP" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/disposal)
 "fEv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -49809,6 +49305,19 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/lobby)
+"fEV" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Library Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/maintenance/fsmaint)
 "fFc" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/effect/landmark/spawner/late/crew,
@@ -49837,21 +49346,18 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
-"fFA" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	name = "Equipment Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/security/storage)
 "fGI" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"fGP" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/science/lobby)
 "fGT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door_control{
@@ -49910,25 +49416,6 @@
 /obj/machinery/power/apc/directional/south,
 /turf/simulated/floor/plasteel,
 /area/station/supply/lobby)
-"fJi" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	name = "E.V.A."
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/eva,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/ai_monitored/storage/eva)
 "fJl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -49967,6 +49454,24 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/sleeper)
+"fKc" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Solitary Confinement 2";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tiles/department/security,
+/turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
 "fKs" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -49974,6 +49479,23 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"fKE" = (
+/obj/effect/mapping_helpers/airlock/access/any/command/captain,
+/obj/machinery/door/airlock/command{
+	name = "Captain's Bedroom";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/command/office/captain/bedroom)
 "fKX" = (
 /obj/structure/closet/l3closet/janitor,
 /obj/item/radio/intercom{
@@ -50011,29 +49533,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
-"fMD" = (
-/obj/machinery/door/airlock/command/glass{
-	id_tag = "blueshieldofficedoor"
+"fMq" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "NTR"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/command/ntrep,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/wood,
-/area/station/command/office/ntrep)
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
 "fMM" = (
 /obj/structure/flora/grass/jungle,
 /turf/simulated/floor/grass,
@@ -50058,6 +49567,33 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_starboard)
+"fNq" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/door/window/brigdoor{
+	id = "Cell 2";
+	name = "Cell 2"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig,
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison/cell_block/a)
 "fNM" = (
 /obj/effect/spawner/random/barrier/possibly_welded_airlock,
 /obj/structure/cable/extra_insulated{
@@ -50161,6 +49697,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/chemistry)
+"fRi" = (
+/obj/machinery/door/poddoor{
+	id_tag = "maint2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "fRo" = (
 /obj/effect/spawner/random/cobweb/right/frequent,
 /obj/structure/chair,
@@ -50225,6 +49770,20 @@
 "fTc" = (
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"fTh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/purple,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/asmaint)
 "fTv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -50251,6 +49810,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
+"fTM" = (
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock";
+	name = "Escape Pod Hatch";
+	dir = 4
+	},
+/obj/docking_port/mobile/pod{
+	id = "pod3";
+	name = "escape pod 3"
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/pod_3)
 "fTR" = (
 /obj/item/radio/intercom{
 	name = "south bump";
@@ -50308,6 +49879,43 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint2)
+"fUY" = (
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/command{
+	name = "Bridge";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/command/bridge)
+"fVg" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "Brig";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/turf/simulated/floor/plasteel,
+/area/station/security/processing)
 "fVk" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/medical/bruise_pack/advanced,
@@ -50358,6 +49966,17 @@
 /turf/simulated/floor/plasteel/fakestairs{
 	dir = 1
 	},
+/area/station/maintenance/fpmaint)
+"fVJ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
 /area/station/maintenance/fpmaint)
 "fVN" = (
 /obj/structure/chair/sofa/corp,
@@ -50516,6 +50135,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/smith_office)
+"gbl" = (
+/obj/machinery/door/airlock{
+	id_tag = "secmaintdorm1";
+	name = "Room 1";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "gbo" = (
 /obj/structure/grille/broken,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -50735,6 +50365,26 @@
 /obj/structure/statue/cyberiad/south/west,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
+"geB" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	name = "Biohazard Shutter";
+	id_tag = "RnDChem"
+	},
+/obj/machinery/door/airlock/research/glass{
+	name = "Test Chamber";
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/tox,
+/obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/misc_lab)
 "geH" = (
 /obj/structure/chair/sofa{
 	dir = 4
@@ -50982,16 +50632,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
-"gky" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Surgery Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/robotics)
 "gkC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -51275,6 +50915,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
+"grB" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "gsd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -51296,17 +50948,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/station/command/office/ce)
-"gsl" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Chamber Hallway"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/catwalk/black,
-/area/station/aisat/hall)
 "gsO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -51392,6 +51033,19 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
+"guA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock{
+	name = "Prison Toilets";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
 /area/station/security/permabrig)
 "guK" = (
 /obj/structure/cable{
@@ -51523,6 +51177,30 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/fpmaint2)
+"gxS" = (
+/obj/machinery/door/airlock/command{
+	name = "Teleport Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/teleporter,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/command/teleporter)
+"gxX" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/garden)
 "gyp" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -51579,6 +51257,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
+"gzm" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/mime,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint2)
+"gzA" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/wood,
+/area/station/maintenance/asmaint)
 "gzC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple,
 /turf/simulated/floor/plating,
@@ -51632,6 +51334,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
+"gAA" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint2)
 "gAJ" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/wood,
@@ -51642,11 +51357,18 @@
 	},
 /turf/simulated/floor/transparent/glass,
 /area/station/hallway/primary/central/south)
-"gBd" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance/external,
-/turf/simulated/floor/plating,
+"gBl" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
 "gCE" = (
 /obj/structure/cable{
@@ -51747,6 +51469,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/south)
+"gEM" = (
+/obj/machinery/door/airlock{
+	name = "Toilet";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/security/main)
 "gEU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -51776,6 +51507,20 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"gFD" = (
+/obj/machinery/door/airlock/vault{
+	locked = 1;
+	name = "abandoned vault";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/door/firedoor/heavy{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/apmaint)
 "gFG" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -51836,34 +51581,6 @@
 "gHr" = (
 /turf/simulated/wall,
 /area/station/procedure/trainer_office)
-"gHJ" = (
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	id = "Cell 3";
-	name = "Cell 3"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison/cell_block/a)
 "gIc" = (
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/east)
@@ -51924,15 +51641,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"gIU" = (
-/obj/machinery/door/airlock/wood{
-	name = "Private Residence";
-	desc = "No solicitors please."
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/station/maintenance/apmaint)
 "gIZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51975,6 +51683,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/asmaint)
+"gJW" = (
+/obj/machinery/door/airlock/vault{
+	locked = 1;
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/vault,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/vault)
 "gKl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -51997,12 +51718,34 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/north)
+"gKx" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/public/arcade)
 "gKN" = (
 /obj/structure/sink/directional/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
 /area/station/medical/cryo)
+"gLf" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/window/classic/reversed{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/autoname/desk{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/hydroponics{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/service/hydroponics)
 "gLu" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -52105,6 +51848,15 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plasteel/dark,
 /area/station/hallway/secondary/entry/south)
+"gMZ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/nw)
 "gNs" = (
 /obj/machinery/firealarm/directional/west,
 /obj/structure/table,
@@ -52151,6 +51903,28 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
+"gOk" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "E.V.A.";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/eva,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/ai_monitored/storage/eva)
 "gOm" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -52241,15 +52015,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
-"gQm" = (
-/obj/item/restraints/legcuffs/beartrap{
-	armed = 1
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "gQI" = (
 /obj/structure/table,
 /obj/item/camera/autopsy{
@@ -52382,6 +52147,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
+"gTE" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/starboard)
 "gTH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -52395,6 +52174,32 @@
 /obj/machinery/alarm/directional/east,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
+"gUk" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	sort_type_txt = "8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "BrigRight";
+	name = "Brig Foyer Right Entrance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "gUm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -52429,14 +52234,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"gUF" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	name = "Evidence Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/evidence,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/evidence)
 "gUR" = (
 /obj/structure/bookcase{
 	name = "bookcase (Non-Fiction)"
@@ -52614,28 +52411,6 @@
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall,
 /area/station/maintenance/apmaint)
-"gYu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/purple,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/white,
-/area/station/maintenance/asmaint)
-"gYw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/captain,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/command,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/station/command/office/captain)
 "gYx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
@@ -52660,18 +52435,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/aft)
-"gYO" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/department/command/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/medical/surgery/observation)
 "gYZ" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id_tag = "hop";
@@ -52909,6 +52672,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
+"hgH" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Turbine Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/turbine)
 "hgO" = (
 /obj/structure/chair/sofa/bench{
 	dir = 8
@@ -52988,6 +52769,25 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/public/toilet/unisex)
+"hhP" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security{
+	name = "Detective's Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/forensics,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/carpet/grimey,
+/area/station/security/prison/cell_block/a)
 "hhX" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Prison Cafeteria"
@@ -53095,6 +52895,21 @@
 /obj/effect/turf_decal/tiles/department/medical/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/security/permabrig)
+"hjZ" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
 "hke" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -53120,24 +52935,24 @@
 /obj/item/target,
 /turf/simulated/floor/engine/airless,
 /area/station/science/toxins/test)
-"hkw" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
-"hkX" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Hydroponics Pasture"
+"hkT" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Solitary Confinement 1";
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/kitchen)
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tiles/department/security,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
 "hlk" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/map_effect/dynamic_airlock/door/exterior,
@@ -53200,6 +53015,18 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/science/robotics)
+"hoy" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fpmaint2)
 "hoz" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -53231,6 +53058,16 @@
 /obj/effect/spawner/random/fungus/probably,
 /turf/simulated/wall,
 /area/station/maintenance/disposal)
+"hps" = (
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "maint3";
+	name = "Blast Door"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "hpI" = (
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre Storage"
@@ -53252,6 +53089,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"hpN" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/hardsuitstorage)
 "hpR" = (
 /obj/structure/chair/sofa/corp{
 	dir = 1
@@ -53269,6 +53119,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
+"hpZ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/white/side,
+/turf/simulated/floor/plasteel,
+/area/station/medical/reception)
 "hqe" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=HOP2";
@@ -53355,26 +53217,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
-"hrA" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/classic/reversed{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/autoname{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id_tag = "kitchenhall";
-	name = "Kitchen Shutters";
-	dir = 2
-	},
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/kitchen)
 "hrW" = (
 /obj/structure/rack{
 	dir = 1
@@ -53490,6 +53332,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/lounge)
+"hvp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/mining{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/smith,
+/turf/simulated/floor/plasteel,
+/area/station/supply/smith_office)
 "hvx" = (
 /obj/effect/turf_decal/trimline/misc/toxins/line{
 	dir = 8
@@ -53518,6 +53377,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
+"hwr" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Prison Forestry";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
 "hwC" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -53532,6 +53410,20 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
+"hwF" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/bananium{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/service/clown,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/station/service/clown)
 "hwJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -53693,15 +53585,6 @@
 /obj/effect/turf_decal/caution,
 /turf/simulated/floor/engine/airless,
 /area/station/science/toxins/test)
-"hzY" = (
-/obj/machinery/door/airlock/medical{
-	locked = 1;
-	name = "Abandoned Chemistry"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
 "hAh" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/simulated/floor/grass,
@@ -53773,21 +53656,6 @@
 /obj/effect/turf_decal/tiles/white/corner,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
-"hCP" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/science/tox_storage,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/sign/science/cans_sci{
-	pixel_x = 32
-	},
-/obj/machinery/door/airlock/research/glass{
-	name = "Toxins Storage"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/science/storage)
 "hCY" = (
 /obj/effect/spawner/random/blood/often,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
@@ -53795,12 +53663,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/maintenance/apmaint)
-"hCZ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/secondary/entry)
 "hDd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -53854,12 +53716,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
-"hEs" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/port)
 "hEu" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -54013,17 +53869,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
-"hHh" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Fore Starboard Solar Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/solar_maintenance/fore_starboard)
 "hHS" = (
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Engineering";
@@ -54031,6 +53876,23 @@
 	},
 /turf/simulated/wall,
 /area/station/engineering/equipmentstorage)
+"hHV" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/security/prisonershuttle)
 "hIc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -54050,6 +53912,18 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/genetics)
+"hIu" = (
+/obj/docking_port/mobile/pod{
+	id = "pod1";
+	name = "escape pod 1"
+	},
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock";
+	name = "Escape Pod Hatch";
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/pod_1)
 "hIR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/sortjunction/reversed{
@@ -54078,6 +53952,18 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/command/bridge)
+"hJd" = (
+/obj/docking_port/mobile/pod{
+	id = "pod2";
+	name = "escape pod 2"
+	},
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock";
+	name = "Escape Pod Hatch";
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/pod_2)
 "hJe" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -54096,6 +53982,16 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel,
+/area/station/command/bridge)
+"hJm" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/spawner/window/reinforced/grilled,
+/turf/simulated/floor/plating,
 /area/station/command/bridge)
 "hJA" = (
 /obj/structure/table/reinforced,
@@ -54149,17 +54045,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"hLu" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tiles/department/science/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/science/hallway)
 "hLv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -54269,6 +54154,20 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/medical/cryo)
+"hOc" = (
+/obj/structure/mineral_door/wood{
+	name = "Abandoned Bar"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/station/maintenance/abandonedbar)
 "hOq" = (
 /obj/structure/rack{
 	dir = 1
@@ -54523,13 +54422,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/security/permabrig)
-"hVu" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Escape Pod 3 Airlock";
-	id_tag = "emergency_home"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
 "hVy" = (
 /turf/simulated/wall/r_wall,
 /area/station/hallway/secondary/entry/north)
@@ -54565,28 +54457,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/meeting_room)
-"hWk" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	dir = 1;
-	location = "Security"
-	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/obj/machinery/door/window/classic/reversed{
-	name = "Security Delivery"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/fore)
 "hWr" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -54608,6 +54478,25 @@
 /obj/structure/sign/poster/contraband/ambrosia_vulgaris/directional/north,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
+"hWw" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Trainer's Office Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/procedure/trainer,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/fpmaint)
+"hWE" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Internal Medbay Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/turf/simulated/floor/plating,
+/area/station/maintenance/medmaint)
 "hWF" = (
 /obj/structure/closet/wardrobe/mixed,
 /obj/machinery/camera{
@@ -54817,27 +54706,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
+"ieo" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/engineering/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/north)
 "ies" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint2)
-"iev" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "medbayfoyerport";
-	name = "Medbay Entrance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/obj/effect/turf_decal/tiles/white/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/medical/reception)
 "iex" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -54883,12 +54769,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/catwalk/grey,
 /area/station/maintenance/assembly_line)
-"ifY" = (
-/obj/effect/map_effect/dynamic_airlock/door/exterior,
-/obj/machinery/door/airlock/external/glass,
-/obj/machinery/access_button/offset/southwest,
-/turf/simulated/floor/plating/airless,
-/area/station/engineering/hardsuitstorage)
 "igi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/structure/lattice,
@@ -55033,6 +54913,22 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/hallway/secondary/entry/north)
+"iiy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/carpet/arcade,
+/area/station/public/arcade)
 "iiN" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -55041,6 +54937,19 @@
 /obj/structure/flora/junglebush,
 /turf/simulated/floor/grass/jungle/no_creep,
 /area/station/command/bridge)
+"iiP" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/controlroom)
 "iiX" = (
 /obj/effect/turf_decal/caution{
 	dir = 8
@@ -55068,6 +54977,18 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
+"ikc" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Custodial Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/janitor,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "ikf" = (
 /obj/machinery/alarm/directional/east,
 /turf/simulated/floor/plating,
@@ -55188,14 +55109,31 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
-"imB" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tiles/department/command/side{
+"inc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/medical/surgery/observation)
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/security/prisonershuttle)
 "ind" = (
 /obj/structure/table/glass,
 /obj/machinery/alarm/directional/south,
@@ -55284,16 +55222,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
-"ioz" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Diner"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/service/bar)
 "ioE" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -55313,6 +55241,19 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/toxins/launch)
+"ipb" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "ipf" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 8;
@@ -55363,14 +55304,20 @@
 /obj/effect/turf_decal/stripes,
 /turf/simulated/floor/engine/airless,
 /area/station/science/toxins/test)
-"iqs" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Research Storage"
+"iqn" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Fore Port Solar Access";
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/science/research,
-/turf/simulated/floor/plasteel,
-/area/station/science/hallway)
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/solar_maintenance/fore_port)
 "iqt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -55381,6 +55328,19 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/maintenance/abandonedservers)
+"iqF" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/atmos{
+	name = "Fore-Port Secondary Atmospherics Maintenance";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fpmaint2)
 "iqH" = (
 /obj/effect/turf_decal/tiles/white/corner{
 	dir = 4
@@ -55408,6 +55368,35 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
+"irh" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Antechamber";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/turf/simulated/floor/catwalk/black,
+/area/station/turret_protected/aisat/interior)
+"irn" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/sw)
 "irE" = (
 /obj/structure/closet/l3closet,
 /obj/effect/decal/cleanable/dirt,
@@ -55427,6 +55416,18 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/command/meeting_room)
+"isB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/north)
 "isD" = (
 /obj/effect/decal/cleanable/blood/tracks/mapped,
 /turf/simulated/floor/plating,
@@ -55436,6 +55437,18 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/grass,
 /area/station/hallway/secondary/exit)
+"isX" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint2)
 "itF" = (
 /obj/structure/rack{
 	dir = 1
@@ -55578,6 +55591,22 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
+"iwN" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/asmaint)
 "iwQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -55620,6 +55649,20 @@
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/simulated/floor/plasteel/reactor_pool,
 /area/station/engineering/engine/reactor)
+"ixU" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/virology/glass{
+	name = "Monkey Pen";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/virology)
 "iyj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -55755,6 +55798,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/supply/storage)
+"iAo" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/maintenance,
+/obj/item/eftpos/register,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "iAE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -55884,21 +55936,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/security/detective)
-"iEA" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
-/obj/machinery/door/airlock/engineering/glass{
-	autoclose = 0;
-	id_tag = "engsm_door_int";
-	locked = 1;
-	name = "Reactor Interior Access"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/control)
 "iFa" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door_control{
@@ -56044,6 +56081,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"iHf" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "iHi" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -56221,6 +56273,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
+"iMu" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "iME" = (
 /obj/machinery/power/apc/directional/east,
 /obj/machinery/bluespace_beacon,
@@ -56311,6 +56375,19 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/electrical/fore_starboard)
+"iOE" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "iOW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -56355,6 +56432,26 @@
 /obj/structure/chair/comfy/teal,
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage)
+"iPX" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/classic/reversed,
+/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/window/classic/reversed{
+	desc = "You have the public fridge, pal, lube off.";
+	dir = 1;
+	name = "Security Shield"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/chemistry{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/chemistry,
+/obj/effect/turf_decal/tiles/department/chemistry,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/chemistry)
 "iPZ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -56514,20 +56611,6 @@
 /obj/effect/turf_decal/tiles/dark/corner,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
-"iTa" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Antechamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/turf/simulated/floor/catwalk/black,
-/area/station/turret_protected/aisat/interior)
 "iTn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -56613,6 +56696,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
+"iTW" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/station/security/checkpoint/secondary)
 "iUc" = (
 /turf/simulated/wall/r_wall,
 /area/station/telecomms/chamber)
@@ -56655,6 +56754,28 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hardsuitstorage)
+"iUH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Engineering";
+	name = "Engineering Security Doors"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/equipmentstorage)
 "iVE" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/tiles/department/engineering/corner{
@@ -56662,6 +56783,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint2)
+"iVG" = (
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external/glass{
+	name = "Labor Camp Airlock";
+	id_tag = "laborcamp_home";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/plasteel,
+/area/station/security/prisonershuttle)
 "iVQ" = (
 /obj/structure/chair{
 	dir = 4
@@ -56677,6 +56809,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
+"iVU" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/external{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "iWm" = (
 /obj/effect/spawner/window/reinforced/polarized/grilled{
 	id = "CE"
@@ -56823,31 +56965,6 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/command/bridge)
-"iZT" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/door/window/brigdoor{
-	id = "Cell 2";
-	name = "Cell 2"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig,
-/obj/item/radio/intercom{
-	name = "west bump";
-	pixel_x = -28
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison/cell_block/a)
 "iZV" = (
 /obj/effect/spawner/random/barrier/grille_often,
 /obj/effect/decal/cleanable/dirt,
@@ -56969,6 +57086,24 @@
 /mob/living/carbon/human/monkey,
 /turf/simulated/floor/plasteel,
 /area/station/medical/virology)
+"jdf" = (
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
+/obj/effect/mapping_helpers/airlock/access/any/science/research,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/science/hallway)
 "jdt" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -57002,12 +57137,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"jdS" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/carpet/arcade,
-/area/station/maintenance/fore)
 "jdY" = (
 /obj/structure/chair/stool{
 	dir = 8
@@ -57032,6 +57161,16 @@
 /obj/effect/turf_decal/tiles/department/virology,
 /turf/simulated/floor/plasteel/white,
 /area/station/public/sleep)
+"jev" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/barrier/possibly_welded_airlock,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/asmaint)
 "jex" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -57044,15 +57183,6 @@
 	},
 /turf/simulated/floor/engine/n20,
 /area/station/engineering/atmos)
-"jeK" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Bar Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/bar,
-/turf/simulated/floor/wood,
-/area/station/service/bar)
 "jeU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -57074,6 +57204,30 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
+"jfc" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/command/bridge)
 "jfQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57129,29 +57283,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/command/teleporter)
-"jhq" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	location = "Hydroponics"
-	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/window/classic/normal{
-	dir = 1;
-	name = "Botany Delivery"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/hydroponics{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery/hollow,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fsmaint2)
 "jhG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -57244,6 +57375,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/secure_storage)
+"jkj" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security{
+	name = "Evidence Storage";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/evidence,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/evidence)
 "jkn" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -57364,29 +57506,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/robotics)
-"jnP" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	id_tag = "cmoofficedoor";
-	name = "CMO's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "CMO"
-	},
-/obj/effect/turf_decal/tiles/department/command,
-/turf/simulated/floor/plasteel/dark,
-/area/station/command/office/cmo)
 "joc" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Checkpoint"
@@ -57405,14 +57524,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint2)
-"joe" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/command/side{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/east,
-/turf/simulated/floor/plasteel/dark,
-/area/station/medical/surgery/observation)
 "jok" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -57420,34 +57531,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"jol" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	id = "Cell 1";
-	name = "Cell 1"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	name = "west bump";
-	pixel_x = -28
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison/cell_block/a)
 "jot" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -57459,6 +57542,18 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/gravitygenerator)
+"joN" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security{
+	name = "Equipment Storage";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/security/storage)
 "jpy" = (
 /turf/simulated/floor/plasteel/white,
 /area/station/command/office/rd)
@@ -57577,13 +57672,6 @@
 /obj/structure/sign/command/conference,
 /turf/simulated/floor/plating,
 /area/station/command/meeting_room)
-"jrI" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fore)
 "jrN" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -57681,23 +57769,27 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
-"jtO" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/north)
 "jtP" = (
 /obj/item/kirbyplants/large,
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/wood,
 /area/station/maintenance/asmaint)
+"jtV" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "mechbay_outer";
+	name = "Mech Bay Public Shutter"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/science/robotics/chargebay)
 "jum" = (
 /obj/machinery/shower/directional/east,
 /obj/structure/curtain/open/shower,
@@ -57806,6 +57898,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"jwB" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "BrigRight";
+	name = "Brig Foyer Right Entrance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "jwE" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-4"
@@ -57839,13 +57953,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
-"jxj" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/random/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
 "jxq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -57870,28 +57977,11 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/break_room)
-"jxK" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Escape Pod 2 Airlock";
-	id_tag = "emergency_home"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/north)
 "jyo" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/slime,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
-"jyy" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/port)
 "jyE" = (
 /obj/item/storage/box/syringes,
 /obj/structure/table,
@@ -57902,19 +57992,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/medical/virology)
-"jyL" = (
-/obj/machinery/door/airlock/tranquillite,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/service/mime,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white{
-	icon_regular_floor = "yellowsiding"
-	},
-/area/station/service/mime)
 "jyO" = (
 /turf/simulated/floor/indestructible/titanium,
 /area/shuttle/arrival/station)
@@ -57940,17 +58017,6 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/toxins/mixing)
-"jzT" = (
-/obj/machinery/door/airlock/command{
-	name = "Teleport Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/teleporter,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/command/teleporter)
 "jzZ" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -58013,6 +58079,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/procedure/trainer_office)
+"jBW" = (
+/obj/machinery/door/airlock/medical{
+	locked = 1;
+	name = "Abandoned Chemistry";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "jCr" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/adv{
@@ -58077,19 +58155,6 @@
 /obj/effect/spawner/random/oil/maybe,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
-"jDJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/apmaint)
 "jDL" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -58115,16 +58180,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/north)
-"jDS" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/engineering,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical/fore_port)
 "jDV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -58165,6 +58220,15 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
+"jEG" = (
+/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "MiniSat Maintenance";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/aisat/hall)
 "jEL" = (
 /obj/structure/sign/vacuum/external{
 	pixel_y = 32
@@ -58183,6 +58247,12 @@
 /obj/item/storage/pill_bottle/random_drug_bottle,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"jFj" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/locker)
 "jFo" = (
 /obj/structure/table,
 /obj/item/roller{
@@ -58212,6 +58282,19 @@
 /obj/structure/closet/l3closet/janitor,
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
+"jFK" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint2)
 "jFW" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -58273,6 +58356,19 @@
 /obj/effect/turf_decal/tiles/department/virology/corner,
 /turf/simulated/floor/plasteel/white,
 /area/station/public/sleep)
+"jHy" = (
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock";
+	name = "Escape Pod Hatch";
+	dir = 4
+	},
+/obj/docking_port/mobile/pod{
+	dir = 2;
+	id = "pod4";
+	name = "escape pod 4"
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/pod_4)
 "jHC" = (
 /obj/machinery/computer/card{
 	dir = 4
@@ -58313,6 +58409,16 @@
 	},
 /turf/simulated/floor/carpet/grimey,
 /area/station/security/detective)
+"jIn" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tiles/department/security/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/security/lobby)
 "jIA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -58358,6 +58464,18 @@
 /obj/machinery/power/apc/directional/south,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/east)
+"jJE" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/north)
 "jKM" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 4;
@@ -58474,6 +58592,15 @@
 /obj/effect/turf_decal/tiles/department/medical/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/security/permabrig)
+"jOg" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "jOj" = (
 /obj/structure/table/wood,
 /obj/item/vending_refill/boozeomat,
@@ -58517,6 +58644,16 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"jOU" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/window/reinforced/grilled,
+/turf/simulated/floor/plating,
+/area/station/command/bridge)
 "jPb" = (
 /obj/machinery/atmospherics/unary/thermomachine/freezer/on/coldroom{
 	dir = 1
@@ -58549,38 +58686,52 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/office/cmo)
-"jPw" = (
-/obj/machinery/door/airlock/freezer,
-/obj/structure/barricade/wooden,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
+"jPp" = (
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "blueshieldofficedoor";
+	dir = 4
 	},
-/area/station/maintenance/asmaint)
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "NTR"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/command/ntrep,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/wood,
+/area/station/command/office/ntrep)
 "jPx" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
-"jPF" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/station/supply/lobby)
-"jPG" = (
-/obj/machinery/door/airlock/engineering/glass{
-	autoclose = 0;
-	id_tag = "engsm_door_ext";
-	locked = 1;
-	name = "Reactor Exterior Access"
+"jPC" = (
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/turf/simulated/floor/plasteel/white,
+/area/station/science/hallway)
+"jPF" = (
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/station/engineering/control)
+/area/station/supply/lobby)
 "jPL" = (
 /obj/effect/spawner/random/barrier/grille_often,
 /turf/simulated/floor/plating,
@@ -58635,6 +58786,16 @@
 /obj/item/soap,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"jRc" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft2)
 "jRo" = (
 /obj/effect/spawner/airlock/s_to_n/long/square,
 /turf/simulated/wall,
@@ -58964,13 +59125,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/distribution)
-"jWI" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/apmaint)
 "jWV" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -59060,17 +59214,25 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/expedition)
-"jZT" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Aft Starboard Solar Access"
+"kac" = (
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/engineering/glass{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/solar_maintenance/aft_starboard)
+/obj/effect/mapping_helpers/airlock/access/all/engineering/station_engineer,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "gravity"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/gravitygenerator)
 "kav" = (
 /obj/effect/turf_decal/caution{
 	dir = 1
@@ -59329,6 +59491,29 @@
 	},
 /turf/simulated/floor/catwalk/grey,
 /area/station/engineering/transmission_laser)
+"kgU" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/window/classic/reversed{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/autoname{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id_tag = "kitchenhall";
+	name = "Kitchen Shutters";
+	dir = 2
+	},
+/obj/item/storage/fancy/donut_box,
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/kitchen)
 "khl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -59344,6 +59529,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/qm)
+"khp" = (
+/obj/effect/map_effect/dynamic_airlock/door/exterior,
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/obj/machinery/access_button/offset/southwest,
+/turf/simulated/floor/plating/airless,
+/area/station/engineering/hardsuitstorage)
 "khs" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/machinery/door/poddoor/preopen{
@@ -59400,21 +59593,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/xenobiology)
-"kij" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Interrogation"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/interrogation)
 "kiq" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/portable/canister/air,
@@ -59442,18 +59620,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
-"kiQ" = (
-/obj/machinery/door/airlock/vault{
-	locked = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/vault,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/dark,
-/area/station/command/vault)
 "kjd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -59661,6 +59827,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
+"kmS" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/security/lobby)
 "knc" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -59681,17 +59858,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint2)
-"knH" = (
-/obj/machinery/door/airlock/vault{
-	locked = 1;
-	name = "abandoned vault"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/apmaint)
 "knT" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
@@ -59756,12 +59922,44 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
+"kpQ" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Internal Medbay Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/station/maintenance/aft)
 "kpR" = (
 /obj/structure/rack,
 /obj/item/wrench,
 /obj/item/clothing/head/welding,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"kqm" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/command/bridge)
 "kqO" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/shelf/security,
@@ -59773,17 +59971,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/south)
-"kre" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/asmaint2)
 "krv" = (
 /obj/structure/window/reinforced,
 /obj/structure/grille,
@@ -59801,6 +59988,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
+"krF" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "BrigLeft";
+	name = "Brig Foyer Left Entrance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "krG" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
@@ -59823,26 +60029,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
-"ksh" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	id_tag = "magistrateofficedoor"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/command/magistrate,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Magistrate"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/station/legal/magistrate)
 "ksi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -59908,18 +60094,24 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/engine/reactor)
+"ksW" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/storage/tools)
 "ktl" = (
 /obj/structure/sign/poster/official/obey/directional/north,
 /obj/effect/spawner/random/trash,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
-"kto" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "ktQ" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -59943,6 +60135,16 @@
 /obj/effect/turf_decal/tiles/department/medical,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/reception)
+"kun" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tiles/department/cargo/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/nw)
 "kuA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59974,30 +60176,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/abandonedbar)
-"kwE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/command/glass{
-	name = "Trainer's Office";
-	id_tag = "nct"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/procedure/trainer,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "NCT"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/procedure/trainer_office)
 "kwG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/spawner/nukedisc_respawn,
@@ -60069,16 +60247,20 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
-"kxY" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering"
+"kxG" = (
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Secondary Storage";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/tiles/department/medical,
 /turf/simulated/floor/plasteel,
-/area/station/engineering/hardsuitstorage)
+/area/station/medical/storage)
 "kyf" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -60158,15 +60340,6 @@
 /obj/effect/turf_decal/tiles/department/medical/side,
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
-"kBe" = (
-/obj/machinery/door/airlock{
-	name = "Prison Toilets"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/security/permabrig)
 "kBk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -60373,27 +60546,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/station/supply/smith_office)
-"kEx" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/obj/effect/turf_decal/tiles/department/medical,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/reception)
-"kEz" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint2)
 "kEA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -60440,6 +60592,25 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/port/east)
+"kFP" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "BrigLeft";
+	name = "Brig Foyer Left Entrance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "kFS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -60577,23 +60748,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
-"kJi" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "medbayfoyerport";
-	name = "Medbay Entrance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/obj/effect/turf_decal/tiles/white/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/medical/reception)
 "kJk" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
@@ -60623,17 +60777,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
-"kJO" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint2)
 "kJW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -60725,6 +60868,57 @@
 /obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/hallway)
+"kLt" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tiles/department/medical/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/medbay2)
+"kLC" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Fore Starboard Solar Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/solar_maintenance/fore_starboard)
+"kLT" = (
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	location = "Medbay"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/obj/machinery/door/window/classic/reversed{
+	dir = 1;
+	name = "Medical Delivery"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/general{
+	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint2)
 "kMc" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -60741,6 +60935,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
+"kMO" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/external{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
 "kNi" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
@@ -60769,6 +60974,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
+"kNH" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "kNS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
@@ -60797,26 +61008,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
-"kOE" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Internal Affairs Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/iaa,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "IAA"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/station/legal/lawoffice)
 "kOU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
@@ -60932,6 +61123,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint2)
+"kRS" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/turf_decal/tiles/department/medical,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/reception)
 "kSn" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
@@ -60989,18 +61192,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"kTh" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/command/side{
-	dir = 8
+"kSS" = (
+/obj/machinery/door/poddoor{
+	id_tag = "maint1"
 	},
-/obj/machinery/light_switch{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/medical/surgery/observation)
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "kTv" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -61172,6 +61372,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
+"kWO" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tiles/department/security/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison/cell_block/a)
 "kXd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -61278,19 +61488,14 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/robotics)
-"kZX" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"kYZ" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Escape Pod 4 Airlock";
+	id_tag = "emergency_home";
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/mining,
-/obj/effect/mapping_helpers/airlock/access/any/supply/smith,
-/turf/simulated/floor/plasteel,
-/area/station/supply/smith_office)
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage)
 "laa" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel/dark,
@@ -61409,6 +61614,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"ldm" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/science/lobby)
 "ldn" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -61430,17 +61642,6 @@
 /obj/item/pen/multi/fountain,
 /turf/simulated/floor/carpet/black,
 /area/station/command/meeting_room)
-"ldZ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	name = "E.V.A."
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/eva,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/ai_monitored/storage/eva)
 "lee" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -61470,19 +61671,6 @@
 "ler" = (
 /turf/simulated/wall,
 /area/station/legal/courtroom/gallery)
-"let" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance";
-	security_level = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
 "lfn" = (
 /obj/effect/turf_decal/tiles/department/security,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -61635,6 +61823,24 @@
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
+"ljF" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/department/medical,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/reception)
 "ljI" = (
 /obj/structure/table,
 /obj/item/stamp/granted,
@@ -61683,6 +61889,22 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/security/warden)
+"llc" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/window/reinforced/normal{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/autoname{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/general{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/station/security/checkpoint/secondary)
 "llf" = (
 /obj/effect/turf_decal/tiles/department/medical/checker,
 /turf/simulated/floor/plasteel/white,
@@ -61788,27 +62010,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/sorting)
-"lnN" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/secondary/entry/north)
 "lnQ" = (
 /obj/effect/turf_decal/delivery/partial,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
-"lnR" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Hydroponics Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint2)
 "lnV" = (
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall/r_wall,
@@ -61865,6 +62070,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
+"lpr" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Prison Library";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/wood,
+/area/station/security/permabrig)
 "lpu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/extra_insulated{
@@ -61904,15 +62127,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
-"lqc" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/station/maintenance/asmaint2)
 "lqd" = (
 /obj/effect/mapping_helpers/turfs/rust/maybe,
 /turf/simulated/wall,
@@ -61970,13 +62184,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/simulated/floor/plasteel,
 /area/station/security/storage)
-"lrk" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Internal Medbay Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/turf/simulated/floor/plating,
-/area/station/maintenance/medmaint)
 "lrm" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor/plating,
@@ -62095,30 +62302,23 @@
 	},
 /turf/simulated/floor/engine/airless,
 /area/station/science/toxins/test)
-"ltR" = (
-/obj/structure/plasticflaps{
-	opacity = 1
+"ltB" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms";
+	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/classic/normal{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/autoname{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/general{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/extra_insulated{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/apmaint2)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/public/toilet/lockerroom)
 "luh" = (
 /obj/machinery/shower/directional/west,
 /turf/simulated/floor/plasteel{
@@ -62292,6 +62492,17 @@
 "lyB" = (
 /turf/simulated/wall,
 /area/station/maintenance/starboard)
+"lyI" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Fabrication";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/control)
 "lyQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -62362,34 +62573,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"lAE" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	autoclose = 0;
-	id_tag = "xeno_door_ext";
-	locked = 1;
-	name = "Xenobiology External Airlock"
+"lAp" = (
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Cloning";
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/access_button{
-	autolink_id = "xeno_btn_ext";
-	name = "Xenobiology Access Button";
-	pixel_x = -24;
-	req_access = list(55)
-	},
-/obj/effect/turf_decal/stripes,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter"
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
 	},
-/turf/simulated/floor/plasteel/white,
-/area/station/science/xenobiology)
+/area/station/medical/cloning)
 "lAG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/carpet,
@@ -62427,20 +62625,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/north)
-"lBq" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
-	name = "Head of Security"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/hos,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/dark,
-/area/station/command/office/hos)
 "lBt" = (
 /obj/effect/turf_decal/woodsiding{
 	dir = 8
@@ -62545,6 +62729,17 @@
 /obj/machinery/atmospherics/refill_station/plasma,
 /turf/simulated/floor/plasteel/white,
 /area/station/hallway/primary/aft/south)
+"lEn" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/se)
 "lEy" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -62654,15 +62849,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/science/storage)
-"lHg" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/rd,
-/turf/simulated/floor/plasteel/dark,
-/area/station/science/server)
 "lHi" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -62676,6 +62862,20 @@
 /obj/item/bodybag,
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/starboard)
+"lHq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/turf/simulated/floor/plasteel,
+/area/station/security/main)
 "lHs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/oil/maybe,
@@ -62724,16 +62924,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
-"lIb" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
-/obj/machinery/door/airlock/engineering/glass{
-	autoclose = 0;
-	id_tag = "engsm_door_ext";
-	locked = 1;
-	name = "Reactor Exterior Access"
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/control)
 "lIl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -62927,13 +63117,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
-"lNi" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance/external,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
 "lNE" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -63022,6 +63205,22 @@
 /obj/structure/sign/poster/official/safety_eye_protection/directional/east,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/transmission_laser)
+"lPA" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Chamber Observation";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/catwalk/black,
+/area/station/turret_protected/ai)
 "lPC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -63133,32 +63332,29 @@
 /obj/effect/turf_decal/tiles/department/medical/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/barber)
-"lRt" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Foyer"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/turret_protected/aisat/interior)
 "lRv" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"lRy" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/science/lobby)
 "lRI" = (
 /obj/machinery/atmospherics/refill_station/nitrogen,
 /turf/simulated/floor/plasteel/white,
 /area/station/hallway/secondary/exit)
+"lRJ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Engineering";
+	name = "Engineering Security Doors"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/equipmentstorage)
 "lSg" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/spawner/random/cobweb/right/frequent,
@@ -63171,6 +63367,18 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/gravitygenerator)
+"lSy" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/cargo/corner{
+	dir = 8
+	},
+/obj/structure/sign/cargo{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/sw)
 "lSz" = (
 /obj/structure/railing{
 	dir = 1
@@ -63308,15 +63516,6 @@
 /obj/machinery/atmospherics/unary/passive_vent,
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/toxins/mixing)
-"lVK" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/white,
-/area/station/maintenance/starboard)
 "lVS" = (
 /obj/structure/statue/cyberiad/center/east,
 /turf/simulated/floor/plasteel,
@@ -63518,14 +63717,6 @@
 /obj/effect/spawner/window,
 /turf/simulated/floor/grass/no_creep,
 /area/station/hallway/primary/central/south)
-"mbO" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint2)
 "mcb" = (
 /obj/structure/chair/sofa/pew/right{
 	dir = 1
@@ -63572,7 +63763,7 @@
 	dir = 1;
 	level = 3;
 	name = "Distribution and Waste Monitor";
-	autolink_sensors = list("mair_in_meter"="Mixed Air In","air_sensor"="Mixed Air Supply Tank","mair_out_meter"="Mixed Air Out","dloop_atm_meter"="Distribution Loop","wloop_atm_meter"="Waste Loop")
+	autolink_sensors = list("mair_in_meter" = "Mixed Air In", "air_sensor" = "Mixed Air Supply Tank", "mair_out_meter" = "Mixed Air Out", "dloop_atm_meter" = "Distribution Loop", "wloop_atm_meter" = "Waste Loop")
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
@@ -63677,6 +63868,22 @@
 /obj/machinery/alarm/directional/east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"mfb" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos/control)
 "mfl" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos{
@@ -63708,6 +63915,21 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
+"mfx" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/station/public/storage/office)
 "mfM" = (
 /turf/simulated/floor/plasteel,
 /area/station/science/lobby)
@@ -63732,19 +63954,6 @@
 /obj/effect/decal/cleanable/blood/tracks/mapped,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"mgx" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/medical/morgue)
 "mgA" = (
 /obj/effect/turf_decal/tiles/department/medical/corner{
 	dir = 8
@@ -63847,6 +64056,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
+"miH" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/mining{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/miningdock)
 "miM" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -64046,6 +64272,21 @@
 /obj/machinery/economy/vending/wallmed/directional/west,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft2)
+"mlK" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/public/storage/tools)
 "mlP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
@@ -64055,12 +64296,6 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
-"mmw" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/apmaint)
 "mmE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -64109,17 +64344,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/east)
-"mnx" = (
-/obj/machinery/door/airlock,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/service/janitor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/service/janitor)
 "mnD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -64166,6 +64390,36 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/reception)
+"mpx" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	id = "Cell 3";
+	name = "Cell 3"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig{
+	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison/cell_block/a)
 "mqP" = (
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Secure Gate";
@@ -64312,17 +64566,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
-"muh" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/virology{
-	name = "Virology Bedroom"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/effect/turf_decal/tiles/department/virology,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/virology)
 "mun" = (
 /obj/machinery/shieldwallgen,
 /obj/structure/window/reinforced{
@@ -64414,6 +64657,40 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/chemistry)
+"mwH" = (
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/machinery/door/window/classic/reversed{
+	dir = 1;
+	name = "Janitor Delivery"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	location = "Janitor"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/janitor{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
+"mxi" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/asmaint2)
 "mxy" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/turf_decal/tiles/department/medical,
@@ -64512,6 +64789,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hardsuitstorage)
+"myY" = (
+/obj/machinery/door/airlock{
+	name = "Bathroom";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/security/main)
 "mze" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags{
@@ -64611,6 +64897,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
+"mCc" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fpmaint)
 "mCr" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Robotics Maintenance"
@@ -64890,6 +65186,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
+"mId" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	name = "Test Lab";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
+/obj/effect/mapping_helpers/airlock/access/any/science/tox,
+/turf/simulated/floor/plasteel,
+/area/station/science/misc_lab)
 "mIu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -65042,28 +65353,6 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/public/dorms)
-"mLR" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/machinery/door/window/classic/reversed{
-	dir = 1;
-	name = "Janitor Delivery"
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	location = "Janitor"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/janitor{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery/hollow,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fore)
 "mLY" = (
 /obj/effect/decal/cleanable/generic,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -65114,6 +65403,28 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/green,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"mMN" = (
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/security/prisonlockers)
 "mNd" = (
 /obj/machinery/airlock_controller/access_controller{
 	name = "Reactor Access Console";
@@ -65136,20 +65447,6 @@
 /obj/machinery/disposal,
 /turf/simulated/floor/wood,
 /area/station/command/office/blueshield)
-"mNq" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/reinforced/normal{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/autoname{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/general{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/security/checkpoint/secondary)
 "mNR" = (
 /obj/machinery/hydroponics/soil,
 /turf/simulated/floor/plating,
@@ -65170,16 +65467,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/station/supply/smith_office)
-"mOi" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/bananium,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/service/clown,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/station/service/clown)
 "mOr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -65288,17 +65575,6 @@
 /obj/machinery/requests_console/directional/north,
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
-"mRs" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Secondary Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/tiles/department/medical,
-/turf/simulated/floor/plasteel,
-/area/station/medical/storage)
 "mRJ" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -65311,6 +65587,16 @@
 /obj/item/clothing/glasses/hud/skills,
 /turf/simulated/floor/carpet,
 /area/station/medical/psych)
+"mRL" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint2)
 "mRO" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
@@ -65518,6 +65804,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
+"mXK" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/asmaint)
 "mXT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -65544,6 +65843,24 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
+"mYq" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/tox_storage,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/sign/science/cans_sci{
+	pixel_x = 32
+	},
+/obj/machinery/door/airlock/research/glass{
+	name = "Toxins Storage";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/science/storage)
 "mZf" = (
 /obj/machinery/conveyor/west{
 	id = "garbage"
@@ -65599,24 +65916,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/ntrep)
-"nab" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/security/prisonlockers)
 "naB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -65760,6 +66059,33 @@
 /obj/item/seeds/poppy,
 /turf/simulated/floor/grass,
 /area/station/maintenance/asmaint2)
+"neZ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor{
+	id = "Cell 4";
+	name = "Cell 4"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig,
+/obj/item/radio/intercom{
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison/cell_block/a)
 "nfe" = (
 /obj/structure/cable,
 /obj/effect/spawner/window/reinforced/polarized/grilled{
@@ -65783,6 +66109,25 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/tools/auxiliary)
+"nfy" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/turf/simulated/floor/plasteel,
+/area/station/security/main)
 "nfE" = (
 /obj/machinery/shower/directional/west,
 /obj/machinery/airlock_controller/access_controller{
@@ -65871,18 +66216,6 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
-"njm" = (
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock";
-	name = "Escape Pod Hatch"
-	},
-/obj/docking_port/mobile/pod{
-	dir = 2;
-	id = "pod4";
-	name = "escape pod 4"
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/pod_4)
 "njn" = (
 /obj/effect/spawner/random/storage,
 /obj/effect/spawner/random/maintenance,
@@ -65909,6 +66242,15 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/storage/secondary)
+"nkl" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/medical/reception)
 "nkX" = (
 /obj/machinery/camera{
 	c_tag = "Brig Labor Camp Airlock North"
@@ -65938,6 +66280,17 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
+"nlt" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint2)
 "nlK" = (
 /obj/machinery/light{
 	dir = 8
@@ -65962,6 +66315,19 @@
 /obj/effect/turf_decal/tiles/white/side,
 /turf/simulated/floor/plasteel,
 /area/station/medical/paramedic)
+"nmX" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/poddoor{
+	id_tag = "maint1"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "nmZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -66136,6 +66502,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/smith_office)
+"nrR" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint)
 "nrS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -66169,6 +66551,23 @@
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"nsR" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/medical/morgue)
 "nsU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -66249,6 +66648,33 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_port)
+"ntG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/command/glass{
+	name = "Trainer's Office";
+	id_tag = "nct";
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/procedure/trainer,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "NCT"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/procedure/trainer_office)
 "nuq" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
@@ -66263,15 +66689,6 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/break_room)
-"nus" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/asmaint2)
 "nuM" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -66395,13 +66812,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"nxI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/purple,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/asmaint)
 "nxN" = (
 /obj/effect/turf_decal/trimline/misc/toxins/arrow_cw,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -66439,6 +66849,31 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
+"nyd" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	id_tag = "viro_door_int";
+	locked = 1;
+	name = "Virology Lab Internal Airlock";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/access_button{
+	autolink_id = "viro_btn_int";
+	name = "Virology Lab Access Button";
+	pixel_x = -24;
+	req_access = list(39)
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/virology)
 "nyC" = (
 /obj/effect/spawner/random/storage,
 /turf/simulated/floor/plating,
@@ -66454,25 +66889,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
-"nzc" = (
-/obj/machinery/door/airlock/research{
-	name = "Research Division Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
-/obj/effect/mapping_helpers/airlock/access/any/science/research,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/science/hallway)
 "nzn" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel/reactor_pool,
@@ -66513,14 +66929,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
-"nAt" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
 "nAy" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
@@ -66533,16 +66941,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
-"nAQ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/service/hydroponics)
 "nAZ" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -66618,6 +67016,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
+"nCg" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage)
 "nCk" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
@@ -66646,6 +67059,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage)
+"nCp" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fpmaint)
 "nCs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -66803,6 +67227,20 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/north)
+"nGd" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/controlroom)
 "nGk" = (
 /obj/structure/sign/service/custodian{
 	pixel_x = 32
@@ -66835,21 +67273,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonershuttle)
-"nGS" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Solitary Confinement 1"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tiles/department/security,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
 "nHq" = (
 /obj/machinery/light/small,
 /obj/structure/cable/extra_insulated{
@@ -66881,6 +67304,21 @@
 /obj/machinery/status_display,
 /turf/simulated/wall,
 /area/station/hallway/secondary/exit)
+"nHz" = (
+/obj/machinery/door/airlock/command{
+	name = "Bridge";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/department/medical/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/command/bridge)
 "nHA" = (
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -66953,6 +67391,20 @@
 /obj/effect/turf_decal/tiles/department/virology,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
+"nJu" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint2)
 "nJv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -67038,16 +67490,6 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
-"nLW" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/atmos{
-	name = "Fore-Port Secondary Atmospherics Maintenance"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint2)
 "nLY" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -67062,6 +67504,16 @@
 /area/station/command/office/rd)
 "nMd" = (
 /obj/effect/mapping_helpers/turfs/burn,
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint)
+"nMe" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "nMi" = (
@@ -67139,6 +67591,25 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
+"nNm" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "Chief Engineer's Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "CE"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/command/office/ce)
 "nNB" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -67227,23 +67698,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"nPG" = (
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/command{
-	name = "Bridge"
-	},
-/obj/effect/turf_decal/tiles/department/medical/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/command/bridge)
 "nPU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -67347,14 +67801,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
-"nSG" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/apmaint)
 "nSQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -67423,6 +67869,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/meeting_room)
+"nUu" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "E.V.A. Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/eva,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fpmaint)
 "nVf" = (
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/engine/reactor)
@@ -67593,6 +68050,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"nYw" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Foyer";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/turret_protected/aisat/interior)
 "nYC" = (
 /obj/structure/cable,
 /obj/structure/cable{
@@ -67945,21 +68419,6 @@
 /obj/effect/landmark/start/chief_medical_officer,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/cmo)
-"ohm" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
 "ohJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 4
@@ -67973,6 +68432,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
+"ohQ" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
 "oij" = (
 /obj/structure/chair/sofa/left{
 	color = "#85130b"
@@ -68048,14 +68518,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/south)
-"ojp" = (
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "MiniSat Maintenance"
-	},
-/turf/simulated/floor/plating,
-/area/station/aisat/hall)
 "ojs" = (
 /obj/effect/turf_decal/tiles/department/cargo/side{
 	dir = 4
@@ -68134,22 +68596,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/solar_maintenance/fore_starboard)
-"okv" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Chief Engineer's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "CE"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/command/office/ce)
 "okS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -68184,18 +68630,6 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/engineering/atmos)
-"olI" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/asmaint)
 "olO" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-8"
@@ -68262,26 +68696,6 @@
 /obj/effect/turf_decal/tiles/white/side,
 /turf/simulated/floor/plasteel,
 /area/station/science/lobby)
-"onW" = (
-/obj/machinery/door/airlock/command{
-	name = "Bridge"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/department/medical/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/command/bridge)
-"onX" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/turf_decal/tiles/department/medical,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/reception)
 "onZ" = (
 /obj/structure/rack{
 	dir = 8;
@@ -68322,6 +68736,16 @@
 /obj/structure/dresser/wardrobe/captain,
 /turf/simulated/floor/carpet,
 /area/station/command/office/captain/bedroom)
+"ooF" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/security/corner{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/simulated/floor/plasteel,
+/area/station/security/lobby)
 "ooI" = (
 /obj/machinery/light{
 	dir = 1
@@ -68433,6 +68857,21 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/server/coldroom)
+"orw" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/starboard)
 "orE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/maintenance,
@@ -68480,16 +68919,6 @@
 /obj/effect/turf_decal/tiles/department/medical/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/security/permabrig)
-"osi" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/controlroom)
 "osm" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/turf_decal/tiles/department/science/side{
@@ -68545,18 +68974,6 @@
 /obj/effect/turf_decal/stripes,
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
-"otk" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint2)
 "otn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -68607,22 +69024,6 @@
 /obj/machinery/alarm/directional/south,
 /turf/simulated/floor/plasteel,
 /area/station/science/storage)
-"ouf" = (
-/obj/machinery/status_display{
-	pixel_x = 32
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry)
 "ouh" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -68669,6 +69070,18 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
+"ovl" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/public/storage/emergency/port)
 "ovL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -68919,30 +69332,30 @@
 /obj/machinery/atmospherics/portable/canister/toxins,
 /turf/simulated/floor/plasteel,
 /area/station/science/storage)
+"oAF" = (
+/obj/machinery/status_display{
+	pixel_x = 32
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "oAS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
-"oBf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Research Division Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
-/obj/effect/mapping_helpers/airlock/access/any/science/research,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/science/hallway)
 "oBz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -69026,6 +69439,19 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/coldroom)
+"oDP" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/starboard)
 "oDT" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/structure/cable/yellow{
@@ -69053,6 +69479,23 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/asmaint)
+"oEA" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/robotics)
 "oEG" = (
 /obj/structure/chair{
 	dir = 8
@@ -69339,17 +69782,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/legal/lawoffice)
-"oJY" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/virology/glass{
-	name = "Monkey Pen"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/virology)
 "oJZ" = (
 /obj/structure/sign/poster/official/science/directional/east,
 /turf/simulated/floor/plating,
@@ -69401,6 +69833,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/ne)
+"oKQ" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Morgue Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint2)
 "oLk" = (
 /obj/machinery/atmospherics/unary/outlet_injector/on{
 	dir = 1;
@@ -69408,27 +69855,6 @@
 	},
 /turf/simulated/floor/engine/o2,
 /area/station/engineering/atmos)
-"oLC" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/holosign/surgery{
-	id = "surgery2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tiles/department/command,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Operating Theatre 2"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Surgery 2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/medical/surgery/secondary)
 "oLJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -69525,6 +69951,25 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/north)
+"oOj" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Internal Affairs Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/iaa,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "IAA"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/legal/lawoffice)
 "oOP" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/simulated/floor/plating,
@@ -69630,17 +70075,23 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/public/vacant_office)
-"oQy" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/extra_insulated{
+"oQN" = (
+/obj/machinery/door/airlock/tranquillite{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/service/mime,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fore)
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white{
+	icon_regular_floor = "yellowsiding"
+	},
+/area/station/service/mime)
 "oRn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -69697,19 +70148,6 @@
 /obj/machinery/door/airlock/maintenance/external,
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage)
-"oSr" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/research,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/rnd)
 "oSt" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -69841,16 +70279,6 @@
 /obj/effect/turf_decal/tiles/department/security/corner,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"oVg" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Library Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/station/maintenance/fsmaint)
 "oVs" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance,
@@ -69893,7 +70321,7 @@
 	dir = 8;
 	level = 3;
 	name = "Distribution and Waste Monitor";
-	autolink_sensors = list("mair_in_meter"="Mixed Air In","air_sensor"="Mixed Air Supply Tank","mair_out_meter"="Mixed Air Out","dloop_atm_meter"="Distribution Loop","wloop_atm_meter"="Waste Loop")
+	autolink_sensors = list("mair_in_meter" = "Mixed Air In", "air_sensor" = "Mixed Air Supply Tank", "mair_out_meter" = "Mixed Air Out", "dloop_atm_meter" = "Distribution Loop", "wloop_atm_meter" = "Waste Loop")
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/control)
@@ -69965,6 +70393,20 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"oYa" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/port)
 "oYb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -70091,6 +70533,20 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/permabrig)
+"pby" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Aft Starboard Solar Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/solar_maintenance/aft_starboard)
 "pbY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 1
@@ -70394,6 +70850,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/disposal)
+"pku" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Chapel Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/fsmaint)
 "pkK" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -70457,20 +70926,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
-"pmZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "Brig"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/turf/simulated/floor/plasteel,
-/area/station/security/processing)
 "pnc" = (
 /turf/simulated/wall,
 /area/station/supply/smith_office)
@@ -70597,18 +71052,6 @@
 /obj/effect/turf_decal/tiles/dark/side,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"pqq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/station/security/range)
 "pqA" = (
 /obj/effect/spawner/random/blood/maybe,
 /turf/simulated/floor/plasteel,
@@ -70688,21 +71131,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
-"psR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/structure/door_assembly/door_assembly_silver{
-	anchored = 1;
-	move_force = 10000;
-	move_resist = 10000;
-	name = "broken toilet airlock"
-	},
-/obj/structure/barricade/wooden/crude,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/maintenance/apmaint)
 "psT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/blood/maybe,
@@ -70713,6 +71141,17 @@
 /obj/item/target/syndicate,
 /turf/simulated/floor/engine/airless,
 /area/station/science/toxins/test)
+"ptx" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/ne)
 "ptK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -70781,6 +71220,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/west)
+"puP" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "pvI" = (
 /obj/effect/turf_decal/tiles/jobs/bar/checker,
 /obj/structure/table/reinforced,
@@ -71209,27 +71659,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
-"pDH" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "medbayfoyerport";
-	name = "Medbay Entrance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/department/medical,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/reception)
 "pDV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tiles/jobs/bar/checker,
@@ -71314,6 +71743,13 @@
 /obj/structure/sign/poster/official/random/directional/west,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"pFq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft2)
 "pFI" = (
 /obj/machinery/power/apc/important/directional/north,
 /obj/structure/cable{
@@ -71369,16 +71805,22 @@
 /obj/effect/turf_decal/tiles/department/medical/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/barber)
-"pHF" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Chapel Maintenance"
+"pHu" = (
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/fsmaint)
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/obj/effect/turf_decal/tiles/department/medical,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/reception)
 "pHN" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -71386,6 +71828,15 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/ai_upload)
+"pHW" = (
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "trader_home";
+	name = "Port Bay 4 Airlock";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/secondary/entry/north)
 "pIq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -71408,14 +71859,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/hallway/secondary/entry/south)
-"pIE" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Warehouse Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/cargo_bay,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
 "pIR" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -71440,6 +71883,16 @@
 /obj/structure/marker_beacon/dock_marker,
 /turf/space,
 /area/space/nearstation)
+"pJB" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/north)
 "pKa" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/turf_decal/tiles/department/engineering/side{
@@ -71465,16 +71918,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonershuttle)
-"pKs" = (
-/obj/machinery/door/airlock/engineering/glass{
-	autoclose = 0;
-	id_tag = "engsm_door_int";
-	locked = 1;
-	name = "Reactor Interior Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/control)
 "pLr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -71573,6 +72016,29 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"pMS" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass{
+	id_tag = "magistrateofficedoor";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/command/magistrate,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Magistrate"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/legal/magistrate)
 "pNd" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -71760,6 +72226,20 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
+"pPJ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/tox_storage,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/research/glass{
+	name = "Toxins Storage";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/science/storage)
 "pQg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -71846,6 +72326,36 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/test_chamber)
+"pSq" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	id = "Cell 1";
+	name = "Cell 1"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison/cell_block/a)
 "pSs" = (
 /obj/structure/toilet/directional/east,
 /turf/simulated/floor/plating,
@@ -71903,14 +72413,6 @@
 	},
 /turf/simulated/floor/catwalk/black,
 /area/station/engineering/control)
-"pUb" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fpmaint2)
 "pUu" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -71982,15 +72484,6 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/wood,
 /area/station/public/dorms)
-"pVr" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Custodial Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/janitor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
 "pVx" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -72018,15 +72511,18 @@
 /obj/machinery/alarm/directional/east,
 /turf/simulated/floor/plasteel,
 /area/station/supply/warehouse)
-"pWT" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable{
-	icon_state = "1-2"
+"pWw" = (
+/obj/machinery/door/airlock/freezer{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fpmaint2)
+/obj/structure/barricade/wooden,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/maintenance/asmaint)
 "pWW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/spawner/nukedisc_respawn,
@@ -72055,11 +72551,21 @@
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plating,
 /area/station/security/permabrig)
-"pYo" = (
-/obj/machinery/door/airlock/titanium/glass,
-/obj/structure/fans/tiny/invisible,
-/turf/simulated/floor/indestructible/titanium,
-/area/shuttle/arrival/station)
+"pYq" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint2)
 "pYy" = (
 /obj/machinery/newscaster/directional/west,
 /obj/structure/closet/wardrobe/yellow,
@@ -72251,6 +72757,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/lounge)
+"qdS" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/secondary/entry/north)
 "qed" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/cable{
@@ -72304,24 +72820,6 @@
 /obj/item/assembly/mousetrap/armed,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"qeL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Warden's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/armory/secure)
-"qeM" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fpmaint)
 "qfA" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -72370,19 +72868,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
-"qhg" = (
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external/glass{
-	name = "Labor Camp Airlock";
-	id_tag = "laborcamp_home"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plasteel,
-/area/station/security/prisonershuttle)
 "qhq" = (
 /turf/simulated/wall,
 /area/station/science/misc_lab)
@@ -72434,6 +72919,16 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/science/xenobiology)
+"qir" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/medical/cryo)
 "qis" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -72466,14 +72961,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
-"qiE" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/service/clown,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint2)
 "qiN" = (
 /obj/structure/urinal{
 	pixel_y = 30
@@ -72571,21 +73058,6 @@
 "qlh" = (
 /turf/simulated/floor/plasteel/stairs/left,
 /area/station/command/bridge)
-"qlp" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/station_engineer,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "gravity"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/gravitygenerator)
 "qlE" = (
 /obj/item/restraints/handcuffs/cable/green,
 /obj/machinery/conveyor{
@@ -72663,6 +73135,29 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/qm)
+"qmU" = (
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "blueshieldofficedoor";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/blueshield,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "BS"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/wood,
+/area/station/command/office/blueshield)
 "qnh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -73037,22 +73532,6 @@
 	},
 /turf/simulated/floor/plasteel/reactor_pool,
 /area/station/engineering/engine/reactor)
-"qsQ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "BrigLeft";
-	name = "Brig Foyer Left Entrance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
 "qta" = (
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -73329,6 +73808,24 @@
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hardsuitstorage)
+"qAB" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Psych Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "psychoffice"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/station/medical/psych)
 "qAE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tiles/department/science/side{
@@ -73435,6 +73932,26 @@
 /obj/item/storage/fancy/cigars/cohiba,
 /turf/simulated/floor/carpet,
 /area/station/command/office/captain)
+"qCe" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "medbayfoyerport";
+	name = "Medbay Entrance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/obj/effect/turf_decal/tiles/white/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/medical/reception)
 "qCk" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -73538,16 +74055,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/permabrig)
-"qDq" = (
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/external/glass{
-	name = "Labor Camp Airlock";
-	id_tag = "laborcamp_home"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plasteel,
-/area/station/security/prisonershuttle)
 "qDr" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil/random,
@@ -73558,12 +74065,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/abandonedservers)
-"qDJ" = (
-/obj/structure/table_frame,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
 "qEg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -73858,6 +74359,29 @@
 	},
 /turf/simulated/floor/catwalk/grey,
 /area/station/maintenance/electrical/fore_starboard)
+"qJf" = (
+/obj/machinery/door/airlock{
+	name = "Prison Toilets";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/security/permabrig)
+"qJw" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/obj/machinery/door/airlock/engineering/glass{
+	autoclose = 0;
+	id_tag = "engsm_door_ext";
+	locked = 1;
+	name = "Reactor Exterior Access";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/control)
 "qJN" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/dark,
@@ -73905,6 +74429,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/apmaint)
+"qKU" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/starboard)
 "qLd" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/dark,
@@ -73963,6 +74497,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/north)
+"qML" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "qMY" = (
 /obj/effect/turf_decal{
 	dir = 8
@@ -74504,7 +75050,7 @@
 	},
 /obj/machinery/computer/general_air_control{
 	name = "Tank Monitor";
-	autolink_sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous Oxide","waste_sensor"="Gas Mix Tank")
+	autolink_sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous Oxide", "waste_sensor" = "Gas Mix Tank")
 	},
 /obj/machinery/light{
 	dir = 4
@@ -74654,6 +75200,30 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/medical/reception)
+"rdh" = (
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	location = "Kitchen"
+	},
+/obj/machinery/door/window/classic/normal{
+	dir = 1;
+	name = "Kitchen Delivery"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint2)
 "rdL" = (
 /obj/item/kirbyplants/large,
 /obj/structure/extinguisher_cabinet{
@@ -74749,6 +75319,20 @@
 /obj/item/stamp/rep,
 /turf/simulated/floor/carpet/royalblack,
 /area/station/command/office/ntrep)
+"rfX" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/engineering{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/electrical/fore_port)
 "rgb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/extra_insulated{
@@ -74849,12 +75433,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
-"rhU" = (
-/obj/effect/map_effect/dynamic_airlock/door/interior,
-/obj/machinery/door/airlock/external/glass,
-/obj/machinery/access_button/offset/west,
-/turf/simulated/floor/plating,
-/area/station/engineering/hardsuitstorage)
 "ris" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/extinguisher_cabinet{
@@ -75030,6 +75608,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/procedure/trainer_office)
+"rmN" = (
+/obj/structure/table_frame,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "rmT" = (
 /obj/effect/turf_decal/trimline/misc/toxins/line{
 	dir = 1
@@ -75097,6 +75683,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
+"rnD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/purple,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/asmaint)
 "rog" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -75177,31 +75774,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 5
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/asmaint2)
-"rqs" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	location = "Medbay"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/obj/machinery/door/window/classic/reversed{
-	dir = 1;
-	name = "Medical Delivery"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/general{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
 "rqB" = (
@@ -75355,6 +75927,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/catwalk/white,
 /area/station/science/hallway)
+"rtX" = (
+/obj/machinery/door/airlock/public/glass{
+	autoclose = 0;
+	heat_proof = 1;
+	id_tag = "turbine_door_int";
+	name = "Turbine Interior Airlock";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/engine,
+/area/station/maintenance/turbine)
 "rtY" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -75414,6 +76001,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
+"rvs" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/ne)
 "rvD" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
@@ -75550,6 +76150,26 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
+"rzb" = (
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/command{
+	name = "Bridge";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/command/bridge)
 "rzk" = (
 /obj/machinery/door/window/classic/reversed{
 	name = "Glass Door"
@@ -75634,6 +76254,20 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/hos)
+"rAC" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Hydroponics Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint2)
 "rAI" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/structure/machine_frame,
@@ -76061,15 +76695,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/station/supply/lobby)
-"rJZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fsmaint)
 "rKV" = (
 /turf/simulated/wall,
 /area/station/science/hallway)
@@ -76148,19 +76773,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
-"rML" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Chamber Observation"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/catwalk/black,
-/area/station/turret_protected/ai)
 "rMP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -76458,15 +77070,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
-"rUf" = (
-/obj/machinery/door/airlock/maintenance{
-	electrified_until = -1;
-	locked = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
 "rUQ" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -76596,17 +77199,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
-"rYy" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/asmaint)
 "rYY" = (
 /obj/item/radio/intercom{
 	name = "north bump";
@@ -76615,22 +77207,6 @@
 /obj/structure/disposalpipe/junction/y,
 /obj/effect/turf_decal/tiles/neutral/corner{
 	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
-"rZd" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
@@ -76729,6 +77305,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
+"saY" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint)
 "sba" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -76779,28 +77367,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
-"sco" = (
-/obj/machinery/door/airlock/command/glass{
-	id_tag = "blueshieldofficedoor"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/blueshield,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "BS"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/wood,
-/area/station/command/office/blueshield)
 "scq" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -76863,6 +77429,19 @@
 /obj/effect/mapping_helpers/turfs/rust/maybe,
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/solar_maintenance/aft_port)
+"sdS" = (
+/obj/machinery/door/airlock/medical{
+	name = "Operating Theatre Storage";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/station/medical/medbay)
 "sem" = (
 /obj/structure/morgue{
 	dir = 8
@@ -76944,6 +77523,25 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
+"sgO" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Interrogation"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/interrogation)
 "sgT" = (
 /obj/structure/grille/broken,
 /obj/effect/mapping_helpers/turfs/damage,
@@ -77001,17 +77599,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
-"siq" = (
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "MiniSat Maintenance"
-	},
-/turf/simulated/floor/catwalk/black,
-/area/station/aisat/hall)
 "sir" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -77029,16 +77616,6 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"siM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock{
-	name = "Prison Toilets"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/security/permabrig)
 "siX" = (
 /obj/effect/mapping_helpers/airlock/access/all/medical/genetics,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -77188,6 +77765,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/electrical/aft_starboard)
+"snL" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/public/locker)
 "snM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -77255,20 +77844,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
-"spy" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/command/bridge)
 "spC" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -77326,19 +77901,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
-"sqx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/maintenance{
-	name = "Internal Medbay Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/medmaint)
 "sqC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -77376,22 +77938,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/south)
-"srM" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	name = "Detective's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/forensics,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet/grimey,
-/area/station/security/prison/cell_block/a)
 "ssf" = (
 /obj/machinery/light{
 	dir = 8
@@ -77462,13 +78008,6 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/service/chapel/office)
-"stS" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/wood,
-/area/station/maintenance/asmaint)
 "stX" = (
 /obj/effect/landmark/start/scientist,
 /obj/effect/turf_decal/tiles/dark/checker,
@@ -77565,6 +78104,17 @@
 /obj/effect/turf_decal/tiles/department/science/corner,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/hallway)
+"swb" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/north)
 "swk" = (
 /obj/structure/chair,
 /obj/machinery/light{
@@ -77628,12 +78178,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
-"sxJ" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fore)
 "syf" = (
 /obj/effect/turf_decal/tiles/department/engineering/side{
 	dir = 5
@@ -77644,16 +78188,6 @@
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
-"syo" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/turf/simulated/floor/plasteel,
-/area/station/security/main)
 "syp" = (
 /obj/effect/turf_decal/trimline/misc/toxins/corner{
 	dir = 1
@@ -77696,6 +78230,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/catwalk/white,
 /area/station/maintenance/starboard)
+"syV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/maintenance{
+	name = "Internal Medbay Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/medmaint)
 "syW" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -77782,6 +78330,22 @@
 /obj/structure/cable,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/execution)
+"sCO" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security{
+	name = "Equipment Storage";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/security/storage)
 "sCW" = (
 /obj/structure/rack{
 	dir = 1
@@ -77860,6 +78424,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
+"sEj" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/virology{
+	name = "Virology Bedroom";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/effect/turf_decal/tiles/department/virology,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/virology)
 "sEl" = (
 /obj/structure/bed,
 /obj/effect/landmark/spawner/nukedisc_respawn,
@@ -77954,17 +78532,6 @@
 /obj/structure/grille,
 /turf/space,
 /area/space/nearstation)
-"sGw" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint2)
 "sGU" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -78012,18 +78579,6 @@
 "sHt" = (
 /turf/simulated/floor/engine,
 /area/holodeck/alphadeck)
-"sHW" = (
-/obj/machinery/door/airlock/welded,
-/obj/structure/barricade/wooden,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/apmaint)
 "sIn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -78057,17 +78612,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/north)
-"sJu" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Crematorium"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/crematorium,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/service/chapel/office)
 "sJC" = (
 /obj/machinery/economy/slot_machine,
 /obj/effect/mapping_helpers/turfs/damage,
@@ -78105,6 +78649,34 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/maintenance/turbine)
+"sKe" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/service/chapel)
+"sKl" = (
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Coldroom Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "sKD" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/random/oil/maybe,
@@ -78127,22 +78699,6 @@
 /obj/structure/sign/poster/official/help_others/directional/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"sLh" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Internal Affairs Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/iaa,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "IAA"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/station/legal/lawoffice)
 "sLv" = (
 /obj/machinery/light,
 /obj/structure/shelf/service,
@@ -78298,6 +78854,28 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/gravitygenerator)
+"sOF" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/window/classic/normal{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/autoname{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id_tag = "kitchenhall";
+	name = "Kitchen Shutters";
+	dir = 2
+	},
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/kitchen)
 "sPb" = (
 /obj/machinery/alarm/directional/north,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -78307,6 +78885,17 @@
 /obj/item/clothing/neck/cloak/old,
 /turf/simulated/floor/carpet,
 /area/station/maintenance/asmaint)
+"sPv" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/service/chapel_office,
+/turf/simulated/floor/plasteel/dark,
+/area/station/service/chapel/office)
 "sPw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -78395,6 +78984,27 @@
 /obj/item/ai_module/corp,
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/ai_upload)
+"sQR" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
+/obj/effect/mapping_helpers/airlock/access/any/science/research,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/science/hallway)
 "sRg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -78437,16 +79047,6 @@
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/wood,
 /area/station/maintenance/aft2)
-"sSb" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Fabrication"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/control)
 "sSf" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -78529,6 +79129,21 @@
 /obj/structure/sign/engineering/atmos,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/control)
+"sWa" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Escape Shuttle Cell";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/secondary/exit)
 "sWc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78604,19 +79219,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
-"sYf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/control)
 "sYi" = (
 /obj/structure/table/glass,
 /obj/machinery/firealarm/directional/north,
@@ -78760,6 +79362,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
+"tbF" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/ne)
 "tbU" = (
 /obj/machinery/light{
 	dir = 1
@@ -78787,15 +79395,23 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
-"tcC" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Maintenance"
+"tco" = (
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/cargo_bay,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
+/obj/machinery/door/airlock/research/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/rnd)
 "tcM" = (
 /obj/effect/spawner/random/cobweb/right/frequent,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -79257,6 +79873,20 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"tmO" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/tiles/department/security/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison/cell_block/a)
 "tmS" = (
 /obj/effect/spawner/random/barrier/grille_maybe,
 /turf/simulated/floor/plating,
@@ -79327,16 +79957,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/north)
-"tpl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
+"tpn" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/north)
+/area/station/hallway/primary/fore)
 "tpM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -79551,6 +80182,20 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hardsuitstorage)
+"tvL" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/department/medical/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/medbay2)
 "twe" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -79851,15 +80496,6 @@
 /obj/vehicle/janicart,
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
-"tDg" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/science/lobby)
 "tDn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 9
@@ -79886,17 +80522,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/station/security/range)
-"tDy" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Kitchen Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint2)
 "tDM" = (
 /obj/effect/spawner/window/reinforced/polarized/grilled{
 	id = "HoS"
@@ -79909,22 +80534,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/office/hos)
-"tEf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "BrigLeft";
-	name = "Brig Foyer Left Entrance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
 "tEh" = (
 /obj/machinery/light{
 	dir = 8
@@ -80200,6 +80809,20 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint2)
+"tKr" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Chamber Hallway";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/catwalk/black,
+/area/station/aisat/hall)
 "tKX" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -80544,35 +81167,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
-"tRp" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/classic/reversed{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/autoname{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id_tag = "kitchenhall";
-	name = "Kitchen Shutters";
-	dir = 2
-	},
-/obj/item/storage/fancy/donut_box,
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/kitchen)
-"tRs" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/wood,
-/area/station/maintenance/asmaint)
 "tRw" = (
 /obj/machinery/shower/directional/east,
 /turf/simulated/floor/plasteel{
@@ -80749,6 +81343,26 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/wood,
 /area/station/maintenance/apmaint)
+"tUj" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Escape Pod 1 Airlock";
+	id_tag = "emergency_home";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/north)
+"tUL" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/public/toilet/unisex)
 "tVd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
@@ -80809,6 +81423,32 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/gravitygenerator)
+"tWm" = (
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/classic/normal{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/autoname{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/general{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint2)
 "tWs" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -81115,6 +81755,26 @@
 /obj/effect/turf_decal/tiles/department/medical,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/sleeper)
+"udA" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "medbayfoyerport";
+	name = "Medbay Entrance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/obj/effect/turf_decal/tiles/white/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/medical/reception)
 "udB" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -81187,12 +81847,6 @@
 /obj/item/beach_ball,
 /turf/simulated/floor/plasteel/reactor_pool,
 /area/station/engineering/engine/reactor)
-"ufq" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tiles/department/science/corner,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/hallway)
 "ufw" = (
 /obj/structure/closet/wardrobe/orange/prison,
 /obj/machinery/status_display{
@@ -81237,14 +81891,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/server)
-"uhi" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/service/mime,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint2)
 "uhl" = (
 /obj/machinery/alarm/directional/west,
 /turf/simulated/floor/plating,
@@ -81253,23 +81899,6 @@
 /obj/effect/spawner/airlock/e_to_w/long/square,
 /turf/simulated/wall/r_wall,
 /area/station/turret_protected/aisat/interior)
-"uhq" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	name = "Biohazard Shutter";
-	id_tag = "RnDChem"
-	},
-/obj/machinery/door/airlock/research/glass{
-	name = "Test Chamber"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/science/tox,
-/obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/misc_lab)
 "uhO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -81496,6 +82125,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/assembly_line)
+"unQ" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "uod" = (
 /obj/structure/rack{
 	dir = 1
@@ -81556,6 +82195,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"upI" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Kitchen Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint2)
 "upS" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/closet/emcloset,
@@ -81908,15 +82561,20 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/robotics)
-"uxZ" = (
-/obj/machinery/door/airlock/multi_tile{
-	name = "maintenance access"
+"uya" = (
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft2)
+/obj/machinery/door/airlock/external/glass{
+	name = "Labor Camp Airlock";
+	id_tag = "laborcamp_home";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/plasteel,
+/area/station/security/prisonershuttle)
 "uyk" = (
 /obj/structure/closet/radiation,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -81991,6 +82649,21 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/science/xenobiology)
+"uzY" = (
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/command{
+	name = "Bridge";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/command/bridge)
 "uAa" = (
 /obj/effect/landmark/start/explorer,
 /turf/simulated/floor/plasteel,
@@ -82066,31 +82739,6 @@
 /obj/machinery/atmospherics/unary/passive_vent,
 /turf/space,
 /area/station/maintenance/starboard)
-"uCq" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/brigdoor{
-	id = "Cell 4";
-	name = "Cell 4"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig,
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison/cell_block/a)
 "uCK" = (
 /obj/structure/closet/wardrobe/white,
 /turf/simulated/floor/plating,
@@ -82103,6 +82751,19 @@
 /obj/effect/spawner/random/library_book/triple,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"uDg" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint2)
 "uDn" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -82262,21 +82923,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"uGG" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prison Library"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/wood,
-/area/station/security/permabrig)
 "uGL" = (
 /obj/effect/turf_decal/trimline/misc/toxins/line{
 	dir = 8
@@ -82336,13 +82982,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"uIs" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
-/turf/simulated/floor/plasteel,
-/area/station/service/hydroponics)
 "uIu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -82461,6 +83100,25 @@
 /obj/item/stack/rods,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
+"uNo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Cryogenics";
+	name = "Cryodorms";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/department/virology/side{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/public/sleep)
 "uNC" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 8
@@ -82615,18 +83273,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/captain)
-"uTl" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Internal Medbay Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
 "uTy" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -82669,6 +83315,18 @@
 /obj/structure/sign/public/salon,
 /turf/simulated/wall,
 /area/station/service/barber)
+"uUV" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/rd,
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/server)
 "uVa" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -82809,11 +83467,40 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"uWs" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	name = "Crematorium";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/crematorium,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/service/chapel/office)
 "uWH" = (
 /obj/machinery/requests_console/directional/west,
 /obj/structure/closet/wardrobe/green,
 /turf/simulated/floor/indestructible/titanium/blue,
 /area/shuttle/arrival/station)
+"uWK" = (
+/obj/machinery/door/airlock/public/glass{
+	autoclose = 0;
+	heat_proof = 1;
+	id_tag = "turbine_door_ext";
+	name = "Turbine Exterior Airlock";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/engine,
+/area/station/maintenance/turbine)
 "uWO" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
@@ -83081,18 +83768,6 @@
 	},
 /turf/simulated/floor/engine/plasma,
 /area/station/engineering/atmos)
-"ves" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Test Lab"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
-/obj/effect/mapping_helpers/airlock/access/any/science/tox,
-/turf/simulated/floor/plasteel,
-/area/station/science/misc_lab)
 "vet" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -83189,15 +83864,6 @@
 /obj/item/clothing/head/hardhat,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
-"vgR" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/asmaint2)
 "vgY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -83223,6 +83889,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/sorting)
+"via" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/white/corner,
+/turf/simulated/floor/plasteel,
+/area/station/medical/reception)
 "vic" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
@@ -83239,6 +83912,21 @@
 /obj/machinery/light,
 /turf/simulated/floor/indestructible/titanium/blue,
 /area/shuttle/arrival/station)
+"vip" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/medical/morgue)
 "viB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -83282,6 +83970,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
+"vjQ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/se)
 "vkC" = (
 /obj/machinery/light{
 	dir = 4
@@ -83388,6 +84085,29 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
+"vnh" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id_tag = "paramedic";
+	name = "Paramedic Garage"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door_control{
+	id = "paramedic";
+	name = "Garage Door Control";
+	pixel_x = -24;
+	req_access = list(66)
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/medical/paramedic)
 "vni" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -83520,21 +84240,20 @@
 /obj/item/bikehorn/rubberducky,
 /turf/simulated/floor/plasteel/reactor_pool,
 /area/station/engineering/engine/reactor)
-"vpR" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Solitary Confinement 2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+"vpQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tiles/department/security,
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Warden's Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/armory/secure)
 "vqH" = (
 /obj/machinery/conveyor/west{
 	id = "garbage"
@@ -83571,14 +84290,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
-"vqX" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/window/reinforced/grilled,
-/turf/simulated/floor/plating,
-/area/station/command/bridge)
 "vrd" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
@@ -83665,6 +84376,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
+"vsS" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/secondary/entry)
 "vtb" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/machinery/door/poddoor/preopen{
@@ -83700,6 +84421,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"vup" = (
+/obj/machinery/door/airlock/engineering{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/electrical/fore_starboard)
 "vuu" = (
 /obj/structure/window/reinforced,
 /obj/machinery/disposal,
@@ -83789,26 +84524,6 @@
 /obj/machinery/atmospherics/portable/pump,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
-"vwp" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/classic/normal{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/autoname{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id_tag = "kitchenhall";
-	name = "Kitchen Shutters";
-	dir = 2
-	},
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/kitchen)
 "vws" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
@@ -83844,18 +84559,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/chemistry)
-"vxt" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/apmaint)
 "vxu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
@@ -84003,6 +84706,20 @@
 /obj/item/stack/sheet/metal,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"vBP" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/engineering{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/electrical/fore_port)
 "vBX" = (
 /obj/structure/reagent_dispensers/spacecleanertank{
 	pixel_y = 27
@@ -84091,6 +84808,17 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
+"vEw" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/wood,
+/area/station/maintenance/asmaint)
 "vEA" = (
 /obj/structure/sink/kitchen/old/directional/east,
 /obj/item/reagent_containers/glass/bucket,
@@ -84112,6 +84840,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
+"vFc" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/asmaint)
 "vFk" = (
 /obj/item/kirbyplants/large,
 /obj/machinery/light,
@@ -84277,17 +85015,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
-"vJQ" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/apmaint2)
 "vJV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -84331,6 +85058,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/storage)
+"vKA" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Diner";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/service/bar)
 "vKD" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -84542,6 +85282,12 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/aft)
+"vOO" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/sw)
 "vPe" = (
 /obj/structure/extinguisher_cabinet{
 	name = "north bump";
@@ -84585,6 +85331,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
+"vRD" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Bay Warehouse Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/cargo_bay,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/port)
 "vRG" = (
 /obj/structure/sign/poster/contraband/revolver/directional/north,
 /turf/simulated/floor/wood,
@@ -84653,6 +85410,20 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
+"vSW" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Security Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fpmaint2)
 "vTg" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -84740,11 +85511,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
-"vVb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft2)
 "vVf" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-4"
@@ -84755,21 +85521,6 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/lounge)
-"vVt" = (
-/obj/machinery/door/airlock/research{
-	name = "Research Division Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
-/obj/effect/mapping_helpers/airlock/access/any/science/research,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/science/hallway)
 "vVK" = (
 /obj/machinery/power/apc/directional/south,
 /obj/structure/cable{
@@ -84863,9 +85614,31 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/tools/auxiliary)
+"vXt" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/science/lobby)
 "vXQ" = (
 /turf/simulated/floor/plasteel/reactor_pool/wall/filter,
 /area/station/engineering/engine/reactor)
+"vXV" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/turf/simulated/floor/plasteel,
+/area/station/service/hydroponics)
 "vYh" = (
 /obj/item/radio/intercom{
 	name = "east bump";
@@ -85102,6 +85875,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/engineering/transmission_laser)
+"wcx" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore)
 "wcA" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light{
@@ -85133,6 +85919,32 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint2)
+"wdg" = (
+/obj/machinery/door/airlock/welded{
+	dir = 4
+	},
+/obj/structure/barricade/wooden,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint)
+"wdj" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/carpet/arcade,
+/area/station/maintenance/fore)
 "wdw" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/crayons,
@@ -85153,7 +85965,7 @@
 	},
 /obj/machinery/computer/general_air_control{
 	name = "Bomb Mix Monitor";
-	autolink_sensors = list("burn_sensor"="Burn Mix")
+	autolink_sensors = list("burn_sensor" = "Burn Mix")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/effect/turf_decal/tiles/department/science/side{
@@ -85331,6 +86143,37 @@
 "whG" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/medmaint)
+"whJ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	autoclose = 0;
+	id_tag = "xeno_door_ext";
+	locked = 1;
+	name = "Xenobiology External Airlock";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/access_button{
+	autolink_id = "xeno_btn_ext";
+	name = "Xenobiology Access Button";
+	pixel_x = -24;
+	req_access = list(55)
+	},
+/obj/effect/turf_decal/stripes,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/science/xenobiology)
 "whN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -85338,6 +86181,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
+"wiK" = (
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
+/obj/effect/mapping_helpers/airlock/access/any/science/research,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/science/hallway)
 "wja" = (
 /obj/structure/rack{
 	dir = 1
@@ -85461,25 +86326,29 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/lounge)
-"wlJ" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
+"wlw" = (
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "BrigRight";
-	name = "Brig Foyer Right Entrance"
+/obj/machinery/door/airlock/glass{
+	name = "Internal Affairs Office";
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/mapping_helpers/airlock/access/all/security/iaa,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Secure Gate";
 	name = "Security Blast Door"
 	},
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "IAA"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/legal/lawoffice)
 "wmh" = (
 /obj/machinery/atmospherics/portable/canister/air,
 /obj/effect/decal/cleanable/dirt,
@@ -85506,6 +86375,17 @@
 	},
 /turf/simulated/floor/carpet/royalblue,
 /area/station/command/office/captain)
+"wmE" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	name = "Research Storage";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/research,
+/turf/simulated/floor/plasteel,
+/area/station/science/hallway)
 "wmU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -85526,20 +86406,19 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
-"wmZ" = (
-/obj/effect/mapping_helpers/airlock/access/any/command/captain,
-/obj/machinery/door/airlock/command{
-	name = "Captain's Bedroom"
-	},
-/obj/structure/cable{
+"wnd" = (
+/obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/station/command/office/captain/bedroom)
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fpmaint2)
 "wni" = (
 /obj/effect/turf_decal/tiles/department/science/corner{
 	dir = 8
@@ -85549,6 +86428,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
+"wnt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/station/security/range)
 "wny" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -85576,16 +86471,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/hallway)
-"woE" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
 "wpf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 6
@@ -85941,17 +86826,6 @@
 /obj/effect/landmark/spawner/nukedisc_respawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
-"wvL" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/medical/morgue)
 "wvO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -85986,18 +86860,29 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/gravitygenerator)
+"wwF" = (
+/obj/effect/mapping_helpers/airlock/access/any/command/hop,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/command{
+	id_tag = "hopofficedoor";
+	name = "Head of Personnel";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/command/office/hop)
 "wwO" = (
 /obj/structure/statue/cyberiad/north/west,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
-"wwY" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
 "wwZ" = (
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "rdrobosurgery"
@@ -86022,6 +86907,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonlockers)
+"wxA" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fpmaint2)
 "wxG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/effect/decal/cleanable/dirt,
@@ -86045,6 +86943,17 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/ai)
+"wyk" = (
+/obj/machinery/door/airlock/engineering/glass{
+	autoclose = 0;
+	id_tag = "engsm_door_int";
+	locked = 1;
+	name = "Reactor Interior Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/control)
 "wym" = (
 /obj/machinery/atmospherics/portable/canister/carbon_dioxide,
 /obj/effect/decal/cleanable/dirt,
@@ -86205,6 +87114,16 @@
 /obj/machinery/alarm/directional/south,
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics/chargebay)
+"wDh" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tiles/department/command/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/medical/surgery/observation)
 "wDt" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -86214,16 +87133,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"wDN" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"wDM" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	dir = 1;
+	location = "Security"
 	},
-/obj/machinery/door/airlock/engineering,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical/fore_port)
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/obj/machinery/door/window/classic/reversed{
+	name = "Security Delivery"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/fore)
 "wDS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -86240,6 +87173,32 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/gravitygenerator)
+"wEe" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "cmoofficedoor";
+	name = "CMO's Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "CMO"
+	},
+/obj/effect/turf_decal/tiles/department/command,
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/office/cmo)
 "wEl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -86264,6 +87223,25 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/hallway)
+"wEv" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "wEz" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery/partial{
@@ -86295,6 +87273,23 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/security/permabrig)
+"wFd" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Chemistry Lab";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/chemistry)
 "wFm" = (
 /obj/machinery/door/airlock/highsecurity,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -86452,6 +87447,28 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/north)
+"wJl" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/window/classic/normal{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id_tag = "kitchenhall";
+	name = "Kitchen Shutters";
+	dir = 2
+	},
+/obj/structure/table/reinforced,
+/obj/effect/mapping_helpers/airlock/windoor/autoname{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
+	dir = 1
+	},
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/kitchen)
 "wJv" = (
 /obj/machinery/light{
 	dir = 4
@@ -86468,17 +87485,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/west)
-"wJH" = (
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock";
-	name = "Escape Pod Hatch"
-	},
-/obj/docking_port/mobile/pod{
-	id = "pod3";
-	name = "escape pod 3"
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/pod_3)
 "wJZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -86504,26 +87510,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/south)
-"wKf" = (
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/command{
-	name = "Bridge"
-	},
-/obj/effect/turf_decal/tiles/department/medical/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/command/bridge)
 "wKl" = (
 /turf/simulated/floor/plasteel,
 /area/station/supply/sorting)
+"wKu" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint)
 "wKx" = (
 /obj/structure/railing{
 	dir = 1
@@ -86603,16 +87602,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
-"wMo" = (
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/station/medical/medbay)
 "wMs" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -86711,24 +87700,6 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/break_room)
-"wOx" = (
-/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/general,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/classic/reversed{
-	desc = "You have the public fridge, pal, lube off.";
-	dir = 1;
-	name = "Security Shield"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/chemistry{
-	dir = 1
-	},
-/obj/machinery/smartfridge/medbay,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/chemistry,
-/obj/machinery/door/window/antitheft/reversed{
-	name = "Anti-Theft Shield"
-	},
-/turf/simulated/floor/plating,
-/area/station/medical/chemistry)
 "wOM" = (
 /obj/effect/turf_decal/tiles/department/security,
 /obj/structure/table,
@@ -86794,6 +87765,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
+"wPW" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/clown,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint2)
 "wQa" = (
 /obj/machinery/requests_console/directional/west,
 /obj/machinery/mineral/equipment_vendor,
@@ -86858,22 +87841,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
-"wRI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	id_tag = "Cryogenics";
-	name = "Cryodorms"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/department/virology/side{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/public/sleep)
 "wRK" = (
 /obj/machinery/light{
 	dir = 1
@@ -86893,6 +87860,26 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"wSB" = (
+/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/window/classic/reversed{
+	desc = "You have the public fridge, pal, lube off.";
+	dir = 1;
+	name = "Security Shield"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/chemistry{
+	dir = 1
+	},
+/obj/machinery/smartfridge/medbay,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/chemistry,
+/obj/machinery/door/window/antitheft/reversed{
+	name = "Anti-Theft Shield"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/chemistry)
 "wSI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -86918,6 +87905,23 @@
 /obj/item/food/cornchips,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/north)
+"wTj" = (
+/obj/machinery/door/airlock/mining{
+	name = "Expedition Headquarters";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/expedition,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/supply/expedition)
 "wTp" = (
 /obj/effect/spawner/random/fungus/probably,
 /turf/simulated/wall,
@@ -87185,18 +88189,6 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
-"xcu" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Cloning"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/unres,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/medical/cloning)
 "xcB" = (
 /obj/structure/chair{
 	dir = 8
@@ -87266,16 +88258,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/genetics)
-"xek" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/freezer,
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/station/service/kitchen)
 "xeG" = (
 /obj/structure/chair/sofa/corp/left,
 /obj/effect/turf_decal/tiles/department/security/side{
@@ -87420,6 +88402,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
+"xim" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Hydroponics Pasture";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/kitchen)
 "xir" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -87442,28 +88437,6 @@
 /obj/machinery/gravity_generator/main/station,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/gravitygenerator)
-"xjn" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	location = "Kitchen"
-	},
-/obj/machinery/door/window/classic/normal{
-	dir = 1;
-	name = "Kitchen Delivery"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery/hollow,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fsmaint2)
 "xjV" = (
 /obj/machinery/power/apc/important/directional/south,
 /obj/structure/cable,
@@ -87579,21 +88552,18 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/xenobiology)
-"xmh" = (
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre Storage"
+"xmg" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "showroomfloor"
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/area/station/medical/surgery)
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "xmi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -87658,18 +88628,6 @@
 /obj/machinery/economy/atm/directional/north,
 /turf/simulated/floor/wood,
 /area/station/maintenance/apmaint2)
-"xnF" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/station/security/checkpoint/secondary)
 "xnT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -87730,15 +88688,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/blueshield)
-"xpW" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/apmaint2)
 "xqa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -87776,6 +88725,19 @@
 /obj/item/kirbyplants/large,
 /turf/simulated/floor/wood,
 /area/station/command/office/hop)
+"xru" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/neutral/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "xrv" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -87844,6 +88806,13 @@
 /obj/machinery/requests_console/directional/south,
 /turf/simulated/floor/wood,
 /area/station/command/office/ntrep)
+"xtB" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/nw)
 "xtZ" = (
 /mob/living/basic/pet/penguin/baby,
 /turf/simulated/floor/carpet,
@@ -87941,6 +88910,25 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
+"xvJ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Escape Shuttle Cell";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/secondary/exit)
 "xvM" = (
 /obj/machinery/door/window{
 	dir = 8
@@ -87980,13 +88968,6 @@
 /obj/machinery/requests_console/directional/east,
 /turf/simulated/floor/carpet/royalblue,
 /area/station/command/office/captain)
-"xwU" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/apmaint2)
 "xwY" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/extra_insulated{
@@ -88034,16 +89015,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"xxZ" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/starboard)
 "xyb" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -88433,6 +89404,28 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"xGB" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/warden)
 "xGP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -88460,14 +89453,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
-"xHw" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Trainer's Office Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/procedure/trainer,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/fpmaint)
 "xHy" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
@@ -88611,13 +89596,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/wood,
 /area/station/command/office/captain)
-"xJZ" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint)
 "xKv" = (
 /obj/machinery/hydroponics/constructable{
 	desc = "These are connected with an irrigation tube. You see a little pipe connecting the trays.";
@@ -88760,6 +89738,22 @@
 /obj/structure/flora/junglebush,
 /turf/simulated/floor/grass/jungle/no_creep,
 /area/station/command/bridge)
+"xLX" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint2)
 "xMk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -88774,19 +89768,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/gravitygenerator)
-"xMy" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/mining,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/supply/miningdock)
 "xMU" = (
 /obj/structure/table,
 /obj/effect/spawner/random/toy/action_figure,
@@ -88832,6 +89813,18 @@
 /obj/effect/spawner/random/barrier/grille_maybe,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
+"xOJ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	name = "Bar Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
+/turf/simulated/floor/wood,
+/area/station/service/bar)
 "xOM" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -88858,6 +89851,20 @@
 /mob/living/basic/lizard/wags_his_tail,
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
+"xPy" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/command/side{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/medical/surgery/observation)
 "xPE" = (
 /obj/effect/mapping_helpers/turfs/rust/maybe,
 /turf/simulated/wall/r_wall,
@@ -88917,17 +89924,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
-"xRr" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Fore Port Solar Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/solar_maintenance/fore_port)
 "xRy" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -88983,21 +89979,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
-"xRR" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/turf/simulated/floor/plasteel,
-/area/station/security/main)
 "xRY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -89066,25 +90047,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
-"xTT" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/command/glass{
-	name = "AI Core"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/turret_protected/ai)
 "xTZ" = (
 /obj/machinery/light{
 	dir = 4
@@ -89242,6 +90204,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"xWC" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/engineering/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/north)
 "xWF" = (
 /obj/machinery/door/window/classic/reversed{
 	dir = 1;
@@ -89259,16 +90231,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage)
-"xWH" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/north)
 "xWJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -89322,19 +90284,6 @@
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
-"xXa" = (
-/obj/effect/mapping_helpers/airlock/access/any/command/hop,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/command{
-	name = "Head of Personnel Office"
-	},
-/turf/simulated/floor/wood,
-/area/station/command/office/hop)
 "xXr" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -89348,6 +90297,30 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/security/main)
+"xXs" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "medbayfoyerport";
+	name = "Medbay Entrance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/department/medical,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/reception)
 "xXO" = (
 /obj/machinery/light,
 /obj/structure/table,
@@ -89386,6 +90359,35 @@
 /obj/structure/sign/biohazard,
 /turf/simulated/wall,
 /area/station/maintenance/aft2)
+"xYG" = (
+/obj/machinery/door/airlock/multi_tile{
+	name = "maintenance access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft2)
+"xYM" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/primary/port/east)
 "xZa" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -89409,18 +90411,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
-"xZq" = (
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/command{
-	name = "Bridge"
-	},
-/obj/effect/turf_decal/tiles/department/medical/side{
+"xZt" = (
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/station/command/bridge)
+/obj/structure/sign/poster/official/random/directional/west,
+/obj/effect/turf_decal/tiles/department/science/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/science/hallway)
 "xZC" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -89452,24 +90452,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
-"xZZ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/classic/reversed,
-/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/general,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/classic/reversed{
-	desc = "You have the public fridge, pal, lube off.";
-	dir = 1;
-	name = "Security Shield"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/chemistry{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/chemistry,
-/obj/effect/turf_decal/tiles/department/chemistry,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/chemistry)
 "yag" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -89486,6 +90468,20 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/aft2)
+"yaj" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/service/hydroponics)
 "yao" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -89523,6 +90519,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft2)
+"ybH" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Internal Medbay Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "ybL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/barrier/grille_maybe,
@@ -89585,22 +90596,6 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
-"ydj" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Escape Shuttle Cell"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/secondary/exit)
 "ydz" = (
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonlockers)
@@ -89625,6 +90620,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"yfg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/door_assembly/door_assembly_silver{
+	anchored = 1;
+	move_force = 10000;
+	move_resist = 10000;
+	name = "broken toilet airlock"
+	},
+/obj/structure/barricade/wooden/crude,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/maintenance/apmaint)
 "yfi" = (
 /obj/structure/cable,
 /obj/effect/spawner/window/reinforced/grilled,
@@ -89642,6 +90654,14 @@
 /obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel,
 /area/station/science/hallway)
+"yfy" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Escape Pod 3 Airlock";
+	id_tag = "emergency_home";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "yfJ" = (
 /turf/simulated/floor/engine/xenobio,
 /area/station/science/xenobiology)
@@ -89916,22 +90936,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
-"ykr" = (
-/obj/effect/mapping_helpers/airlock/access/any/command/hop,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/command{
-	id_tag = "hopofficedoor";
-	name = "Head of Personnel"
-	},
-/turf/simulated/floor/wood,
-/area/station/command/office/hop)
 "yks" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -89983,6 +90987,16 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/patients_rooms1)
+"ylm" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fpmaint2)
 "ylB" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -90042,6 +91056,18 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_port)
+"ymg" = (
+/obj/machinery/door/airlock/wood{
+	name = "Private Residence";
+	desc = "No solicitors please.";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/maintenance/apmaint)
 
 (1,1,1) = {"
 aaa
@@ -97331,10 +98357,10 @@ aaa
 aaa
 aaa
 aaa
-dGd
+pHW
 pdl
 gwQ
-dGd
+pHW
 dyJ
 feN
 feN
@@ -97348,11 +98374,11 @@ aab
 aaa
 aaa
 aaa
-cqY
+aVV
 pDb
 jyO
 vig
-cqY
+aVV
 aaa
 aaa
 aaa
@@ -97588,10 +98614,10 @@ aaa
 aaa
 aaa
 pNm
-dGd
+pHW
 fKZ
 gwQ
-dGd
+pHW
 dyJ
 feN
 feN
@@ -97605,11 +98631,11 @@ aab
 aaa
 aaa
 aVV
-cqY
+aVV
 wIc
 jyO
 qrc
-cqY
+aVV
 aVV
 aaa
 aaa
@@ -97861,13 +98887,13 @@ fay
 aab
 aaa
 aVV
-cqY
+aVV
 oqj
-cqY
+aVV
 jMw
-cqY
+aVV
 oqj
-cqY
+aVV
 aVV
 aaa
 aab
@@ -98117,7 +99143,7 @@ vKU
 fay
 aab
 aaa
-cqY
+aVV
 aXu
 aXx
 pYy
@@ -98125,7 +99151,7 @@ jyO
 uWH
 aXv
 hWF
-cqY
+aVV
 aaa
 aab
 apx
@@ -98374,7 +99400,7 @@ kES
 hVy
 hVy
 hVy
-cqY
+aVV
 aXr
 aXs
 aXs
@@ -98382,7 +99408,7 @@ pCA
 aXs
 aXs
 gdQ
-cqY
+aVV
 aLd
 aLd
 aLd
@@ -98628,10 +99654,10 @@ fPr
 ghv
 aQa
 ksJ
-lnN
+qdS
 gwQ
-lnN
-pYo
+qdS
+eao
 jyO
 jyO
 jyO
@@ -98639,10 +99665,10 @@ nfS
 jyO
 jyO
 jyO
-pYo
-hCZ
+eao
+vsS
 dRr
-hCZ
+vsS
 qgd
 imz
 tuC
@@ -98888,7 +99914,7 @@ mKX
 hVy
 hVy
 hVy
-cqY
+aVV
 wRK
 jyO
 hqB
@@ -98896,7 +99922,7 @@ hqB
 hqB
 jyO
 vig
-cqY
+aVV
 aLd
 aLd
 aLd
@@ -99393,9 +100419,9 @@ aaa
 aJS
 aLb
 aMp
-aNt
+hIu
 ygg
-aPZ
+tUj
 keI
 feN
 qIw
@@ -100173,7 +101199,7 @@ aRa
 hVy
 hVy
 hVy
-cqY
+aVV
 wRK
 jyO
 hqB
@@ -100181,7 +101207,7 @@ hqB
 hqB
 jyO
 vig
-cqY
+aVV
 aLd
 aLd
 aLd
@@ -100421,16 +101447,16 @@ aaa
 aJV
 aLf
 aMt
-aNy
+hJd
 ygg
-jxK
+dFo
 kmm
 foj
 ksJ
-lnN
+qdS
 gwQ
-lnN
-pYo
+qdS
+eao
 jyO
 jyO
 jyO
@@ -100438,10 +101464,10 @@ nfS
 jyO
 jyO
 jyO
-pYo
-hCZ
+eao
+vsS
 dRr
-hCZ
+vsS
 qgd
 mEp
 wJZ
@@ -100462,7 +101488,7 @@ riu
 kPW
 kPW
 wrG
-pIy
+eqo
 aaa
 aaa
 aaa
@@ -100687,7 +101713,7 @@ aPQ
 hVy
 hVy
 hVy
-cqY
+aVV
 oga
 aXs
 aYZ
@@ -100695,7 +101721,7 @@ aYZ
 aYZ
 aXs
 mvP
-cqY
+aVV
 aLd
 aLd
 aLd
@@ -100719,7 +101745,7 @@ uVl
 kPW
 kPW
 uzD
-pIy
+eqo
 bPN
 aaa
 aaa
@@ -100944,7 +101970,7 @@ vKU
 aRd
 aab
 aaa
-cqY
+aVV
 mOC
 bex
 qqY
@@ -100952,7 +101978,7 @@ kRu
 qqY
 bex
 dtK
-cqY
+aVV
 aaa
 aab
 brc
@@ -101201,15 +102227,15 @@ vKU
 hVy
 aab
 aaa
-cqY
+aVV
 aYV
 aYV
 aYV
-cqY
+aVV
 aYV
 aYV
 aYV
-cqY
+aVV
 aaa
 aab
 aLd
@@ -101458,15 +102484,15 @@ vKU
 hVy
 aab
 aaa
-cqY
+aVV
 aYT
 aYT
 aYT
-cqY
+aVV
 aYT
 aYT
 aYT
-cqY
+aVV
 aaa
 aab
 aLd
@@ -102222,14 +103248,14 @@ aSt
 aSt
 jEL
 elS
-pUb
+hoy
 mZr
 feN
 feN
 pwv
 dcT
 gKo
-xWH
+jJE
 gGI
 gGI
 gGI
@@ -102244,7 +103270,7 @@ boP
 aSf
 aSf
 aUl
-eBd
+iMu
 bMb
 pNe
 jXy
@@ -102486,7 +103512,7 @@ iTx
 iTx
 iTx
 iTx
-tpl
+isB
 fTL
 xcR
 nCs
@@ -102501,7 +103527,7 @@ mEp
 nIp
 aSf
 aME
-bgG
+kNH
 vwz
 vwz
 vwz
@@ -102743,7 +103769,7 @@ qhI
 qhI
 qhI
 fCu
-aTt
+pJB
 bqf
 aXq
 bqf
@@ -102758,7 +103784,7 @@ iqH
 bsq
 buf
 buS
-ouf
+oAF
 boR
 bBs
 xlw
@@ -103518,7 +104544,7 @@ aGn
 aWc
 aXA
 aZW
-xnF
+iTW
 bgu
 bda
 oXm
@@ -104015,10 +105041,10 @@ dap
 hoD
 aEE
 aFS
-xRr
+iqn
 aON
 whA
-kEz
+wnd
 whA
 nxX
 aGn
@@ -104032,7 +105058,7 @@ aGn
 doi
 aXC
 aZa
-mNq
+llc
 vfO
 cjK
 oXm
@@ -104060,7 +105086,7 @@ bnw
 bnK
 bII
 pcH
-nSG
+saY
 bGn
 swy
 swy
@@ -104069,7 +105095,7 @@ bGn
 swy
 qzE
 bGn
-jWI
+cCy
 noP
 qFl
 ubK
@@ -104542,7 +105568,7 @@ aHl
 aSp
 aGn
 tqH
-kJO
+vSW
 way
 aXE
 aZb
@@ -104844,7 +105870,7 @@ iez
 dDR
 swy
 hGW
-hkw
+dOR
 mfQ
 rog
 rrh
@@ -105105,7 +106131,7 @@ gYs
 cgQ
 tcM
 dsP
-lNi
+kMO
 esK
 xhq
 bCf
@@ -105326,7 +106352,7 @@ cXB
 fzD
 mtd
 boW
-jyy
+oYa
 coV
 cfg
 btL
@@ -105345,7 +106371,7 @@ mpk
 blQ
 fDM
 gqA
-jDJ
+fyJ
 rgb
 xwY
 rgb
@@ -105354,7 +106380,7 @@ rgb
 kSP
 dSe
 uEr
-cFX
+iHf
 bLA
 bLA
 gNx
@@ -105568,7 +106594,7 @@ mPx
 mPx
 mPx
 aRu
-pWT
+wxA
 aTz
 aTz
 aTz
@@ -106076,11 +107102,11 @@ jwO
 aKW
 aLt
 aMN
-jDS
+vBP
 oEl
 aOX
 kHb
-wDN
+rfX
 pxE
 aGn
 aUs
@@ -106090,7 +107116,7 @@ tsI
 cgH
 iyU
 iyU
-beQ
+gxX
 cna
 bly
 bgz
@@ -106100,7 +107126,7 @@ dfh
 cwy
 dhy
 bnD
-hEs
+dQl
 bnK
 cEb
 bnK
@@ -106642,7 +107668,7 @@ aaa
 cgQ
 qiN
 hCY
-psR
+yfg
 nPE
 rEa
 saV
@@ -107161,7 +108187,7 @@ wja
 fmh
 swy
 lDe
-fDP
+ceI
 ffv
 jZL
 sRR
@@ -107356,7 +108382,7 @@ bat
 aOZ
 aOZ
 plj
-nLW
+iqF
 aNI
 aHS
 pRR
@@ -107369,13 +108395,13 @@ aLu
 dwT
 aHS
 aHl
-fdn
+ylm
 aXQ
 aYi
 aXN
 aXN
 aXN
-bhT
+ksW
 biC
 blH
 bpc
@@ -107385,7 +108411,7 @@ bnD
 bvv
 bvp
 bvT
-bzQ
+ltB
 bBP
 bDv
 bEz
@@ -107413,7 +108439,7 @@ aaa
 gzN
 tUd
 bIH
-gIU
+ymg
 gYx
 oqb
 cmh
@@ -108103,7 +109129,7 @@ aaa
 xPE
 rRa
 rLK
-siM
+guA
 guy
 uVj
 pMP
@@ -108150,7 +109176,7 @@ aVi
 bEt
 puM
 bgz
-bkx
+jFj
 bnD
 bnD
 bqx
@@ -108407,7 +109433,7 @@ aVi
 tha
 fVo
 bpg
-bqh
+snL
 brv
 brv
 bug
@@ -108617,7 +109643,7 @@ aaa
 xPE
 hUX
 wEP
-kBe
+qJf
 hDl
 hDl
 vWw
@@ -108887,7 +109913,7 @@ hIc
 ado
 krG
 asi
-atA
+bVb
 avg
 awS
 tRw
@@ -108937,7 +109963,7 @@ bDP
 bKE
 bKY
 bMh
-tcC
+dlJ
 bQc
 bKz
 bKz
@@ -109174,7 +110200,7 @@ aXN
 aXN
 ihX
 bgQ
-aVh
+mlK
 aSF
 wem
 bEt
@@ -109740,7 +110766,7 @@ cKR
 tEt
 wzD
 eAq
-xpW
+jFK
 iUo
 cSz
 cLi
@@ -110162,7 +111188,7 @@ laL
 mBf
 ybQ
 tvr
-uGG
+lpr
 nDZ
 nDZ
 nDZ
@@ -110172,7 +111198,7 @@ akG
 anN
 mIM
 aqu
-atO
+hwr
 avj
 twu
 jkw
@@ -110463,7 +111489,7 @@ waF
 bgA
 seV
 bkg
-hEs
+dQl
 svp
 svp
 htV
@@ -110762,7 +111788,7 @@ aaa
 cgQ
 uuD
 kSn
-knH
+gFD
 fzd
 jOA
 cvp
@@ -110971,9 +111997,9 @@ aVm
 aWw
 aXP
 aZp
-kiQ
+gJW
 bcZ
-beO
+xYM
 biD
 bms
 sHf
@@ -111193,7 +112219,7 @@ wjM
 kPE
 ybN
 utC
-nGS
+hkT
 hqC
 ado
 oUV
@@ -111241,7 +112267,7 @@ bui
 blQ
 mSb
 bnK
-pIE
+vRD
 cCh
 bEB
 bGY
@@ -111491,7 +112517,7 @@ gdZ
 bgA
 aBG
 bkk
-czN
+ovl
 bnz
 bpi
 iYO
@@ -112221,7 +113247,7 @@ wjM
 kPE
 pgW
 lJV
-vpR
+fKc
 jSq
 anf
 hNf
@@ -112515,7 +113541,7 @@ aSz
 aSz
 aLI
 aSz
-qeM
+fVJ
 ikL
 bmx
 bpj
@@ -112544,7 +113570,7 @@ bVs
 bXh
 vcd
 bYN
-xMy
+miH
 cbK
 hQn
 cis
@@ -113039,7 +114065,7 @@ bpl
 uAa
 bsm
 bBU
-dDY
+wTj
 tSN
 bDN
 tPw
@@ -113078,7 +114104,7 @@ cgQ
 cgQ
 aeP
 qKQ
-sHW
+wdg
 yfT
 lqg
 cZw
@@ -113242,7 +114268,7 @@ aaa
 aaa
 aaa
 hoB
-qhg
+uya
 aBA
 aBA
 aBA
@@ -113286,7 +114312,7 @@ aYn
 bkS
 cGQ
 bgY
-dil
+mfx
 biF
 dmv
 bkg
@@ -113571,7 +114597,7 @@ nxW
 rJJ
 bXk
 bYD
-kZX
+hvp
 cap
 bku
 cHB
@@ -113600,7 +114626,7 @@ rhx
 nph
 mJb
 pGh
-vJQ
+pYq
 pYT
 jix
 anC
@@ -113868,7 +114894,7 @@ mAq
 kyo
 rne
 bUv
-qlp
+kac
 eac
 osT
 bFE
@@ -114270,13 +115296,13 @@ aaa
 aaa
 aaa
 aaa
-qDq
+iVG
 aeG
 afa
 afa
 afa
 wvb
-afT
+hHV
 aqW
 axw
 aqW
@@ -114533,7 +115559,7 @@ mOZ
 aeI
 afc
 afp
-afV
+inc
 wvz
 akU
 akY
@@ -114582,7 +115608,7 @@ bun
 tvf
 bnO
 bnO
-bxi
+kun
 glV
 bzM
 bBq
@@ -114592,7 +115618,7 @@ bEj
 bEj
 bMn
 bKS
-bMJ
+lSy
 bOw
 bOw
 bUZ
@@ -114620,10 +115646,10 @@ coL
 cqT
 xJR
 lNb
-mmw
+wKu
 cXV
 dET
-ltR
+tWm
 cLz
 mfo
 cMC
@@ -114820,7 +115846,7 @@ aMA
 aOr
 awg
 aPi
-xHw
+hWw
 mUR
 aTx
 atD
@@ -114828,7 +115854,7 @@ gNX
 ban
 cGX
 cYS
-kwE
+ntG
 biH
 hdm
 bpm
@@ -114839,7 +115865,7 @@ bum
 brJ
 bwB
 brJ
-bCt
+gMZ
 wNl
 wxi
 rFd
@@ -114849,7 +115875,7 @@ wxi
 wxi
 igI
 eum
-bQn
+irn
 kgz
 kgz
 bUY
@@ -114877,7 +115903,7 @@ ilh
 uIo
 rgb
 ilh
-vxt
+nrR
 xwE
 cZw
 cLi
@@ -115096,7 +116122,7 @@ bnP
 bnP
 bmV
 bAz
-bxk
+xtB
 gtr
 bMu
 kUF
@@ -115106,7 +116132,7 @@ cYP
 cZj
 oxX
 iwZ
-cdI
+vOO
 kKa
 bTy
 jgb
@@ -115118,7 +116144,7 @@ caw
 bTy
 cfq
 bTy
-mmw
+wKu
 lNb
 coL
 lNb
@@ -115565,7 +116591,7 @@ guK
 wyJ
 aie
 aDJ
-kOE
+wlw
 aKs
 aKs
 asN
@@ -115575,7 +116601,7 @@ avN
 asN
 azC
 aAH
-sLh
+oOj
 aDd
 aDM
 aFl
@@ -115599,7 +116625,7 @@ aQl
 aPi
 biE
 aQl
-eAY
+mCc
 bgS
 yhp
 bkv
@@ -115619,11 +116645,11 @@ yfK
 ntz
 vBG
 gHb
-gYw
+eLS
 mBv
 ojw
 mBv
-jzT
+gxS
 pMv
 fCW
 hwK
@@ -116075,7 +117101,7 @@ gZy
 utu
 qKk
 iyj
-nab
+mMN
 agp
 ajS
 aDJ
@@ -116146,7 +117172,7 @@ bSi
 cdV
 cfu
 cfj
-sco
+qmU
 rZr
 pNd
 hJe
@@ -116370,7 +117396,7 @@ ptP
 baq
 bdO
 aSC
-ldZ
+cmU
 bgP
 yhp
 bkv
@@ -116443,10 +117469,10 @@ cXS
 cYv
 uVt
 uVt
-rhU
+dlm
 dcl
 ehs
-ifY
+khp
 aaa
 aaa
 dhf
@@ -116593,7 +117619,7 @@ vrz
 aqX
 aie
 atg
-qsQ
+krF
 aog
 aog
 asQ
@@ -116850,7 +117876,7 @@ goy
 aqX
 aie
 ajR
-tEf
+kFP
 axL
 axL
 axL
@@ -116884,7 +117910,7 @@ lHJ
 bar
 bdR
 bdz
-fJi
+gOk
 aWl
 aMv
 bkv
@@ -116904,7 +117930,7 @@ wmt
 gEe
 xwJ
 fdo
-wmZ
+fKE
 pkK
 lQz
 vTg
@@ -117386,7 +118412,7 @@ aLV
 aJF
 aOB
 aPD
-eAY
+mCc
 aPi
 awg
 aYa
@@ -117409,7 +118435,7 @@ kmo
 fvb
 jiQ
 xil
-nPG
+fUY
 tNG
 rFW
 lwI
@@ -117666,7 +118692,7 @@ bqR
 sIn
 bqS
 owy
-xZq
+uzY
 qUH
 fcC
 fcC
@@ -117688,7 +118714,7 @@ doo
 cfv
 cgi
 cqI
-fMD
+jPp
 clL
 cmM
 jkq
@@ -117714,7 +118740,7 @@ srx
 kcO
 usH
 usH
-xwU
+nlt
 exN
 rgM
 dsK
@@ -117729,7 +118755,7 @@ rJr
 pjn
 eaW
 xGt
-sSb
+lyI
 ycA
 fhr
 cSF
@@ -117892,7 +118918,7 @@ aCi
 aCf
 aCn
 aFr
-ksh
+pMS
 hRa
 hRa
 aKv
@@ -117904,10 +118930,10 @@ ler
 aPi
 aVK
 aYb
-xJZ
+nCp
 bbR
 bdC
-tgl
+nUu
 aSC
 bbN
 bee
@@ -118135,7 +119161,7 @@ eRA
 aqX
 aiu
 akb
-ohm
+wEv
 aon
 aoO
 asY
@@ -118388,7 +119414,7 @@ amA
 any
 aot
 amy
-eXG
+xGB
 agM
 ash
 ajR
@@ -118659,7 +119685,7 @@ axD
 axA
 ayj
 jPg
-azP
+jIn
 aBY
 aCv
 aCZ
@@ -118680,7 +119706,7 @@ aST
 bdF
 aSN
 aSN
-aZx
+wcx
 bbr
 dcb
 bdv
@@ -118706,7 +119732,7 @@ jxq
 vmN
 bmc
 fqw
-vqX
+jOU
 xuw
 fdz
 fdz
@@ -118717,7 +119743,7 @@ sjK
 cgl
 cjk
 wuu
-clO
+ieo
 ckO
 ckO
 cpi
@@ -118727,7 +119753,7 @@ ckO
 cua
 wIt
 tpi
-crX
+xWC
 czA
 ris
 cAN
@@ -118749,7 +119775,7 @@ cQI
 dsT
 cSG
 cTM
-okv
+nNm
 cWI
 uEh
 jNB
@@ -118897,7 +119923,7 @@ acH
 adg
 ajj
 alj
-qeL
+vpQ
 amB
 anB
 aov
@@ -118906,7 +119932,7 @@ rZj
 agN
 eWm
 alb
-eHw
+gUk
 anY
 anY
 anY
@@ -118916,7 +119942,7 @@ awb
 axy
 axF
 axF
-azJ
+kmS
 aAU
 aCo
 aCJ
@@ -118937,7 +119963,7 @@ aSS
 aUp
 tiP
 tiP
-baE
+fjw
 bhd
 bhd
 bhd
@@ -118961,9 +119987,9 @@ ntk
 tMe
 ogC
 bPk
-spy
+kqm
 vrd
-drs
+jfc
 tSR
 cev
 cev
@@ -118974,7 +120000,7 @@ cev
 cgk
 sRk
 lcw
-jtO
+bJe
 tDt
 tDt
 kEA
@@ -118984,7 +120010,7 @@ cvJ
 cGo
 cvJ
 fDx
-ctt
+swb
 czz
 gtZ
 cAM
@@ -119163,7 +120189,7 @@ vom
 agP
 aso
 qkk
-wlJ
+jwB
 aAz
 aAz
 aAz
@@ -119173,7 +120199,7 @@ awI
 axB
 aAz
 aAz
-azR
+ooF
 aCa
 aCx
 aDk
@@ -119194,7 +120220,7 @@ aHT
 aUq
 aHT
 aHT
-baF
+tpn
 bev
 bhh
 bhV
@@ -119220,7 +120246,7 @@ jxq
 mgA
 bmc
 yci
-evX
+hJm
 xgt
 fdz
 fdz
@@ -119231,7 +120257,7 @@ cdN
 cgm
 cfv
 cdN
-ciN
+dVP
 cfn
 clZ
 cQF
@@ -119241,7 +120267,7 @@ ctl
 cue
 qjH
 lUC
-cuu
+fzV
 cnA
 krd
 cHD
@@ -119448,7 +120474,7 @@ sFo
 awl
 awl
 aPm
-rZd
+buZ
 aDN
 aDN
 aDN
@@ -119524,10 +120550,10 @@ cRR
 cZP
 cXx
 jNB
-lIb
+qJw
 qLI
 xBs
-pKs
+wyk
 exC
 fTc
 cVy
@@ -119703,7 +120729,7 @@ ygJ
 ygJ
 iGR
 avq
-sxJ
+fMq
 aRx
 bdN
 aDN
@@ -119930,7 +120956,7 @@ amF
 anF
 aoy
 apl
-cIM
+sCO
 agQ
 ask
 jEB
@@ -119938,10 +120964,10 @@ awK
 aow
 apz
 ata
-jol
+pSq
 avX
 awJ
-iZT
+fNq
 azK
 ayR
 aCp
@@ -120014,11 +121040,11 @@ cvL
 cwM
 cxq
 czB
-osi
+iiP
 cAO
 cEj
 cDz
-ewu
+nGd
 cGr
 cHm
 cHP
@@ -120027,21 +121053,21 @@ cJo
 cKU
 cMW
 cKU
-bRh
+iUH
 cPn
 cPM
 cQK
 cRO
 cSJ
 cTN
-kxY
+hpN
 cWI
 cXF
 yjK
-jPG
+dUZ
 pTR
 sys
-iEA
+dwz
 tmE
 aaX
 lYB
@@ -120187,7 +121213,7 @@ amI
 anJ
 aoB
 apC
-fFA
+joN
 agU
 aiP
 eqN
@@ -120236,7 +121262,7 @@ bqY
 sIn
 bqS
 mgA
-onW
+nHz
 qlh
 wqU
 wqU
@@ -120452,10 +121478,10 @@ awK
 aoW
 arn
 atd
-gHJ
+mpx
 avX
 axG
-uCq
+neZ
 dof
 azx
 aCr
@@ -120468,13 +121494,13 @@ ayA
 axe
 aCz
 sZa
-pVr
+ikc
 mSN
 lEy
 qed
 izv
 xBd
-mnx
+fkj
 xGn
 kHT
 bgT
@@ -120493,7 +121519,7 @@ iim
 qwo
 pQg
 gPI
-wKf
+rzb
 vSs
 qxm
 qxm
@@ -120515,7 +121541,7 @@ bMG
 ceC
 cgj
 cfv
-aWZ
+ehU
 thN
 xVe
 qcB
@@ -120768,7 +121794,7 @@ gMQ
 est
 rJb
 eop
-ykr
+wwF
 ceF
 wgO
 wcQ
@@ -121209,7 +122235,7 @@ aqd
 aeu
 adk
 adx
-pqq
+wnt
 aek
 aeA
 aoJ
@@ -121219,7 +122245,7 @@ anA
 ahk
 aiQ
 akk
-alQ
+tmO
 aoZ
 arx
 aCt
@@ -121232,14 +122258,14 @@ aAX
 aCt
 aDo
 aEr
-srM
+hhP
 aGD
 aEA
 aJn
 axe
 awl
 lQP
-mLR
+mwH
 pDG
 mJJ
 wKH
@@ -121253,7 +122279,7 @@ aZs
 xEG
 dyw
 iAE
-djg
+xru
 bhg
 bns
 bwj
@@ -121273,7 +122299,7 @@ qFK
 dUM
 dUM
 nGC
-xXa
+fly
 tow
 oCj
 ozk
@@ -121312,7 +122338,7 @@ dcj
 dcj
 dcj
 dcj
-dZF
+lRJ
 cRX
 cRX
 cQP
@@ -121476,7 +122502,7 @@ uBr
 ahj
 aiP
 akj
-alP
+kWO
 aoY
 arw
 art
@@ -121510,7 +122536,7 @@ gPu
 jro
 qCk
 fMW
-djf
+qML
 dko
 bnN
 bwj
@@ -121800,11 +122826,11 @@ bMG
 ccn
 xUU
 gYI
-dhw
+tUL
 ssK
 ssK
 fXp
-wwY
+grB
 xqH
 nHG
 cep
@@ -122114,14 +123140,14 @@ fhJ
 iBf
 mhG
 dop
-dor
+nCg
 dos
 dgp
 tNe
 thU
-ePc
+kYZ
 thU
-njm
+jHy
 aGP
 fqc
 doz
@@ -122524,7 +123550,7 @@ aJp
 aJp
 aJp
 sRg
-jrI
+ohQ
 ilk
 aSM
 aTE
@@ -122571,12 +123597,12 @@ tgQ
 bFO
 xUU
 lLv
-eEA
+qAB
 cdW
 uor
 tNn
 jzZ
-nAt
+xmg
 cJN
 cep
 pxz
@@ -122761,14 +123787,14 @@ anA
 ahD
 xZF
 akn
-pmZ
+fVg
 apb
 arz
 atl
 ayq
 awA
 apb
-kij
+sgO
 azY
 aBo
 aAB
@@ -122807,11 +123833,11 @@ bod
 bnn
 bwj
 bwj
-bza
+rvs
 bAl
 bFU
 bFU
-bEw
+vjQ
 bFU
 bFU
 bMT
@@ -122852,7 +123878,7 @@ cxO
 cxO
 van
 cLK
-sYf
+mfb
 cDj
 iJi
 iJi
@@ -123004,7 +124030,7 @@ aaa
 aab
 anA
 acw
-acD
+gEM
 acS
 anA
 akv
@@ -123064,11 +124090,11 @@ bvD
 byx
 bpA
 bpA
-bEg
+ptx
 bFi
 bHo
 bIR
-bJT
+lEn
 cbm
 cbm
 cbm
@@ -123321,11 +124347,11 @@ bvL
 buC
 bhq
 bhq
-bzb
+tbF
 bhq
 gVV
 bFO
-bEn
+eEv
 bFW
 bFO
 bFO
@@ -123352,7 +124378,7 @@ xFM
 dLZ
 pBP
 xkF
-chI
+sKl
 eDL
 qpx
 kjn
@@ -123777,7 +124803,7 @@ anA
 acB
 acB
 acw
-adp
+myY
 aoJ
 alu
 amn
@@ -123785,7 +124811,7 @@ amO
 anU
 aoP
 apN
-xRR
+nfy
 ahE
 asv
 aFL
@@ -123802,7 +124828,7 @@ oRr
 ayd
 aDp
 dNJ
-jdS
+wdj
 aGN
 aGN
 mOR
@@ -124042,7 +125068,7 @@ amN
 ahf
 aoN
 aoJ
-syo
+lHq
 ago
 aiU
 aFL
@@ -124054,7 +125080,7 @@ auY
 atG
 atw
 tCL
-aBv
+ipb
 dEM
 sht
 ruJ
@@ -124066,7 +125092,7 @@ fmN
 aKK
 aJw
 tcm
-aPg
+iiy
 aQt
 aOv
 aUd
@@ -124106,7 +125132,7 @@ bSn
 bLt
 bQP
 bRt
-xZZ
+iPX
 bZD
 mcM
 bZk
@@ -124302,7 +125328,7 @@ apO
 iOl
 aqX
 aiW
-gUF
+jkj
 avF
 aol
 arP
@@ -124323,7 +125349,7 @@ aJz
 oem
 dwg
 iQP
-ckc
+gKx
 aZs
 aSJ
 aUI
@@ -124363,14 +125389,14 @@ bTL
 bPf
 fTv
 bQZ
-wOx
+wSB
 bZG
 caz
 bWo
 udz
 bZj
 caz
-bZv
+aUZ
 jLy
 cfw
 chk
@@ -124386,7 +125412,7 @@ tsJ
 cAr
 cuf
 cuI
-wMo
+sdS
 wGR
 cxE
 cyS
@@ -124593,7 +125619,7 @@ aUS
 bjc
 baJ
 beH
-jeK
+xOJ
 bft
 aYd
 bnQ
@@ -124620,14 +125646,14 @@ bDl
 nHW
 fRh
 wYh
-emZ
+wFd
 kdm
 mVm
 bWm
 cjt
 bYs
 cjt
-bYC
+qir
 nuX
 jrh
 chj
@@ -124648,7 +125674,7 @@ cxn
 ddw
 czg
 czg
-eiP
+kpQ
 yhm
 cep
 cxO
@@ -124863,7 +125889,7 @@ iOW
 iOW
 iOW
 iOW
-ioz
+vKA
 wJE
 bHy
 bDa
@@ -125157,7 +126183,7 @@ crp
 csW
 cug
 cvO
-xmh
+epQ
 cFx
 cxF
 vfs
@@ -125377,7 +126403,7 @@ bto
 buR
 bmq
 bmq
-bAv
+dQF
 bAk
 boi
 bDA
@@ -125665,7 +126691,7 @@ cnY
 cxh
 acY
 cnY
-kTh
+xPy
 cup
 cuh
 csY
@@ -125725,7 +126751,7 @@ dpD
 dpN
 dkM
 dlq
-ojp
+jEG
 dme
 dme
 dme
@@ -125841,7 +126867,7 @@ and
 aeW
 aoT
 eVU
-lBq
+ewx
 ari
 aiZ
 akD
@@ -125855,7 +126881,7 @@ aIq
 avq
 aAc
 kjd
-ifp
+ePL
 aCh
 aEw
 awl
@@ -125878,7 +126904,7 @@ eOj
 ees
 aWA
 bfn
-sGw
+nJu
 djk
 dkN
 boM
@@ -125895,7 +126921,7 @@ aUS
 bAk
 boi
 bDb
-aTL
+via
 bYu
 gIZ
 bYu
@@ -125905,7 +126931,7 @@ bYu
 bYu
 bYu
 bYu
-kJi
+qCe
 dUc
 tWs
 bWx
@@ -125922,7 +126948,7 @@ crY
 cnw
 rHw
 rHw
-imB
+wDh
 ejO
 crt
 kJW
@@ -126102,7 +127128,7 @@ aih
 aqX
 aqW
 atg
-let
+aRq
 avq
 avq
 aBw
@@ -126122,7 +127148,7 @@ oiD
 oiD
 oiD
 eDZ
-wRI
+uNo
 okj
 aSM
 aUT
@@ -126152,7 +127178,7 @@ aUS
 bFj
 bHA
 tHZ
-bJY
+hpZ
 bLh
 ktW
 fuU
@@ -126162,7 +127188,7 @@ bZR
 bZR
 bZR
 bZR
-pDH
+xXs
 bZK
 cbQ
 cnx
@@ -126185,7 +127211,7 @@ czO
 cta
 uma
 uma
-oLC
+dHj
 uwJ
 lwt
 ciQ
@@ -126359,7 +127385,7 @@ aih
 aqX
 aqW
 hlm
-hWk
+wDM
 nTH
 aCh
 avq
@@ -126409,7 +127435,7 @@ aUS
 bAo
 boi
 bDb
-aTM
+nkl
 can
 can
 can
@@ -126419,7 +127445,7 @@ rda
 can
 bNz
 can
-iev
+udA
 sbd
 kFS
 cnY
@@ -126436,7 +127462,7 @@ crZ
 mOr
 coc
 coc
-gYO
+bty
 yif
 crv
 ctd
@@ -126645,7 +127671,7 @@ eDj
 mZq
 eAL
 sGj
-otk
+xLX
 jVw
 bbd
 eOj
@@ -126693,7 +127719,7 @@ uVC
 dLR
 gqr
 ure
-joe
+fkz
 cum
 cuh
 ctc
@@ -126742,18 +127768,18 @@ nrh
 dhj
 dhz
 dii
-lRt
+nYw
 diC
 diE
 diM
 djD
 rWq
-iTa
+irh
 djJ
 dkf
 aah
 dlt
-gsl
+tKr
 cSK
 cSK
 cSK
@@ -126763,10 +127789,10 @@ dmT
 adZ
 dmf
 dmV
-rML
+lPA
 dnf
 dnj
-xTT
+evd
 dnq
 dnt
 cCk
@@ -126874,7 +127900,7 @@ aaa
 atG
 apZ
 avq
-atr
+gbl
 ava
 pZr
 dVA
@@ -126893,7 +127919,7 @@ qZO
 qZO
 qZO
 qZO
-oQy
+hjZ
 xkh
 rET
 aVs
@@ -126905,7 +127931,7 @@ jUa
 eOj
 mlP
 bbs
-tDy
+upI
 bht
 bhW
 biV
@@ -127185,7 +128211,7 @@ aVy
 bDi
 bGv
 bJW
-kEx
+pHu
 bNA
 bNz
 bNz
@@ -127213,7 +128239,7 @@ czW
 ctg
 cum
 uno
-uTl
+ybH
 cep
 cep
 cep
@@ -127395,7 +128421,7 @@ iTT
 awF
 att
 avq
-sxJ
+fMq
 aPm
 aPm
 lkw
@@ -127645,7 +128671,7 @@ aaa
 atG
 aqb
 aCh
-ats
+bzY
 ava
 ava
 sqq
@@ -127676,12 +128702,12 @@ aIc
 eOj
 ees
 ujt
-xjn
+rdh
 bdL
 rGM
 biY
 boQ
-xek
+cQd
 bqB
 brY
 btI
@@ -127713,7 +128739,7 @@ bZq
 caL
 ccy
 eGV
-sqx
+syV
 chs
 ciP
 wgW
@@ -127781,7 +128807,7 @@ dpA
 dkI
 dld
 dlK
-siq
+eDu
 dmg
 dmg
 dmg
@@ -127961,10 +128987,10 @@ bDH
 bQA
 bRa
 bOQ
-dbc
+ljF
 ecs
 spC
-xcu
+lAp
 ccB
 ccB
 koW
@@ -127973,7 +128999,7 @@ dRb
 wgW
 fHD
 fBH
-lrk
+hWE
 tXI
 lKS
 cnI
@@ -127993,7 +129019,7 @@ dPe
 cKn
 cLW
 dbd
-woE
+fdH
 dbd
 dbd
 dbd
@@ -128184,14 +129210,14 @@ aSM
 iWq
 rNy
 rNy
-mOi
+hwF
 aKn
 aKm
 aVU
 eOj
 raC
 bfB
-jhq
+cKW
 djt
 bjd
 boV
@@ -128203,7 +129229,7 @@ iRs
 bsS
 bof
 yag
-cEU
+wJl
 bzf
 bAk
 boi
@@ -128218,7 +129244,7 @@ hSA
 mxy
 bHO
 uAC
-onX
+kRS
 mPX
 iTB
 bTZ
@@ -128445,7 +129471,7 @@ aIe
 bdr
 aUA
 bhk
-qiE
+wPW
 bbC
 xuM
 eOj
@@ -128453,14 +129479,14 @@ djw
 bFJ
 boX
 bpH
-hkX
+xim
 bro
 btN
 buu
 bsV
 buJ
 yag
-hrA
+dtV
 bzf
 bAk
 boi
@@ -128668,9 +129694,9 @@ aaa
 avw
 hiP
 iBx
-wJH
+fTM
 pLr
-hVu
+yfy
 fuc
 ava
 avq
@@ -128717,7 +129743,7 @@ brm
 bsU
 bof
 yag
-vwp
+sOF
 bzf
 bAk
 boi
@@ -128782,7 +129808,7 @@ xQL
 dbA
 dcp
 ygw
-eiT
+hgH
 dcG
 dcQ
 deu
@@ -128974,7 +130000,7 @@ buv
 bof
 bof
 yag
-tRp
+kgU
 bzf
 nuq
 uZL
@@ -128998,7 +130024,7 @@ ivo
 caQ
 ccE
 cei
-dWF
+eqE
 chx
 ciU
 ckB
@@ -129046,9 +130072,9 @@ nqN
 inV
 ddk
 ddy
-dxQ
+rtX
 dlX
-fsW
+uWK
 dmA
 dmO
 dne
@@ -129236,7 +130262,7 @@ bzh
 bAk
 gKl
 bJb
-aTN
+vnh
 aYl
 bEx
 bHG
@@ -129249,7 +130275,7 @@ nbE
 bEu
 ipf
 mZI
-jnP
+wEe
 bXR
 nPD
 avh
@@ -129469,7 +130495,7 @@ wfQ
 omD
 eJZ
 eJZ
-jyL
+oQN
 aXi
 rHR
 jqS
@@ -129520,7 +130546,7 @@ uBn
 cxj
 ckC
 jDB
-mRs
+kxG
 crE
 dXp
 cvX
@@ -129730,7 +130756,7 @@ aIh
 bdt
 dzb
 rhh
-uhi
+gzm
 bbU
 beJ
 eOj
@@ -129973,7 +130999,7 @@ sPb
 lop
 xcB
 mzv
-mbO
+isX
 fUX
 xuM
 eOj
@@ -130053,7 +131079,7 @@ cep
 foC
 dGn
 hcb
-eIN
+iAo
 gpB
 nTv
 wSs
@@ -130247,7 +131273,7 @@ eOj
 eOj
 bbX
 fzc
-lnR
+rAC
 djF
 xZa
 beb
@@ -130260,11 +131286,11 @@ brr
 brr
 brr
 bxL
-fiB
+gLf
 bAr
 boi
 wBF
-wvL
+vip
 aZT
 iPZ
 lqw
@@ -130277,7 +131303,7 @@ fsQ
 bEu
 cXo
 cbZ
-bWC
+kLt
 bXT
 oZa
 cjF
@@ -130310,7 +131336,7 @@ tHl
 tHl
 uJa
 efJ
-qDJ
+rmN
 sir
 gkw
 cIl
@@ -130531,10 +131557,10 @@ fdK
 bQH
 bRe
 bSE
-mgx
+nsR
 caa
 mUG
-bWF
+tvL
 cbE
 bZA
 caV
@@ -130558,7 +131584,7 @@ daI
 tpP
 rMX
 fCX
-kre
+dGo
 czt
 cAA
 cMH
@@ -130567,7 +131593,7 @@ lPP
 cEp
 fSM
 rhR
-jxj
+jOg
 pnT
 qBo
 jot
@@ -130576,7 +131602,7 @@ cYi
 cYi
 cYi
 otn
-uxZ
+xYG
 kvp
 dce
 fQQ
@@ -130774,7 +131800,7 @@ boA
 boA
 boB
 bxM
-uIs
+vXV
 bAr
 lFG
 bJc
@@ -130804,7 +131830,7 @@ ckE
 clk
 cmw
 cnQ
-oJY
+ixU
 nnv
 hxx
 qnK
@@ -130833,7 +131859,7 @@ rnd
 iac
 chf
 wSO
-vVb
+pFq
 ivI
 dcd
 dfL
@@ -131031,7 +132057,7 @@ boA
 boA
 boB
 oPv
-nAQ
+yaj
 vVQ
 bHy
 bDa
@@ -131259,7 +132285,7 @@ jOz
 sDz
 aHI
 aIA
-hHh
+kLC
 aKS
 bRx
 bRx
@@ -131302,13 +132328,13 @@ sNP
 wMl
 mXZ
 bSF
-eYG
+oKQ
 bGG
 cdb
 cuQ
 bGG
 pMM
-rqs
+kLT
 tqE
 wjQ
 cfY
@@ -131535,7 +132561,7 @@ beb
 bdW
 bfN
 fny
-fxR
+ezH
 bpI
 bqL
 brZ
@@ -131545,7 +132571,7 @@ bow
 byM
 bru
 qWx
-fiB
+gLf
 bAr
 boi
 bJh
@@ -131600,7 +132626,7 @@ hFe
 cIa
 cyP
 lYc
-hzY
+jBW
 vcO
 cJG
 pnV
@@ -132089,7 +133115,7 @@ gwz
 lvL
 ini
 rFP
-muh
+sEj
 fmH
 cxD
 jLT
@@ -132312,7 +133338,7 @@ aZd
 aZd
 lZG
 aZd
-rJZ
+iOE
 mBJ
 kbO
 nyS
@@ -132340,7 +133366,7 @@ qZN
 wcA
 clT
 cnt
-ahu
+nyd
 cpq
 crg
 csd
@@ -132371,7 +133397,7 @@ chf
 pak
 ukQ
 mba
-rUf
+aFz
 huR
 cep
 pWW
@@ -132577,7 +133603,7 @@ xWq
 anx
 qlS
 dmu
-nus
+uDg
 trR
 trR
 jYt
@@ -132614,7 +133640,7 @@ bGG
 oYN
 gZH
 spH
-vgR
+mxi
 sYT
 pio
 cBH
@@ -132640,7 +133666,7 @@ ofA
 ofA
 tBJ
 nMU
-syL
+jRc
 fQQ
 fQQ
 fQQ
@@ -132860,7 +133886,7 @@ cpU
 oHl
 ctw
 cuK
-muh
+sEj
 oVU
 cxD
 gkn
@@ -133063,13 +134089,13 @@ aQI
 aGX
 aMi
 aRJ
-aTe
+dHC
 xRy
 aXX
 aZX
-bbF
+fsm
 aZX
-bfK
+nmX
 aWg
 bkN
 bmH
@@ -133314,19 +134340,19 @@ ruY
 aGY
 cZV
 aGY
-gBd
+iVU
 aGY
 aGY
-tTn
+dMR
 aGY
 keD
-aPK
+hps
 aGY
 aGY
 aQI
-aUc
+fRi
 aAY
-aVQ
+kSS
 bbY
 bkN
 aGX
@@ -133349,7 +134375,7 @@ bwv
 dMT
 xcm
 wbh
-bwL
+jtV
 bBm
 bMW
 bOS
@@ -133606,7 +134632,7 @@ ePN
 bHr
 bzc
 qEE
-eYY
+dxj
 gby
 iNP
 gVU
@@ -133843,7 +134869,7 @@ aGY
 aGX
 oPP
 oSJ
-oVg
+fEV
 bfU
 bhx
 bij
@@ -133883,7 +134909,7 @@ bzT
 kUB
 bzT
 bzT
-lqc
+gAA
 bzT
 bzT
 bzT
@@ -134911,7 +135937,7 @@ clg
 clW
 bGG
 coA
-qTI
+mRL
 cri
 csB
 bYm
@@ -135157,7 +136183,7 @@ uwr
 xyr
 uxI
 bUe
-gky
+eJJ
 cax
 cci
 qvZ
@@ -135633,7 +136659,7 @@ obU
 hpJ
 aMc
 aNn
-aNR
+gBl
 wuI
 lrA
 aRK
@@ -136149,7 +137175,7 @@ iOn
 aMq
 aTj
 aUg
-fsv
+vup
 aZQ
 vEl
 asD
@@ -136452,7 +137478,7 @@ jdY
 bTw
 rlZ
 jpy
-lHg
+uUV
 cpt
 crn
 jSa
@@ -136674,7 +137700,7 @@ bcu
 ber
 bga
 bis
-qfI
+sPv
 bcD
 bld
 blw
@@ -136699,11 +137725,11 @@ kmE
 dDQ
 liO
 kYS
-euX
+oEA
 bYi
 kLs
 aKL
-dGS
+fup
 ppy
 ppy
 ppy
@@ -137183,7 +138209,7 @@ aSg
 aGX
 aXk
 aXe
-sJu
+uWs
 stD
 stD
 bhA
@@ -137423,7 +138449,7 @@ vcb
 ttU
 rTe
 csU
-aGc
+hOc
 obU
 qhT
 aMq
@@ -137456,11 +138482,11 @@ boJ
 boJ
 boJ
 boJ
-bEl
+sKe
 oNo
 tLN
 bIv
-flN
+ldm
 rvD
 rvD
 ued
@@ -137479,7 +138505,7 @@ bNp
 bNp
 bNp
 bNp
-hLu
+eNU
 dsy
 cpG
 crs
@@ -137491,7 +138517,7 @@ ctI
 ctI
 crs
 cKT
-cBB
+xZt
 cEs
 pSY
 cNx
@@ -137514,7 +138540,7 @@ oJr
 tlI
 vum
 ojz
-vKk
+vFc
 lon
 cga
 xsx
@@ -137717,17 +138743,17 @@ aYQ
 aSI
 bHQ
 wjC
-tDg
+vXt
 vet
 bIo
 onM
 ncf
 fES
-nzc
+wiK
 bUR
 bVG
 bWr
-vVt
+jdf
 otA
 dJu
 aFC
@@ -137736,7 +138762,7 @@ chW
 fbS
 chW
 chW
-cDC
+jPC
 chW
 chW
 bYA
@@ -137748,7 +138774,7 @@ lkd
 fbS
 kcJ
 chW
-cDC
+jPC
 chW
 chW
 cFH
@@ -137758,11 +138784,11 @@ mdt
 fbS
 pLR
 izl
-oBf
+sQR
 rtF
 wpf
 orG
-lAE
+whJ
 aoo
 vJv
 cWw
@@ -137970,11 +138996,11 @@ boJ
 boJ
 boJ
 boJ
-bEl
+sKe
 aSI
 bHI
 bwv
-lRy
+fGP
 mfM
 mfM
 gCJ
@@ -137993,7 +139019,7 @@ cEt
 cgq
 cEt
 keJ
-ufq
+bGu
 pGl
 cEt
 iyM
@@ -138005,7 +139031,7 @@ kCg
 rHm
 cEt
 aac
-ufq
+bGu
 cEt
 cEt
 cFE
@@ -138465,7 +139491,7 @@ aMz
 aOF
 aGY
 aSi
-pHF
+pku
 aUX
 aUX
 aZF
@@ -138755,7 +139781,7 @@ cZp
 cZT
 lXF
 cBD
-oSr
+tco
 alx
 cyF
 cdP
@@ -139016,23 +140042,23 @@ wkr
 caS
 spl
 pwk
-hCP
+mYq
 kHG
 gkm
 vKr
 dGW
 hzy
 cmZ
-dXf
+pPJ
 crG
 csP
 ctI
-iqs
+wmE
 nOo
 afJ
 yfn
 fHF
-ves
+mId
 rSX
 cDs
 cEu
@@ -139295,7 +140321,7 @@ cDt
 cFY
 cHo
 cIH
-uhq
+geB
 nXB
 ygu
 cNu
@@ -139305,7 +140331,7 @@ cQv
 cRy
 gJU
 mxA
-gYu
+fTh
 wpT
 qEt
 fMi
@@ -139316,7 +140342,7 @@ mBE
 ueT
 feQ
 sXX
-rYy
+mXK
 ldn
 lko
 dIQ
@@ -139566,7 +140592,7 @@ ciY
 ciY
 eaT
 kmA
-olI
+iwN
 ldn
 ldn
 dIQ
@@ -139584,7 +140610,7 @@ ePu
 csL
 isD
 csL
-jPw
+pWw
 fqt
 lHw
 dbo
@@ -139819,7 +140845,7 @@ oJr
 pbY
 gOr
 wxG
-fcM
+jev
 wxG
 dSH
 mfR
@@ -140308,11 +141334,11 @@ oPp
 lsl
 lsl
 clz
-lVK
+oDP
 syN
 bJo
 mOX
-aaA
+orw
 nXc
 nXc
 nXc
@@ -140598,17 +141624,17 @@ ciY
 kMc
 csL
 csL
-stS
+vEw
 opZ
 nOE
 tZu
 fvV
 mpl
-tRs
+gzA
 vro
 cOm
 cOm
-jZT
+pby
 deN
 dfa
 tMT
@@ -140806,7 +141832,7 @@ bPq
 cYk
 bmm
 bmm
-xPe
+qKU
 sOw
 sOw
 gww
@@ -141108,7 +142134,7 @@ ciY
 euQ
 gwq
 gzC
-nxI
+rnD
 gzC
 dfi
 csL
@@ -141326,7 +142352,7 @@ xwF
 eGo
 xwF
 nGk
-tfn
+unQ
 xwF
 ptL
 vcm
@@ -141375,7 +142401,7 @@ gzC
 dfi
 csL
 csL
-oUq
+nMe
 csL
 cga
 ciY
@@ -141606,7 +142632,7 @@ tjd
 tmc
 eBY
 qoX
-xxZ
+gTE
 crB
 sYp
 lpu
@@ -142895,7 +143921,7 @@ awx
 jPZ
 fmn
 xwF
-kto
+puP
 cga
 ePu
 cQw
@@ -143919,7 +144945,7 @@ sOg
 unh
 uDX
 sKQ
-gQm
+eTF
 llx
 upZ
 lHm
@@ -144649,7 +145675,7 @@ bol
 qms
 vJV
 bvP
-ydj
+xvJ
 hwJ
 oWE
 oWE
@@ -144906,7 +145932,7 @@ bol
 edQ
 bvR
 bvR
-dUS
+sWa
 lEZ
 ido
 pya

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -365,14 +365,6 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/security/warden)
-"acm" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/disposal/north)
 "acr" = (
 /obj/machinery/conveyor/auto{
 	dir = 6
@@ -400,20 +392,6 @@
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
-"acK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/generic,
-/obj/effect/mapping_helpers/turfs/damage,
-/obj/item/trash/spentcasing/bullet/lasershot,
-/obj/item/trash/spentcasing/bullet/lasershot,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/command/fore)
 "acM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -477,6 +455,23 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/ai)
+"ady" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/port/north)
 "adD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -933,20 +928,31 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/reception)
-"agz" = (
+"agr" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Trainer's Office";
+	id_tag = "nct";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "NCT"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/procedure/trainer,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/command/starboard)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/dark,
+/area/station/procedure/trainer_office)
 "agA" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -1051,6 +1057,15 @@
 /obj/structure/closet/secure_closet/librarian,
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/library)
+"ahg" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Laser Room";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/control)
 "ahr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -1106,6 +1121,18 @@
 "ahF" = (
 /turf/simulated/floor/plating/asteroid/ancient/airless,
 /area/mine/unexplored/cere/ai)
+"ahG" = (
+/obj/machinery/door/airlock/maintenance/external{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/maintenance/maintcentral)
 "ahI" = (
 /obj/structure/table,
 /obj/item/cartridge/signal/toxins,
@@ -1431,18 +1458,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/ai)
-"ajP" = (
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock";
-	name = "Escape Pod Hatch"
-	},
-/obj/docking_port/mobile/pod{
-	id = "pod4";
-	name = "escape pod 4"
-	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/pod_4)
 "ajS" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel/dark,
@@ -1609,30 +1624,22 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
-"aln" = (
-/obj/machinery/door/airlock/security/glass{
-	locked = 1;
-	id_tag = "perma_door_ext"
+"alg" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/red,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/access_button{
-	autolink_id = "perma_btn_ext";
-	name = "Prison Wing Access Button";
-	req_access = list(2);
-	pixel_x = -21
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/permabrig)
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/station/maintenance/service/fore_port)
 "alp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1759,6 +1766,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/external/southwest)
+"amH" = (
+/obj/machinery/door/airlock/vault{
+	locked = 1;
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/vault,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/station/command/vault)
 "amI" = (
 /obj/machinery/light{
 	dir = 1
@@ -2360,20 +2380,6 @@
 /obj/item/clothing/under/plasmaman,
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonlockers)
-"asc" = (
-/obj/machinery/door/airlock/security/glass{
-	security_level = 1
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/permabrig)
 "asi" = (
 /obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/plating,
@@ -2449,6 +2455,26 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/misc_lab)
+"asO" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	color = "#954535"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "scilockdown";
+	layer = 2.6;
+	name = "Science Lockdown"
+	},
+/obj/effect/turf_decal/caution/red,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/servsci)
 "asS" = (
 /obj/item/trash/can,
 /turf/simulated/floor/plating,
@@ -2853,18 +2879,6 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
 /area/station/telecomms/computer)
-"avr" = (
-/obj/machinery/door/airlock/hatch,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/catwalk/black,
-/area/station/turret_protected/aisat/interior/secondary)
 "avv" = (
 /obj/item/kirbyplants/large,
 /obj/effect/decal/cleanable/cobweb,
@@ -3054,23 +3068,6 @@
 /obj/effect/spawner/airlock,
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/disposal/westalt)
-"axO" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/structure/disposalpipe/segment{
-	color = "#954535"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "scilockdown";
-	layer = 2.6;
-	name = "Science Lockdown"
-	},
-/obj/effect/turf_decal/caution/red,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/servsci)
 "axP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3082,6 +3079,23 @@
 	},
 /turf/simulated/floor/catwalk/black,
 /area/station/aisat/service)
+"axS" = (
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/virology/glass{
+	name = "Virology Patient Room 1";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "viro_1"
+	},
+/obj/effect/turf_decal/tiles/department/virology,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/virology)
 "axU" = (
 /obj/structure/table/wood,
 /obj/machinery/button/windowtint{
@@ -3247,6 +3261,23 @@
 /obj/item/stack/sheet/metal,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/fsmaint)
+"azf" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "servlockdown";
+	layer = 2.6;
+	name = "Service Lockdown"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/sercom)
 "azr" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -3500,6 +3531,19 @@
 /obj/item/storage/fancy/matches,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/security/fore_starboard)
+"aBt" = (
+/obj/structure/disposalpipe/segment{
+	color = "#954535"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore/east)
 "aBy" = (
 /obj/structure/window/reinforced,
 /obj/structure/filingcabinet/chestdrawer/autopsy,
@@ -3626,6 +3670,21 @@
 /obj/effect/turf_decal/tiles/department/medical/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/barber)
+"aCn" = (
+/obj/machinery/door/airlock/engineering/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/equipmentstorage)
 "aCo" = (
 /turf/simulated/floor/plating,
 /area/station/supply/miningdock)
@@ -3807,12 +3866,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat/service)
-"aDH" = (
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/station/service/chapel)
 "aDM" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
@@ -3993,6 +4046,22 @@
 /obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/plasteel/freezer,
 /area/station/maintenance/gambling_den)
+"aFu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/security/port)
 "aFz" = (
 /obj/structure/table,
 /obj/item/ashtray/bronze,
@@ -4061,6 +4130,23 @@
 /obj/effect/decal/remains/robot,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/northeast)
+"aGz" = (
+/obj/machinery/door/airlock/mining/glass{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/cargo_bay,
+/turf/simulated/floor/plasteel/dark,
+/area/station/supply/storage)
 "aGC" = (
 /obj/structure/closet/secure_closet/miner,
 /turf/simulated/floor/plasteel,
@@ -4077,6 +4163,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
+"aGI" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "medlockdown";
+	layer = 2.6;
+	name = "Medical Lockdown"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/dockmed)
 "aGL" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable,
@@ -4365,6 +4468,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/storage)
+"aKM" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "aKP" = (
 /obj/machinery/economy/vending/cola,
 /turf/simulated/floor/plasteel,
@@ -4466,6 +4579,19 @@
 /obj/structure/chair/office/dark,
 /turf/simulated/floor/wood,
 /area/station/maintenance/service/fore_port)
+"aLy" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "aLH" = (
 /obj/effect/mapping_helpers/turfs/rust,
 /turf/simulated/wall,
@@ -4723,19 +4849,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/telecomms/computer)
-"aOl" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/structure/fans/tiny,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood/nitrogen,
-/area/station/maintenance/abandonedbar)
 "aOn" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -4947,6 +5060,23 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/storage)
+"aPN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tiles/department/medical/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/barber)
 "aPO" = (
 /obj/structure/extinguisher_cabinet{
 	name = "west bump";
@@ -5110,6 +5240,14 @@
 "aRx" = (
 /turf/simulated/wall,
 /area/station/maintenance/fsmaint)
+"aRE" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/south)
 "aRT" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -5182,6 +5320,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/security/fore_starboard)
+"aSw" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/security/port)
 "aSy" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -5358,20 +5512,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
-"aTW" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/station_engineer,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/highsecurity{
-	name = "Gravity Generator"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/gravitygenerator)
 "aUb" = (
 /obj/machinery/door/airlock{
 	id_tag = "b2"
@@ -5402,19 +5542,6 @@
 "aUp" = (
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/meeting_room)
-"aUq" = (
-/obj/machinery/door/airlock/glass{
-	name = "Internal Affairs Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/iaa,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "IAA"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/station/legal/lawoffice)
 "aUr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -5457,16 +5584,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/maintcentral)
-"aUK" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock,
-/obj/effect/mapping_helpers/airlock/access/all/supply/cargo_bay,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "aUU" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -5474,16 +5591,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/starboard)
-"aUY" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/effect/spawner/random/dirt/frequent,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/security/starboard)
 "aVc" = (
 /obj/effect/turf_decal/tiles/department/science/corner{
 	dir = 8
@@ -5643,23 +5750,6 @@
 "aVS" = (
 /turf/simulated/wall/r_wall,
 /area/station/command/bridge)
-"aVY" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	color = "#505050"
-	},
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/north)
 "aWk" = (
 /obj/machinery/alarm/directional/north,
 /turf/simulated/floor/carpet/black,
@@ -5817,6 +5907,18 @@
 /obj/structure/cable,
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat/service)
+"aXu" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/north)
 "aXz" = (
 /obj/effect/map_effect/dynamic_airlock,
 /turf/simulated/floor/plating,
@@ -6257,19 +6359,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass/jungle,
 /area/station/hallway/secondary/garden)
-"baL" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Criminal Delivery Chute"
-	},
-/obj/effect/turf_decal/stripes,
-/obj/effect/turf_decal/stripes/red,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/structure/disposalpipe/segment{
-	color = "#954535"
-	},
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/north)
 "baR" = (
 /turf/simulated/wall,
 /area/station/engineering/tech_storage)
@@ -6334,6 +6423,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/supply/sorting)
+"bbT" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/door/airlock/virology/glass{
+	name = "Virology Patient Room 2";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "viro_2"
+	},
+/obj/effect/turf_decal/tiles/department/virology,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/virology)
 "bca" = (
 /obj/machinery/computer/arcade/orion_trail{
 	dir = 8
@@ -6352,11 +6458,6 @@
 /obj/item/flag/ian,
 /turf/simulated/floor/wood,
 /area/station/public/pet_store)
-"bcr" = (
-/obj/machinery/door/airlock/hatch,
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
-/turf/simulated/floor/plasteel/dark,
-/area/station/aisat/service)
 "bcy" = (
 /turf/simulated/wall/r_wall,
 /area/station/aisat/service)
@@ -6385,16 +6486,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/lobby)
-"bcG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/hatch,
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/catwalk/black,
-/area/station/aisat/service)
 "bcJ" = (
 /obj/structure/extinguisher_cabinet{
 	name = "west bump";
@@ -6441,6 +6532,17 @@
 "bcS" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/service/aft_port)
+"bcT" = (
+/obj/machinery/door/airlock/mining/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/cargo_bay,
+/turf/simulated/floor/plasteel/dark,
+/area/station/supply/storage)
 "bdh" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass,
@@ -6502,6 +6604,19 @@
 /obj/effect/turf_decal/tiles/department/security,
 /turf/simulated/floor/plasteel,
 /area/station/security/storage)
+"bdT" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/dirt/frequent,
+/obj/machinery/door/airlock/engineering{
+	name = "Aft Starboard Solar Access";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/solar_maintenance/fore_starboard)
 "bdX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6835,17 +6950,6 @@
 	},
 /turf/simulated/wall,
 /area/station/security/range)
-"bgt" = (
-/obj/structure/disposalpipe/segment{
-	color = "#954535"
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/port/north)
 "bgx" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -6986,21 +7090,20 @@
 /obj/machinery/economy/atm/directional/north,
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
-"bhy" = (
-/obj/machinery/door/airlock/glass{
-	name = "Internal Affairs Office"
+"bhz" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/iaa,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "IAA"
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 4
 	},
-/area/station/legal/lawoffice)
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/dockmed)
 "bhD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7210,20 +7313,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/service/bar)
-"bjs" = (
-/obj/machinery/door/airlock/medical/glass,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/break_room)
 "bjA" = (
 /obj/machinery/cryopod{
 	dir = 2
@@ -7875,20 +7964,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/processing)
-"bnG" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Solitary Confinement 1"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/department/security,
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
 "bnN" = (
 /obj/vehicle/secway,
 /obj/effect/turf_decal/delivery/hollow,
@@ -7900,33 +7975,10 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/space,
 /area/space/nearstation)
-"bnR" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Laser Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/control)
 "bnT" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /turf/simulated/floor/carpet/royalblack,
 /area/station/supply/qm)
-"bnV" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/public/locker)
-"boh" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Starboard Asteroid Maintenance Access"
-	},
-/obj/structure/barricade/wooden/crude,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/abandonedservers)
 "bok" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/service/bar{
@@ -8435,6 +8487,23 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/east)
+"bsJ" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance/external{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/service/aft_starboard)
 "bsK" = (
 /obj/structure/table/glass,
 /obj/item/clothing/gloves/color/latex,
@@ -8908,19 +8977,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/hallway/spacebridge/serveng)
-"bvr" = (
-/obj/machinery/door/airlock/command,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/command/captain,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/black,
-/area/station/command/office/captain)
 "bvt" = (
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
@@ -9071,6 +9127,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/a)
+"bwA" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/airlock/engineering{
+	name = "Science Asteroid Substation";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "bwD" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -9078,6 +9145,19 @@
 /obj/effect/turf_decal/tiles/department/virology/side,
 /turf/simulated/floor/plasteel/dark,
 /area/station/public/quantum/service)
+"bwN" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "med1"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/patients_rooms1)
 "bwR" = (
 /obj/effect/spawner/random/dirt/often,
 /obj/structure/disposalpipe/segment{
@@ -9238,6 +9318,17 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/east)
+"bxY" = (
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/storage)
 "byi" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -9451,17 +9542,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/security/permabrig)
-"bzR" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering{
-	name = "Docking Asteroid Substation"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical/aft_starboard)
 "bzY" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -9551,29 +9631,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
-"bAy" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Central Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/maintcentral)
 "bAz" = (
 /obj/structure/chair/sofa/right,
 /turf/simulated/floor/wood,
 /area/station/medical/psych)
-"bAA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/map_effect/dynamic_airlock/door/interior,
-/obj/machinery/access_button/offset/east,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/central/north)
 "bAI" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -9603,17 +9664,6 @@
 "bAO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/wall/r_wall,
-/area/station/engineering/engine/supermatter)
-"bAP" = (
-/obj/machinery/door/airlock/engineering/glass{
-	heat_proof = 1;
-	name = "Supermatter Chamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/engine,
 /area/station/engineering/engine/supermatter)
 "bAQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
@@ -10250,34 +10300,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/break_room/secondary)
-"bFl" = (
-/obj/machinery/door/airlock/engineering/glass{
-	autoclose = 0;
-	id_tag = "engsm_door_int";
-	name = "Supermatter Interior Access"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/control)
-"bFs" = (
-/obj/machinery/door/airlock/engineering/glass{
-	autoclose = 0;
-	id_tag = "engsm_door_int";
-	name = "Supermatter Interior Access"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/engine,
-/area/station/engineering/control)
 "bFB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10373,6 +10395,18 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/north)
+"bGm" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Starboard Asteroid Maintenance Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "bGp" = (
 /obj/effect/turf_decal/tiles/jobs/bar/checker,
 /obj/structure/table/reinforced,
@@ -10411,6 +10445,18 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/library)
+"bGz" = (
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/kitchen)
 "bGB" = (
 /obj/effect/spawner/random/barrier/grille_maybe,
 /obj/structure/cable/extra_insulated{
@@ -10418,21 +10464,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"bGF" = (
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
-/obj/machinery/door/firedoor,
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external/glass{
-	name = "Mining Dock Airlock";
-	id_tag = "mining_home"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plasteel,
-/area/station/supply/miningdock)
 "bGI" = (
 /obj/structure/chair/stool{
 	dir = 4
@@ -11031,6 +11062,18 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
+"bLS" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/dockmed)
 "bLU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11090,6 +11133,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/supply/lobby)
+"bMv" = (
+/obj/machinery/door/airlock/external{
+	name = "Toxins Test Chamber";
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/science/toxins/test)
 "bMw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11305,10 +11355,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/westalt)
-"bNY" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/public/quantum/cargo)
 "bOd" = (
 /obj/machinery/atmospherics/portable/canister/air,
 /obj/structure/sign/vacuum/external{
@@ -11442,6 +11488,22 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/public/fitness)
+"bPh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/port/south)
 "bPi" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/wood,
@@ -11626,17 +11688,6 @@
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/meeting_room)
-"bQe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/science/research,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/research/glass,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/science/rnd)
 "bQg" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/turf_decal/tiles/dark/checker,
@@ -12050,14 +12101,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
-"bTa" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
 "bTb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 10
@@ -12885,19 +12928,6 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/engineering/atmos)
-"bXi" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft-Starboard Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/asmaint2)
 "bXj" = (
 /turf/simulated/mineral/ancient,
 /area/station/service/chapel/office)
@@ -13252,6 +13282,13 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/supply/office)
+"cad" = (
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "cag" = (
 /obj/machinery/door/poddoor{
 	id_tag = "QMLoaddoor2";
@@ -13266,30 +13303,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/disposal/southwest)
-"cau" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "hopshutter"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/reinforced/normal{
-	dir = 1;
-	name = "Head of Personnel's Desk"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/command/hop{
-	dir = 1
-	},
-/obj/machinery/door/window{
-	name = "Desk Door"
-	},
-/obj/item/desk_bell{
-	pixel_x = 7;
-	pixel_y = 7;
-	anchored = 1
-	},
-/turf/simulated/floor/plating,
-/area/station/command/office/hop)
 "caC" = (
 /obj/machinery/camera{
 	c_tag = "Docking Asteroid Hall 2";
@@ -13310,17 +13323,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/starboard)
-"caM" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "caQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -13371,6 +13373,23 @@
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/mine/unexplored/cere/orbiting)
+"cbz" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment{
+	color = "#505050"
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/south)
 "cbP" = (
 /obj/machinery/door_timer/cell_1{
 	pixel_y = -32
@@ -13862,21 +13881,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/security/starboard)
-"cgh" = (
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "BrigRight";
-	name = "Brig Foyer Right Entrance"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
 "cgl" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/cyan,
 /obj/machinery/atmospherics/meter,
@@ -13946,6 +13950,25 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/north)
+"cgD" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access";
+	dir = 4
+	},
+/obj/effect/spawner/random/dirt/frequent,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/security/starboard)
 "cgE" = (
 /obj/machinery/camera{
 	c_tag = "Brig Processing East";
@@ -13968,23 +13991,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"cgP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/starboard/south)
 "cgU" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -14445,6 +14451,17 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/east)
+"ckX" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Escape Shuttle Cell";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/secondary/exit)
 "cle" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/atmospherics/meter,
@@ -14869,20 +14886,6 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall,
 /area/station/command/bridge)
-"cpk" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/command/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge_upper";
-	layer = 2.6;
-	name = "Emergency Blast Door"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel/dark,
-/area/station/command/bridge)
 "cpl" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -14987,6 +14990,20 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/command/starboard)
+"cpR" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Command Asteroid Solar Array";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/solar_maintenance/fore_port)
 "cpT" = (
 /obj/machinery/atmospherics/refill_station/plasma,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -15078,6 +15095,26 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/hallway)
+"cqB" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/north)
 "cqD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15099,15 +15136,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/hallway)
-"cqN" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/external/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/map_effect/dynamic_airlock/door/interior,
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/access_button/offset/northeast,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/central/east)
 "cqO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -16584,18 +16612,6 @@
 /obj/effect/turf_decal/tiles/department/command/side,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/meeting_room)
-"cDh" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "cDi" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -16645,6 +16661,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
+"cEh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/storage)
 "cEl" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -16755,19 +16787,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/security/fore_starboard)
-"cFf" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Escape Shuttle Cell"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/secondary/exit)
 "cFg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -16994,6 +17013,33 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/public/storefront)
+"cGG" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/window/brigdoor{
+	id = "Cell 1";
+	name = "Cell 1"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison/cell_block/a)
 "cGJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -17068,6 +17114,28 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/supply/storage)
+"cHg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/atmos{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "atmos";
+	name = "Atmospherics Blast Door"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/atmos)
 "cHj" = (
 /obj/structure/railing,
 /obj/structure/flora/ausbushes/stalkybush,
@@ -17413,6 +17481,20 @@
 /obj/item/clothing/head/sombrero/shamebrero,
 /turf/simulated/floor/plating/asteroid/ancient/airless,
 /area/mine/unexplored/cere/orbiting)
+"cKE" = (
+/obj/effect/spawner/random/dirt/frequent,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	name = "Storefront Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/station/public/storefront)
 "cKG" = (
 /turf/simulated/floor/carpet/black,
 /area/station/legal/magistrate)
@@ -17560,6 +17642,24 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
+"cMe" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/research{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/department/science,
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/robotics)
 "cMh" = (
 /obj/effect/spawner/random/fungus/probably,
 /turf/simulated/wall,
@@ -17632,6 +17732,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
+"cMR" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "cMT" = (
 /turf/simulated/wall,
 /area/station/service/theatre)
@@ -17641,21 +17751,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/command/fore)
-"cNb" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "hopexternal"
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
-/obj/machinery/ticket_machine{
-	layer = 4;
-	pixel_x = -32
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/command/office/hop)
 "cNh" = (
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white{
@@ -18072,14 +18167,6 @@
 /obj/effect/turf_decal/tiles/department/virology,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
-"cPM" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Medical Asteroid Solars"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "cPP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -18175,6 +18262,15 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/engine_foyer)
+"cQp" = (
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "trader_home";
+	name = "Docking Port 4";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/secondary/entry/south)
 "cQr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -18318,19 +18414,6 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/station/service/library)
-"cRu" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Central Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/maintcentral)
 "cRv" = (
 /turf/simulated/mineral/ancient/outer,
 /area/mine/unexplored/cere/command)
@@ -18499,6 +18582,18 @@
 /obj/item/megaphone,
 /turf/simulated/floor/carpet/black,
 /area/station/legal/magistrate)
+"cSK" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/sercom)
 "cSL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -18552,16 +18647,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
-"cTd" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "med2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/patients_rooms_secondary)
 "cTh" = (
 /turf/simulated/wall,
 /area/station/maintenance/disposal/south)
@@ -18644,15 +18729,6 @@
 /obj/effect/turf_decal/tiles/department/medical/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/public/dorms)
-"cTN" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/effect/turf_decal/tiles/department/engineering/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/east)
 "cTX" = (
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/maintenance/electrical/fore_starboard)
@@ -18740,6 +18816,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/starboard/south)
+"cUD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/security/aft_port)
 "cUW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 6
@@ -19226,18 +19320,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/hallway/spacebridge/scidock)
-"cZc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/service/aft_port)
 "cZi" = (
 /obj/effect/mapping_helpers/airlock/access/all/service/chapel_office,
 /obj/machinery/door/airlock/glass,
@@ -19350,15 +19432,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/hallway/spacebridge/scidock)
-"cZY" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/west)
 "dab" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -19642,15 +19715,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/engine_foyer)
-"ddk" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/starboard/south)
 "ddn" = (
 /obj/structure/table/glass/reinforced,
 /obj/item/ashtray/bronze,
@@ -20068,15 +20132,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
-"dfT" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/security/fore_starboard)
 "dfW" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -20114,14 +20169,6 @@
 /obj/effect/turf_decal/tiles/department/virology/side,
 /turf/simulated/floor/plasteel/white,
 /area/station/public/sleep)
-"dgs" = (
-/obj/machinery/door/airlock/external/glass{
-	id_tag = "trader_home";
-	name = "Docking Port 4"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/secondary/entry/south)
 "dgD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 5
@@ -20641,18 +20688,6 @@
 /obj/machinery/economy/vending/cigarette,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/north)
-"dlL" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
 "dlR" = (
 /obj/machinery/power/apc/directional/north,
 /obj/structure/cable/orange{
@@ -20683,12 +20718,6 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/west)
-"dmb" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
 "dmd" = (
 /obj/machinery/economy/vending/cigarette,
 /turf/simulated/floor/plasteel,
@@ -20706,23 +20735,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/genetics)
-"dmo" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge";
-	layer = 2.6;
-	name = "Emergency Blast Door"
-	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge Lobby"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/department/command/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/command/meeting_room)
 "dmx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -20730,23 +20742,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/public/fitness)
-"dmy" = (
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge";
-	layer = 2.6;
-	name = "Emergency Blast Door"
-	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge Lobby"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/department/command/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/command/meeting_room)
 "dmA" = (
 /turf/simulated/wall/r_wall,
 /area/station/hallway/primary/fore/north)
@@ -20818,6 +20813,14 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/north)
+"dnr" = (
+/obj/machinery/mineral/ore_redemption,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/cargo,
+/turf/simulated/floor/plasteel/dark,
+/area/station/supply/office)
 "dnw" = (
 /obj/structure/chair{
 	dir = 1
@@ -21010,6 +21013,21 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/execution)
+"doV" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/south)
 "doX" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -21293,28 +21311,32 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
-"dsn" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/white/corner{
+"dsj" = (
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
-/obj/effect/turf_decal/tiles/department/medical/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/south)
-"dsq" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/command/ntrep,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/engineering/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/break_room)
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "ntrepofficedoor";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "ntr"
+	},
+/turf/simulated/floor/wood,
+/area/station/command/office/ntrep)
 "dss" = (
 /obj/machinery/status_display{
 	layer = 4
@@ -21440,21 +21462,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
-"dtv" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Criminal Delivery Chute"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/turf_decal/stripes,
-/obj/effect/turf_decal/stripes/red,
-/obj/structure/disposalpipe/segment{
-	color = "#954535"
-	},
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/east)
 "dtD" = (
 /obj/structure/extinguisher_cabinet{
 	name = "east bump";
@@ -21666,26 +21673,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/hallway/spacebridge/sercom)
-"dvp" = (
-/obj/machinery/smartfridge/medbay,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "chemisttop";
-	name = "Chemistry Lobby Shutters"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/chemistry,
-/obj/machinery/door/window/classic/normal,
-/obj/effect/mapping_helpers/airlock/windoor/autoname,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/chemistry)
 "dvq" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -21709,14 +21696,6 @@
 	},
 /turf/simulated/floor/noslip,
 /area/station/engineering/control)
-"dvy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry)
 "dvA" = (
 /obj/item/kirbyplants/large,
 /obj/machinery/light{
@@ -21790,6 +21769,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/supply/storage)
+"dwS" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access";
+	dir = 4
+	},
+/obj/effect/spawner/random/dirt/frequent,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/security/starboard)
 "dwV" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/dirt,
@@ -22370,6 +22362,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/service/aft_starboard)
+"dAX" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Turbine Access";
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/random/dirt/frequent,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/turbine)
 "dBi" = (
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -22619,6 +22629,18 @@
 "dDo" = (
 /obj/structure/sign/directions/evac,
 /turf/simulated/wall,
+/area/station/maintenance/starboard)
+"dDr" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Starboard Asteroid Maintenance Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
 /area/station/maintenance/starboard)
 "dDw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22904,21 +22926,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/ntrep)
-"dIv" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/effect/turf_decal/tiles/department/engineering/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/storage)
 "dID" = (
 /obj/structure/sign/security,
 /turf/simulated/wall/r_wall,
@@ -22996,6 +23003,20 @@
 	},
 /turf/space,
 /area/space/nearstation/disposals)
+"dJX" = (
+/obj/machinery/door/airlock/mining/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/supply/smith,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/supply/smith_office)
 "dJZ" = (
 /obj/machinery/light/small,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
@@ -23218,18 +23239,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/disposal/northwest)
-"dMd" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/bananium,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/service/clown,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/station/service/clown)
 "dMk" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/drinks/flask/gold,
@@ -23330,6 +23339,19 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/station/service/clown)
+"dNQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "dNR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23442,6 +23464,20 @@
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_starboard)
+"dOG" = (
+/obj/machinery/door/airlock/engineering/glass{
+	autoclose = 0;
+	id_tag = "engsm_door_ext";
+	name = "Supermatter Exterior Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/control)
 "dOH" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -23518,15 +23554,6 @@
 /obj/item/weldingtool/mini,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/disposal/external/southeast)
-"dPF" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/north)
 "dPP" = (
 /obj/machinery/computer/arcade{
 	dir = 4
@@ -23655,20 +23682,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/service/aft_starboard)
-"dRp" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry)
 "dRs" = (
 /obj/structure/railing/corner,
 /obj/effect/turf_decal/tiles/neutral,
@@ -23717,30 +23730,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/public/quantum/cargo)
-"dRX" = (
-/obj/machinery/door/airlock/security/glass{
-	locked = 1;
-	id_tag = "perma_door_int"
-	},
-/obj/effect/turf_decal/stripes,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/access_button{
-	autolink_id = "perma_btn_int";
-	name = "Prison Wing Access Button";
-	req_access = list(2);
-	pixel_x = -21
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/permabrig)
 "dSk" = (
 /obj/machinery/alarm/directional/east,
 /obj/effect/turf_decal/stripes/corner{
@@ -24109,29 +24098,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"dVv" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/reinforced/normal{
-	name = "Security Reception";
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/general{
-	dir = 1
-	},
-/obj/structure/table/reinforced{
-	layer = 2.5
-	},
-/obj/item/desk_bell{
-	pixel_x = 7;
-	pixel_y = 7;
-	anchored = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/lobby)
 "dVA" = (
 /obj/effect/spawner/airlock/s_to_n,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -24780,6 +24746,18 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/security/aft_port)
+"efh" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/sercom)
 "efv" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -24880,22 +24858,6 @@
 /obj/effect/turf_decal/tiles/jobs/bar/checker,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"egr" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "cargolockdown";
-	layer = 2.6;
-	name = "Cargo Lockdown"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/starboard/south)
 "egv" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -25133,20 +25095,6 @@
 /obj/structure/flora/tree/jungle/small,
 /turf/simulated/floor/grass/jungle/no_creep,
 /area/station/hallway/primary/port/south)
-"ejc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/research,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
-/obj/effect/mapping_helpers/airlock/access/any/science/tox,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/misc_lab)
 "ejd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -25465,11 +25413,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/engine_foyer)
-"emL" = (
-/obj/machinery/door/airlock/glass,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating/airless,
-/area/station/maintenance/apmaint)
 "emN" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -25518,6 +25461,24 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/command/fore)
+"eno" = (
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/break_room)
 "env" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -25721,6 +25682,20 @@
 "epR" = (
 /turf/simulated/wall,
 /area/station/security/permabrig)
+"eqf" = (
+/obj/machinery/door/airlock/highsecurity{
+	locked = 1;
+	name = "AI Upload Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel/dark,
+/area/station/turret_protected/ai_upload)
 "eqh" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -25780,15 +25755,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
-"eqG" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/airlock/engineering{
-	name = "Command Asteroid Security Area Substation"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/electrical/fore_port)
 "eqN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25886,12 +25852,6 @@
 /obj/structure/closet/l3closet/scientist,
 /turf/simulated/floor/engine,
 /area/station/science/misc_lab)
-"erD" = (
-/obj/machinery/door/airlock{
-	name = "Toilet"
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/station/security/storage)
 "erH" = (
 /mob/living/simple_animal/bot/cleanbot{
 	name = "Na2CO3"
@@ -25958,6 +25918,27 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/north)
+"esI" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "servlockdown";
+	layer = 2.6;
+	name = "Service Lockdown"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/sercom)
 "esK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -26089,6 +26070,19 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
+"eut" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "euv" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -26507,18 +26501,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/misc_lab)
-"ezc" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/south)
 "ezd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26562,6 +26544,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/transmission_laser)
+"ezo" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Starboard Asteroid Maintenance Access";
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "ezp" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -26712,6 +26706,25 @@
 /obj/effect/turf_decal/tiles/department/security,
 /turf/simulated/floor/plasteel,
 /area/station/security/storage)
+"eAD" = (
+/obj/machinery/door/airlock/mining/glass{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/supply/expedition,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/supply/break_room)
 "eAE" = (
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/airlock/maintenance,
@@ -27347,10 +27360,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
-"eHs" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/public/quantum/security)
 "eHu" = (
 /obj/structure/falsewall/rock_ancient,
 /turf/simulated/floor/plating,
@@ -27712,6 +27721,19 @@
 /obj/effect/turf_decal/tiles/department/cargo/corner,
 /turf/simulated/floor/plasteel/dark,
 /area/station/supply/storage)
+"eKT" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/service/fore_starboard)
 "eKU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27939,6 +27961,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/port)
+"eMZ" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Throne Room";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/disposal/northeast)
 "eNa" = (
 /obj/machinery/firealarm/directional/west,
 /obj/structure/mopbucket/full{
@@ -28085,6 +28119,14 @@
 	},
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/disposal/west)
+"eOS" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Escape Pod 5 Airlock";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/plating,
+/area/station/maintenance/security/fore_starboard)
 "eOW" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -28212,6 +28254,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/fore/north)
+"ePR" = (
+/obj/machinery/door/airlock/vault{
+	locked = 1;
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/vault,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore/north)
 "ePW" = (
 /obj/effect/mapping_helpers/turfs/burn,
 /obj/effect/turf_decal/tiles/department/command/side{
@@ -28265,6 +28323,40 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/hallway/secondary/exit)
+"eQM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/engineering/glass{
+	heat_proof = 1;
+	name = "Supermatter Chamber";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/turf/simulated/floor/engine,
+/area/station/engineering/engine/supermatter)
+"eQV" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/classic/normal{
+	dir = 1;
+	name = "Robotics Desk"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/science/robotics{
+	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "RoboticsShutters"
+	},
+/obj/item/desk_bell{
+	pixel_x = 7;
+	pixel_y = 7;
+	anchored = 1
+	},
+/obj/effect/turf_decal/tiles/department/science,
+/turf/simulated/floor/plasteel,
+/area/station/science/robotics)
 "eQY" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/command/starboard)
@@ -28296,6 +28388,26 @@
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/security/fore_starboard)
+"eRv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/south)
 "eRw" = (
 /obj/machinery/alarm/directional/north,
 /obj/machinery/button/windowtint{
@@ -28320,6 +28432,23 @@
 /obj/effect/turf_decal/tiles/department/security/corner,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/security/port)
+"eRK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/highsecurity{
+	locked = 1;
+	name = "AI Upload Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel/dark,
+/area/station/turret_protected/ai_upload)
 "eRT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tiles/department/virology/corner,
@@ -28471,6 +28600,23 @@
 "eTm" = (
 /turf/simulated/wall,
 /area/station/command/office/captain)
+"eTo" = (
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external/glass{
+	name = "Mining Dock Airlock";
+	id_tag = "mining_home";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/plasteel,
+/area/station/supply/miningdock)
 "eTp" = (
 /obj/machinery/alarm/directional/west,
 /turf/simulated/floor/engine,
@@ -28688,6 +28834,22 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/purple,
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/security/starboard)
+"eWg" = (
+/obj/machinery/door/airlock/engineering/glass{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/smes)
 "eWm" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable,
@@ -28800,19 +28962,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/wood,
 /area/station/service/library)
-"eYh" = (
-/obj/machinery/door/airlock/engineering/glass{
-	autoclose = 0;
-	id_tag = "engsm_door_ext";
-	name = "Supermatter Exterior Access"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/control)
 "eYz" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -28940,14 +29089,6 @@
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
-"eZR" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance/external,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/maintcentral)
 "eZW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29004,15 +29145,6 @@
 /obj/effect/turf_decal/tiles/jobs/bar/checker,
 /turf/simulated/floor/plasteel,
 /area/station/service/theatre)
-"faD" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/command/starboard)
 "faF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -29039,6 +29171,17 @@
 /obj/item/cigbutt,
 /turf/simulated/floor/carpet/grimey,
 /area/station/maintenance/security/fore_starboard)
+"faW" = (
+/obj/machinery/door/airlock{
+	name = "Bathroom";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/spawner/random/dirt/frequent,
+/turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
 "fbk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29357,6 +29500,14 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/engine_foyer)
+"ffm" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/service/fore_starboard)
 "ffy" = (
 /obj/machinery/economy/vending/genedrobe,
 /obj/effect/turf_decal/tiles/department/science/side{
@@ -29435,6 +29586,25 @@
 /obj/effect/turf_decal/tiles/department/science,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
+"fgw" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "scilockdown";
+	layer = 2.6;
+	name = "Science Lockdown"
+	},
+/obj/effect/turf_decal/caution/red,
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/servsci)
 "fgx" = (
 /obj/machinery/requests_console/directional/north,
 /obj/structure/cable{
@@ -29482,15 +29652,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
-"fhE" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/sercom)
 "fhQ" = (
 /obj/structure/sign/directions/medical{
 	dir = 1;
@@ -29665,16 +29826,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/service/aft_starboard)
-"fjt" = (
-/obj/effect/mapping_helpers/airlock/access/all/service/crematorium,
-/obj/machinery/door/airlock{
-	name = "Crematorium"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/service/chapel)
 "fjw" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tiles/neutral/corner{
@@ -29970,6 +30121,16 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/electrical/fore_port)
+"fme" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "fmj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30523,13 +30684,6 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/south)
-"fss" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/medical/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/sleeper)
 "fsx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30546,14 +30700,6 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
-"fsP" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft-Starboard Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/asmaint)
 "fsQ" = (
 /obj/machinery/atmospherics/portable/canister/nitrogen,
 /obj/effect/turf_decal/delivery/hollow,
@@ -30790,23 +30936,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/service/fore_starboard)
-"fvb" = (
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/window/reinforced/reversed{
-	name = "Arrival Security Checkpoint";
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/doors{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	color = "#954535"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/security/checkpoint/secondary)
 "fvd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31004,6 +31133,23 @@
 	},
 /turf/simulated/wall,
 /area/station/hallway/primary/aft/west)
+"fxj" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/security/fore_starboard)
 "fxo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -31089,6 +31235,29 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/command/bridge)
+"fxP" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/classic/normal,
+/obj/effect/mapping_helpers/airlock/windoor/autoname,
+/obj/machinery/door/window/classic/normal{
+	name = "Kitchen";
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
+	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/hydroponics,
+/obj/item/desk_bell{
+	pixel_x = 7;
+	pixel_y = 7;
+	anchored = 1
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/service/kitchen)
 "fye" = (
 /obj/effect/map_effect/dynamic_airlock,
 /turf/simulated/floor/plating,
@@ -31349,6 +31518,24 @@
 /obj/effect/spawner/random/engineering/materials,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"fCB" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/south)
 "fCE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31684,21 +31871,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/supermatter)
-"fGb" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/sign/cargo{
-	pixel_x = 32
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore/east)
 "fGg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -31799,6 +31971,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central/east)
+"fGS" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "hopexternal"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/obj/machinery/ticket_machine{
+	layer = 4;
+	pixel_x = -32
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/command/office/hop)
 "fGT" = (
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 1
@@ -32063,6 +32252,25 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
+"fJL" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "cargolockdown";
+	layer = 2.6;
+	name = "Cargo Lockdown"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/south)
 "fKi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -32295,13 +32503,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/service/fore_port)
-"fMV" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/dark,
-/area/station/public/quantum/docking)
 "fMX" = (
 /obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/tiles/department/virology/corner{
@@ -32411,22 +32612,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/science/toxins/test)
-"fOh" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/classic/normal{
-	name = "Kitchen";
-	dir = 1
-	},
-/obj/machinery/door/window/classic/normal,
-/obj/effect/mapping_helpers/airlock/windoor/autoname,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/hydroponics,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
-	dir = 1
-	},
-/obj/machinery/smartfridge/food/chef,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/service/kitchen)
 "fOo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -32437,28 +32622,15 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/hallway)
-"fOr" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Trainer's Office";
-	id_tag = "nct"
+"fOq" = (
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "NCT"
+/obj/effect/turf_decal/tiles/department/medical/side{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/procedure/trainer,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/dark,
-/area/station/procedure/trainer_office)
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/sleeper)
 "fOt" = (
 /obj/structure/sign/poster/contraband/clown/directional/north,
 /obj/item/bedsheet/clown,
@@ -32546,6 +32718,16 @@
 /mob/living/basic/pig,
 /turf/simulated/floor/grass,
 /area/station/service/hydroponics)
+"fPB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/obj/effect/map_effect/dynamic_airlock/door/interior,
+/obj/machinery/access_button/offset/east,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/central/north)
 "fPE" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -32802,20 +32984,6 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/hallway)
-"fTn" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/security/aft_starboard)
 "fTu" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -32842,6 +33010,33 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/west)
+"fTD" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "rdofficedoor";
+	name = "Research Director's Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/rd,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "rd"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/command/office/rd)
 "fTT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -33006,6 +33201,15 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/station/command/office/cmo)
+"fWr" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Madical Atmospherics Checkpoint";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "fWs" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -33037,6 +33241,18 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/security/aft_port)
+"fWF" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Central Asteroid Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/maintcentral)
 "fWN" = (
 /obj/structure/extinguisher_cabinet{
 	name = "east bump";
@@ -33097,14 +33313,6 @@
 	},
 /turf/space,
 /area/space)
-"fXM" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft-Starboard Asteroid Maintenance"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/asmaint)
 "fXN" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-4"
@@ -33252,12 +33460,6 @@
 /obj/effect/turf_decal/tiles/department/engineering/side,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/smes)
-"fZO" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/department/virology,
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/secondary/garden)
 "fZS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -33327,17 +33529,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/service/fore_starboard)
-"gar" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/multi_tile/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/department/virology,
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/secondary/garden)
 "gav" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -33368,6 +33559,19 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/south)
+"gaC" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/department/virology,
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/secondary/garden)
 "gaJ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -33472,6 +33676,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/storage)
+"gca" = (
+/obj/machinery/door/airlock/tranquillite{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/service/mime,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/mineral/tranquillite,
+/area/station/service/mime)
 "gch" = (
 /turf/simulated/wall,
 /area/station/command/office/ntrep)
@@ -33484,19 +33704,6 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/north)
-"gck" = (
-/obj/machinery/door/airlock/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Courtroom"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/security/doors,
-/obj/effect/mapping_helpers/airlock/access/any/security/court,
-/turf/simulated/floor/wood,
-/area/station/legal/courtroom)
 "gcu" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tiles/department/engineering/side{
@@ -33536,6 +33743,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/aft_port)
+"gdy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/catwalk/black,
+/area/station/aisat/service)
 "gdG" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -33552,19 +33771,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/port)
-"ger" = (
-/obj/machinery/door/airlock/vault{
-	locked = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/vault,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore/north)
 "geu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -33609,47 +33815,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/service/fore_port)
-"geS" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/window/brigdoor{
-	id = "Cell 1";
-	name = "Cell 1"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/obj/item/radio/intercom{
-	name = "west bump";
-	pixel_x = -28
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison/cell_block/a)
-"gfb" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
-"gfd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore/north)
 "gfe" = (
 /obj/structure/chair/office/dark,
 /obj/structure/cable{
@@ -33694,6 +33859,15 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/starboard)
+"gfK" = (
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/obj/effect/map_effect/dynamic_airlock/door/interior,
+/obj/machinery/access_button/offset/northeast,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal/southwest)
 "gfS" = (
 /obj/effect/turf_decal/tiles/department/security/side,
 /turf/simulated/floor/plasteel/dark,
@@ -33787,22 +33961,6 @@
 /obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/indestructible/titanium,
 /area/shuttle/arrival/station)
-"ghq" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/tiles/department/engineering/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/east)
 "ghv" = (
 /obj/machinery/light{
 	dir = 1
@@ -33972,6 +34130,31 @@
 /obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
 /area/station/security/prisonershuttle)
+"gjz" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Interrogation"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/interrogation)
 "gjC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -33996,15 +34179,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
-"gjU" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "hopexternal"
-	},
-/obj/effect/turf_decal/loading_area,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/command/office/hop)
 "gjW" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -34020,21 +34194,6 @@
 "gka" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/lobby)
-"gkb" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry)
 "gkn" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -34109,6 +34268,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/east)
+"gkT" = (
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Prison Gate";
+	name = "Prison Lockdown Blast Doors";
+	opacity = 0
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/permabrig)
 "gkX" = (
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/break_room/secondary)
@@ -34259,14 +34435,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
-"gnd" = (
-/obj/effect/map_effect/dynamic_airlock/door/interior,
-/obj/machinery/door/airlock/external/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/access_button/offset/west,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/central/west)
 "gnh" = (
 /obj/structure/table,
 /obj/item/clothing/head/soft/cargo{
@@ -34345,6 +34513,33 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/east)
+"gnM" = (
+/obj/machinery/door/airlock/security/glass{
+	locked = 1;
+	id_tag = "perma_door_int";
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Prison Gate";
+	name = "Prison Lockdown Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/access_button{
+	autolink_id = "perma_btn_int";
+	name = "Prison Wing Access Button";
+	req_access = list(2);
+	pixel_x = -21
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/permabrig)
 "gnS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -34391,6 +34586,23 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/disposal/west)
+"goD" = (
+/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/medical{
+	name = "Operating Theatre Storage";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/surgery)
 "goE" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance,
@@ -34431,6 +34643,27 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/asmaint)
+"goI" = (
+/obj/machinery/door/airlock/glass{
+	id_tag = "magistrateofficedoor";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/command/magistrate,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Magistrate"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/station/legal/magistrate)
 "goJ" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
@@ -34489,6 +34722,21 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/patients_rooms1)
+"gpe" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/barricade/wooden/crude,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "gpi" = (
 /obj/structure/chair/comfy/lime{
 	dir = 8
@@ -35053,19 +35301,23 @@
 	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/maintenance/apmaint)
+"gwy" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/port/north)
 "gwz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm/directional/north,
 /turf/simulated/floor/plasteel/dark,
 /area/station/supply/warehouse)
-"gwA" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Abandoned Infirmary"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plasteel/white,
-/area/station/maintenance/starboard)
 "gwC" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -35133,15 +35385,6 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/engine,
 /area/station/medical/chemistry)
-"gxo" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/port/south)
 "gxx" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
@@ -35298,15 +35541,6 @@
 	},
 /turf/simulated/floor/plating/asteroid/ancient/airless,
 /area/mine/unexplored/cere/civilian)
-"gAg" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/east)
 "gAq" = (
 /obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/tiles/jobs/bar/checker,
@@ -35428,6 +35662,14 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/service/aft_starboard)
+"gCa" = (
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/structure/barricade/wooden,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/maintcentral)
 "gCj" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "QMLoad2"
@@ -35564,6 +35806,22 @@
 	},
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/security/starboard)
+"gEh" = (
+/obj/machinery/door/airlock/glass{
+	name = "Internal Affairs Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/iaa,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "IAA"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/legal/lawoffice)
 "gEj" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -35665,6 +35923,22 @@
 /obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/noslip,
 /area/station/medical/virology)
+"gFe" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/station/maintenance/service/fore_port)
 "gFg" = (
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -35686,6 +35960,35 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/security/aft_starboard)
+"gFB" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/sign/cargo{
+	pixel_x = 32
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore/east)
+"gFM" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/east)
 "gGh" = (
 /obj/machinery/firealarm/directional/east,
 /turf/simulated/floor/engine,
@@ -35804,20 +36107,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
-"gIh" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/port/north)
 "gIk" = (
 /obj/structure/table/reinforced,
 /obj/item/tank/internals/anesthetic,
@@ -35977,13 +36266,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/external/southeast)
-"gJT" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/virology,
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/spacebridge/scidock)
 "gJZ" = (
 /obj/effect/turf_decal/tiles/white/corner{
 	dir = 8
@@ -36155,6 +36437,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/command/fore)
+"gLP" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/airlock/engineering{
+	name = "Cargo/Medical Asteroid Substation";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "gLV" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -36256,19 +36549,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/office/ce)
-"gNb" = (
-/obj/machinery/door/airlock/highsecurity{
-	locked = 1;
-	name = "AI Upload Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel/dark,
-/area/station/turret_protected/ai_upload)
 "gNk" = (
 /turf/simulated/wall/r_wall,
 /area/station/command/vault)
@@ -36281,6 +36561,12 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/paramedic)
+"gNw" = (
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/multi_tile/glass,
+/turf/simulated/floor/carpet/arcade,
+/area/station/public/arcade)
 "gNx" = (
 /obj/machinery/camera{
 	c_tag = "Vault Airlock";
@@ -36292,6 +36578,18 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/vault)
+"gNM" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance/external{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/maintcentral)
 "gNQ" = (
 /turf/simulated/wall,
 /area/station/hallway/primary/fore/east)
@@ -36497,6 +36795,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/east)
+"gPM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/obj/effect/map_effect/dynamic_airlock/door/interior,
+/obj/machinery/access_button/offset/southwest,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/central/north)
 "gPS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -36517,6 +36825,26 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/west)
+"gQa" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "engilockdown";
+	layer = 2.6;
+	name = "Engineering Lockdown"
+	},
+/obj/structure/disposalpipe/segment{
+	color = "#954535"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/comeng)
 "gQc" = (
 /obj/machinery/door/poddoor{
 	id_tag = "mixvent";
@@ -36530,6 +36858,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
+"gQA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/command/starboard)
 "gQH" = (
 /obj/structure/rack,
 /obj/item/airlock_electronics,
@@ -36674,6 +37019,24 @@
 "gSQ" = (
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/starboard)
+"gTa" = (
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external/glass{
+	name = "Mining Dock Airlock";
+	id_tag = "mining_home";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/plasteel,
+/area/station/supply/miningdock)
 "gTc" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Walkway"
@@ -36853,39 +37216,6 @@
 	},
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/service/aft_port)
-"gUH" = (
-/obj/machinery/door/airlock/security/glass{
-	locked = 1;
-	id_tag = "perma_door_ext"
-	},
-/obj/effect/turf_decal/stripes/red,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/access_button{
-	autolink_id = "perma_btn_ext";
-	name = "Prison Wing Access Button";
-	req_access = list(2);
-	pixel_x = 21
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/permabrig)
 "gUJ" = (
 /mob/living/basic/crab{
 	desc = "The local trainer hired to keep the crew in shape by aggressively snipping at them.";
@@ -36924,6 +37254,23 @@
 /obj/effect/turf_decal/tiles/department/cargo/corner,
 /turf/simulated/floor/plasteel,
 /area/station/supply/lobby)
+"gVs" = (
+/obj/machinery/door/airlock/security/glass{
+	security_level = 1;
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/permabrig)
 "gVx" = (
 /obj/machinery/firealarm/directional/east,
 /obj/structure/closet/secure_closet/medical1,
@@ -37065,6 +37412,22 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/surgery/primary)
+"gXH" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Criminal Delivery Chute";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/turf_decal/stripes,
+/obj/effect/turf_decal/stripes/red,
+/obj/structure/disposalpipe/segment{
+	color = "#954535"
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/east)
 "gXL" = (
 /obj/structure/closet/firecloset/full,
 /turf/simulated/floor/plating,
@@ -37170,19 +37533,6 @@
 /obj/item/flag/nt,
 /turf/simulated/floor/wood,
 /area/station/command/office/blueshield)
-"gYP" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
-/obj/machinery/door/airlock/engineering,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/tech_storage)
 "gYT" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -37279,17 +37629,6 @@
 	},
 /turf/simulated/mineral/ancient,
 /area/station/public/dorms)
-"gZH" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
 "gZI" = (
 /turf/simulated/floor/wood,
 /area/station/command/office/blueshield)
@@ -37606,6 +37945,21 @@
 	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/maintenance/electrical/aft_starboard)
+"hdw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/department/virology,
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/secondary/garden)
 "hdD" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/delivery,
@@ -38018,18 +38372,6 @@
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/aft_port)
-"his" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering{
-	name = "Docking Asteroid Substation"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical/aft_starboard)
 "hiu" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/monkeycubes,
@@ -38038,25 +38380,6 @@
 /obj/effect/turf_decal/tiles/department/science/side,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/test_chamber)
-"hiw" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	dir = 1;
-	location = "Engineering";
-	name = "navigation beacon (Engineering Delivery)"
-	},
-/obj/effect/turf_decal/delivery/hollow,
-/obj/machinery/door/window{
-	name = "Engineering Delivery Chute"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/general,
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/maintcentral)
 "hiC" = (
 /obj/structure/lattice,
 /turf/space,
@@ -38431,29 +38754,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/security/range)
-"hmq" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/command/ntrep,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/door/airlock/command/glass{
-	id_tag = "ntrepofficedoor"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "ntr"
-	},
-/turf/simulated/floor/wood,
-/area/station/command/office/ntrep)
 "hmz" = (
 /obj/structure/table/reinforced,
 /obj/item/toy/figure/crew/qm{
@@ -38497,6 +38797,25 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/west)
+"hmV" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/tiles/department/engineering/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/east)
 "hmZ" = (
 /obj/structure/table,
 /obj/machinery/alarm/directional/north,
@@ -38567,7 +38886,7 @@
 "hnE" = (
 /obj/machinery/computer/general_air_control{
 	name = "Distribution and Waste Monitor";
-	autolink_sensors = list("mair_in_meter"="Mixed Air In","air_sensor"="Mixed Air Supply Tank","mair_out_meter"="Mixed Air Out","dloop_atm_meter"="Distribution Loop","wloop_atm_meter"="Waste Loop")
+	autolink_sensors = list("mair_in_meter" = "Mixed Air In", "air_sensor" = "Mixed Air Supply Tank", "mair_out_meter" = "Mixed Air Out", "dloop_atm_meter" = "Distribution Loop", "wloop_atm_meter" = "Waste Loop")
 	},
 /obj/machinery/alarm/directional/north,
 /obj/effect/turf_decal/tiles/department/engineering/side{
@@ -38657,18 +38976,6 @@
 /obj/effect/spawner/random/fungus/frequent,
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/disposal/northeast)
-"hox" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/storage)
 "hoB" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -38794,6 +39101,24 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/south)
+"hpy" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/janitor,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/service/janitor)
 "hpA" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light{
@@ -38816,6 +39141,20 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
+"hpK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel/dark,
+/area/station/public/quantum/docking)
 "hpO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -39115,6 +39454,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/service/fore_port)
+"hsI" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	color = "#954535"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/sercom)
 "hsK" = (
 /obj/vehicle/ambulance{
 	dir = 4
@@ -39479,6 +39838,22 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/service/aft_port)
+"hwT" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft-Starboard Asteroid Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/asmaint2)
 "hxa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -39738,6 +40113,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/west)
+"hzN" = (
+/obj/machinery/door/airlock/command{
+	name = "Teleport Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/teleporter)
 "hzP" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
@@ -39918,6 +40309,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/east)
+"hBl" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/multi_tile/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/wood,
+/area/station/service/bar)
 "hBs" = (
 /obj/machinery/alarm/directional/west,
 /obj/effect/turf_decal/tiles/white/corner{
@@ -40259,6 +40656,24 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
+"hFj" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/barricade/wooden/crude,
+/obj/effect/decal/cleanable/blood/tracks/mapped{
+	dir = 1
+	},
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/service/aft_port)
 "hFp" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/chair/sofa/pew{
@@ -40301,14 +40716,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/supply/storage)
-"hFS" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/wood,
-/area/station/service/bar)
 "hGb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -40339,17 +40746,6 @@
 /obj/machinery/alarm/directional/north,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/interrogation)
-"hGp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/public/quantum/security)
 "hGq" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small{
@@ -40531,20 +40927,6 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/south)
-"hIo" = (
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external/glass{
-	name = "Mining Dock Airlock";
-	id_tag = "mining_home"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plasteel,
-/area/station/supply/miningdock)
 "hIv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40807,30 +41189,32 @@
 /obj/machinery/firealarm/directional/south,
 /turf/simulated/floor/engine,
 /area/station/science/misc_lab)
-"hLn" = (
-/obj/structure/disposalpipe/segment,
+"hLj" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/fore/north)
+"hLs" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/command/glass{
-	id_tag = "cmoofficedoor";
-	name = "CMO's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "cmo"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/station/command/office/cmo)
+/turf/simulated/floor/plasteel/dark,
+/area/station/public/quantum/engineering)
 "hLx" = (
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall,
@@ -41106,6 +41490,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"hOJ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
+/obj/machinery/door/airlock/engineering{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/tech_storage)
 "hOK" = (
 /turf/simulated/wall,
 /area/station/supply/break_room)
@@ -41137,39 +41538,6 @@
 "hPl" = (
 /turf/simulated/mineral/ancient,
 /area/station/maintenance/service/aft_starboard)
-"hPp" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	color = "#954535"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/sercom)
-"hPv" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "scilockdown";
-	layer = 2.6;
-	name = "Science Lockdown"
-	},
-/obj/effect/turf_decal/caution/red,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/servsci)
 "hPy" = (
 /turf/simulated/floor/light{
 	color = "#763C3A"
@@ -41373,6 +41741,18 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/sleeper)
+"hQT" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/sandbags,
+/obj/machinery/door/firedoor/heavy{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/command/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/disposal/northeast)
 "hQU" = (
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/storage/secondary)
@@ -41606,29 +41986,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"hTa" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/command/blueshield,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+"hTj" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Service Asteroid Substation";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/door/airlock/command/glass{
-	id_tag = "blueshieldofficedoor"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "bs"
-	},
-/turf/simulated/floor/wood,
-/area/station/command/office/blueshield)
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/electrical/port)
 "hTn" = (
 /obj/machinery/economy/vending/snack,
 /obj/structure/window/reinforced{
@@ -41808,18 +42179,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage)
-"hVC" = (
-/obj/machinery/door/airlock/glass{
-	name = "Library reading room"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "library"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/station/service/library)
 "hVP" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -42284,15 +42643,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/a)
-"hZV" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/effect/map_effect/dynamic_airlock/door/interior,
-/obj/machinery/door/airlock/external/glass,
-/obj/machinery/access_button/offset/east,
-/turf/simulated/floor/plating,
-/area/station/maintenance/maintcentral)
 "hZW" = (
 /obj/structure/table/reinforced,
 /obj/machinery/alarm/directional/north,
@@ -42306,24 +42656,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hardsuitstorage)
-"hZX" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors";
-	opacity = 0
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/permabrig)
 "iag" = (
 /obj/machinery/computer/med_data{
 	dir = 1
@@ -42592,19 +42924,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/main)
-"icS" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/station/maintenance/service/aft_starboard)
 "icW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -42618,18 +42937,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/security/processing)
-"idc" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/north)
 "idf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42846,18 +43153,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
-"ieX" = (
-/obj/machinery/door/airlock/engineering/glass,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/smes)
 "ieY" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "Escape Pod 2 Airlock";
@@ -43126,6 +43421,33 @@
 /obj/effect/turf_decal/tiles/department/virology,
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/hydroponics)
+"iiL" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/window/brigdoor{
+	id = "Cell 2";
+	name = "Cell 2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison/cell_block/a)
 "iiN" = (
 /obj/effect/spawner/window/reinforced/polarized/grilled{
 	id = "Detective"
@@ -43205,13 +43527,6 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
-"ijC" = (
-/obj/machinery/door/airlock/glass,
-/obj/structure/barricade/wooden,
-/obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/maintcentral)
 "ijM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -43403,6 +43718,17 @@
 /obj/machinery/light,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/gravitygenerator)
+"ilN" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/command/fore)
 "ilR" = (
 /obj/docking_port/stationary/whiteship{
 	dir = 8;
@@ -43552,15 +43878,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/west)
-"inr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/fore/north)
 "inD" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -43715,21 +44032,6 @@
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/mine/unexplored/cere/command)
-"ipn" = (
-/obj/machinery/door/airlock/research{
-	name = "Research Division Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
-/obj/effect/mapping_helpers/airlock/access/any/science/research,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/science/hallway)
 "ipr" = (
 /obj/item/radio/intercom{
 	pixel_y = -28;
@@ -43987,12 +44289,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/apmaint)
-"irM" = (
-/obj/machinery/door/airlock/glass,
-/obj/structure/barricade/wooden,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/maintcentral)
 "irS" = (
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating{
@@ -44062,24 +44358,26 @@
 "isI" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/service/fore_port)
-"isZ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/spawner/random/dirt/frequent,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/any/science/tox,
-/obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
-/turf/simulated/floor/plasteel/white,
-/area/station/maintenance/apmaint)
 "itf" = (
 /turf/simulated/mineral/ancient,
 /area/station/maintenance/starboard)
+"itr" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/department/engineering/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/west)
 "itB" = (
 /obj/structure/railing{
 	dir = 10
@@ -44149,24 +44447,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/north)
-"iuE" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+"iuu" = (
+/obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "servlockdown";
-	layer = 2.6;
-	name = "Service Lockdown"
+/obj/machinery/door/airlock/multi_tile/glass,
+/turf/simulated/floor/carpet/arcade,
+/area/station/public/arcade)
+"iuA" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft-Starboard Asteroid Maintenance";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/servsci)
+/area/station/maintenance/asmaint)
 "iuK" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/chinese,
@@ -44183,43 +44480,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"iuO" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/window/brigdoor{
-	id = "Cell 3";
-	name = "Cell 3"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/obj/item/radio/intercom{
-	name = "west bump";
-	pixel_x = -28
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison/cell_block/a)
-"iuS" = (
-/obj/machinery/door/airlock/command,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/rd,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/science/server)
 "iuV" = (
 /obj/structure/chair/sofa/corp{
 	dir = 4
@@ -44238,14 +44498,6 @@
 /obj/structure/table,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"ivw" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/command/starboard)
 "ivB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -44296,6 +44548,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/north)
+"iwv" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel/dark,
+/area/station/public/quantum/cargo)
 "iwx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -44516,6 +44783,13 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/chemistry)
+"iyU" = (
+/obj/structure/mineral_door/wood,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/station/maintenance/gambling_den)
 "iyZ" = (
 /obj/effect/spawner/window/reinforced/polarized/grilled{
 	id = "cmo"
@@ -44552,6 +44826,26 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/engine_foyer)
+"izj" = (
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Prison Gate";
+	name = "Prison Lockdown Blast Doors";
+	opacity = 0
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/permabrig)
 "izk" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/light/small{
@@ -44707,20 +45001,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
-"iAF" = (
-/obj/machinery/door/airlock,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/service/janitor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/service/janitor)
 "iAG" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/dark,
@@ -44728,24 +45008,6 @@
 "iAJ" = (
 /turf/simulated/mineral/ancient,
 /area/station/security/checkpoint/secondary)
-"iAO" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "servlockdown";
-	layer = 2.6;
-	name = "Service Lockdown"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/sercom)
 "iAP" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -44982,20 +45244,6 @@
 /obj/effect/turf_decal/tiles/department/science,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
-"iCR" = (
-/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre Storage"
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/surgery)
 "iCT" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -45041,6 +45289,17 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/asmaint)
+"iDE" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/department/engineering/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/storage)
 "iDM" = (
 /obj/machinery/nuclearbomb/training,
 /obj/effect/turf_decal/tiles/department/security/side,
@@ -45090,6 +45349,25 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/medbay2)
+"iEt" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	color = "#954535"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "servlockdown";
+	layer = 2.6;
+	name = "Service Lockdown"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/servsci)
 "iEw" = (
 /obj/machinery/door/poddoor{
 	id_tag = "toxinsdriver";
@@ -45120,6 +45398,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/fore/north)
+"iEU" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/station/maintenance/service/fore_starboard)
 "iFb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -45214,6 +45501,23 @@
 /obj/item/bikehorn/rubberducky,
 /turf/simulated/floor/plasteel/freezer,
 /area/station/public/toilet/lockerroom)
+"iFX" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/service/fore_port)
 "iFY" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/effect/turf_decal/woodsiding{
@@ -45316,6 +45620,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"iHm" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/station_engineer,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/gravitygenerator)
 "iHo" = (
 /obj/item/radio/intercom{
 	name = "east bump";
@@ -45994,17 +46315,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/command/fore)
-"iNT" = (
-/obj/structure/disposalpipe/segment{
-	color = "#954535"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore/east)
 "iNX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -46025,6 +46335,21 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/command/bridge)
+"iOf" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock{
+	name = "Bathroom";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/station/public/toilet/unisex)
 "iOg" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -46185,6 +46510,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/evidence)
+"iPX" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/maintenance/external{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/service/fore_starboard)
 "iPY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/binary/pump{
@@ -46474,6 +46815,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/starboard/south)
+"iSx" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/service/chapel)
 "iSD" = (
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 4
@@ -46585,23 +46936,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/command/fore)
-"iTt" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Detective"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/forensics,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Detective"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet/grimey,
-/area/station/security/detective)
 "iTu" = (
 /obj/effect/mapping_helpers/turfs/rust,
 /obj/effect/mapping_helpers/turfs/rust,
@@ -46625,17 +46959,25 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/west)
-"iTx" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
+"iTD" = (
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/window/reinforced/reversed{
+	name = "Arrival Security Checkpoint";
 	dir = 1
 	},
-/obj/effect/turf_decal/tiles/neutral/corner{
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/doors{
+	dir = 1
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	color = "#954535"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/west)
+/area/station/security/checkpoint/secondary)
 "iTF" = (
 /turf/simulated/wall/r_wall,
 /area/station/command/office/ce)
@@ -46656,6 +46998,33 @@
 /obj/effect/mapping_helpers/airlock/windoor/access/any/science/xenobio,
 /turf/simulated/floor/engine,
 /area/station/science/xenobiology)
+"iTR" = (
+/obj/machinery/door/airlock/security/glass{
+	locked = 1;
+	id_tag = "perma_door_ext";
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Prison Gate";
+	name = "Prison Lockdown Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/access_button{
+	autolink_id = "perma_btn_ext";
+	name = "Prison Wing Access Button";
+	req_access = list(2);
+	pixel_x = -21
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/permabrig)
 "iUb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -46956,14 +47325,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
-"iYa" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance/external,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/storage)
 "iYc" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -47057,6 +47418,23 @@
 /obj/machinery/atmospherics/refill_station/nitrogen,
 /turf/simulated/floor/plasteel/white,
 /area/station/hallway/primary/fore/east)
+"iZK" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "iZM" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -47167,17 +47545,6 @@
 /obj/effect/turf_decal/tiles/department/security/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/west)
-"jas" = (
-/obj/effect/spawner/random/dirt/frequent,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance{
-	name = "Storefront Access"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/station/public/storefront)
 "jau" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -47341,6 +47708,20 @@
 	},
 /turf/space,
 /area/station/engineering/solar/aft)
+"jcA" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Docking Asteroid Substation";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/electrical/aft_starboard)
 "jcG" = (
 /obj/effect/spawner/random/dirt/frequent,
 /obj/machinery/power/apc/reinforced/directional/north,
@@ -47354,6 +47735,33 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel/dark,
 /area/station/supply/storage)
+"jdr" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "cmoofficedoor";
+	name = "CMO's Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "cmo"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/station/command/office/cmo)
 "jdA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -47536,20 +47944,6 @@
 "jft" = (
 /turf/simulated/mineral/ancient,
 /area/mine/unexplored/cere/orbiting)
-"jfu" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Solitary Confinement 2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/department/security,
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
 "jfC" = (
 /obj/machinery/hydroponics/constructable{
 	desc = "These are connected with an irrigation tube. You see a little pipe connecting the trays.";
@@ -47963,6 +48357,17 @@
 "jiW" = (
 /turf/simulated/floor/carpet/grimey,
 /area/station/security/detective)
+"jiX" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft-Starboard Asteroid Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint)
 "jiY" = (
 /obj/structure/chair/sofa/left{
 	color = "#2C2C2C";
@@ -47991,6 +48396,26 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
+"jjg" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	color = "#954535"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/spawner/random/dirt/often,
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 1
+	},
+/obj/structure/sign/public/pods{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/west)
 "jjo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -48122,14 +48547,6 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/supply/storage)
-"jkM" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
 "jlh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -48386,15 +48803,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/south)
-"joo" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/comeng)
 "jop" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -48453,27 +48861,6 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/security/lobby)
-"joW" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "bridge"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge_lower";
-	layer = 2.6;
-	name = "Emergency Blast Door"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge Conference Room"
-	},
-/obj/effect/turf_decal/tiles/department/command/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/command/meeting_room)
 "joZ" = (
 /obj/effect/map_effect/dynamic_airlock,
 /turf/simulated/floor/plating,
@@ -48566,6 +48953,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/service/fore_port)
+"jpI" = (
+/obj/machinery/door/airlock/atmos{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/purple,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/atmos)
 "jpK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -48779,24 +49180,23 @@
 /mob/living/basic/lizard/wags_his_tail,
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
-"jso" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors";
-	opacity = 0
+"jsp" = (
+/obj/machinery/door/airlock/command{
+	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/command/captain,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/permabrig)
+/turf/simulated/floor/carpet/black,
+/area/station/command/office/captain)
 "jsv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -48944,10 +49344,33 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/misc_lab)
+"jtS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore/north)
 "jud" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/maintenance/electrical/fore_starboard)
+"jug" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Labor Camp Airlock";
+	id_tag = "laborcamp_home";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/plasteel,
+/area/station/security/prisonershuttle)
 "jul" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/turf_decal/tiles/neutral,
@@ -48971,23 +49394,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"juN" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/atmos,
-/obj/item/desk_bell{
-	pixel_x = 7;
-	pixel_y = 7;
-	anchored = 1
-	},
-/obj/machinery/door/window/reinforced/normal,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/control)
 "juW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -48999,22 +49405,6 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
-"juZ" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "medlockdown";
-	layer = 2.6;
-	name = "Medical Lockdown"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/dockmed)
 "jvd" = (
 /obj/effect/spawner/random/dirt/frequent,
 /obj/effect/turf_decal/tiles/neutral/corner{
@@ -49342,23 +49732,6 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/service/fore_starboard)
-"jxJ" = (
-/obj/machinery/door/airlock/vault{
-	locked = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/vault,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/station/command/vault)
-"jxN" = (
-/obj/machinery/door/airlock/mining/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/supply/cargo_bay,
-/turf/simulated/floor/plasteel/dark,
-/area/station/supply/storage)
 "jyg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -49378,6 +49751,26 @@
 /obj/effect/turf_decal/tiles/department/virology/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/south)
+"jyu" = (
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Prison Gate";
+	name = "Prison Lockdown Blast Doors";
+	opacity = 0
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/permabrig)
 "jyx" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-4"
@@ -49512,17 +49905,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/storage/secondary)
-"jAr" = (
-/obj/machinery/door/airlock/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Courtroom"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/security/doors,
-/obj/effect/mapping_helpers/airlock/access/any/security/court,
-/turf/simulated/floor/wood,
-/area/station/legal/courtroom)
 "jAv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -49797,12 +50179,60 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/service/chapel/office)
+"jCw" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Solitary Confinement 2";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/department/security,
+/turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
 "jCz" = (
 /obj/machinery/atmospherics/refill_station/plasma,
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
 /area/station/security/permabrig)
+"jCC" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/item/radio/phone/medbay{
+	pixel_x = -11;
+	pixel_y = 7
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/item/clothing/neck/stethoscope,
+/obj/item/clothing/neck/stethoscope{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/storage/box/rxglasses{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/side{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/reception)
 "jCF" = (
 /obj/structure/sign/poster/official/state_laws/directional/south,
 /obj/structure/table/reinforced,
@@ -49975,16 +50405,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/service/fore_port)
-"jEC" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/security/fore_starboard)
 "jED" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -50009,18 +50429,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/maintcentral)
-"jEO" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry)
 "jEQ" = (
 /obj/machinery/camera/motion{
 	c_tag = "AI Core South";
@@ -50066,17 +50474,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
-"jFq" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/effect/turf_decal/tiles/department/engineering/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/west)
 "jFs" = (
 /obj/effect/decal/cleanable/blood/tracks/mapped{
 	dir = 10
@@ -50107,6 +50504,29 @@
 /obj/effect/turf_decal/tiles/department/engineering/side,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/maintcentral)
+"jFQ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "kitchen2"
+	},
+/obj/item/desk_bell{
+	pixel_x = 7;
+	pixel_y = 7;
+	anchored = 1
+	},
+/obj/machinery/door/window/classic/reversed,
+/obj/effect/mapping_helpers/airlock/windoor/autoname,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen,
+/obj/effect/turf_decal/tiles/dark/checker,
+/obj/structure/sign/service/kitchen{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/service/kitchen)
 "jFT" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -50125,22 +50545,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/disposal/external/southeast)
-"jFY" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
-"jFZ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/public/arcade)
 "jGh" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -50378,15 +50782,6 @@
 "jJc" = (
 /turf/simulated/mineral/ancient,
 /area/station/science/robotics)
-"jJd" = (
-/obj/effect/decal/cleanable/insectguts,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/barricade/wooden/crude,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/service/aft_port)
 "jJf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50529,18 +50924,6 @@
 /obj/effect/decal/cleanable/blood/tracks/mapped,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/port)
-"jKE" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Asteroid Substation"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/electrical/fore_starboard)
 "jKH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -50638,6 +51021,12 @@
 /obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
+"jLE" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/locker)
 "jLI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -51082,6 +51471,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/asmaint)
+"jQs" = (
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock";
+	name = "Escape Pod Hatch";
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/mine/unexplored/cere/orbiting)
 "jQy" = (
 /obj/structure/table/reinforced{
 	layer = 2.5
@@ -51218,6 +51615,31 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft)
+"jRV" = (
+/obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	location = "Chapel";
+	dir = 4
+	},
+/obj/machinery/door/window/classic/reversed{
+	dir = 1;
+	name = "Chapel Delivery"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/chapel_office{
+	dir = 1
+	},
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/service/fore_port)
 "jSc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -51319,6 +51741,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/north)
+"jSX" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "jTe" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -51713,38 +52147,6 @@
 /obj/structure/closet/secure_closet/brig,
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonlockers)
-"jYk" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/north)
-"jYy" = (
-/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "surg1"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/holosign/surgery{
-	id = "surgery1"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/medical/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/medical/surgery/primary)
-"jYD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/map_effect/dynamic_airlock/door/interior,
-/obj/machinery/access_button/offset/southwest,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/central/north)
 "jYR" = (
 /obj/structure/chair/office,
 /obj/effect/turf_decal/tiles/department/security/side,
@@ -51754,21 +52156,14 @@
 /obj/structure/sign/public/cryo,
 /turf/simulated/wall/r_wall,
 /area/station/public/sleep)
-"jYZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
+"jYW" = (
+/obj/machinery/door/airlock/command{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/security/aft_port)
+/obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/office/ce)
 "jZa" = (
 /turf/simulated/mineral/ancient,
 /area/station/hallway/primary/fore/east)
@@ -51987,16 +52382,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/north)
-"kbJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry)
 "kbL" = (
 /obj/effect/spawner/airlock/long,
 /turf/simulated/wall/r_wall,
@@ -52058,27 +52443,6 @@
 	},
 /turf/simulated/floor/carpet/royalblack,
 /area/station/service/bar)
-"kcE" = (
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Interrogation"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/interrogation)
 "kcG" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable/extra_insulated,
@@ -52103,19 +52467,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
-"kcL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/public/storage/emergency/port)
 "kcT" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -52131,17 +52482,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
-"kdb" = (
-/obj/machinery/door/airlock/engineering/glass,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/equipmentstorage)
 "kdd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -52312,18 +52652,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
-"keT" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance{
-	name = "Starboard Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "kfe" = (
 /obj/machinery/door/window{
 	dir = 1;
@@ -52655,6 +52983,33 @@
 /obj/structure/table/glass/reinforced,
 /turf/simulated/floor/carpet/blue,
 /area/station/command/office/cmo)
+"kiU" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "cargolockdown";
+	layer = 2.6;
+	name = "Cargo Lockdown"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 1
+	},
+/obj/structure/sign/medical{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/south)
 "kja" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -53026,18 +53381,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/hallway/spacebridge/cargocom)
-"koi" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/mineral_door/wood{
-	name = "Secret Clown HQ"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/service/clown/secret)
 "kok" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -53123,6 +53466,19 @@
 /obj/effect/turf_decal/tiles/neutral/side,
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/tools)
+"kpq" = (
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/barricade/wooden/crude,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/service/aft_port)
 "kpx" = (
 /obj/structure/transit_tube,
 /obj/effect/decal/cleanable/dirt,
@@ -53322,6 +53678,20 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/clown)
+"krB" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/north)
 "krI" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -53385,16 +53755,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
-"ksi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/atmos{
-	name = "Research Atmospherics Checkpoint"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/any/supply/mule_bot,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/aft/west)
 "ksl" = (
 /turf/simulated/floor/carpet,
 /area/station/public/locker)
@@ -53431,21 +53791,6 @@
 	icon_state = "bcircuit"
 	},
 /area/station/command/vault)
-"ksN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance{
-	name = "Central Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/storage)
 "ksS" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/meson,
@@ -53567,6 +53912,22 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/ntrep)
+"kuv" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/break_room/secondary)
 "kuw" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "Escape Pod 3 Airlock";
@@ -53657,6 +54018,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard)
+"kvP" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance{
+	name = "Starboard Asteroid Maintenance Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "kvZ" = (
 /obj/structure/chair/sofa/pew/right{
 	dir = 1
@@ -53705,6 +54079,30 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
+"kwH" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "medlockdown";
+	layer = 2.6;
+	name = "Medical Lockdown"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/dockmed)
 "kwQ" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-4"
@@ -54089,6 +54487,17 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/asmaint)
+"kzT" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel/dark,
+/area/station/public/quantum/docking)
 "kzU" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/atmospherics/portable/canister/air,
@@ -54097,6 +54506,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/port)
+"kzV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/generic,
+/obj/effect/mapping_helpers/turfs/damage,
+/obj/item/trash/spentcasing/bullet/lasershot,
+/obj/item/trash/spentcasing/bullet/lasershot,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/command/fore)
 "kzX" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -54178,24 +54603,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/east)
-"kAX" = (
-/obj/machinery/door/airlock/glass{
-	id_tag = "magistrateofficedoor"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/command/magistrate,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Magistrate"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/station/legal/magistrate)
 "kAY" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24;
@@ -54209,13 +54616,6 @@
 "kAZ" = (
 /turf/simulated/wall,
 /area/station/procedure/trainer_office)
-"kBa" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Central Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/maintcentral)
 "kBq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -55009,6 +55409,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/north)
+"kJy" = (
+/obj/machinery/door/airlock/command{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/rd,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/server)
 "kJE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -55066,14 +55482,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/supply/storage)
-"kKa" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/medical{
-	name = "Abandoned Infirmary"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/starboard)
 "kKb" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
@@ -55210,32 +55618,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/service/theatre)
-"kLk" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "ailockdown";
-	layer = 2.6;
-	name = "AI Asteroid Lockdown"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch,
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
-/obj/effect/mapping_helpers/airlock/access/any/command/teleporter,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/turret_protected/aisat/interior)
-"kLt" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/port/north)
 "kLy" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Hall 4";
@@ -55330,15 +55712,6 @@
 /obj/machinery/seed_extractor,
 /turf/simulated/floor/grass/jungle,
 /area/station/hallway/secondary/garden)
-"kMA" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/sercom)
 "kMC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55571,6 +55944,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/main)
+"kPl" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/engineering/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/break_room)
 "kPm" = (
 /obj/machinery/light,
 /obj/structure/cable{
@@ -55646,6 +56036,24 @@
 	temperature = 80
 	},
 /area/station/science/xenobiology)
+"kPU" = (
+/obj/machinery/door/airlock/command/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "bridge_upper";
+	layer = 2.6;
+	name = "Emergency Blast Door"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/bridge)
 "kQc" = (
 /obj/machinery/light{
 	dir = 4
@@ -55678,6 +56086,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/service/aft_starboard)
+"kQF" = (
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/structure/barricade/wooden,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/station/hallway/spacebridge/scidock)
 "kQK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -55781,6 +56199,25 @@
 /obj/machinery/power/apc/directional/west,
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
+"kRP" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "engilockdown";
+	layer = 2.6;
+	name = "Engineering Lockdown"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/comeng)
 "kRQ" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tiles/department/cargo/corner{
@@ -55788,6 +56225,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/lobby)
+"kRT" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/spawner/random/dirt/frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "kSc" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -55856,6 +56303,18 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/medical/cloning)
+"kSH" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/heavy{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/command/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/disposal/northeast)
 "kSR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -56000,6 +56459,18 @@
 	icon_state = "chapel"
 	},
 /area/station/service/chapel)
+"kUB" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/security/fore_starboard)
 "kUG" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -56237,6 +56708,20 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/hallway/spacebridge/dockmed)
+"kWS" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/green,
+/area/station/maintenance/service/fore_port)
 "kWU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -56393,18 +56878,6 @@
 /obj/structure/closet/bombclosetsecurity,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
-"kZj" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/engineering/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/break_room/secondary)
 "kZl" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -56578,6 +57051,23 @@
 /obj/structure/sign/security,
 /turf/simulated/wall/r_wall,
 /area/mine/unexplored/cere/engineering)
+"lcq" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "lcC" = (
 /obj/structure/shelf/security,
 /obj/item/storage/fancy/shell/beanbag{
@@ -56728,6 +57218,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
+"ldY" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/comeng)
 "led" = (
 /obj/machinery/disposal/delivery_chute{
 	dir = 1
@@ -56739,6 +57246,18 @@
 /obj/machinery/atmospherics/refill_station/oxygen,
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/apmaint)
+"len" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/public/glass{
+	name = "Trade Lounge";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/south)
 "lev" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -56802,6 +57321,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
+"leZ" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "medlockdown";
+	layer = 2.6;
+	name = "Medical Lockdown"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/dockmed)
 "lfd" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/corner{
@@ -57179,16 +57717,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/service/fore_port)
-"lje" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance/external,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/storage)
 "ljm" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -57268,6 +57796,17 @@
 	},
 /turf/simulated/mineral/ancient,
 /area/station/hallway/spacebridge/scidock)
+"lkh" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/service/aft_port)
 "lko" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57734,22 +58273,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/service/clown/secret)
-"lnN" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Medbay Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "lnO" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -57922,6 +58445,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"lpO" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/station/service/bar)
 "lpT" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -58185,16 +58724,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/hallway)
-"lsq" = (
-/obj/structure/barricade/sandbags,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/heavy,
-/obj/effect/turf_decal/tiles/department/command/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/disposal/northeast)
 "lsv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -58299,30 +58828,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/command/starboard)
-"ltP" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/door/airlock/command/glass{
-	id_tag = "rdofficedoor";
-	name = "Research Director's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/rd,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "rd"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/command/office/rd)
 "ltX" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -58357,31 +58862,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/north)
-"lug" = (
-/obj/structure/window/reinforced,
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/flashlight/pen,
-/obj/machinery/door_control{
-	id = "medmain";
-	name = "Medbay Doors";
-	normaldoorcontrol = 1;
-	pixel_x = -24;
-	pixel_y = 9
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/medical/side{
-	dir = 10
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/reception)
 "lum" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tiles/white/corner{
@@ -58614,6 +59094,22 @@
 	color = "#4C763A"
 	},
 /area/station/public/quantum/docking)
+"lwn" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/catwalk/black,
+/area/station/turret_protected/aisat/interior/secondary)
 "lws" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
@@ -58755,21 +59251,20 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/apmaint)
-"lxm" = (
-/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/structure/cable{
-	icon_state = "1-4"
+"lxq" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Criminal Delivery Chute";
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/turf_decal/stripes,
+/obj/effect/turf_decal/stripes/red,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/structure/disposalpipe/segment{
+	color = "#954535"
 	},
-/obj/machinery/door/airlock/research{
-	name = "Kill Chamber"
-	},
-/turf/simulated/floor/plating,
-/area/station/science/xenobiology)
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/north)
 "lxu" = (
 /obj/machinery/button/windowtint{
 	id = "Magistrate";
@@ -58869,6 +59364,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/tools)
+"lyc" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "lyk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/engineering/materials,
@@ -58917,6 +59428,24 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/evidence)
+"lyQ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/heavy{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/tiles/department/command/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/disposal/northeast)
 "lyX" = (
 /obj/structure/closet/secure_closet/brig/temp/cell_6,
 /obj/effect/turf_decal/tiles/department/security/corner{
@@ -59082,17 +59611,6 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/north)
-"lBh" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Command Asteroid Solar Array"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/solar_maintenance/fore_port)
 "lBk" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -59136,21 +59654,6 @@
 /obj/item/kirbyplants/medium/medium6,
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
-"lBW" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors";
-	opacity = 0
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/permabrig)
 "lCk" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -59192,6 +59695,35 @@
 /obj/machinery/light,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
+"lCw" = (
+/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "surg1"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/holosign/surgery{
+	id = "surgery1"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/medical/surgery/primary)
+"lCB" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Medical Asteroid Solars";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "lCC" = (
 /turf/simulated/mineral/ancient/outer,
 /area/mine/unexplored/cere/cargo)
@@ -60030,6 +60562,12 @@
 /obj/machinery/door/airlock/research/glass,
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/genetics)
+"lKR" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/public/quantum/engineering)
 "lKW" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -60066,18 +60604,17 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/secure_storage)
-"lLQ" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
+"lLW" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "hopexternal"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/station/maintenance/service/fore_port)
+/obj/effect/turf_decal/loading_area,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/command/office/hop)
 "lMe" = (
 /obj/item/storage/belt/holster,
 /obj/item/camera,
@@ -60105,17 +60642,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/north)
-"lMr" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal/south)
 "lMB" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -60143,17 +60669,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
-"lMS" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Starboard Asteroid Maintenance Access"
-	},
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "lMW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -60232,20 +60747,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/supply/storage)
-"lNz" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/security/fore_starboard)
 "lNM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -60263,6 +60764,23 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/virology)
+"lNN" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/dockmed)
 "lNU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -60326,15 +60844,6 @@
 /obj/effect/turf_decal/tiles/department/cargo,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/meeting_room)
-"lOr" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Service Atmospherics Checkpoint"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/catwalk,
-/area/station/maintenance/service/fore_starboard)
 "lOz" = (
 /obj/effect/mapping_helpers/turfs/rust,
 /obj/effect/spawner/random/fungus/probably,
@@ -60428,6 +60937,30 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/storage)
+"lPx" = (
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	id_tag = "viro_door_ext";
+	locked = 1;
+	name = "Virology Lab External Airlock";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/access_button{
+	layer = 3.6;
+	autolink_id = "viro_btn_ext";
+	name = "Virology Lab Access Button";
+	req_access = list(39);
+	pixel_x = 28
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/virology)
 "lPK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -60485,6 +61018,21 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/station/command/office/cmo)
+"lQi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/public/quantum/security)
 "lQk" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -60493,6 +61041,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/security/fore_starboard)
+"lQq" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/medical/cryo)
 "lQw" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -60628,6 +61184,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
+"lRW" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "med2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/patients_rooms_secondary)
 "lSa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -60665,6 +61240,30 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonlockers)
+"lSr" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "bridge"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "bridge_lower";
+	layer = 2.6;
+	name = "Emergency Blast Door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge Conference Room";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/command/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/meeting_room)
 "lSE" = (
 /obj/machinery/power/apc/reinforced/directional/south,
 /obj/effect/turf_decal/stripes/asteroid/end{
@@ -60704,6 +61303,13 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/misc_lab)
+"lST" = (
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating/airless,
+/area/station/maintenance/apmaint)
 "lSZ" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/disposalpipe/segment,
@@ -60717,6 +61323,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/xenobiology)
+"lTa" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Starboard Asteroid Maintenance Access";
+	dir = 4
+	},
+/obj/structure/barricade/wooden/crude,
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/abandonedservers)
 "lTc" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
@@ -60967,27 +61581,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/meeting_room)
-"lVs" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id_tag = "kitchen2"
+"lVi" = (
+/obj/machinery/door/airlock{
+	name = "Bathroom";
+	dir = 4
 	},
-/obj/item/desk_bell{
-	pixel_x = 7;
-	pixel_y = 7;
-	anchored = 1
-	},
-/obj/machinery/door/window/classic/reversed,
-/obj/effect/mapping_helpers/airlock/windoor/autoname,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen,
-/obj/effect/turf_decal/tiles/dark/checker,
-/obj/structure/sign/service/kitchen{
-	pixel_x = 32
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/service/kitchen)
+/turf/simulated/floor/plasteel/freezer,
+/area/station/medical/virology)
 "lVz" = (
 /obj/structure/bookcase{
 	name = "bookcase (Religious)"
@@ -61017,16 +61617,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/hallway/spacebridge/dockmed)
-"lVG" = (
-/obj/machinery/door/airlock/glass{
-	name = "Library reading room"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "library"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/station/service/library)
 "lVI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -61224,14 +61814,6 @@
 /obj/effect/turf_decal/tiles/department/engineering/side,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
-"lYE" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Laser Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/control)
 "lYH" = (
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave{
@@ -61347,13 +61929,12 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/command/office/rd)
-"lZU" = (
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
+"lZT" = (
+/obj/machinery/door/airlock/titanium/glass{
+	dir = 4
+	},
+/turf/simulated/floor/indestructible/titanium,
+/area/shuttle/arrival/station)
 "lZX" = (
 /obj/machinery/requests_console/directional/east,
 /obj/structure/closet/cabinet,
@@ -61599,6 +62180,20 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
+"mdf" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "med2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/patients_rooms_secondary)
 "mdl" = (
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plasteel,
@@ -61699,6 +62294,23 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/test_chamber)
+"mdZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/disposal/north)
 "mef" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -61735,6 +62347,23 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/break_room/secondary)
+"mex" = (
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Courtroom"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/doors,
+/obj/effect/mapping_helpers/airlock/access/any/security/court,
+/turf/simulated/floor/wood,
+/area/station/legal/courtroom)
 "meB" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -61833,6 +62462,33 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/service/aft_port)
+"mge" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "ceofficedoor";
+	name = "Chief Engineer's Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "CE"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/office/ce)
 "mgh" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
@@ -61864,19 +62520,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/security/starboard)
-"mgI" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id_tag = "kitchen2"
-	},
-/obj/machinery/door/window/classic/normal,
-/obj/effect/mapping_helpers/airlock/windoor/autoname,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen,
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/kitchen)
 "mgN" = (
 /obj/structure/table/wood,
 /obj/item/lighter/zippo/black,
@@ -61928,6 +62571,18 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/service/clown/secret)
+"mhJ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/west)
 "mia" = (
 /obj/machinery/alarm/directional/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -61939,6 +62594,63 @@
 "mic" = (
 /turf/simulated/wall,
 /area/mine/unexplored/cere/civilian)
+"mik" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/locker)
+"mil" = (
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/cloning)
+"mip" = (
+/obj/machinery/smartfridge/medbay,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "chemisttop";
+	name = "Chemistry Lobby Shutters"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/chemistry,
+/obj/machinery/door/window/classic/normal,
+/obj/effect/mapping_helpers/airlock/windoor/autoname,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/chemistry)
 "miw" = (
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/toxin{
@@ -61999,11 +62711,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/disposal/northeast)
-"mjm" = (
-/obj/machinery/door/airlock/glass,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "mjo" = (
 /turf/simulated/wall/r_wall,
 /area/station/science/toxins/launch)
@@ -62159,6 +62866,26 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
+"mlr" = (
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "bridge";
+	layer = 2.6;
+	name = "Emergency Blast Door"
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge Lobby";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/department/command/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/meeting_room)
 "mls" = (
 /obj/effect/decal/cleanable/blood/tracks/mapped{
 	dir = 10
@@ -62253,6 +62980,17 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/disposal/northeast)
+"mmU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/atmos{
+	name = "Research Atmospherics Checkpoint";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/any/supply/mule_bot,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/aft/west)
 "mmW" = (
 /turf/simulated/wall/r_wall,
 /area/station/turret_protected/aisat/interior)
@@ -62604,20 +63342,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/public/quantum/science)
-"mrc" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "servlockdown";
-	layer = 2.6;
-	name = "Service Lockdown"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/servsci)
 "mrh" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -62634,12 +63358,41 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/lobby)
+"mrB" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/window/classic/normal{
+	name = "Kitchen";
+	dir = 1
+	},
+/obj/machinery/door/window/classic/normal,
+/obj/effect/mapping_helpers/airlock/windoor/autoname,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/hydroponics,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
+	dir = 1
+	},
+/obj/machinery/smartfridge/food/chef,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/service/kitchen)
 "mrF" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
+"mrO" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/virology,
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/spacebridge/scidock)
 "mrR" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -63113,6 +63866,15 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/station/service/library)
+"myO" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Starboard Asteroid Maintenance Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/starboard)
 "myT" = (
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
@@ -63361,21 +64123,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/interrogation)
-"mBR" = (
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "ailockdown";
-	layer = 2.6;
-	name = "AI Asteroid Lockdown"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch,
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
-/obj/effect/mapping_helpers/airlock/access/any/command/teleporter,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/neutral/corner,
-/turf/simulated/floor/plasteel,
-/area/station/turret_protected/aisat/interior)
 "mCc" = (
 /obj/machinery/light_switch{
 	pixel_y = 24;
@@ -63686,6 +64433,22 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/patients_rooms1)
+"mFB" = (
+/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/door/airlock/research{
+	name = "Kill Chamber";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/science/xenobiology)
 "mFJ" = (
 /obj/effect/spawner/random/dirt/frequent,
 /obj/machinery/firealarm/directional/north,
@@ -63771,6 +64534,19 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/south)
+"mGQ" = (
+/obj/machinery/door/airlock/glass{
+	name = "Library reading room";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "library"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/service/library)
 "mGV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -63880,14 +64656,6 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/south)
-"mHE" = (
-/obj/machinery/door/airlock{
-	name = "Bathroom"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/spawner/random/dirt/frequent,
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
 "mHF" = (
 /obj/effect/spawner/random/food_trash,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -63921,6 +64689,17 @@
 "mIr" = (
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/hallway/primary/fore/east)
+"mIw" = (
+/obj/structure/barricade/wooden,
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/station/hallway/spacebridge/scidock)
 "mIG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -64135,10 +64914,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/east)
-"mKQ" = (
-/obj/machinery/door/airlock,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "mKT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -64251,6 +65026,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"mLP" = (
+/obj/machinery/door/airlock/hatch{
+	name = "AI Satellite Secondary Antechamber";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
+/turf/simulated/floor/plasteel{
+	icon_state = "bcircuit"
+	},
+/area/station/turret_protected/ai)
 "mLX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -64258,19 +65051,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/station/maintenance/storage)
-"mMh" = (
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "BrigLeft";
-	name = "Brig Foyer Left Entrance"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
 "mMx" = (
 /obj/effect/spawner/random/dirt/frequent,
 /obj/effect/turf_decal/stripes/line{
@@ -64315,6 +65095,15 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/disposal/east)
+"mMT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/obj/effect/map_effect/dynamic_airlock/door/exterior,
+/obj/machinery/access_button/offset/northeast,
+/turf/simulated/floor/plating/airless,
+/area/station/hallway/primary/central/north)
 "mNg" = (
 /obj/structure/sign/directions/medical{
 	dir = 4;
@@ -64494,12 +65283,6 @@
 "mPl" = (
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/engine_foyer)
-"mPm" = (
-/obj/machinery/door/airlock/command,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/command/office/ce)
 "mPp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -64612,15 +65395,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/south)
-"mRk" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/door/airlock/atmos{
-	name = "Security Atmospherics Checkpoint"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/security/aft_port)
 "mRz" = (
 /obj/structure/table,
 /obj/item/analyzer,
@@ -64703,25 +65477,6 @@
 /obj/effect/turf_decal/tiles/department/security/corner,
 /turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/a)
-"mSo" = (
-/obj/machinery/door/airlock/research{
-	name = "Research Division Access"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "researchlockdown";
-	layer = 2.6;
-	name = "Research Emergency Lockdown"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
-/obj/effect/mapping_helpers/airlock/access/any/science/research,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/hallway)
 "mSt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10
@@ -65656,7 +66411,7 @@
 "ncS" = (
 /obj/machinery/computer/general_air_control{
 	name = "Tank Monitor";
-	autolink_sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous Oxide","waste_sensor"="Gas Mix Tank")
+	autolink_sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous Oxide", "waste_sensor" = "Gas Mix Tank")
 	},
 /obj/item/radio/intercom{
 	name = "north bump";
@@ -65820,18 +66575,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/processing)
-"nfn" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/spawner/random/dirt/often,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/west)
 "nfq" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
@@ -65857,23 +66600,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/service/aft_port)
-"nfI" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "engilockdown";
-	layer = 2.6;
-	name = "Engineering Lockdown"
-	},
-/obj/structure/disposalpipe/segment{
-	color = "#954535"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/comeng)
 "ngb" = (
 /obj/item/storage/toolbox/emergency{
 	pixel_y = 5;
@@ -65902,6 +66628,12 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/south)
+"ngy" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "ngz" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty{
@@ -65987,15 +66719,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/north)
-"nhY" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Starboard Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/supply/expedition,
-/obj/effect/mapping_helpers/airlock/access/any/supply/general,
-/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "nii" = (
 /obj/machinery/economy/atm/directional/west,
 /turf/simulated/floor/wood,
@@ -66167,27 +66890,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/east)
-"njT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-4"
+"njW" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance";
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	color = "#954535"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Processing"
-	},
-/obj/machinery/door/airlock/security/glass,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/processing)
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "nkb" = (
 /turf/simulated/mineral/ancient,
 /area/station/public/storage/emergency/port)
@@ -66282,6 +66992,17 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/public/quantum/security)
+"nle" = (
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/main)
 "nlk" = (
 /obj/machinery/clonepod,
 /turf/simulated/floor/plasteel{
@@ -66467,6 +67188,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/north)
+"nnY" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Service Atmospherics Checkpoint";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/service/fore_starboard)
 "nnZ" = (
 /obj/machinery/atmospherics/refill_station/nitrogen,
 /turf/simulated/floor/plasteel/white,
@@ -66663,18 +67396,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/service/hydroponics)
-"nrf" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	color = "#954535"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/comeng)
 "nrh" = (
 /obj/item/kirbyplants/medium/medium6,
 /obj/structure/sign/securearea{
@@ -66682,6 +67403,26 @@
 	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/hallway/spacebridge/cargocom)
+"nrj" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	color = "#505050"
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/north)
 "nrl" = (
 /obj/machinery/hydroponics/soil,
 /obj/structure/sign/poster/contraband/ambrosia_vulgaris/directional/north,
@@ -66894,6 +67635,64 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/ai_upload)
+"ntg" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/window/reinforced/normal{
+	name = "Security Reception";
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/general{
+	dir = 1
+	},
+/obj/structure/table/reinforced{
+	layer = 2.5
+	},
+/obj/item/desk_bell{
+	pixel_x = 7;
+	pixel_y = 7;
+	anchored = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/lobby)
+"ntk" = (
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "BrigRight";
+	name = "Brig Foyer Right Entrance";
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
+"nts" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/command{
+	name = "Head of Personnel";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/hop,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/station/command/office/hop)
 "ntB" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -67072,28 +67871,6 @@
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/service/fore_port)
-"nvf" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Transfer Processing"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prisonershuttle)
 "nvn" = (
 /obj/item/radio/intercom{
 	name = "north bump";
@@ -67205,6 +67982,14 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
+"nwk" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "nwo" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -67556,6 +68341,20 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard)
+"nAB" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Central Asteroid Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/maintcentral)
 "nAT" = (
 /obj/structure/closet/wardrobe/xenos,
 /turf/simulated/floor/indestructible/titanium/blue,
@@ -67570,6 +68369,59 @@
 /obj/structure/sink/directional/north,
 /turf/simulated/floor/plasteel/freezer,
 /area/station/security/storage)
+"nBs" = (
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "BrigLeft";
+	name = "Brig Foyer Left Entrance";
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
+"nBw" = (
+/obj/machinery/door/airlock/security/glass{
+	locked = 1;
+	id_tag = "perma_door_int";
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Prison Gate";
+	name = "Prison Lockdown Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/access_button{
+	autolink_id = "perma_btn_int";
+	name = "Prison Wing Access Button";
+	req_access = list(2);
+	pixel_x = 21
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/permabrig)
 "nBA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -67647,6 +68499,22 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/hallway/primary/starboard/south)
+"nCp" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "kitchen2"
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/kitchen)
 "nCr" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/reagent_containers/glass/beaker/waterbottle{
@@ -68264,13 +69132,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/lobby)
-"nJP" = (
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock";
-	name = "Escape Pod Hatch"
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/mine/unexplored/cere/orbiting)
 "nJT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/refill_station/plasma,
@@ -68482,6 +69343,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/east)
+"nLU" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "med1"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/patients_rooms1)
 "nLZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -68532,6 +69411,18 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/station/command/office/hos)
+"nMM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "nMN" = (
 /obj/structure/chair{
 	dir = 1
@@ -68608,15 +69499,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/chapel/office)
-"nNH" = (
-/obj/effect/decal/cleanable/blood/tracks/mapped,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/barricade/wooden/crude,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/service/aft_port)
 "nNM" = (
 /obj/machinery/computer/guestpass{
 	pixel_y = 30
@@ -68626,6 +69508,22 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/cmo)
+"nNP" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/port/north)
 "nNY" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -68648,6 +69546,23 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
+"nOt" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/security/aft_starboard)
 "nOF" = (
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/control)
@@ -68709,20 +69624,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/control)
-"nPv" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "med1"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/patients_rooms1)
 "nPH" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 2;
@@ -68730,6 +69631,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/southwest)
+"nPI" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/engineering/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/east)
 "nPM" = (
 /turf/simulated/wall,
 /area/station/public/storage/emergency)
@@ -68937,18 +69850,6 @@
 "nSn" = (
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/hallway/spacebridge/engmed)
-"nSu" = (
-/obj/machinery/door/airlock/tranquillite,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/service/mime,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/mineral/tranquillite,
-/area/station/service/mime)
 "nSK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -68987,6 +69888,16 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/north)
+"nTh" = (
+/obj/effect/map_effect/dynamic_airlock/door/interior,
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/access_button/offset/west,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/central/west)
 "nTi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -69050,6 +69961,23 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/starboard)
+"nTB" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/public/glass{
+	name = "Trade Lounge";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/south)
 "nTN" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -69334,6 +70262,23 @@
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/engine,
 /area/station/science/test_chamber)
+"nXz" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance/external{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/service/aft_starboard)
 "nXI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -69453,12 +70398,6 @@
 /obj/structure/dresser,
 /turf/simulated/floor/wood,
 /area/station/maintenance/service/fore_port)
-"nYR" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/public/quantum/science)
 "nYY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -69694,6 +70633,21 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/east)
+"obc" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "obd" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -70000,6 +70954,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/east)
+"oez" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "oeC" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -70051,19 +71015,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/fore/north)
-"ofk" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/service/fore_port)
 "ofv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -70076,21 +71027,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
-"ofB" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Turbine Access"
+"ofx" = (
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
 	},
-/obj/effect/spawner/random/dirt/frequent,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
-/area/station/maintenance/turbine)
+/area/station/hallway/primary/port/north)
 "ofE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks/mapped{
@@ -70239,21 +71187,6 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/disposal/east)
-"ohd" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors";
-	opacity = 0
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/permabrig)
 "ohh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -70286,6 +71219,18 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/apmaint)
+"ohN" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Starboard Asteroid Maintenance Access";
+	dir = 4
+	},
+/obj/structure/barricade/wooden/crude,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/abandonedservers)
 "oib" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -70695,13 +71640,18 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/spacebridge/cargocom)
-"omq" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/medical/side{
+"omC" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
 	dir = 4
 	},
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/sleeper)
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/port/south)
 "omE" = (
 /obj/machinery/computer/arcade{
 	dir = 1
@@ -70825,6 +71775,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/service/aft_port)
+"onF" = (
+/obj/structure/disposalpipe/segment{
+	color = "#954535"
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/port/north)
 "onO" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/wall,
@@ -71138,21 +72102,6 @@
 /obj/effect/mapping_helpers/turfs/rust/maybe,
 /turf/simulated/wall,
 /area/station/maintenance/security/fore_starboard)
-"org" = (
-/obj/machinery/door/airlock/medical/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/cloning)
 "orj" = (
 /obj/machinery/atmospherics/unary/tank/air,
 /obj/effect/spawner/random/dirt/frequent,
@@ -71172,17 +72121,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/public/quantum/service)
-"orl" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/public/quantum/engineering)
 "ors" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -71292,17 +72230,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/security/starboard)
-"orR" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Starboard Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "orU" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1
@@ -71690,6 +72617,31 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/west)
+"ovT" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Transfer Processing";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prisonershuttle)
 "ovU" = (
 /obj/machinery/button/windowtint{
 	id = "coroner";
@@ -71918,17 +72870,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/external/southeast)
-"oxO" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft-Starboard Asteroid Maintenance"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/asmaint2)
 "oxQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -71941,15 +72882,6 @@
 /obj/effect/turf_decal/tiles/department/cargo/side,
 /turf/simulated/floor/plasteel/dark,
 /area/station/supply/office)
-"oyg" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/service/fore_starboard)
 "oyh" = (
 /obj/effect/spawner/random/barrier/obstruction,
 /turf/simulated/floor/plasteel,
@@ -72287,6 +73219,21 @@
 "oCg" = (
 /turf/simulated/mineral/ancient,
 /area/station/aisat/atmos)
+"oCm" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/spawner/random/dirt/frequent,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
+/obj/effect/mapping_helpers/airlock/access/any/science/tox,
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/apmaint)
 "oCu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/engine,
@@ -72332,18 +73279,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/south)
-"oDf" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "oDm" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -72354,6 +73289,23 @@
 	},
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/command/starboard)
+"oDp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/public/storage/emergency/port)
 "oDs" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -72414,6 +73366,19 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
+"oDX" = (
+/obj/effect/mapping_helpers/airlock/access/all/service/crematorium,
+/obj/machinery/door/airlock{
+	name = "Crematorium";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/service/chapel)
 "oDZ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -72504,6 +73469,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_starboard)
+"oEQ" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/service/fore_starboard)
 "oEV" = (
 /obj/structure/ore_box,
 /turf/simulated/floor/plating,
@@ -72557,39 +73533,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/storage)
-"oFr" = (
-/obj/machinery/door/airlock/security/glass{
-	locked = 1;
-	id_tag = "perma_door_int"
-	},
-/obj/effect/turf_decal/stripes,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/access_button{
-	autolink_id = "perma_btn_int";
-	name = "Prison Wing Access Button";
-	req_access = list(2);
-	pixel_x = 21
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/permabrig)
 "oFt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -72735,6 +73678,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/turret_protected/aisat/interior/secondary)
+"oHg" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Labor Camp Airlock";
+	id_tag = "laborcamp_home";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/security/prisonershuttle)
 "oHk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -72987,18 +73944,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/east)
-"oLl" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/dirt/frequent,
-/obj/machinery/door/airlock/engineering{
-	name = "Aft Starboard Solar Access"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/solar_maintenance/fore_starboard)
 "oLm" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -73088,19 +74033,6 @@
 /obj/structure/cable/extra_insulated,
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/maintenance/electrical/port)
-"oMr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tiles/department/medical/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/barber)
 "oMs" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -73203,7 +74135,7 @@
 	dir = 1;
 	level = 3;
 	name = "Distribution and Waste Monitor";
-	autolink_sensors = list("mair_in_meter"="Mixed Air In","air_sensor"="Mixed Air Supply Tank","mair_out_meter"="Mixed Air Out","dloop_atm_meter"="Distribution Loop","wloop_atm_meter"="Waste Loop")
+	autolink_sensors = list("mair_in_meter" = "Mixed Air In", "air_sensor" = "Mixed Air Supply Tank", "mair_out_meter" = "Mixed Air Out", "dloop_atm_meter" = "Distribution Loop", "wloop_atm_meter" = "Waste Loop")
 	},
 /obj/effect/turf_decal/tiles/department/engineering/side{
 	dir = 10
@@ -73474,6 +74406,37 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/west)
+"oPU" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/engineering/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/west)
+"oPY" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/security/fore_starboard)
 "oPZ" = (
 /obj/effect/turf_decal/tiles/department/science/corner{
 	dir = 4
@@ -73547,14 +74510,6 @@
 /obj/machinery/alarm/directional/north,
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonlockers)
-"oRb" = (
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/public/arcade)
 "oRh" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -73646,6 +74601,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/storage)
+"oSf" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/north)
 "oSs" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -73692,6 +74657,21 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/captain)
+"oTk" = (
+/obj/machinery/door/airlock/engineering/glass{
+	autoclose = 0;
+	id_tag = "engsm_door_int";
+	name = "Supermatter Interior Access";
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/engine,
+/area/station/engineering/control)
 "oTn" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/atmospherics/portable/canister/air,
@@ -73834,20 +74814,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/ce)
-"oUU" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/south)
 "oVb" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -73859,19 +74825,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/hallway/secondary/exit)
-"oVj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/station/public/vacant_office)
 "oVs" = (
 /obj/effect/spawner/random/storage,
 /obj/item/soap/nanotrasen,
@@ -73984,17 +74937,6 @@
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"oWv" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance{
-	name = "Starboard Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "oWw" = (
 /obj/machinery/economy/vending/cargodrobe,
 /obj/effect/turf_decal/tiles/dark/checker,
@@ -74015,6 +74957,33 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/aft/west)
+"oWL" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/window/brigdoor{
+	id = "Cell 3";
+	name = "Cell 3"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison/cell_block/a)
 "oWP" = (
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 8
@@ -74233,6 +75202,23 @@
 "oYZ" = (
 /turf/simulated/floor/plasteel/white,
 /area/station/science/rnd)
+"oZn" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/effect/turf_decal/tiles/department/engineering/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/storage)
 "oZw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -74375,6 +75361,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/port)
+"paA" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "paL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -74384,6 +75380,13 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
+"paR" = (
+/obj/effect/spawner/random/dirt/frequent,
+/obj/machinery/door/airlock/freezer{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/station/maintenance/starboard)
 "paT" = (
 /obj/effect/turf_decal/tiles/department/security/side,
 /obj/structure/table/reinforced,
@@ -74687,11 +75690,6 @@
 	},
 /turf/simulated/mineral/ancient,
 /area/station/maintenance/asmaint)
-"pdP" = (
-/obj/effect/spawner/random/dirt/frequent,
-/obj/machinery/door/airlock/freezer,
-/turf/simulated/floor/plasteel/freezer,
-/area/station/maintenance/starboard)
 "pec" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -74844,6 +75842,17 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/test_chamber)
+"pfp" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/effect/map_effect/dynamic_airlock/door/interior,
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/obj/machinery/access_button/offset/east,
+/turf/simulated/floor/plating,
+/area/station/maintenance/maintcentral)
 "pfv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -74872,6 +75881,23 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
+"pfG" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "servlockdown";
+	layer = 2.6;
+	name = "Service Lockdown"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/servsci)
 "pfP" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -75067,18 +76093,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/robotics/chargebay)
-"pix" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Central Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/maintcentral)
 "piy" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8;
@@ -75107,24 +76121,6 @@
 "piQ" = (
 /turf/simulated/wall/r_wall,
 /area/station/hallway/primary/central/east)
-"piR" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Madical Atmospherics Checkpoint"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
-"piZ" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Cargo/Medical Asteroid Substation"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "pjd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -75145,21 +76141,25 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/west)
-"pje" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
+"pjw" = (
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "ailockdown";
+	layer = 2.6;
+	name = "AI Asteroid Lockdown"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/teleporter,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/neutral/corner,
 /turf/simulated/floor/plasteel,
-/area/station/maintenance/command/fore)
-"pjm" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Escape Pod 4 Airlock";
-	id_tag = "emergency_home"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/command/fore)
+/area/station/turret_protected/aisat/interior)
 "pjx" = (
 /obj/machinery/camera{
 	c_tag = "Chapel North"
@@ -75172,6 +76172,26 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
+"pjS" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "bridge";
+	layer = 2.6;
+	name = "Emergency Blast Door"
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge Lobby";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/department/command/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/meeting_room)
 "pjU" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/delivery_chute{
@@ -75333,15 +76353,6 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/west)
-"plL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/fore/north)
 "pma" = (
 /obj/effect/turf_decal/stripes/white/corner{
 	dir = 8
@@ -75389,12 +76400,6 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
-"pnf" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/south)
 "pni" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -75490,6 +76495,32 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/toxins/mixing)
+"pot" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "General Population Cell";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison/cell_block/a)
 "pox" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -75536,13 +76567,19 @@
 /obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/plasteel/freezer,
 /area/station/maintenance/gambling_den)
-"ppc" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Starboard Asteroid Maintenance Access"
-	},
+"ppn" = (
+/obj/effect/decal/cleanable/blood/tracks/mapped,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/structure/barricade/wooden/crude,
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/abandonedservers)
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/service/aft_port)
 "ppq" = (
 /obj/structure/table,
 /obj/machinery/plantgenes{
@@ -75551,6 +76588,32 @@
 /obj/effect/turf_decal/tiles/department/virology,
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/hydroponics)
+"ppv" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/command/blueshield,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "blueshieldofficedoor";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "bs"
+	},
+/turf/simulated/floor/wood,
+/area/station/command/office/blueshield)
 "ppw" = (
 /obj/machinery/atmospherics/unary/tank/toxins{
 	dir = 4
@@ -75612,6 +76675,26 @@
 /obj/structure/disposalpipe/segment/corner,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/starboard)
+"ppZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tiles/department/medical/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/storage)
 "pqa" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/dark,
@@ -76146,6 +77229,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"pvh" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/public/quantum/security)
 "pvl" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
@@ -76879,22 +77968,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/aft_port)
-"pEJ" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "engilockdown";
-	layer = 2.6;
-	name = "Engineering Lockdown"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/comeng)
 "pFc" = (
 /obj/structure/railing,
 /turf/simulated/floor/plating/asteroid/ancient/airless,
@@ -76903,12 +77976,6 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/station/maintenance/service/fore_starboard)
-"pFp" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore/east)
 "pFv" = (
 /obj/machinery/economy/vending/janidrobe,
 /obj/structure/window/reinforced{
@@ -76927,39 +77994,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/chapel)
-"pFJ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "chemisttop";
-	name = "Chemistry Lobby Shutters"
-	},
-/obj/machinery/door/window/classic/normal,
-/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
-/obj/item/folder/yellow,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/item/desk_bell{
-	pixel_x = 7;
-	pixel_y = 7;
-	anchored = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/chemistry,
-/obj/machinery/door/window/classic/normal{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/autoname/desk{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/medical/chemistry)
 "pFO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -77044,6 +78078,19 @@
 	},
 /turf/simulated/floor/carpet/royalblack,
 /area/station/command/office/captain)
+"pGX" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "pHf" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -77128,6 +78175,15 @@
 /obj/structure/closet/l3closet/virology,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"pIe" = (
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/structure/barricade/wooden,
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/maintcentral)
 "pIs" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 8;
@@ -77287,6 +78343,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/port)
+"pKe" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/west)
 "pKn" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood,
@@ -77507,26 +78576,54 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/south)
-"pLU" = (
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/research,
-/obj/structure/cable{
-	icon_state = "1-2"
+"pMb" = (
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/effect/turf_decal/tiles/department/science,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "BrigLeft";
+	name = "Brig Foyer Left Entrance";
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
 /turf/simulated/floor/plasteel/dark,
-/area/station/science/robotics)
+/area/station/security/brig)
 "pMk" = (
 /obj/item/assembly/mousetrap/armed,
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/service/fore_starboard)
+"pMn" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "hopshutter"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/window/reinforced/normal{
+	dir = 1;
+	name = "Head of Personnel's Desk"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/command/hop{
+	dir = 1
+	},
+/obj/machinery/door/window{
+	name = "Desk Door"
+	},
+/obj/item/desk_bell{
+	pixel_x = 7;
+	pixel_y = 7;
+	anchored = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/command/office/hop)
 "pMq" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/disposalpipe/segment,
@@ -77577,6 +78674,16 @@
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
+"pNj" = (
+/obj/effect/map_effect/dynamic_airlock/door/interior,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/obj/machinery/access_button/offset/southwest,
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage)
 "pNt" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -77636,20 +78743,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/service/bar)
-"pOl" = (
-/obj/machinery/door/airlock/command/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge_upper";
-	layer = 2.6;
-	name = "Emergency Blast Door"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel/dark,
-/area/station/command/bridge)
 "pOn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -77693,6 +78786,15 @@
 /obj/machinery/cooking/oven/loaded,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
+"pOB" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/medical/cryo)
 "pOC" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-8"
@@ -77835,6 +78937,20 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/secure_storage)
+"pQk" = (
+/obj/machinery/door/airlock/engineering/glass{
+	autoclose = 0;
+	id_tag = "engsm_door_ext";
+	name = "Supermatter Exterior Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/control)
 "pQm" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -77961,6 +79077,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/west)
+"pRm" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/command/starboard)
 "pRo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -78062,19 +79190,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/apmaint)
-"pSz" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Labor Camp Airlock";
-	id_tag = "laborcamp_home"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/security/prisonershuttle)
 "pSC" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -78161,22 +79276,6 @@
 /obj/item/flag/sec,
 /turf/simulated/floor/wood,
 /area/station/maintenance/security/fore_starboard)
-"pTQ" = (
-/obj/structure/table/reinforced,
-/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/general,
-/obj/machinery/door/window/classic/normal,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/medical/side,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/reception)
 "pUf" = (
 /turf/simulated/wall/r_wall,
 /area/station/hallway/secondary/exit)
@@ -78479,6 +79578,24 @@
 /obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/plasteel/freezer,
 /area/station/maintenance/gambling_den)
+"pWV" = (
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "BrigRight";
+	name = "Brig Foyer Right Entrance";
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "pWX" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -78691,18 +79808,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/storage)
-"qax" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/multi_tile/glass,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood,
-/area/station/service/bar)
 "qaI" = (
 /obj/effect/spawner/random/dirt/frequent,
 /obj/effect/turf_decal/tiles/department/engineering/side{
@@ -78855,19 +79960,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/asmaint2)
-"qdb" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft-Starboard Asteroid Maintenance"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	color = "#505050"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/asmaint)
 "qde" = (
 /turf/simulated/mineral/ancient/outer,
 /area/station/hallway/secondary/entry/east)
@@ -79006,27 +80098,6 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/west)
-"qfa" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "engilockdown";
-	layer = 2.6;
-	name = "Engineering Lockdown"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/comeng)
 "qff" = (
 /obj/machinery/power/apc/reinforced/directional/north,
 /obj/structure/cable/extra_insulated{
@@ -79142,6 +80213,31 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/starboard)
+"qgN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	color = "#954535"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Processing"
+	},
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/processing)
 "qgQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -79633,11 +80729,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/lobby)
-"qmQ" = (
-/obj/machinery/door/airlock/glass,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage)
 "qmR" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/rods/fifty,
@@ -79728,20 +80819,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/station/medical/surgery)
-"qnu" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/comeng)
 "qnw" = (
 /obj/structure/chair/comfy/beige{
 	dir = 8
@@ -79794,16 +80871,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_port)
-"qoc" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/carpet/green,
-/area/station/maintenance/service/fore_port)
 "qor" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -79886,6 +80953,19 @@
 /obj/effect/landmark/start/doctor,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/patients_rooms_secondary)
+"qpb" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/public/storage/tools)
 "qpe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -80019,6 +81099,20 @@
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"qrc" = (
+/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white{
+	icon_regular_floor = "yellowsiding"
+	},
+/area/station/maintenance/service/aft_port)
 "qre" = (
 /obj/machinery/power/emitter,
 /turf/simulated/floor/plasteel/dark,
@@ -80034,16 +81128,6 @@
 /obj/effect/turf_decal/tiles/department/security,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/permabrig)
-"qrv" = (
-/obj/machinery/door/airlock/atmos,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/atmos)
 "qry" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -80122,6 +81206,22 @@
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
+"qsC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/main)
 "qsD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -80425,19 +81525,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint2)
-"qvt" = (
-/obj/machinery/door/airlock/engineering/glass{
-	autoclose = 0;
-	id_tag = "engsm_door_ext";
-	name = "Supermatter Exterior Access"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/control)
 "qvu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -80573,17 +81660,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/rnd)
-"qxo" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Service Asteroid Substation"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/catwalk,
-/area/station/maintenance/electrical/port)
 "qxv" = (
 /turf/simulated/floor/plating,
 /area/station/public/storage/emergency/port)
@@ -80633,15 +81709,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/command/starboard)
-"qyc" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/spawner/random/dirt/frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "qye" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -80740,17 +81807,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/external/southeast)
-"qzd" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel/dark,
-/area/station/public/quantum/cargo)
 "qze" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -80921,6 +81977,18 @@
 	},
 /turf/space,
 /area/station/engineering/solar/fore_port)
+"qBl" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
 "qBm" = (
 /turf/simulated/floor/plasteel/white,
 /area/station/science/test_chamber)
@@ -81015,24 +82083,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat/atmos)
-"qDv" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	color = "#954535"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/spawner/random/dirt/often,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 1
-	},
-/obj/structure/sign/public/pods{
-	pixel_x = -32
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/west)
 "qDF" = (
 /obj/structure/stone_tile/block/burnt{
 	dir = 4
@@ -81087,6 +82137,18 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
+"qEe" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/airlock/engineering{
+	name = "Command Asteroid Security Area Substation";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/electrical/fore_port)
 "qEv" = (
 /obj/machinery/atmospherics/portable/canister/toxins,
 /obj/effect/turf_decal/delivery/hollow,
@@ -81203,6 +82265,13 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/north)
+"qFN" = (
+/obj/machinery/door/airlock{
+	name = "Toilet";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/station/security/storage)
 "qFR" = (
 /obj/machinery/power/tracker,
 /obj/structure/lattice/catwalk,
@@ -81310,18 +82379,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/procedure/trainer_office)
-"qGA" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/station/maintenance/service/fore_port)
 "qGB" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/corner{
@@ -81583,35 +82640,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/supply/storage)
-"qIl" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/item/radio/phone/medbay{
-	pixel_x = -11;
-	pixel_y = 7
-	},
-/obj/machinery/door/firedoor,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/clothing/neck/stethoscope{
-	pixel_x = 7;
-	pixel_y = 6
-	},
-/obj/item/storage/box/rxglasses{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/tiles/department/medical/side{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/reception)
 "qIq" = (
 /obj/machinery/power/solar_control{
 	dir = 8;
@@ -81820,15 +82848,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
-"qKp" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "med1"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/patients_rooms1)
 "qKt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/table/wood/fancy/red,
@@ -81930,20 +82949,6 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/south)
-"qLv" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/highsecurity{
-	locked = 1;
-	name = "AI Upload Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel/dark,
-/area/station/turret_protected/ai_upload)
 "qLz" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable,
@@ -82028,6 +83033,22 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
+"qMD" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft-Starboard Asteroid Maintenance";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	color = "#505050"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/asmaint)
 "qMO" = (
 /obj/effect/turf_decal/stripes/end,
 /obj/machinery/power/apc/directional/north,
@@ -82061,19 +83082,28 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/south)
-"qMW" = (
-/obj/structure/cable/extra_insulated{
+"qMU" = (
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access";
+	dir = 4
+	},
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "researchlockdown";
+	layer = 2.6;
+	name = "Research Emergency Lockdown"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
+/obj/effect/mapping_helpers/airlock/access/any/science/research,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/command/starboard)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/hallway)
 "qNf" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/table,
@@ -82308,6 +83338,21 @@
 /obj/item/roller,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"qQn" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Central Asteroid Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/maintcentral)
 "qQo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -82339,6 +83384,21 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/service/fore_port)
+"qQH" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	color = "#954535"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/comeng)
 "qQJ" = (
 /obj/structure/chair/comfy/black,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -82767,14 +83827,6 @@
 "qUT" = (
 /turf/simulated/wall,
 /area/station/maintenance/abandonedbar)
-"qVe" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Escape Shuttle Cell"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/secondary/exit)
 "qVg" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -83262,14 +84314,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
-"raU" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Starboard Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/starboard)
 "raV" = (
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -83615,27 +84659,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
-"reZ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/classic/normal,
-/obj/effect/mapping_helpers/airlock/windoor/autoname,
-/obj/machinery/door/window/classic/normal{
-	name = "Kitchen";
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/hydroponics,
-/obj/item/desk_bell{
-	pixel_x = 7;
-	pixel_y = 7;
-	anchored = 1
-	},
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/service/kitchen)
 "rfh" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
@@ -83785,20 +84808,6 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/east)
-"riv" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/department/engineering/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/west)
 "rix" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -84030,6 +85039,33 @@
 /obj/effect/turf_decal/tiles/department/cargo/side,
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/starboard)
+"rlc" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/tiles/department/virology,
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/secondary/garden)
+"rlq" = (
+/obj/machinery/door/airlock/glass{
+	name = "Internal Affairs Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/iaa,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "IAA"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/legal/lawoffice)
 "rls" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -84144,23 +85180,15 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
-"roh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"rol" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Laser Room";
+	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/north)
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/control)
 "ron" = (
 /obj/structure/disposalpipe/junction/reversed{
 	dir = 1
@@ -84407,13 +85435,6 @@
 "rrb" = (
 /turf/simulated/floor/plating,
 /area/station/turret_protected/aisat/interior)
-"rrc" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/service/fore_starboard)
 "rrj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -84688,13 +85709,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/aft_port)
-"ruM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/map_effect/dynamic_airlock/door/exterior,
-/obj/machinery/access_button/offset/northeast,
-/turf/simulated/floor/plating/airless,
-/area/station/hallway/primary/central/north)
 "ruS" = (
 /obj/structure/chair/comfy/beige{
 	dir = 4
@@ -84727,6 +85741,21 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
+"rvt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/research/glass{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/science/rnd)
 "rvu" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -84865,29 +85894,6 @@
 	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/maintenance/electrical/port)
-"rxb" = (
-/obj/effect/turf_decal/delivery/hollow,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	location = "Chapel";
-	dir = 4
-	},
-/obj/machinery/door/window/classic/reversed{
-	dir = 1;
-	name = "Chapel Delivery"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/chapel_office{
-	dir = 1
-	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/service/fore_port)
 "rxg" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -85430,14 +86436,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
-"rCS" = (
-/obj/machinery/door/airlock/glass,
-/obj/structure/barricade/wooden,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/station/hallway/spacebridge/scidock)
 "rCT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -85577,20 +86575,6 @@
 /obj/item/stack/sheet/wood,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/asmaint)
-"rEz" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/structure/disposalpipe/segment{
-	color = "#505050"
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/starboard/south)
 "rEE" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -85763,6 +86747,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
+"rGn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/fore/north)
 "rGv" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/window/reinforced{
@@ -85976,6 +86972,27 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/asmaint)
+"rIp" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	dir = 1;
+	location = "Engineering";
+	name = "navigation beacon (Engineering Delivery)"
+	},
+/obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/door/window{
+	name = "Engineering Delivery Chute"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/general,
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/maintcentral)
 "rIu" = (
 /turf/simulated/wall,
 /area/station/maintenance/disposal)
@@ -86021,6 +87038,19 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
+"rIU" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "rIY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -86265,13 +87295,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/fore/north)
-"rLO" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/service/fore_starboard)
 "rLS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -86443,18 +87466,6 @@
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/wood,
 /area/station/maintenance/asmaint)
-"rNs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/main)
 "rNv" = (
 /obj/machinery/light{
 	dir = 8
@@ -86490,13 +87501,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/maintcentral)
-"rNH" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Escape Pod 5 Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plating,
-/area/station/maintenance/security/fore_starboard)
 "rNK" = (
 /turf/space,
 /area/space)
@@ -86616,17 +87620,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/storage)
-"rPc" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/public/storage/tools)
 "rPg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -86743,20 +87736,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/control)
-"rQf" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/spawner/random/dirt/frequent,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance{
-	name = "Storefront Access"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/station/public/storefront)
 "rQg" = (
 /obj/effect/turf_decal/caution/red{
 	dir = 1
@@ -86910,15 +87889,6 @@
 	},
 /turf/simulated/floor/carpet/royalblack,
 /area/station/service/bar)
-"rRe" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Medbay Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "rRj" = (
 /obj/structure/disposalpipe/segment{
 	color = "#954535"
@@ -87380,10 +88350,6 @@
 	},
 /turf/simulated/floor/indestructible/titanium/blue,
 /area/shuttle/arrival/station)
-"rWJ" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/public/quantum/engineering)
 "rWL" = (
 /obj/machinery/door_control{
 	id = "chemisttop";
@@ -87556,17 +88522,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/north)
-"rYF" = (
-/obj/structure/disposalpipe/segment{
-	color = "#954535"
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/port/south)
 "rYK" = (
 /obj/structure/closet/secure_closet/explorer,
 /obj/machinery/requests_console/directional/south,
@@ -87693,6 +88648,21 @@
 /obj/item/flashlight,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"sae" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "kitchen2"
+	},
+/obj/machinery/door/window/classic/normal,
+/obj/effect/mapping_helpers/airlock/windoor/autoname,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen,
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/kitchen)
 "saq" = (
 /obj/effect/turf_decal/stripes/end,
 /obj/machinery/power/apc/reinforced/directional/north,
@@ -87742,6 +88712,24 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
+"saS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/research{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
+/obj/effect/mapping_helpers/airlock/access/any/science/tox,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/misc_lab)
 "saW" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 1;
@@ -87799,16 +88787,6 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/north)
-"sbC" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/sandbags,
-/obj/machinery/door/firedoor/heavy,
-/obj/effect/turf_decal/tiles/department/command/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/disposal/northeast)
 "sbF" = (
 /obj/structure/chair/wood/wings,
 /turf/simulated/floor/wood,
@@ -88017,21 +88995,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/east)
-"sey" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/security/fore_starboard)
 "seK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -88105,15 +89068,6 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/hallway)
-"sfo" = (
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/starboard/south)
 "sfq" = (
 /obj/machinery/light{
 	dir = 1
@@ -88193,17 +89147,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/asmaint)
-"sgo" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/barricade/wooden/crude,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "sgp" = (
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -88409,6 +89352,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/east)
+"siE" = (
+/obj/machinery/door/airlock/engineering/glass{
+	autoclose = 0;
+	id_tag = "engsm_door_int";
+	name = "Supermatter Interior Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/engineering/control)
 "siJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -88432,6 +89390,12 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/service/fore_port)
+"siZ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/public/quantum/cargo)
 "sjk" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -88547,18 +89511,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/aisat/service)
-"sks" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "skB" = (
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -88732,6 +89684,26 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/meeting_room)
+"sma" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Detective";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/forensics,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Detective"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/carpet/grimey,
+/area/station/security/detective)
 "smf" = (
 /obj/machinery/computer/guestpass{
 	pixel_x = -28
@@ -88783,6 +89755,33 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/hallway)
+"smt" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/flashlight/pen,
+/obj/machinery/door_control{
+	id = "medmain";
+	name = "Medbay Doors";
+	normaldoorcontrol = 1;
+	pixel_x = -24;
+	pixel_y = 9
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/side{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/reception)
 "smz" = (
 /obj/machinery/light{
 	dir = 4
@@ -88873,6 +89872,27 @@
 /obj/structure/chair/wood,
 /turf/simulated/floor/wood,
 /area/station/maintenance/gambling_den)
+"snM" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "servlockdown";
+	layer = 2.6;
+	name = "Service Lockdown"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/servsci)
 "snQ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -88960,6 +89980,30 @@
 /obj/effect/spawner/random/food_trash,
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/fsmaint)
+"soY" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "engilockdown";
+	layer = 2.6;
+	name = "Engineering Lockdown"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/comeng)
 "spe" = (
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall/r_wall,
@@ -89025,6 +90069,18 @@
 /obj/machinery/atmospherics/portable/canister/air,
 /turf/simulated/floor/plating,
 /area/station/maintenance/service/fore_starboard)
+"spX" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/airlock/atmos{
+	name = "Security Atmospherics Checkpoint";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/security/aft_port)
 "sqe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -89198,19 +90254,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/freezer,
 /area/station/service/kitchen)
-"ssm" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/service/aft_starboard)
 "ssn" = (
 /obj/effect/turf_decal/tiles/white/corner{
 	dir = 8
@@ -89355,20 +90398,6 @@
 "stw" = (
 /turf/simulated/mineral/ancient,
 /area/station/maintenance/abandonedbar)
-"sty" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "servlockdown";
-	layer = 2.6;
-	name = "Service Lockdown"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/sercom)
 "stC" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
@@ -89376,6 +90405,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/west)
+"stF" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Docking Asteroid Substation";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/electrical/aft_starboard)
 "stK" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical,
@@ -89432,6 +90476,13 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/supply/break_room)
+"sue" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/turf/simulated/floor/plasteel/dark,
+/area/station/aisat/service)
 "sug" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -89460,20 +90511,6 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/maintcentral)
-"suI" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/command{
-	name = "Head of Personnel"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/hop,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/station/command/office/hop)
 "suL" = (
 /obj/structure/lattice,
 /turf/simulated/mineral/ancient,
@@ -89518,19 +90555,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/robotics)
-"sve" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prison Garden"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
 "svh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -89751,6 +90775,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
+"sxP" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Asteroid Substation";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/electrical/fore_starboard)
 "sxT" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/dark,
@@ -89824,6 +90863,16 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/north)
+"szD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/research{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/electrical/aft_port)
 "szH" = (
 /obj/machinery/light{
 	dir = 4
@@ -90291,6 +91340,22 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/storage)
+"sEd" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Central Asteroid Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/maintcentral)
 "sEg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -90393,6 +91458,19 @@
 /obj/effect/turf_decal/tiles/department/medical,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/paramedic)
+"sFv" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "sFw" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
@@ -90522,6 +91600,21 @@
 /obj/effect/turf_decal/tiles/department/science,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
+"sGS" = (
+/obj/machinery/door/airlock/glass{
+	name = "Library reading room";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "library"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/service/library)
 "sGT" = (
 /obj/machinery/computer/arcade/orion_trail{
 	dir = 4
@@ -90557,18 +91650,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/supermatter)
-"sHw" = (
-/obj/machinery/door/airlock/mining/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/supply/smith,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/supply/smith_office)
 "sHB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/reinforced/directional/north,
@@ -90814,30 +91895,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/west)
-"sKr" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/door/airlock/command/glass{
-	id_tag = "ceofficedoor";
-	name = "Chief Engineer's Office"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "CE"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/command/office/ce)
 "sKs" = (
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison/cell_block/a)
@@ -91051,18 +92108,6 @@
 /obj/structure/closet/firecloset/full,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/control)
-"sNj" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/multi_tile/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/locker)
 "sNn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -91147,20 +92192,21 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/apmaint)
-"sNU" = (
-/obj/machinery/door/airlock/glass,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating/airless,
-/area/station/maintenance/storage)
 "sNX" = (
 /turf/simulated/wall/r_wall,
 /area/station/hallway/secondary/entry/south)
-"sNY" = (
-/obj/machinery/mineral/ore_redemption,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/cargo,
-/turf/simulated/floor/plasteel/dark,
-/area/station/supply/office)
+"sNZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/cargo_bay,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "sOa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -91381,36 +92427,6 @@
 /obj/effect/landmark/spawner/late/crew,
 /turf/simulated/floor/indestructible/titanium/blue,
 /area/shuttle/arrival/station)
-"sPv" = (
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "researchlockdown";
-	layer = 2.6;
-	name = "Research Emergency Lockdown"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/classic/normal{
-	name = "R&D Desk"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "researchlockdown";
-	layer = 2.6;
-	name = "Research Emergency Lockdown"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "RnDShutters"
-	},
-/obj/item/desk_bell{
-	pixel_x = 7;
-	pixel_y = 7;
-	anchored = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/science/tox,
-/obj/effect/turf_decal/tiles/department/science,
-/turf/simulated/floor/plasteel,
-/area/station/science/rnd)
 "sPx" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel/dark,
@@ -91448,19 +92464,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
-"sPL" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id_tag = "kitchen2"
-	},
-/obj/machinery/door/window/classic/reversed,
-/obj/effect/mapping_helpers/airlock/windoor/autoname,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen,
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/kitchen)
 "sPM" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -91562,6 +92565,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/surgery/primary)
+"sRu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance{
+	name = "Central Asteroid Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/storage)
 "sRx" = (
 /obj/effect/turf_decal/tiles/department/chemistry/corner{
 	dir = 4
@@ -91645,15 +92666,6 @@
 /obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
-"sSv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/engineering/glass{
-	heat_proof = 1;
-	name = "Supermatter Chamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
-/turf/simulated/floor/engine,
-/area/station/engineering/engine/supermatter)
 "sSF" = (
 /obj/item/book/manual/wiki/sop_medical,
 /obj/structure/table/glass/reinforced,
@@ -91764,6 +92776,18 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/supply/break_room)
+"sUd" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance/external{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/storage)
 "sUf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -92037,6 +93061,20 @@
 "sXj" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/maintcentral)
+"sXp" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft-Starboard Asteroid Maintenance";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint2)
 "sXv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -92211,6 +93249,16 @@
 	},
 /turf/simulated/wall,
 /area/station/hallway/primary/fore/north)
+"sZB" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/public/quantum/science)
 "sZF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -92449,6 +93497,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet/green,
 /area/station/service/library)
+"tbG" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Escape Pod 4 Airlock";
+	id_tag = "emergency_home";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/command/fore)
 "tbJ" = (
 /obj/machinery/economy/vending/coffee,
 /obj/effect/turf_decal/tiles/dark/checker,
@@ -92940,20 +93996,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
-"tip" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/public/glass{
-	name = "Trade Lounge"
-	},
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/south)
 "tiu" = (
 /obj/machinery/light{
 	dir = 8
@@ -92985,19 +94027,6 @@
 "tiG" = (
 /turf/simulated/wall,
 /area/station/medical/storage)
-"tiJ" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/security/port)
 "tiL" = (
 /obj/machinery/light{
 	dir = 1
@@ -93077,6 +94106,27 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/xenobiology)
+"tju" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "ailockdown";
+	layer = 2.6;
+	name = "AI Asteroid Lockdown"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/teleporter,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/turret_protected/aisat/interior)
 "tjx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -93116,20 +94166,6 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central/west)
-"tjI" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/barricade/wooden/crude,
-/obj/effect/decal/cleanable/blood/tracks/mapped{
-	dir = 1
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/service/aft_port)
 "tjL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -93329,6 +94365,19 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/asmaint2)
+"tme" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/south)
 "tmf" = (
 /obj/effect/spawner/random/dirt/maybe,
 /obj/effect/turf_decal/tiles/department/engineering/corner{
@@ -93452,6 +94501,24 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/medbay2)
+"tnO" = (
+/obj/structure/table/reinforced,
+/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/general,
+/obj/machinery/door/window/classic/normal,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/side,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/reception)
 "tnS" = (
 /obj/machinery/door/poddoor/shutters{
 	id_tag = "Secure Armory";
@@ -93654,18 +94721,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/starboard)
-"tpZ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/public/glass{
-	name = "Trade Lounge"
-	},
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/south)
 "tqb" = (
 /obj/structure/chair{
 	dir = 1
@@ -93725,6 +94780,23 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
+"tqq" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/random/dirt/frequent,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	name = "Storefront Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/station/public/storefront)
 "tqE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -93743,6 +94815,18 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/north)
+"tqN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/fore/north)
 "tqQ" = (
 /obj/machinery/newscaster/directional/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -93857,14 +94941,22 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/asmaint2)
-"tsN" = (
-/obj/machinery/door/airlock/maintenance/external,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+"tsL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/maintenance/maintcentral)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/service/aft_port)
 "tsV" = (
 /obj/machinery/chem_dispenser,
 /obj/structure/reagent_dispensers/fueltank/chem{
@@ -94002,20 +95094,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/disposal/east)
-"tuu" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/spawner/random/dirt/frequent,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
-/obj/effect/mapping_helpers/airlock/access/any/science/tox,
-/turf/simulated/floor/plasteel/white,
-/area/station/maintenance/apmaint)
 "tuC" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
 	dir = 8
@@ -94263,14 +95341,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/aisat/atmos)
-"txf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/public/quantum/science)
 "txk" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -94370,6 +95440,14 @@
 /obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"tzq" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore/east)
 "tzw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -94502,13 +95580,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/hallway/primary/starboard/south)
-"tBg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/map_effect/dynamic_airlock/door/exterior,
-/obj/machinery/access_button/offset/west,
-/turf/simulated/floor/plating/airless,
-/area/station/hallway/primary/central/north)
 "tBi" = (
 /turf/simulated/floor/plating/airless,
 /area/station/hallway/secondary/exit)
@@ -94758,6 +95829,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
+"tEx" = (
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/starboard/south)
 "tEy" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -94776,7 +95857,7 @@
 "tEA" = (
 /obj/machinery/computer/general_air_control{
 	name = "Tank Monitor";
-	autolink_sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous Oxide","waste_sensor"="Gas Mix Tank");
+	autolink_sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous Oxide", "waste_sensor" = "Gas Mix Tank");
 	dir = 1
 	},
 /obj/machinery/light,
@@ -95118,6 +96199,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/north)
+"tIU" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/medical{
+	name = "Abandoned Infirmary";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/starboard)
 "tIW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple,
 /obj/effect/turf_decal/tiles/department/engineering/side{
@@ -95383,6 +96473,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/north)
+"tLi" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/wood/nitrogen,
+/area/station/maintenance/abandonedbar)
 "tLo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -95702,20 +96809,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/east)
-"tOJ" = (
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "BrigLeft";
-	name = "Brig Foyer Left Entrance"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
 "tOL" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/lifestar,
@@ -95834,12 +96927,6 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/port)
-"tPV" = (
-/obj/machinery/door/airlock{
-	name = "Bathroom"
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/station/medical/virology)
 "tQa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -96134,30 +97221,6 @@
 "tTs" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/electrical/aft_starboard)
-"tTt" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "cargolockdown";
-	layer = 2.6;
-	name = "Cargo Lockdown"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 1
-	},
-/obj/structure/sign/medical{
-	pixel_x = -32
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/starboard/south)
 "tTu" = (
 /obj/structure/table/reinforced{
 	layer = 2.5
@@ -96192,31 +97255,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/aft/west)
-"tTL" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/window/brigdoor{
-	id = "Cell 2";
-	name = "Cell 2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/obj/item/radio/intercom{
-	name = "west bump";
-	pixel_x = -28
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison/cell_block/a)
 "tTW" = (
 /obj/structure/chair/stool/bar{
 	dir = 4
@@ -96248,14 +97286,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
-"tUm" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/fore/north)
 "tUx" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs,
@@ -96510,10 +97540,6 @@
 	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/maintenance/command/starboard)
-"tXi" = (
-/obj/machinery/door/airlock/titanium/glass,
-/turf/simulated/floor/indestructible/titanium,
-/area/shuttle/arrival/station)
 "tXn" = (
 /obj/item/assembly/mousetrap/armed,
 /obj/structure/cable/extra_insulated{
@@ -96868,6 +97894,12 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
+"uaL" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/multi_tile/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/public/quantum/science)
 "uaM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
@@ -96985,21 +98017,25 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/north)
-"ubB" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "med2"
+"ubG" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/patients_rooms_secondary)
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "cargolockdown";
+	layer = 2.6;
+	name = "Cargo Lockdown"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/south)
 "ubJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet/black,
@@ -97051,22 +98087,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/engine,
 /area/station/hallway/spacebridge/engmed)
-"uct" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/effect/spawner/random/dirt/frequent,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/security/starboard)
 "ucx" = (
 /obj/item/toy/plushie/shark,
 /turf/simulated/floor/plating{
@@ -97345,24 +98365,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/simulated/floor/carpet,
 /area/station/service/bar)
-"uga" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/atmos,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/atmos)
 "ugj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 10
@@ -97610,18 +98612,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/hos)
-"uiQ" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Asteroid Substation"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/electrical/fore_starboard)
 "uiV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -97649,6 +98639,20 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/hallway/primary/starboard/south)
+"ujh" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance/external{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/storage)
 "ujl" = (
 /obj/structure/shelf/engineering,
 /obj/effect/spawner/random/engineering/materials,
@@ -98173,6 +99177,23 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/security/starboard)
+"uom" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/station/maintenance/service/aft_starboard)
 "uop" = (
 /obj/effect/turf_decal/tiles/department/virology,
 /turf/simulated/floor/plasteel/white,
@@ -98192,16 +99213,30 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet/green,
 /area/station/service/library)
-"uow" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/airlock/engineering{
-	name = "Cargo/Medical Asteroid Substation"
+"uov" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
 	},
-/obj/structure/cable{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/map_effect/dynamic_airlock/door/interior,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/access_button/offset/northeast,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/central/east)
+"uoC" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/disposal/south)
 "uoF" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -98279,15 +99314,6 @@
 	},
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/disposal/west)
-"upz" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/dockmed)
 "upC" = (
 /obj/structure/rack{
 	dir = 8;
@@ -98445,6 +99471,23 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/hallway)
+"urw" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Solitary Confinement 1";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/department/security,
+/turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
 "urz" = (
 /turf/simulated/wall/r_wall,
 /area/station/hallway/spacebridge/dockmed)
@@ -98521,9 +99564,40 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/hallway/spacebridge/servsci)
+"usI" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/spawner/random/dirt/frequent,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/science/tox,
+/obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/apmaint)
 "usK" = (
 /turf/simulated/wall/r_wall,
 /area/station/hallway/primary/starboard/south)
+"usR" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Pet Shop";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/public/pet_store)
 "usW" = (
 /obj/structure/railing{
 	dir = 8
@@ -98589,19 +99663,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/fore/north)
-"utt" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/disposal/north)
 "utz" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -98609,16 +99670,6 @@
 	},
 /turf/space,
 /area/station/engineering/solar/aft)
-"utA" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/sleeper)
 "utC" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -98700,6 +99751,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central/north)
+"uuB" = (
+/obj/machinery/door/airlock/wood{
+	name = "Private Residence";
+	desc = "No solicitors please.";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/wood,
+/area/station/maintenance/storage)
 "uuF" = (
 /obj/structure/punching_bag,
 /obj/structure/sign/poster/official/random/directional/east,
@@ -98719,6 +99784,28 @@
 /obj/machinery/firealarm/directional/east,
 /turf/simulated/wall,
 /area/station/medical/reception)
+"uuO" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/mineral_door/wood{
+	name = "Secret Clown HQ"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/service/clown/secret)
+"uuS" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/department/virology,
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/secondary/garden)
 "uuU" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -98816,6 +99903,21 @@
 "uvT" = (
 /turf/simulated/mineral/ancient,
 /area/station/maintenance/electrical/aft_port)
+"uvV" = (
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Courtroom"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/doors,
+/obj/effect/mapping_helpers/airlock/access/any/security/court,
+/turf/simulated/floor/wood,
+/area/station/legal/courtroom)
 "uwc" = (
 /obj/effect/spawner/random/dirt/often,
 /obj/item/radio/intercom{
@@ -99072,22 +100174,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/south)
-"uyz" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "cargolockdown";
-	layer = 2.6;
-	name = "Cargo Lockdown"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/starboard/south)
 "uyA" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -99117,6 +100203,30 @@
 "uyM" = (
 /turf/simulated/wall,
 /area/station/public/arcade)
+"uyQ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge Conference Room";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "bridge"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "bridge_lower";
+	layer = 2.6;
+	name = "Emergency Blast Door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/department/command/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/meeting_room)
 "uyV" = (
 /obj/machinery/economy/vending/coffee,
 /obj/machinery/light{
@@ -99139,6 +100249,20 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/supply/expedition)
+"uzd" = (
+/obj/structure/disposalpipe/segment{
+	color = "#954535"
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/port/south)
 "uze" = (
 /obj/effect/turf_decal/tiles/department/cargo/corner{
 	dir = 1
@@ -99148,6 +100272,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/lobby)
+"uzf" = (
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating/airless,
+/area/station/maintenance/storage)
 "uzh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -99222,13 +100353,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/processing)
-"uzO" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/service/aft_port)
 "uzQ" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -99328,20 +100452,6 @@
 	},
 /turf/space,
 /area/space)
-"uBd" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/machinery/door/airlock/virology/glass{
-	name = "Virology Patient Room 2"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "viro_2"
-	},
-/obj/effect/turf_decal/tiles/department/virology,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/virology)
 "uBe" = (
 /obj/machinery/suit_storage_unit/captain/secure,
 /turf/simulated/floor/wood,
@@ -99391,12 +100501,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
-"uBR" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/service/fore_starboard)
 "uCb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -99416,27 +100520,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
-"uCk" = (
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	id_tag = "viro_door_ext";
-	locked = 1;
-	name = "Virology Lab External Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/machinery/door/firedoor,
-/obj/machinery/access_button{
-	layer = 3.6;
-	autolink_id = "viro_btn_ext";
-	name = "Virology Lab Access Button";
-	req_access = list(39);
-	pixel_x = 28
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/virology)
 "uCn" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -99454,17 +100537,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"uCt" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/south)
 "uCu" = (
 /turf/simulated/wall/r_wall,
 /area/station/science/toxins/mixing)
@@ -100305,6 +101377,17 @@
 /obj/effect/turf_decal/tiles/department/engineering/side,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/engine_foyer)
+"uLd" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id_tag = "MechbayShutters";
+	name = "Mech Bay Shutters"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/science/robotics/chargebay)
 "uLo" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -100379,29 +101462,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/external/southeast)
-"uMD" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "General Population Cell"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison/cell_block/a)
 "uMN" = (
 /obj/machinery/light{
 	dir = 8
@@ -100425,6 +101485,17 @@
 /obj/effect/turf_decal/delivery/white/hollow,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
+"uNr" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Cargo/Medical Asteroid Substation";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -100556,13 +101627,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/east)
-"uON" = (
-/obj/machinery/door/airlock/highsecurity,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/telecomms/computer)
 "uOP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -100638,20 +101702,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/apmaint)
-"uPR" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "medlockdown";
-	layer = 2.6;
-	name = "Medical Lockdown"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/dockmed)
 "uPU" = (
 /obj/effect/spawner/random/dirt/often,
 /obj/effect/turf_decal/tiles/department/medical/side{
@@ -100946,9 +101996,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
-"uSP" = (
-/turf/simulated/wall/indestructible/titanium,
-/area/shuttle/arrival/station)
 "uSS" = (
 /obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/wood,
@@ -101003,19 +102050,21 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/service/chapel/office)
-"uTR" = (
-/obj/machinery/door/airlock/command{
-	name = "Teleport Access"
+"uTX" = (
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/public/glass{
+	name = "Trade Lounge";
+	dir = 4
 	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/command/teleporter)
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/south)
 "uUo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -101609,6 +102658,16 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/starboard)
+"vbu" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Starboard Asteroid Maintenance Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/expedition,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "vbE" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 4;
@@ -101770,15 +102829,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_starboard)
-"vcJ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/public/glass{
-	name = "Trade Lounge"
-	},
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/south)
 "vcK" = (
 /obj/machinery/cryopod{
 	dir = 2
@@ -101839,6 +102889,20 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/processing)
+"vdW" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/spawner/random/dirt/often,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/west)
 "vdZ" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=ArrivalsWest";
@@ -101911,22 +102975,6 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/science/xenobiology)
-"veF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tiles/department/medical/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/storage)
 "veO" = (
 /turf/simulated/floor/mineral/tranquillite,
 /area/station/service/mime)
@@ -102034,6 +103082,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/starboard/south)
+"vfN" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/disposal/north)
 "vfP" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
@@ -102649,18 +103709,6 @@
 /obj/effect/turf_decal/tiles/department/security/checker,
 /turf/simulated/floor/plasteel/dark,
 /area/station/public/quantum/science)
-"vmW" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/maintenance/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/service/fore_starboard)
 "vng" = (
 /turf/simulated/wall,
 /area/station/command/office/rd)
@@ -102742,6 +103790,41 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/legal/lawoffice)
+"vnC" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "chemisttop";
+	name = "Chemistry Lobby Shutters"
+	},
+/obj/machinery/door/window/classic/normal,
+/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
+/obj/item/folder/yellow,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/item/desk_bell{
+	pixel_x = 7;
+	pixel_y = 7;
+	anchored = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/chemistry,
+/obj/machinery/door/window/classic/normal{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/autoname/desk{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/medical/chemistry)
 "vnE" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -102849,19 +103932,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/apmaint)
-"voU" = (
-/obj/machinery/door/airlock/mining/glass,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/supply/cargo_bay,
-/turf/simulated/floor/plasteel/dark,
-/area/station/supply/storage)
 "vpe" = (
 /obj/effect/mapping_helpers/turfs/rust,
 /turf/simulated/wall,
@@ -102985,14 +104055,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
-"vqM" = (
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/kitchen)
 "vqQ" = (
 /obj/structure/marker_beacon/dock_marker/collision,
 /obj/structure/lattice/catwalk,
@@ -103028,16 +104090,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"vrm" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Labor Camp Airlock";
-	id_tag = "laborcamp_home"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plasteel,
-/area/station/security/prisonershuttle)
 "vrp" = (
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating{
@@ -103191,34 +104243,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/lobby)
-"vsw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/security/port)
-"vsD" = (
-/obj/machinery/door/airlock/hatch{
-	name = "AI Satellite Secondary Antechamber"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
-/turf/simulated/floor/plasteel{
-	icon_state = "bcircuit"
-	},
-/area/station/turret_protected/ai)
 "vsE" = (
 /obj/machinery/space_heater,
 /obj/structure/railing{
@@ -103227,6 +104251,15 @@
 /obj/effect/turf_decal/tiles/department/engineering/side,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
+"vsO" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Abandoned Infirmary";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/starboard)
 "vsP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -103351,6 +104384,14 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/hallway/spacebridge/scidock)
+"vtY" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/north)
 "vul" = (
 /obj/effect/mapping_helpers/turfs/rust,
 /turf/simulated/wall/r_wall,
@@ -103552,6 +104593,32 @@
 /obj/structure/rack,
 /turf/simulated/floor/plasteel/white,
 /area/station/command/office/rd)
+"vxg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/obj/effect/map_effect/dynamic_airlock/door/exterior,
+/obj/machinery/access_button/offset/west,
+/turf/simulated/floor/plating/airless,
+/area/station/hallway/primary/central/north)
+"vxh" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/south)
 "vxi" = (
 /obj/structure/chair/stool/wood,
 /obj/effect/landmark/start/assistant,
@@ -103584,22 +104651,6 @@
 /obj/effect/spawner/random/oil/maybe,
 /turf/simulated/floor/plating,
 /area/station/maintenance/electrical/aft_port)
-"vxt" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/structure/barricade/sandbags,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/tiles/department/command/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/disposal/northeast)
 "vxC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -103801,15 +104852,6 @@
 /obj/effect/turf_decal/tiles/department/medical/side,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
-"vzD" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Central Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/maintcentral)
 "vzL" = (
 /obj/machinery/kitchen_machine/microwave{
 	pixel_y = 6
@@ -103873,17 +104915,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/starboard)
-"vAc" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry)
 "vAl" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -104174,6 +105205,25 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics)
+"vCu" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "servlockdown";
+	layer = 2.6;
+	name = "Service Lockdown"
+	},
+/obj/structure/disposalpipe/segment{
+	color = "#954535"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/sercom)
 "vCx" = (
 /obj/effect/mapping_helpers/turfs/rust,
 /turf/simulated/wall,
@@ -104270,6 +105320,38 @@
 /obj/effect/turf_decal/tiles/department/virology,
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/hydroponics)
+"vDI" = (
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "researchlockdown";
+	layer = 2.6;
+	name = "Research Emergency Lockdown"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/classic/normal{
+	name = "R&D Desk"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "researchlockdown";
+	layer = 2.6;
+	name = "Research Emergency Lockdown"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "RnDShutters"
+	},
+/obj/item/desk_bell{
+	pixel_x = 7;
+	pixel_y = 7;
+	anchored = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/science/tox,
+/obj/effect/turf_decal/tiles/department/science,
+/turf/simulated/floor/plasteel,
+/area/station/science/rnd)
 "vDM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tiles/department/security/side{
@@ -104283,6 +105365,22 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/reception)
+"vDV" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Escape Shuttle Cell";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/secondary/exit)
 "vDW" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -104441,27 +105539,6 @@
 "vFk" = (
 /obj/machinery/atmospherics/portable/scrubber/huge/stationary,
 /turf/simulated/floor/grass,
-/area/station/security/permabrig)
-"vFo" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors";
-	opacity = 0
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
 /area/station/security/permabrig)
 "vFq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -104635,6 +105712,17 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/service/fore_port)
+"vHk" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/south)
 "vHo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -104761,6 +105849,29 @@
 /obj/effect/spawner/random/food_trash,
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/fsmaint)
+"vIN" = (
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Prison Gate";
+	name = "Prison Lockdown Blast Doors";
+	opacity = 0
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/permabrig)
 "vIO" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -104791,17 +105902,6 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/east)
-"vJj" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	color = "#954535"
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/port/north)
 "vJl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -104824,6 +105924,12 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/hallway/spacebridge/cargocom)
+"vJG" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/service/bar)
 "vKh" = (
 /obj/structure/plasticflaps/mining,
 /obj/machinery/conveyor/west{
@@ -105042,13 +106148,6 @@
 /obj/effect/turf_decal/tiles/department/virology/side,
 /turf/simulated/floor/plasteel/dark,
 /area/station/hallway/spacebridge/scidock)
-"vMs" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/map_effect/dynamic_airlock/door/interior,
-/obj/machinery/access_button/offset/northeast,
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal/southwest)
 "vMt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -105196,6 +106295,23 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/checkpoint/secondary)
+"vOv" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "vOH" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor/transparent/glass/reinforced,
@@ -105453,6 +106569,24 @@
 /obj/item/stock_parts/manipulator,
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
+"vRL" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/command/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "bridge_upper";
+	layer = 2.6;
+	name = "Emergency Blast Door"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/bridge)
 "vRO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -105680,17 +106814,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/captain)
-"vUo" = (
-/obj/machinery/door/airlock/wood{
-	name = "Private Residence";
-	desc = "No solicitors please."
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
-/area/station/maintenance/storage)
 "vUp" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/window/reinforced/grilled,
@@ -105713,6 +106836,18 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/security/starboard)
+"vUG" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance{
+	name = "Starboard Asteroid Maintenance Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "vUJ" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -105748,20 +106883,22 @@
 	},
 /turf/simulated/floor/catwalk,
 /area/station/public/storage/emergency)
-"vVo" = (
-/obj/structure/cable{
+"vVl" = (
+/obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access";
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/dockmed)
+/area/station/maintenance/command/starboard)
 "vVp" = (
 /obj/structure/flora/ausbushes/genericbush,
 /turf/simulated/floor/grass/jungle,
@@ -106331,18 +107468,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
-"wds" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id_tag = "kitchen2"
-	},
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/kitchen)
 "wdx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -106475,6 +107600,17 @@
 /obj/machinery/alarm/directional/north,
 /turf/simulated/floor/wood,
 /area/station/maintenance/gambling_den)
+"wfm" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/command/starboard)
 "wfq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel/dark,
@@ -107029,22 +108165,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/toxins/mixing)
-"wkC" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/structure/disposalpipe/segment{
-	color = "#954535"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "servlockdown";
-	layer = 2.6;
-	name = "Service Lockdown"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/servsci)
 "wkH" = (
 /obj/structure/sink/directional/north,
 /obj/effect/turf_decal/tiles/department/medical/side{
@@ -107141,27 +108261,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/medical/chemistry)
-"wlZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge Conference Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "bridge"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge_lower";
-	layer = 2.6;
-	name = "Emergency Blast Door"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/department/command/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/command/meeting_room)
 "wmp" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/turbine)
@@ -107221,14 +108320,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
-"wmH" = (
-/obj/effect/map_effect/dynamic_airlock/door/interior,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/door/airlock/external/glass,
-/obj/machinery/access_button/offset/southwest,
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage)
 "wmP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -107252,6 +108343,18 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
+"wnh" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/security/fore_starboard)
 "wnj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -107297,18 +108400,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"wnF" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock{
-	name = "Bathroom"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/freezer,
-/area/station/public/toilet/unisex)
 "wnG" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
@@ -107409,15 +108500,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/west)
-"woR" = (
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/department/engineering/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/storage)
 "woU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -107516,13 +108598,6 @@
 /obj/effect/mapping_helpers/turfs/rust,
 /turf/simulated/wall,
 /area/mine/unexplored/cere/research)
-"wqE" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal/south)
 "wqI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -107571,19 +108646,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/tools)
-"wrh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/port/south)
 "wrl" = (
 /obj/machinery/power/apc/directional/east,
 /obj/structure/cable{
@@ -107649,34 +108711,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/service/fore_port)
-"wrU" = (
-/obj/machinery/door/airlock/mining/glass,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/supply/expedition,
-/obj/effect/mapping_helpers/airlock/access/any/supply/general,
-/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/supply/break_room)
-"wrW" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
 "wrZ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -108211,12 +109245,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
-"wwA" = (
-/obj/machinery/door/firedoor,
+"wwC" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	color = "#954535"
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/north)
+/area/station/hallway/primary/port/north)
 "wwM" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -108292,20 +109334,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/sleeper)
-"wxJ" = (
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/virology/glass{
-	name = "Virology Patient Room 1"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "viro_1"
-	},
-/obj/effect/turf_decal/tiles/department/virology,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/virology)
 "wxO" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -108369,6 +109397,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
+"wyu" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Central Asteroid Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/maintcentral)
 "wyx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -108439,15 +109475,6 @@
 	},
 /turf/simulated/wall,
 /area/station/hallway/primary/starboard/south)
-"wzj" = (
-/obj/structure/barricade/wooden,
-/obj/machinery/door/airlock/glass,
-/obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/station/hallway/spacebridge/scidock)
 "wzk" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -108516,19 +109543,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
-"wzF" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/port/north)
 "wzH" = (
 /turf/simulated/mineral/ancient/outer,
 /area/station/hallway/primary/fore/east)
@@ -108855,16 +109869,6 @@
 "wDs" = (
 /turf/simulated/mineral/ancient,
 /area/station/maintenance/security/starboard)
-"wDx" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/airlock/engineering{
-	name = "Science Asteroid Substation"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "wDz" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -109080,15 +110084,6 @@
 /obj/item/shovel/spade,
 /turf/simulated/floor/grass,
 /area/station/service/hydroponics)
-"wFy" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/multi_tile/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/department/virology,
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/secondary/garden)
 "wFB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -109172,6 +110167,23 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
+"wGG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/station/public/vacant_office)
 "wGJ" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -109337,6 +110349,42 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/hallway/primary/starboard/south)
+"wIk" = (
+/obj/machinery/door/airlock/security/glass{
+	locked = 1;
+	id_tag = "perma_door_ext";
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Prison Gate";
+	name = "Prison Lockdown Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/access_button{
+	autolink_id = "perma_btn_ext";
+	name = "Prison Wing Access Button";
+	req_access = list(2);
+	pixel_x = 21
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/permabrig)
 "wIl" = (
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 10
@@ -109652,6 +110700,25 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/toxins/launch)
+"wLC" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/atmos,
+/obj/item/desk_bell{
+	pixel_x = 7;
+	pixel_y = 7;
+	anchored = 1
+	},
+/obj/machinery/door/window/reinforced/normal,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "atmos";
+	name = "Atmospherics Blast Door"
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos/control)
 "wLL" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
 /obj/effect/decal/cleanable/dirt,
@@ -109747,6 +110814,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/west)
+"wMv" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "scilockdown";
+	layer = 2.6;
+	name = "Science Lockdown"
+	},
+/obj/effect/turf_decal/caution/red,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/servsci)
 "wME" = (
 /obj/machinery/door_control{
 	id = "brig_courtroom";
@@ -110024,28 +111108,6 @@
 "wOD" = (
 /turf/simulated/floor/plasteel,
 /area/station/security/range)
-"wOH" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/classic/normal{
-	dir = 1;
-	name = "Robotics Desk"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/science/robotics{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "RoboticsShutters"
-	},
-/obj/item/desk_bell{
-	pixel_x = 7;
-	pixel_y = 7;
-	anchored = 1
-	},
-/obj/effect/turf_decal/tiles/department/science,
-/turf/simulated/floor/plasteel,
-/area/station/science/robotics)
 "wOP" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/sop_legal{
@@ -110078,6 +111140,17 @@
 /obj/machinery/light,
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/chapel)
+"wPl" = (
+/obj/machinery/door/airlock/highsecurity{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/telecomms/computer)
 "wPr" = (
 /turf/simulated/wall,
 /area/station/hallway/secondary/entry/north)
@@ -110277,11 +111350,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/command/fore)
-"wSm" = (
-/obj/structure/mineral_door/wood,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/freezer,
-/area/station/maintenance/gambling_den)
 "wSn" = (
 /turf/simulated/mineral/ancient,
 /area/station/maintenance/disposal/northeast)
@@ -110544,6 +111612,24 @@
 /obj/item/camera,
 /turf/simulated/floor/carpet/black,
 /area/station/command/office/captain)
+"wVj" = (
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
+/obj/effect/mapping_helpers/airlock/access/any/science/research,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/science/hallway)
 "wVm" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/structure/disposalpipe/segment{
@@ -110902,6 +111988,18 @@
 /obj/effect/turf_decal/tiles/department/virology,
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/service/aft_starboard)
+"wYz" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/sleeper)
 "wYG" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -110995,20 +112093,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/robotics/chargebay)
-"wZI" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "scilockdown";
-	layer = 2.6;
-	name = "Science Lockdown"
-	},
-/obj/effect/turf_decal/caution/red,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/servsci)
 "wZJ" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -111250,19 +112334,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/starboard)
-"xcl" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/service/aft_starboard)
 "xcn" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
@@ -111499,34 +112570,22 @@
 /obj/item/seeds/harebell,
 /turf/simulated/floor/grass/jungle,
 /area/station/hallway/secondary/garden)
-"xfi" = (
+"xfn" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
+	name = "Prison Garden";
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/delivery,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tiles/neutral,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/south)
-"xfm" = (
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "BrigRight";
-	name = "Brig Foyer Right Entrance"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
+/area/station/security/permabrig)
 "xfG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -111853,6 +112912,18 @@
 /obj/item/stack/sheet/cardboard,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"xig" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/south)
 "xis" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -111915,6 +112986,21 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/service/fore_port)
+"xiY" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Asteroid Substation";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/electrical/fore_starboard)
 "xja" = (
 /obj/structure/window/plasmareinforced{
 	dir = 8
@@ -112114,17 +113200,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/northwest)
-"xmR" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
 "xnd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -112449,16 +113524,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/port/north)
-"xrF" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel/dark,
-/area/station/public/quantum/docking)
 "xrJ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/cargo/salvage{
@@ -112718,16 +113783,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
-"xuT" = (
-/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white{
-	icon_regular_floor = "yellowsiding"
-	},
-/area/station/maintenance/service/aft_port)
 "xuZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -113089,6 +114144,13 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/vault)
+"xyV" = (
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage)
 "xyW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -113162,18 +114224,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/processing)
-"xzT" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Pet Shop"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/public/pet_store)
 "xAu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -113224,6 +114274,23 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/supply/storage)
+"xAP" = (
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Prison Gate";
+	name = "Prison Lockdown Blast Doors";
+	opacity = 0
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/permabrig)
 "xAS" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/machinery/light,
@@ -113304,6 +114371,15 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/robotics/chargebay)
+"xBK" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/sleeper)
 "xBO" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -113354,22 +114430,6 @@
 	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/maintenance/electrical/aft_starboard)
-"xCu" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "servlockdown";
-	layer = 2.6;
-	name = "Service Lockdown"
-	},
-/obj/structure/disposalpipe/segment{
-	color = "#954535"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/sercom)
 "xCx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -113493,13 +114553,6 @@
 /obj/effect/turf_decal/tiles/department/engineering/side,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/smes)
-"xDj" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/medical/cryo)
 "xDk" = (
 /obj/item/radio/intercom{
 	name = "south bump";
@@ -113912,13 +114965,6 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
-"xHD" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/tiles/department/virology,
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/secondary/garden)
 "xHI" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -114205,6 +115251,15 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
+"xKE" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal/south)
 "xKH" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -114221,6 +115276,21 @@
 "xLj" = (
 /turf/simulated/wall,
 /area/station/service/chapel/office)
+"xLy" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "kitchen2"
+	},
+/obj/machinery/door/window/classic/reversed,
+/obj/effect/mapping_helpers/airlock/windoor/autoname,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen,
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/kitchen)
 "xLC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks/mapped,
@@ -114712,6 +115782,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/gravitygenerator)
+"xRg" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Walkway";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/comeng)
 "xRh" = (
 /obj/machinery/economy/vending/cola,
 /obj/effect/turf_decal/tiles/dark/checker,
@@ -114888,6 +115970,17 @@
 /obj/item/candle,
 /turf/simulated/floor/wood,
 /area/station/service/bar)
+"xSW" = (
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "xSX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -114924,6 +116017,13 @@
 "xTc" = (
 /turf/simulated/floor/grass,
 /area/station/maintenance/security/fore_starboard)
+"xTf" = (
+/obj/machinery/door/airlock/research{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/tox,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "xTj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall,
@@ -115048,27 +116148,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
-"xUV" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "medlockdown";
-	layer = 2.6;
-	name = "Medical Lockdown"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/dockmed)
 "xUW" = (
 /obj/machinery/computer/shuttle/labor{
 	dir = 4
@@ -115233,6 +116312,19 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/command/starboard)
+"xXk" = (
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock";
+	name = "Escape Pod Hatch";
+	dir = 4
+	},
+/obj/docking_port/mobile/pod{
+	id = "pod4";
+	name = "escape pod 4"
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/pod_4)
 "xXt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -115322,6 +116414,24 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"xXX" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "xYd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -115432,6 +116542,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"xZG" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/bananium{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/service/clown,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/station/service/clown)
 "xZI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -115800,6 +116926,14 @@
 "yfZ" = (
 /turf/simulated/wall,
 /area/station/medical/storage/secondary)
+"ygb" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/airlock/engineering{
+	name = "Cargo/Medical Asteroid Substation";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "yge" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Aft Asteroid Maintenance"
@@ -115983,17 +117117,6 @@
 "yhW" = (
 /turf/simulated/wall,
 /area/station/maintenance/security/port)
-"yhZ" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Walkway"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/dockmed)
 "yie" = (
 /obj/effect/spawner/random/dirt/frequent,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -116100,14 +117223,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/hallway)
-"yjt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/research,
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/electrical/aft_port)
 "yjw" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -116131,15 +117246,6 @@
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/service/fore_starboard)
-"yjC" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Throne Room"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/disposal/northeast)
 "yjH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 9
@@ -116281,6 +117387,18 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/north)
+"ykG" = (
+/obj/machinery/door/airlock/engineering/glass{
+	heat_proof = 1;
+	name = "Supermatter Chamber";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/engineering/engine/supermatter)
 "ykH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -116408,17 +117526,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
-"ylS" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Starboard Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/station/maintenance/starboard)
 "ylX" = (
 /obj/machinery/disposal/delivery_chute{
 	dir = 8;
@@ -120744,13 +121851,13 @@ rNK
 tJe
 tpl
 tpl
-mSS
+bMv
 sWf
 sWf
 tpl
 sWf
 sWf
-mSS
+bMv
 tpl
 rth
 tJe
@@ -123547,7 +124654,7 @@ rbT
 cak
 bWw
 kFV
-vMs
+gfK
 mpp
 gRZ
 rNK
@@ -125494,11 +126601,11 @@ cdD
 eMK
 jdK
 tcv
-lBh
+cpR
 oOh
 jGh
 jwd
-vsw
+aFu
 hXj
 bjW
 jgS
@@ -125511,7 +126618,7 @@ jGh
 aLf
 wka
 mQI
-tiJ
+aSw
 pEB
 ruF
 hyY
@@ -125569,7 +126676,7 @@ xYn
 pDZ
 tnB
 mUk
-aOl
+tLi
 bhD
 sxK
 eCI
@@ -125591,7 +126698,7 @@ hKu
 eMB
 dDQ
 nNx
-uzO
+lkh
 nyl
 rFZ
 vqD
@@ -126113,7 +127220,7 @@ eoI
 hBa
 jLW
 gtn
-tjI
+hFj
 mfS
 xLC
 ons
@@ -126617,7 +127724,7 @@ cfF
 grG
 orD
 ryi
-cZc
+tsL
 cts
 cts
 wOv
@@ -127056,7 +128163,7 @@ wOq
 kzo
 fGF
 tjP
-mRk
+spX
 kDr
 xzh
 eXG
@@ -127119,7 +128226,7 @@ jee
 jee
 wez
 xDm
-rxb
+jRV
 iVQ
 oUr
 mOe
@@ -127891,7 +128998,7 @@ eCI
 hqi
 dTA
 dTA
-ofk
+iFX
 tFJ
 tFJ
 ryi
@@ -127901,7 +129008,7 @@ dqn
 pEs
 rJw
 gqf
-fjt
+oDX
 lrl
 vuX
 tAT
@@ -128180,7 +129287,7 @@ lTM
 rLT
 rDg
 sBR
-nNH
+ppn
 upV
 eoI
 aue
@@ -128437,7 +129544,7 @@ lTM
 hnc
 lQX
 bWE
-jJd
+kpq
 qUG
 eoI
 eoI
@@ -128685,7 +129792,7 @@ cbc
 jNl
 cTy
 rci
-koi
+uuO
 vxj
 wNu
 cRq
@@ -128845,7 +129952,7 @@ saw
 lol
 lFW
 kRx
-jAr
+uvV
 crs
 fuO
 eDo
@@ -128934,7 +130041,7 @@ nvU
 cNh
 vHp
 qsR
-xuT
+qrc
 pnB
 eoI
 lTM
@@ -129102,7 +130209,7 @@ bIR
 rmq
 ubg
 ncN
-gck
+mex
 ioc
 xQe
 yaN
@@ -129154,7 +130261,7 @@ eMz
 gvA
 puY
 uWS
-lLQ
+alg
 gvA
 kgg
 vGZ
@@ -129396,7 +130503,7 @@ lIs
 fMP
 qui
 uWS
-qGA
+gFe
 uWS
 fDz
 lRT
@@ -129468,7 +130575,7 @@ lTM
 eoI
 sxD
 vBm
-sgo
+gpe
 pVB
 jmG
 rWw
@@ -129684,7 +130791,7 @@ dsc
 bHZ
 bHZ
 bHZ
-lVG
+mGQ
 bHZ
 bHZ
 bHZ
@@ -129878,7 +130985,7 @@ eHX
 ojx
 ctc
 rYO
-kAX
+goI
 sOm
 uRU
 cKY
@@ -129969,7 +131076,7 @@ rNT
 rNT
 eSh
 nRN
-nSu
+gca
 pwM
 sJd
 xam
@@ -130101,7 +131208,7 @@ rNK
 rNK
 rNK
 nxt
-pSz
+oHg
 mFT
 rnm
 qBv
@@ -130187,7 +131294,7 @@ isI
 mKZ
 eyI
 dlk
-qoc
+kWS
 ejZ
 qOg
 dQV
@@ -130198,13 +131305,13 @@ tqf
 tbC
 uXh
 xqN
-hVC
+sGS
 osb
 feJ
 dvq
 eOW
 kqs
-aDH
+iSx
 bYT
 mKT
 cuR
@@ -130247,7 +131354,7 @@ mKh
 rza
 lMW
 vgI
-gfb
+nwk
 sKh
 sKh
 sKh
@@ -130504,7 +131611,7 @@ tzw
 nIv
 wuP
 nIv
-oDf
+rIU
 lZg
 rtj
 rtj
@@ -130515,18 +131622,18 @@ lZg
 lZg
 lZg
 nIv
-cDh
+sFv
 oas
 iXc
 xDv
-sks
+aLy
 dNv
 uZl
 uZl
 uZl
 lWU
 lMW
-czM
+njW
 lMW
 jfl
 gtZ
@@ -130626,7 +131733,7 @@ rMK
 tKg
 mzw
 nrQ
-nvf
+ovT
 dtp
 dzj
 dtp
@@ -130681,7 +131788,7 @@ vyZ
 aED
 tku
 rxa
-qxo
+hTj
 lRb
 oAB
 wOk
@@ -130917,7 +132024,7 @@ sJw
 vvP
 pLq
 rgH
-eqG
+qEe
 hDn
 quE
 vim
@@ -130994,10 +132101,10 @@ cMT
 upa
 vSr
 hRk
-wnF
+iOf
 fIj
 tJP
-dMd
+xZG
 oRH
 odg
 fLg
@@ -131129,7 +132236,7 @@ rNK
 rNK
 rNK
 rNK
-vrm
+jug
 mFT
 apb
 mFT
@@ -131163,7 +132270,7 @@ hTn
 ujO
 dyS
 kmo
-aUq
+gEh
 vFG
 vGt
 aUo
@@ -131210,7 +132317,7 @@ bHM
 kAv
 sMu
 sMu
-rPc
+qpb
 yll
 fYF
 uIs
@@ -131308,7 +132415,7 @@ irG
 irG
 uVg
 czI
-wqE
+xKE
 oyp
 dwy
 ira
@@ -131403,7 +132510,7 @@ xQS
 kCx
 bqV
 dtr
-bTa
+cMR
 eqB
 pOr
 nFR
@@ -131420,7 +132527,7 @@ qGR
 ojx
 oku
 sOu
-bhy
+rlq
 shl
 cEC
 wSk
@@ -131565,7 +132672,7 @@ qUd
 mvK
 uZl
 mvK
-lMr
+uoC
 orU
 ron
 qvp
@@ -131660,7 +132767,7 @@ xQS
 iIZ
 nnk
 bap
-xmR
+eut
 bap
 bap
 dfL
@@ -131672,7 +132779,7 @@ uFg
 xnL
 qNy
 iEp
-tOJ
+nBs
 joR
 nse
 joR
@@ -131917,7 +133024,7 @@ xQS
 kCx
 pBh
 yhN
-jkM
+aKM
 iGx
 iGx
 daG
@@ -131929,7 +133036,7 @@ dXq
 iGx
 daG
 dpu
-mMh
+pMb
 yaN
 aNG
 xzA
@@ -132696,11 +133803,11 @@ nbI
 aGP
 bkF
 bdI
-rNs
+qsC
 nJL
 cHB
 kGm
-dVv
+ntg
 uTo
 djD
 jko
@@ -132716,7 +133823,7 @@ hId
 esb
 dvh
 nGN
-iTt
+sma
 jgp
 vnS
 bQu
@@ -132768,7 +133875,7 @@ dPu
 dPu
 ogq
 dPu
-bgt
+onF
 mFM
 hsb
 mFM
@@ -132785,7 +133892,7 @@ wGo
 wGo
 nbB
 wEe
-rYF
+uzd
 nbB
 vms
 nbB
@@ -132798,7 +133905,7 @@ gaB
 wGo
 wYn
 kQS
-wkC
+iEt
 wnT
 kqf
 kqf
@@ -132807,14 +133914,14 @@ aqo
 kqf
 lHm
 tRP
-axO
+asO
 kxM
 vgJ
 gwg
 pEi
 qbD
 fKX
-qDv
+jjg
 gwg
 gwg
 gwg
@@ -132832,7 +133939,7 @@ lsp
 lxD
 cuD
 sKb
-iuS
+kJy
 dCe
 ctF
 jyL
@@ -133025,7 +134132,7 @@ xsS
 qZe
 aTJ
 xsS
-oXU
+gwy
 mCM
 kCb
 mCM
@@ -133042,7 +134149,7 @@ mCM
 mCM
 oKK
 mCM
-gxo
+omC
 mCM
 vyW
 qWO
@@ -133055,7 +134162,7 @@ mKs
 sIJ
 mCM
 rQg
-mrc
+pfG
 fFA
 xrc
 xrc
@@ -133064,14 +134171,14 @@ few
 xrc
 ssZ
 cgp
-wZI
+wMv
 xEd
 xEd
 mOX
 xEd
 eFq
 qnb
-nfn
+vdW
 gfV
 mzo
 mzo
@@ -133282,7 +134389,7 @@ xAC
 xHO
 tbR
 fAE
-wzF
+nNP
 uyf
 unP
 oDB
@@ -133299,7 +134406,7 @@ pwN
 pwN
 bIa
 ewC
-wrh
+bPh
 uyw
 hzv
 ngv
@@ -133312,7 +134419,7 @@ fpx
 mnu
 ycu
 idj
-iuE
+snM
 usH
 aJh
 aJh
@@ -133321,14 +134428,14 @@ qzH
 laG
 xFa
 hwf
-hPv
+fgw
 fhQ
 dBS
 eYG
 vfu
 hkA
 kAY
-iTx
+pKe
 iEx
 eTA
 vSG
@@ -133467,11 +134574,11 @@ byN
 xkf
 mCo
 xkf
-mng
+nle
 dpu
 dpu
 chK
-xfm
+ntk
 joR
 yfY
 gYW
@@ -133487,7 +134594,7 @@ dlp
 tDz
 dcu
 wWK
-jYZ
+cUD
 wLR
 wLR
 lEM
@@ -133533,7 +134640,7 @@ aZZ
 aZZ
 bok
 xOB
-hFS
+hBl
 bCt
 aZZ
 aZZ
@@ -133587,7 +134694,7 @@ vkl
 lyI
 lyI
 kBq
-txf
+uaL
 lyI
 lyI
 vGl
@@ -133703,10 +134810,10 @@ vdq
 vdq
 vdq
 vnG
-dRX
+gnM
 iCK
 bCE
-aln
+iTR
 llK
 qqn
 aou
@@ -133728,7 +134835,7 @@ uqz
 tur
 dpu
 buL
-cgh
+pWV
 oku
 ewb
 aVO
@@ -133943,7 +135050,7 @@ rNK
 rNK
 rNK
 rNK
-lBW
+gkT
 fMn
 iiQ
 ciF
@@ -134103,7 +135210,7 @@ kDB
 xwj
 rcB
 van
-nYR
+sZB
 mdz
 xEd
 emG
@@ -134117,7 +135224,7 @@ uRf
 rjy
 paV
 sOo
-ltP
+fTD
 bVI
 lZS
 gZS
@@ -134200,7 +135307,7 @@ rNK
 rNK
 rNK
 rNK
-hZX
+jyu
 vBJ
 uoq
 jGi
@@ -134217,20 +135324,20 @@ ukT
 ahJ
 ahJ
 nEZ
-oFr
+nBw
 vEz
 rEO
-gUH
+wIk
 lYK
 jRI
 qrh
 uHn
 fkW
-asc
+gVs
 ukz
 aYK
 dtr
-bTa
+cMR
 pOr
 pOr
 nFR
@@ -134245,7 +135352,7 @@ dUV
 qxe
 lta
 dpu
-lZU
+xSW
 vIr
 sKs
 ylw
@@ -134457,7 +135564,7 @@ rNK
 rNK
 rNK
 rNK
-vFo
+vIN
 rjA
 hsM
 vED
@@ -134466,7 +135573,7 @@ ciF
 daF
 eiG
 ahJ
-sve
+xfn
 wYH
 ahJ
 hyT
@@ -134487,7 +135594,7 @@ afd
 hgA
 efS
 lqp
-gZH
+dNQ
 cHH
 tkd
 hhe
@@ -134507,7 +135614,7 @@ sKs
 sKs
 cdq
 jZi
-geS
+cGG
 yfW
 lYp
 rpm
@@ -134545,11 +135652,11 @@ ujf
 ujf
 uyM
 fsx
-oRb
+iuu
 uyM
 uyM
 sUM
-jFZ
+gNw
 uyM
 uyM
 eHG
@@ -134557,7 +135664,7 @@ xsS
 wAK
 bjo
 bjo
-qax
+lpO
 nQC
 wmA
 wgI
@@ -134617,15 +135724,15 @@ qLe
 jsv
 drV
 bRZ
-nYR
+sZB
 cqV
 sUf
 rWs
-mSo
+qMU
 vtv
 kVs
 gDr
-ipn
+wVj
 rFR
 ogV
 ntP
@@ -134714,7 +135821,7 @@ rNK
 rNK
 rNK
 rNK
-jso
+izj
 ngP
 ciF
 gFa
@@ -134744,7 +135851,7 @@ afd
 nsC
 yfn
 qgc
-jkM
+aKM
 iGx
 daG
 tIK
@@ -134759,7 +135866,7 @@ tYe
 daG
 iBP
 nMn
-wrW
+vOv
 vxC
 auc
 wWR
@@ -134780,7 +135887,7 @@ gyl
 bjZ
 dCN
 wMl
-hPp
+hsI
 rMc
 rMc
 rMc
@@ -134789,7 +135896,7 @@ bpf
 pbY
 pbY
 qJc
-xCu
+vCu
 abT
 jSU
 grv
@@ -134808,13 +135915,13 @@ kIg
 rBJ
 rBJ
 lDm
-vJj
+wwC
 tfU
 xsS
 edF
 xrn
 xrn
-xOB
+vJG
 tLQ
 wDV
 ukn
@@ -134971,7 +136078,7 @@ rNK
 rNK
 rNK
 rNK
-ohd
+xAP
 oVM
 uoq
 xdA
@@ -135037,7 +136144,7 @@ dCF
 chV
 chV
 qnc
-fhE
+cSK
 mQF
 nmW
 nmW
@@ -135046,7 +136153,7 @@ aXA
 nmW
 nmW
 qcx
-sty
+azf
 eIk
 fsW
 xsS
@@ -135065,7 +136172,7 @@ dwD
 fsW
 xsS
 xsS
-kLt
+ofx
 xsS
 xsS
 tLa
@@ -135095,7 +136202,7 @@ rZn
 dBI
 lRt
 mrt
-reZ
+fxP
 prN
 cBs
 cBs
@@ -135247,7 +136354,7 @@ vdq
 kNz
 xZx
 tiO
-bnG
+urw
 alp
 aax
 lko
@@ -135278,7 +136385,7 @@ exK
 uXJ
 mYr
 bZW
-tTL
+iiL
 yfW
 lYp
 evO
@@ -135294,7 +136401,7 @@ chV
 jao
 evL
 sAI
-kMA
+efh
 lEI
 oCu
 oCu
@@ -135303,7 +136410,7 @@ mia
 lQI
 lQI
 mQU
-iAO
+esI
 aZb
 jpg
 iGF
@@ -135322,7 +136429,7 @@ ekr
 gAJ
 uqI
 sJy
-gIh
+ady
 dUE
 acM
 nxu
@@ -135343,7 +136450,7 @@ wmR
 wmR
 wmR
 pVQ
-wds
+nCp
 xHx
 tYD
 pxi
@@ -135352,7 +136459,7 @@ mrt
 mrt
 mrt
 mrt
-fOh
+mrB
 prN
 cBs
 cBs
@@ -135388,7 +136495,7 @@ hhd
 fil
 fil
 fil
-ksi
+mmU
 jGC
 xEd
 lxP
@@ -135526,7 +136633,7 @@ dxN
 xrZ
 mzz
 caQ
-kcE
+gjz
 aJQ
 liB
 nII
@@ -135600,7 +136707,7 @@ sxz
 wmR
 wmR
 tgc
-mgI
+sae
 mrt
 jau
 sFw
@@ -135857,7 +136964,7 @@ xSR
 wmR
 wmR
 tgc
-sPL
+xLy
 mrt
 jau
 rCs
@@ -136008,7 +137115,7 @@ aTz
 aTz
 gkK
 yjw
-mHE
+faW
 vdq
 vdq
 vdq
@@ -136049,7 +137156,7 @@ uQA
 qqw
 cdq
 aQc
-iuO
+oWL
 hPz
 lYp
 jpx
@@ -136057,7 +137164,7 @@ xla
 xoy
 dCF
 gPS
-hGp
+lQi
 nla
 bZz
 sot
@@ -136114,7 +137221,7 @@ wzk
 ier
 wmR
 tgc
-mgI
+sae
 mrt
 sbo
 mrt
@@ -136275,7 +137382,7 @@ vdq
 xgg
 xZx
 tiO
-jfu
+jCw
 alp
 lmh
 lko
@@ -136286,7 +137393,7 @@ pXO
 kCx
 fmj
 bLe
-hox
+cEh
 mCG
 mCG
 dqF
@@ -136314,7 +137421,7 @@ xla
 lsx
 oND
 ary
-eHs
+pvh
 tYi
 fmA
 tYi
@@ -136371,7 +137478,7 @@ wmR
 wmR
 wmR
 sOf
-lVs
+jFQ
 mrt
 rQV
 oBr
@@ -136416,7 +137523,7 @@ fxp
 fxp
 fxp
 fxp
-uTv
+uLd
 vBs
 xEd
 ifz
@@ -136543,7 +137650,7 @@ gmC
 pkp
 uaJ
 dpu
-rCG
+bxY
 fEL
 nkH
 eAC
@@ -136816,7 +137923,7 @@ nII
 pOW
 hNs
 svs
-njT
+qgN
 otP
 exm
 knF
@@ -136894,7 +138001,7 @@ eBQ
 eBQ
 eBQ
 mrt
-vqM
+bGz
 rxy
 lYO
 bdh
@@ -137192,12 +138299,12 @@ ovQ
 jTe
 dEz
 cxV
-sPv
+vDI
 qlv
 xOw
 fCc
 cnU
-bQe
+rvt
 sKb
 vvb
 fHA
@@ -137382,7 +138489,7 @@ wSt
 boJ
 xsS
 lOc
-oMr
+aPN
 qSS
 vjj
 srN
@@ -137700,7 +138807,7 @@ oEl
 suZ
 pKB
 xFn
-pLU
+cMe
 uOP
 wHT
 idI
@@ -137720,17 +138827,17 @@ nQw
 wTm
 uxx
 cuU
-ejc
+saS
 lSP
 pwx
 asL
 czb
 cza
 oUJ
-isZ
+usI
 eJf
 wpX
-tuu
+oCm
 aFn
 dZA
 oqN
@@ -137871,7 +138978,7 @@ hLE
 veg
 mXA
 fYh
-lOr
+nnY
 iaw
 uaM
 hLE
@@ -138214,12 +139321,12 @@ oUw
 eDf
 qWS
 heU
-wOH
+eQV
 alw
 nJq
 bqU
 xNk
-wDx
+bwA
 jUk
 uxn
 jgw
@@ -138406,16 +139513,16 @@ pFj
 hzj
 acY
 ptO
-vmW
+iPX
 eyZ
 sbA
 wDN
-ssm
+bsJ
 vkX
 dAQ
 dAQ
 eiE
-xcl
+nXz
 eiE
 nLH
 cqO
@@ -138748,7 +139855,7 @@ wAG
 uCn
 vld
 ylO
-lxm
+mFB
 vWk
 dHO
 wQY
@@ -138876,7 +139983,7 @@ wUX
 qqw
 dCs
 kao
-uMD
+pot
 cyX
 vYr
 dhd
@@ -138911,7 +140018,7 @@ iNs
 hHV
 fBn
 ooq
-oyg
+eKT
 jfe
 kUi
 rAQ
@@ -139121,7 +140228,7 @@ sOp
 ecV
 swq
 aoC
-erD
+qFN
 qON
 wUX
 lma
@@ -139141,7 +140248,7 @@ vax
 gBE
 qjL
 aWr
-fTn
+nOt
 upZ
 vWT
 hGb
@@ -139205,7 +140312,7 @@ nwo
 oMV
 sPM
 sPM
-icS
+uom
 rFK
 sPM
 viU
@@ -139214,7 +140321,7 @@ qxQ
 sbn
 pWT
 poY
-wSm
+iyU
 qDR
 kfE
 pUm
@@ -139677,7 +140784,7 @@ iaw
 iaw
 qMu
 iaw
-rLO
+iEU
 iaw
 iaw
 fmr
@@ -139934,7 +141041,7 @@ qye
 eGi
 pbT
 qdy
-uBR
+ffm
 qdy
 eGi
 yjO
@@ -140366,7 +141473,7 @@ afc
 nKC
 lhY
 abm
-utt
+mdZ
 tmn
 tmn
 fQQ
@@ -140379,7 +141486,7 @@ bJn
 vwe
 wSi
 dSp
-sey
+oPY
 aKY
 kZP
 nQJ
@@ -140422,7 +141529,7 @@ pAo
 pAo
 aXZ
 ihH
-uct
+cgD
 xCB
 meY
 tuO
@@ -140623,7 +141730,7 @@ uvA
 abl
 cZD
 cif
-acm
+vfN
 eyz
 qhm
 iRv
@@ -140636,7 +141743,7 @@ eyz
 lQk
 dgM
 gdG
-jEC
+wnh
 egT
 egT
 egT
@@ -140679,7 +141786,7 @@ vrp
 bbc
 bbc
 tbe
-aUY
+dwS
 rpq
 dCF
 iEe
@@ -140789,7 +141896,7 @@ vFW
 nxX
 irU
 sOk
-qyc
+kRT
 dhH
 uPP
 sKh
@@ -140959,7 +142066,7 @@ xxs
 aAT
 qye
 qye
-rrc
+oEQ
 eGi
 hLE
 aXn
@@ -141299,7 +142406,7 @@ ccW
 ccW
 dXV
 iky
-dtv
+gXH
 imU
 fyR
 qHP
@@ -141841,7 +142948,7 @@ xPU
 wsR
 lMW
 aPY
-iwJ
+xTf
 lMW
 ivY
 mDy
@@ -142449,7 +143556,7 @@ akj
 vQx
 nQJ
 nQJ
-lNz
+fxj
 tOe
 tOe
 uvq
@@ -142531,7 +143638,7 @@ oZU
 fID
 qMR
 mGn
-lje
+ujh
 ydS
 cct
 joq
@@ -142706,7 +143813,7 @@ tEy
 iIj
 iIo
 viL
-dfT
+kUB
 eIM
 cgg
 vUy
@@ -142742,7 +143849,7 @@ iNE
 jZl
 vyb
 wUU
-iAF
+hpy
 jwW
 rSu
 rSu
@@ -142795,7 +143902,7 @@ xuZ
 wCu
 hrP
 hPT
-ksN
+sRu
 tQZ
 dAw
 dAw
@@ -142816,7 +143923,7 @@ aXR
 gwb
 kqg
 yiE
-vUo
+uuB
 mLX
 gEo
 knr
@@ -142839,9 +143946,9 @@ pkO
 ajq
 vCk
 nHm
-gNb
+eqf
 mfu
-qLv
+eRK
 rMW
 ciG
 uJF
@@ -143554,7 +144661,7 @@ fID
 kuf
 hVz
 wVd
-wmH
+pNj
 lOi
 qwC
 tzE
@@ -143756,14 +144863,14 @@ sxM
 ftN
 owH
 jog
-sNj
+mik
 rKA
 cGw
 nvI
 nxa
 ewO
 thd
-dlL
+lyc
 hoB
 ugQ
 oBw
@@ -143799,7 +144906,7 @@ dWD
 dWD
 tYC
 lxJ
-gnd
+nTh
 qWd
 txD
 jjo
@@ -143954,7 +145061,7 @@ lRR
 csJ
 sII
 cbt
-nJP
+jQs
 rNK
 rNK
 rNK
@@ -143985,7 +145092,7 @@ rNK
 rNK
 rNK
 xyW
-rNH
+eOS
 wCb
 bIo
 hfb
@@ -144013,7 +145120,7 @@ qSK
 qSK
 jlW
 oec
-bnV
+jLE
 cEQ
 kJd
 kcs
@@ -144097,7 +145204,7 @@ oZU
 kNB
 xgA
 sgp
-woR
+iDE
 pbo
 cRo
 blw
@@ -144145,7 +145252,7 @@ gxI
 qpu
 rjn
 qpu
-caM
+jSX
 yiT
 aTT
 sKh
@@ -144277,7 +145384,7 @@ cLN
 sZx
 sZx
 sZx
-dmb
+oez
 oWs
 ugQ
 xEY
@@ -144321,7 +145428,7 @@ anO
 anO
 lYS
 inn
-iYa
+sUd
 qeQ
 qeQ
 fZE
@@ -144354,13 +145461,13 @@ oZU
 oZU
 lAj
 eqi
-dIv
+oZn
 kQq
 kqM
 qwC
-qmQ
+xyV
 kKq
-sNU
+uzf
 qJG
 qJG
 lzH
@@ -144402,7 +145509,7 @@ vPd
 rSX
 nta
 sKh
-gfb
+nwk
 sKh
 hYF
 wIq
@@ -144538,11 +145645,11 @@ fjf
 hye
 kFq
 sNC
-ger
+ePR
 xyM
 cuL
 iCo
-jxJ
+amH
 jXD
 rRO
 jXD
@@ -145011,9 +146118,9 @@ rNK
 agm
 aiN
 ajz
-ajP
+xXk
 cMU
-pjm
+tbG
 alP
 glf
 uEU
@@ -145081,7 +146188,7 @@ vFq
 qry
 lrw
 qrT
-orl
+hLs
 xrr
 bIH
 tOM
@@ -145092,7 +146199,7 @@ gsF
 rMZ
 wUB
 nvS
-juN
+wLC
 xHa
 dLq
 kyy
@@ -145101,7 +146208,7 @@ sAA
 fqs
 wwl
 tgL
-qrv
+jpI
 pVh
 kFC
 jUL
@@ -145338,7 +146445,7 @@ cIc
 jCl
 rEe
 jCl
-rWJ
+lKR
 lYS
 qeY
 tOM
@@ -145434,7 +146541,7 @@ dGU
 iwD
 bxf
 aOi
-yjt
+szD
 eCl
 qMj
 bxf
@@ -146109,7 +147216,7 @@ gcU
 rZe
 rZe
 cIZ
-jFq
+oPU
 mZd
 jfQ
 xrr
@@ -146120,7 +147227,7 @@ mSa
 hBU
 wIg
 hRn
-kZj
+kuv
 bsv
 iZA
 xUl
@@ -146303,7 +147410,7 @@ xNo
 ykf
 iQQ
 wAw
-pje
+ilN
 vrQ
 vrQ
 vrQ
@@ -146366,7 +147473,7 @@ gcU
 hSy
 bgf
 wZc
-cZY
+mhJ
 ksd
 jTu
 plG
@@ -146428,9 +147535,9 @@ rNK
 rNK
 rNK
 qJG
-emL
+lST
 tyP
-mjm
+cad
 roL
 ftr
 ftr
@@ -146623,7 +147730,7 @@ rZe
 rZe
 bgf
 bfW
-riv
+itr
 lwh
 yiN
 ocO
@@ -146671,7 +147778,7 @@ bDR
 oZU
 mSV
 ame
-ofB
+dAX
 nck
 yjH
 kuy
@@ -146872,7 +147979,7 @@ nzX
 wXi
 gKI
 gKI
-aTW
+iHm
 akp
 akp
 chU
@@ -147357,7 +148464,7 @@ bwm
 cQs
 bAK
 dLC
-cNb
+fGS
 pWY
 vuY
 vTH
@@ -147365,7 +148472,7 @@ vTH
 sEC
 ece
 wBC
-xzT
+usR
 qrB
 sVU
 bco
@@ -147419,7 +148526,7 @@ bFh
 nMX
 xVj
 lsc
-uga
+cHg
 rrq
 eBf
 uGM
@@ -148379,7 +149486,7 @@ aVS
 slZ
 tkv
 fPE
-suI
+nts
 btJ
 uEp
 aZV
@@ -148640,9 +149747,9 @@ djE
 djE
 bxr
 byt
-cau
+pMn
 mZB
-gjU
+lLW
 koP
 jMO
 iwu
@@ -148964,7 +150071,7 @@ uEj
 ssJ
 tJU
 lqx
-ieX
+eWg
 cQC
 rNU
 xDh
@@ -149270,7 +150377,7 @@ uVb
 czZ
 smI
 vBR
-wFy
+gaC
 fYd
 kZW
 aXP
@@ -149421,7 +150528,7 @@ gYx
 ltY
 lfg
 uOz
-inr
+rGn
 uFX
 uFX
 uFX
@@ -149457,7 +150564,7 @@ cKs
 dkl
 bmA
 bmA
-bnR
+rol
 bpc
 ieN
 eoe
@@ -149527,7 +150634,7 @@ uVb
 rQp
 mqs
 dmW
-fZO
+uuS
 jiV
 aXP
 aZH
@@ -149694,10 +150801,10 @@ fxe
 uHv
 htb
 htb
-tBg
+vxg
 uuA
 ocB
-jYD
+gPM
 iOg
 hUC
 xOq
@@ -149780,7 +150887,7 @@ cYB
 oiA
 jGj
 cYC
-gJT
+mrO
 qgZ
 fsl
 rzs
@@ -149917,17 +151024,17 @@ imn
 xLP
 hor
 chM
-cpk
+vRL
 sxT
 ulw
 cBp
 cCR
 cGP
-wlZ
+uyQ
 cQP
 cUa
 djc
-dmo
+pjS
 mty
 nMA
 nMA
@@ -150041,7 +151148,7 @@ uVb
 fGj
 mqs
 vMp
-gar
+hdw
 jfb
 beR
 aXP
@@ -150166,7 +151273,7 @@ aCg
 aCg
 bjh
 rtY
-bvr
+jsp
 lnf
 lGj
 plu
@@ -150200,7 +151307,7 @@ jBP
 wgh
 hdR
 qoV
-qnu
+ldY
 drO
 lBx
 lBx
@@ -150209,7 +151316,7 @@ cki
 lBx
 lBx
 hJp
-qfa
+soY
 olY
 pLv
 jNy
@@ -150242,10 +151349,10 @@ bAO
 wmE
 glA
 bEe
-bFl
+siE
 voE
 uRH
-eYh
+pQk
 vbU
 dlz
 ciY
@@ -150298,7 +151405,7 @@ uVb
 gTD
 nPm
 erI
-xHD
+rlc
 nHZ
 vxi
 bTT
@@ -150431,17 +151538,17 @@ fxL
 xLP
 rMM
 chM
-pOl
+kPU
 sxT
 vvZ
 txk
 lVh
 cGP
-joW
+lSr
 cRh
 cUb
 bSg
-dmy
+mlr
 mty
 nMA
 nMA
@@ -150457,7 +151564,7 @@ qoO
 qFM
 qoO
 gRl
-nrf
+qQH
 who
 qBx
 qBx
@@ -150466,7 +151573,7 @@ cYa
 qBx
 qBx
 elj
-nfI
+gQa
 dOa
 mTR
 mTR
@@ -150493,9 +151600,9 @@ btx
 bxz
 mWL
 bxz
-sSv
+eQM
 bzB
-bAP
+ykG
 bBQ
 uRu
 ggk
@@ -150714,7 +151821,7 @@ jCu
 cWn
 jKN
 xhH
-joo
+xRg
 cXW
 cXW
 cXW
@@ -150723,7 +151830,7 @@ iSr
 cXW
 cXW
 xgG
-pEJ
+kRP
 htG
 qGq
 iSD
@@ -150756,10 +151863,10 @@ bAQ
 xdu
 bCV
 bEg
-bFs
+oTk
 elN
 tOY
-qvt
+dOG
 mlM
 rls
 uKW
@@ -151020,7 +152127,7 @@ vLI
 mFk
 pIs
 qAf
-sKr
+mge
 qIU
 oSO
 sgR
@@ -151040,17 +152147,17 @@ wJC
 wJC
 eAS
 fLT
-ijC
+pIe
 cNB
 mkk
 fLT
-irM
+gCa
 rNK
 lzH
-rCS
+kQF
 cYC
 cYM
-wzj
+mIw
 cYC
 nyX
 cYC
@@ -151236,10 +152343,10 @@ oGa
 oGa
 oGa
 olj
-ruM
+mMT
 wBt
 qoM
-bAA
+fPB
 ePn
 rYC
 kbl
@@ -151477,7 +152584,7 @@ kAZ
 vrW
 gOg
 ouS
-plL
+tqN
 reL
 vkr
 reL
@@ -151513,7 +152620,7 @@ cKs
 ofO
 rfw
 rfw
-lYE
+ahg
 dzc
 qcI
 lQT
@@ -151539,7 +152646,7 @@ sCs
 bPH
 bQH
 bRF
-mPm
+jYW
 amm
 amm
 ycn
@@ -152710,7 +153817,7 @@ uhI
 ncD
 tKp
 tvQ
-sbC
+hQT
 aoF
 mkP
 rSh
@@ -152758,7 +153865,7 @@ eQg
 fqD
 feB
 jdL
-fOr
+agr
 ooJ
 nTd
 ygA
@@ -152967,7 +154074,7 @@ nIa
 miU
 xMZ
 sBt
-lsq
+kSH
 woD
 eRs
 cCd
@@ -153019,7 +154126,7 @@ kAZ
 tLh
 mDq
 qyR
-hTa
+ppv
 hab
 hXC
 iKW
@@ -153249,7 +154356,7 @@ fkK
 fkK
 fkK
 fkK
-qMW
+vVl
 fkK
 fkK
 ogC
@@ -153272,7 +154379,7 @@ uJU
 qpn
 qpn
 qpn
-agz
+gQA
 eRq
 xCz
 ygA
@@ -153296,7 +154403,7 @@ hAY
 shv
 rrT
 yil
-gYP
+hOJ
 mtV
 ptS
 iSa
@@ -153472,7 +154579,7 @@ aoR
 hjo
 ioI
 pAw
-yjC
+eMZ
 tJz
 kET
 tab
@@ -153481,7 +154588,7 @@ bUh
 gvd
 eup
 ibw
-vxt
+lyQ
 jKn
 iNM
 jLI
@@ -153491,7 +154598,7 @@ rXx
 amk
 nBG
 anB
-acK
+kzV
 wdU
 fBY
 pig
@@ -153506,7 +154613,7 @@ pig
 pig
 pig
 vJf
-ivw
+wfm
 tKh
 aQq
 shb
@@ -153529,7 +154636,7 @@ gKc
 gKc
 gKc
 shb
-faD
+pRm
 qNO
 oyu
 eat
@@ -153573,7 +154680,7 @@ nTa
 hBi
 mfs
 bsC
-dsq
+kPl
 jbr
 jbr
 jbr
@@ -153738,7 +154845,7 @@ tKp
 fqa
 lNh
 sIe
-lsq
+kSH
 aoF
 eRs
 oSa
@@ -154111,7 +155218,7 @@ pMT
 cFE
 xXM
 iTb
-hiw
+rIp
 tSs
 gEn
 eSn
@@ -154361,7 +155468,7 @@ qgv
 ujM
 dBN
 dBN
-kdb
+aCn
 pwh
 pwh
 wgt
@@ -154561,7 +155668,7 @@ aKp
 lhU
 mDq
 qsg
-hmq
+dsj
 dIp
 xpD
 aMh
@@ -154839,7 +155946,7 @@ kOr
 agn
 cll
 uYO
-baL
+lxq
 nIz
 gcj
 pfd
@@ -154882,7 +155989,7 @@ gsl
 xXM
 jOq
 dKC
-bAy
+nAB
 dhN
 mkk
 hxE
@@ -154890,7 +155997,7 @@ bWy
 mZW
 dUG
 lNi
-vzD
+fWF
 fLk
 nXI
 fLk
@@ -154927,14 +156034,14 @@ sFj
 dbg
 dbg
 dbg
-tip
+nTB
 glO
 glO
 lBn
 bUa
 bUa
 ftz
-uCt
+tme
 wiv
 lBn
 dMY
@@ -154946,10 +156053,10 @@ eex
 bUa
 bUa
 bUa
-dgs
+cQp
 xGW
 ifc
-dgs
+cQp
 uBa
 rNK
 rNK
@@ -155071,7 +156178,7 @@ aKp
 mbi
 cWz
 cWz
-tUm
+hLj
 mHc
 vuY
 ygA
@@ -155104,7 +156211,7 @@ bgf
 eLK
 hQG
 wSq
-ghq
+hmV
 wHh
 ijW
 wMg
@@ -155147,7 +156254,7 @@ oxG
 kBL
 kho
 nQj
-pix
+qQn
 pNt
 eyB
 eyB
@@ -155177,21 +156284,21 @@ bYZ
 veo
 xtU
 vkv
-kcL
+oDp
 rvu
 svF
 rFo
 uTd
 koo
 dbg
-vcJ
+len
 bUa
 bUa
 bUa
 bUa
 bUa
 bUa
-pnf
+aRE
 mQf
 qLr
 dMY
@@ -155203,10 +156310,10 @@ sgJ
 bUa
 bUa
 bUa
-dgs
+cQp
 xGW
 xJF
-dgs
+cQp
 rNK
 rNK
 rNK
@@ -155361,7 +156468,7 @@ iSD
 eLK
 bgf
 wNj
-gAg
+gFM
 rin
 fCz
 cJF
@@ -155441,14 +156548,14 @@ dbg
 ctu
 dbg
 bRz
-tpZ
+uTX
 uhc
 gJz
 jpF
 uhc
 qJT
 uhc
-dsn
+vHk
 qJL
 cGJ
 dMY
@@ -155618,7 +156725,7 @@ iSD
 eLK
 cNr
 cIk
-cTN
+nPI
 xRk
 jLX
 rOc
@@ -155846,7 +156953,7 @@ dnb
 dAc
 dSs
 uOz
-gfd
+jtS
 hmJ
 cWz
 ckx
@@ -155886,7 +156993,7 @@ dwz
 itP
 fgJ
 avx
-tsN
+ahG
 lcD
 lcD
 ale
@@ -155907,7 +157014,7 @@ mJM
 inY
 lNi
 lNi
-kBa
+wyu
 mkk
 eAS
 eAS
@@ -155948,7 +157055,7 @@ kwQ
 hjb
 gET
 qRB
-qdb
+qMD
 obd
 uJK
 sRZ
@@ -156135,7 +157242,7 @@ wts
 baS
 dDj
 fJB
-cqN
+uov
 tOC
 fGQ
 jli
@@ -156205,7 +157312,7 @@ abc
 fLk
 npD
 vRX
-fXM
+iuA
 dbg
 dbg
 dbg
@@ -156404,7 +157511,7 @@ sXj
 wMZ
 qlx
 eBa
-hZV
+pfp
 lpT
 oDR
 mJM
@@ -156664,7 +157771,7 @@ sIg
 mJM
 cVX
 unw
-eZR
+gNM
 ePG
 ePG
 ePG
@@ -156676,7 +157783,7 @@ xFx
 hGd
 lgI
 rXt
-cRu
+sEd
 tdi
 tdi
 xlX
@@ -156726,7 +157833,7 @@ dbg
 ctu
 dbg
 ssn
-oUU
+vxh
 glO
 mCs
 glO
@@ -156983,7 +158090,7 @@ oDs
 qtQ
 gRQ
 cSo
-xfi
+fCB
 coo
 coo
 hIe
@@ -157240,7 +158347,7 @@ caC
 osp
 eWu
 bRz
-ezc
+doV
 ogc
 uhc
 wEk
@@ -157998,7 +159105,7 @@ tjg
 dOW
 cAR
 pbK
-his
+stF
 eyB
 jVj
 vWF
@@ -158255,7 +159362,7 @@ tjg
 upk
 hdq
 ppC
-bzR
+jcA
 wKu
 vqL
 wcl
@@ -158273,7 +159380,7 @@ hUU
 weD
 bhO
 bhO
-uSP
+cFY
 cFY
 cFY
 ghi
@@ -158521,7 +159628,7 @@ jZQ
 woU
 woU
 cAC
-uTR
+hzN
 sKq
 eWu
 vjb
@@ -158529,7 +159636,7 @@ pCL
 bhO
 bhO
 bhO
-uSP
+cFY
 cFY
 uOy
 nKF
@@ -158784,7 +159891,7 @@ eWu
 vjb
 xvu
 bhO
-uSP
+cFY
 cFY
 cFY
 lHH
@@ -159301,7 +160408,7 @@ bhO
 pkt
 mvN
 mvN
-tXi
+lZT
 mvN
 utI
 qBa
@@ -159812,7 +160919,7 @@ eWu
 vjb
 xvu
 bhO
-uSP
+cFY
 cFY
 cFY
 aBe
@@ -159994,7 +161101,7 @@ stK
 vBP
 rPz
 cQt
-sfo
+tEx
 sZF
 bvt
 ifW
@@ -160063,7 +161170,7 @@ vWF
 chG
 eYI
 cjy
-fvb
+iTD
 unr
 eWu
 vjb
@@ -160071,7 +161178,7 @@ pCL
 bhO
 bhO
 bhO
-uSP
+cFY
 cFY
 rrx
 hay
@@ -160329,7 +161436,7 @@ hUU
 weD
 bhO
 bhO
-uSP
+cFY
 cFY
 cFY
 ghi
@@ -160453,7 +161560,7 @@ vdu
 aBO
 vdu
 vdu
-uON
+wPl
 bll
 bll
 bll
@@ -160573,7 +161680,7 @@ vpJ
 wLr
 wIS
 aDj
-fsP
+jiX
 omT
 dKa
 pCI
@@ -161224,14 +162331,14 @@ kVY
 aCy
 fBB
 sFa
-bcr
+sue
 bkj
 dce
 bvT
 aQG
 xKC
 cXU
-mBR
+pjw
 wUI
 cXi
 cXi
@@ -161274,7 +162381,7 @@ uWV
 fmI
 ttd
 oVG
-tTt
+kiU
 nuU
 rLb
 sdy
@@ -161296,7 +162403,7 @@ lfd
 eYB
 ukL
 wiO
-cgP
+eRv
 qMS
 fgi
 tqQ
@@ -161308,7 +162415,7 @@ ooM
 bmR
 wDU
 oXl
-xUV
+kwH
 lVF
 nos
 ksp
@@ -161320,14 +162427,14 @@ hbw
 nKc
 nKc
 nKc
-vVo
+lNN
 mUf
 qnI
 wkP
 aXr
 mBh
 ybh
-idc
+krB
 vkm
 jLv
 cJi
@@ -161341,7 +162448,7 @@ cJi
 oow
 wZh
 kUj
-roh
+cqB
 wlD
 war
 kUL
@@ -161352,7 +162459,7 @@ rYf
 eSv
 vOM
 cJA
-dRp
+iZK
 wPP
 jBN
 wKD
@@ -161369,7 +162476,7 @@ nna
 tEv
 uiu
 osw
-vAc
+pGX
 jBN
 jBN
 iAv
@@ -161466,7 +162573,7 @@ vTo
 akt
 akZ
 gUh
-vsD
+mLP
 amJ
 sOe
 aNf
@@ -161476,7 +162583,7 @@ aZL
 kTL
 btr
 atK
-avr
+lwn
 axP
 aDi
 aXd
@@ -161527,11 +162634,11 @@ sQf
 lCk
 vHL
 oOB
-qzd
+iwv
 tcx
 tcx
 hfV
-egr
+ubG
 hqG
 ljp
 bKM
@@ -161553,7 +162660,7 @@ bvt
 bvt
 ljp
 xag
-ddk
+xig
 hpx
 bvt
 bvt
@@ -161565,7 +162672,7 @@ bvt
 bvt
 bvt
 qkV
-uPR
+aGI
 oEj
 bio
 bio
@@ -161577,14 +162684,14 @@ vXZ
 bio
 bio
 bio
-upz
+bLS
 wLU
 pQa
 pQa
 pHf
 pQa
 pQa
-wwA
+vtY
 pQa
 oes
 pQa
@@ -161598,7 +162705,7 @@ pQa
 pQa
 okL
 pQa
-dPF
+aXu
 dnc
 jLe
 pHf
@@ -161609,7 +162716,7 @@ pQa
 bGl
 heH
 qUq
-gkb
+xXX
 ybD
 ybD
 gss
@@ -161626,7 +162733,7 @@ cyx
 myi
 cyx
 cyx
-dvy
+fme
 gVU
 cyx
 cyx
@@ -161738,14 +162845,14 @@ dgb
 aDl
 aPB
 aXe
-bcG
+gdy
 bkl
 cXB
 mvC
 bEJ
 uKE
 bSC
-kLk
+tju
 wUI
 cXi
 cXi
@@ -161784,11 +162891,11 @@ nmu
 wve
 gXb
 wve
-bNY
+siZ
 fmI
 fmI
 lUQ
-uyz
+fJL
 nde
 qMn
 seO
@@ -161810,7 +162917,7 @@ eCZ
 ycI
 xhY
 sKm
-rEz
+cbz
 xqq
 ycI
 ycI
@@ -161822,7 +162929,7 @@ fXz
 hCz
 npl
 jLn
-juZ
+leZ
 lAC
 xwI
 xwI
@@ -161834,14 +162941,14 @@ neo
 xwI
 xwI
 xwI
-yhZ
+bhz
 edO
 dsL
 dxM
 dxM
 ghE
 dxM
-jYk
+oSf
 dSV
 dOn
 jnH
@@ -161855,7 +162962,7 @@ cvq
 bkg
 cJW
 tPd
-aVY
+nrj
 lBb
 nTc
 dxM
@@ -161866,7 +162973,7 @@ dxM
 qmy
 pQa
 vwz
-jEO
+obc
 eOf
 ryd
 eOf
@@ -161883,7 +162990,7 @@ eOf
 tlM
 uix
 boE
-kbJ
+nMM
 jWo
 ryd
 eOf
@@ -162571,7 +163678,7 @@ mGu
 sBp
 gpY
 vDS
-lug
+smt
 wAX
 sBp
 glR
@@ -162633,7 +163740,7 @@ lwk
 hBh
 eEM
 hPN
-xrF
+hpK
 bIb
 djw
 lgt
@@ -162828,7 +163935,7 @@ sfq
 sBp
 lkV
 cys
-pTQ
+tnO
 hFH
 knx
 bPJ
@@ -162836,7 +163943,7 @@ vbM
 bPJ
 bBd
 xdk
-pFJ
+vnC
 xUh
 sjT
 mKj
@@ -163085,7 +164192,7 @@ rbF
 bdC
 apG
 knx
-qIl
+jCC
 hFH
 vDS
 rfV
@@ -163093,7 +164200,7 @@ byl
 rfV
 rue
 xdk
-dvp
+mip
 rWL
 dBL
 dBL
@@ -163147,7 +164254,7 @@ vqp
 nlJ
 wzD
 cLc
-fMV
+kzT
 mJW
 djw
 jUc
@@ -163625,7 +164732,7 @@ vHH
 vHH
 gFg
 eSj
-mKQ
+ngy
 uZP
 fqw
 lzH
@@ -163817,7 +164924,7 @@ uJv
 lLu
 gOh
 bJH
-jas
+cKE
 ove
 vno
 uJv
@@ -164077,7 +165184,7 @@ pkM
 uJv
 qjq
 cGF
-rQf
+tqq
 sdH
 aVD
 aVD
@@ -164119,7 +165226,7 @@ jPr
 uvF
 lgv
 dBy
-fss
+xBK
 lfl
 gXg
 pcM
@@ -164175,7 +165282,7 @@ giJ
 aVH
 xog
 omi
-oxO
+sXp
 cFp
 nYM
 tKN
@@ -164348,7 +165455,7 @@ mBb
 cqp
 gjc
 ver
-iNT
+aBt
 obv
 fgj
 fXO
@@ -164376,7 +165483,7 @@ hdV
 hKs
 nik
 uqH
-utA
+wYz
 fOL
 vNb
 uyd
@@ -164386,7 +165493,7 @@ aRr
 aRr
 llx
 wxw
-veF
+ppZ
 wWj
 xjW
 aoB
@@ -164580,7 +165687,7 @@ rAX
 hqL
 cpC
 cpC
-cPM
+lCB
 jvd
 ftZ
 cjh
@@ -164605,7 +165712,7 @@ hsS
 fmI
 tvE
 qcK
-pFp
+tzq
 oAj
 fmI
 rsv
@@ -164620,7 +165727,7 @@ pfT
 fKt
 oag
 img
-bjs
+eno
 xDU
 cvf
 dBm
@@ -164633,7 +165740,7 @@ vhp
 gCv
 nOc
 dBm
-omq
+fOq
 pyV
 ezA
 kQf
@@ -164862,7 +165969,7 @@ aVD
 qgA
 inM
 mcZ
-fGb
+gFB
 fic
 iVe
 huE
@@ -164946,7 +166053,7 @@ tWq
 wLZ
 wLZ
 eWH
-oVj
+wGG
 gUo
 lqQ
 jPk
@@ -165652,12 +166759,12 @@ idF
 ikv
 nyY
 pex
-nPv
+nLU
 mFo
 xKe
 lpt
 tGq
-qKp
+bwN
 ngZ
 qhg
 bSw
@@ -165861,7 +166968,7 @@ qMm
 dsZ
 dOC
 xrj
-oLl
+bdT
 whN
 vdj
 aRx
@@ -165890,7 +166997,7 @@ sqG
 feO
 bMt
 jaz
-sHw
+dJX
 fjY
 kmP
 hIQ
@@ -166177,7 +167284,7 @@ fLG
 hfk
 miB
 sCU
-xDj
+pOB
 fnP
 hvz
 anA
@@ -166434,7 +167541,7 @@ hbf
 mHt
 mum
 mJF
-xaq
+lQq
 qFw
 eIT
 dUW
@@ -166661,7 +167768,7 @@ jxd
 ebn
 dDJ
 tjS
-uow
+gLP
 iHj
 dUp
 dUp
@@ -166923,7 +168030,7 @@ lbw
 pmZ
 jdY
 jMX
-phZ
+ygb
 vHH
 gFg
 gFg
@@ -167180,7 +168287,7 @@ sfJ
 vpG
 vpG
 lxO
-piZ
+uNr
 xTb
 vFQ
 vFQ
@@ -167190,16 +168297,16 @@ wWt
 gEG
 qmS
 oKR
-hLn
+jdr
 iNy
 afj
 cQr
-ubB
+lRW
 jCo
 pOP
 smA
 ixe
-cTd
+mdf
 ahC
 drP
 mWF
@@ -167263,7 +168370,7 @@ ceQ
 lcR
 jED
 sZW
-bXi
+hwT
 qao
 qao
 xeG
@@ -167426,7 +168533,7 @@ dyG
 ntW
 ntW
 oya
-sNY
+dnr
 het
 aWQ
 lHd
@@ -167721,7 +168828,7 @@ ngZ
 kDH
 mJV
 uNd
-jYy
+lCw
 fcP
 cOG
 cOM
@@ -168014,7 +169121,7 @@ hud
 eFI
 eFI
 aJy
-qVe
+ckX
 wrL
 ceQ
 ceQ
@@ -168484,7 +169591,7 @@ bKZ
 kSE
 eYN
 wiY
-org
+mil
 lsa
 vCz
 oSI
@@ -168688,7 +169795,7 @@ uoF
 kSR
 kFu
 kFu
-uiQ
+xiY
 bhi
 nak
 cpC
@@ -168717,7 +169824,7 @@ ntW
 ntW
 pJa
 pym
-wrU
+eAD
 cKT
 sCF
 ikd
@@ -168945,7 +170052,7 @@ lbU
 nCL
 wdC
 wdC
-jKE
+sxP
 gQS
 eMM
 cpC
@@ -168985,11 +170092,11 @@ itf
 yfF
 bwq
 jih
-lnN
+lcq
 qyM
 hWH
 hWH
-rRe
+paA
 glw
 lnI
 dla
@@ -169042,7 +170149,7 @@ eFI
 nDN
 fhe
 cJq
-cFf
+vDV
 pUj
 fiX
 wSg
@@ -169220,7 +170327,7 @@ hdL
 fBa
 jcO
 kJY
-voU
+aGz
 bgR
 wTO
 bgR
@@ -169477,7 +170584,7 @@ wiQ
 fBa
 fBa
 nLZ
-jxN
+bcT
 ntW
 rbC
 qFc
@@ -169495,7 +170602,7 @@ myT
 myT
 myT
 myT
-nhY
+vbu
 gSQ
 vbq
 vce
@@ -169525,7 +170632,7 @@ hBw
 pOn
 plE
 mvj
-ylS
+dDr
 aec
 vHH
 vHH
@@ -169777,7 +170884,7 @@ cHT
 bne
 bTS
 ddr
-iCR
+goD
 jeh
 vTM
 mSL
@@ -169976,7 +171083,7 @@ lCC
 dUj
 lKD
 jti
-aUK
+sNZ
 aTj
 lNs
 wCe
@@ -170017,7 +171124,7 @@ bni
 gFd
 siv
 bJe
-uCk
+lPx
 tnN
 bXk
 vgN
@@ -171059,7 +172166,7 @@ dYr
 rsA
 oof
 oof
-raU
+myO
 xKH
 qvH
 sLa
@@ -171285,10 +172392,10 @@ mdl
 mdl
 cHF
 hYI
-hIo
+eTo
 mdl
 mdl
-bGF
+gTa
 rkf
 rNK
 rNK
@@ -171306,7 +172413,7 @@ tOD
 eHi
 cZw
 aBR
-wxJ
+axS
 eDT
 otp
 cPK
@@ -171820,7 +172927,7 @@ dAi
 rPM
 dAi
 lFv
-uBd
+bbT
 gOM
 qtc
 lON
@@ -172027,7 +173134,7 @@ pup
 mgh
 dMn
 urI
-ppc
+lTa
 cpC
 rPm
 doy
@@ -172101,7 +173208,7 @@ itf
 itf
 qcs
 eFU
-gwA
+vsO
 ull
 nTz
 vHH
@@ -172284,7 +173391,7 @@ pup
 jtd
 hLO
 gHG
-boh
+ohN
 oqT
 mqq
 nlU
@@ -172825,7 +173932,7 @@ rqf
 cMN
 cMN
 dzm
-orR
+bGm
 pQu
 pQu
 pQu
@@ -172846,7 +173953,7 @@ dzE
 cSL
 srs
 dSt
-tPV
+lVi
 bfr
 bni
 kKU
@@ -173370,7 +174477,7 @@ qVN
 igN
 kvw
 tfe
-piR
+fWr
 owU
 xXH
 gFg
@@ -173575,7 +174682,7 @@ loi
 cEw
 fda
 fda
-keT
+kvP
 vuW
 vuW
 doh
@@ -174102,7 +175209,7 @@ alc
 alc
 alc
 kGl
-jFY
+qBl
 eke
 cPw
 vIz
@@ -174640,7 +175747,7 @@ itf
 itf
 pvf
 rTa
-lMS
+ezo
 gDt
 lfe
 rCP
@@ -174650,7 +175757,7 @@ gDt
 gDt
 gDt
 pQu
-oWv
+vUG
 pQu
 pQu
 pQu
@@ -174671,7 +175778,7 @@ kAz
 uYX
 ovW
 obt
-kKa
+tIU
 kXb
 pal
 iJY
@@ -176431,7 +177538,7 @@ lCC
 lCC
 tZj
 dxJ
-pdP
+paR
 noL
 pLe
 fGq

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -7,17 +7,6 @@
 /obj/structure/marker_beacon/dock_marker/collision,
 /turf/space,
 /area/space/nearstation)
-"aaT" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/department/security,
-/turf/simulated/floor/plasteel,
-/area/station/security/storage)
 "aaZ" = (
 /obj/effect/landmark/spawner/carp,
 /turf/space,
@@ -130,6 +119,29 @@
 	},
 /turf/space,
 /area/station/engineering/solar/fore_starboard)
+"acl" = (
+/obj/machinery/door/airlock/engineering/glass{
+	autoclose = 0;
+	id_tag = "engsm_door_int";
+	locked = 1;
+	name = "Reactor Interior Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/access_button{
+	autolink_id = "engsm_btn_int";
+	name = "Reactor Access Button";
+	pixel_y = 1;
+	req_access = list(10);
+	pixel_x = 25
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/engine)
 "aco" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -220,6 +232,20 @@
 /obj/structure/cable/yellow,
 /turf/space,
 /area/space/nearstation)
+"adi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/storage/emergency/port)
 "ado" = (
 /obj/item/radio/intercom{
 	name = "south bump";
@@ -460,12 +486,6 @@
 /obj/structure/flora/ausbushes/pointybush,
 /turf/simulated/floor/grass/no_creep,
 /area/station/hallway/secondary/entry/north)
-"aeJ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/south)
 "aeK" = (
 /obj/structure/shuttle/engine/propulsion/burst{
 	dir = 8
@@ -556,17 +576,6 @@
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/pod_4)
-"afb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/north)
 "afc" = (
 /obj/machinery/alarm/directional/south,
 /obj/effect/turf_decal/tiles/white/corner{
@@ -985,16 +994,6 @@
 /obj/effect/turf_decal/tiles/department/command,
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/storage/secondary)
-"ahg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external/glass{
-	id_tag = "admin_home"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/north)
 "ahh" = (
 /obj/effect/turf_decal/tiles/neutral/side{
 	dir = 8
@@ -1170,6 +1169,16 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/north)
+"aiq" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/lounge)
 "ait" = (
 /obj/structure/chair/sofa/bench,
 /obj/effect/landmark/start/assistant,
@@ -2565,17 +2574,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore2)
-"apu" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/lounge)
 "apv" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8
@@ -2630,6 +2628,17 @@
 /obj/effect/turf_decal/tiles/dark/corner,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/transmission_laser)
+"apD" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Public Access";
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/south)
 "apF" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable/yellow{
@@ -4129,12 +4138,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/electrical_shop)
-"auk" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/station/maintenance/electrical_shop)
 "aup" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -4142,13 +4145,6 @@
 /obj/machinery/newscaster/directional/east,
 /turf/simulated/floor/wood,
 /area/station/maintenance/electrical_shop)
-"auq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fore)
 "aur" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-8"
@@ -4245,18 +4241,6 @@
 /obj/effect/mapping_helpers/turfs/rust,
 /turf/simulated/wall,
 /area/station/maintenance/disposal)
-"auF" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/engineering/controlroom)
 "auG" = (
 /obj/structure/sign/electricshock,
 /turf/simulated/wall/r_wall,
@@ -4681,14 +4665,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/public/pet_store)
-"awh" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/lounge)
 "awi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4966,6 +4942,27 @@
 /obj/effect/spawner/random/fungus/frequent,
 /turf/simulated/wall,
 /area/station/maintenance/starboard2)
+"axc" = (
+/obj/machinery/door/airlock/glass{
+	name = "Internal Affairs Office";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/iaa,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "IAA"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/carpet/grimey,
+/area/station/legal/lawoffice)
 "axd" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -4988,12 +4985,6 @@
 /obj/effect/turf_decal/tiles/neutral/corner{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/lounge)
-"axi" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/lounge)
 "axj" = (
@@ -5324,14 +5315,6 @@
 	icon_regular_floor = "yellowsiding"
 	},
 /area/station/service/theatre)
-"aya" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Fore-Port Atmospherics Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
 "aye" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5954,15 +5937,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/supply/warehouse)
-"aAL" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
 "aAM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -6217,20 +6191,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/supermatter)
-"aBj" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore/east)
 "aBk" = (
 /obj/structure/window/plasmareinforced{
 	dir = 8
@@ -6434,17 +6394,6 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
-"aBU" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Access"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore/east)
 "aBX" = (
 /obj/machinery/atmospherics/supermatter_crystal,
 /turf/simulated/floor/engine,
@@ -6565,6 +6514,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/engine,
 /area/station/engineering/controlroom)
+"aCt" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Cloning";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/medical/cloning)
 "aCw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7473,20 +7441,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/abandoned_garden)
-"aFQ" = (
-/obj/machinery/door/airlock{
-	name = "Auxillary Restrooms"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/public/toilet/unisex)
 "aFS" = (
 /obj/machinery/status_display/supply_display,
 /turf/simulated/wall,
@@ -9228,16 +9182,6 @@
 /obj/effect/turf_decal/tiles/neutral/side,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
-"aLD" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id_tag = "janitorshutters";
-	name = "Janitor Shutters"
-	},
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/service/janitor)
 "aLE" = (
 /obj/structure/table/reinforced,
 /obj/structure/mirror{
@@ -10064,25 +10008,6 @@
 	},
 /turf/space,
 /area/space/nearstation)
-"aPb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/security/glass,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/permabrig)
 "aPg" = (
 /obj/machinery/disposal,
 /obj/structure/cable{
@@ -10305,24 +10230,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/gambling_den)
-"aPP" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door_control{
-	id = "janitorshutters";
-	name = "Janitor Shutters Control";
-	pixel_x = 25;
-	req_access = list(26)
-	},
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id_tag = "janitorshutters";
-	name = "Janitor Shutters"
-	},
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/service/janitor)
 "aPS" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/grass,
@@ -10482,6 +10389,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
+"aQH" = (
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/processing)
 "aQM" = (
 /obj/structure/sign/magboots{
 	pixel_x = -32
@@ -11303,28 +11221,6 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/equipmentstorage)
-"aTJ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	locked = 1;
-	id_tag = "perma_door_ext"
-	},
-/obj/machinery/access_button{
-	autolink_id = "perma_btn_ext";
-	name = "Prison Wing Access Button";
-	req_access = list(2);
-	pixel_x = 23
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/tiles/department/security,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/permabrig)
 "aTL" = (
 /obj/machinery/computer/secure_data,
 /obj/effect/turf_decal/tiles/department/security,
@@ -11935,6 +11831,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"aWa" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plasteel,
+/area/station/public/construction)
 "aWf" = (
 /obj/item/storage/toolbox/emergency{
 	pixel_x = 3;
@@ -12955,6 +12858,17 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"bab" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id_tag = "evashutters2";
+	name = "E.V.A. Storage Shutters"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/apmaint)
 "bac" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
@@ -13062,19 +12976,6 @@
 "baF" = (
 /turf/simulated/wall,
 /area/station/service/hydroponics)
-"baG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/nw)
 "baH" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plasteel,
@@ -13962,14 +13863,6 @@
 /obj/machinery/cooking/oven/loaded,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
-"bfp" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/department/virology/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore/east)
 "bfq" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -14194,6 +14087,22 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
+"bgr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/maintenance/electrical_shop)
 "bgs" = (
 /turf/simulated/wall,
 /area/station/maintenance/starboard2)
@@ -14207,31 +14116,6 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
-"bgw" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore/east)
-"bgx" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/department/cargo/corner{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28;
-	dir = 5
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore/east)
 "bgB" = (
 /obj/structure/table,
 /obj/item/reagent_containers/cooking/board,
@@ -14318,21 +14202,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
-"bhf" = (
-/obj/structure/table/wood,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id_tag = "detective";
-	name = "Detective Office Shutters"
-	},
-/turf/simulated/floor/carpet/black,
-/area/station/security/detective)
 "bhi" = (
 /obj/machinery/flasher/portable,
 /obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
+"bhj" = (
+/obj/machinery/door/airlock/atmos/glass{
+	heat_proof = 1;
+	name = "Supermatter Chamber";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/engineering/engine/supermatter)
 "bhn" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -14755,22 +14641,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard2)
-"biy" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prisonlockers)
 "biA" = (
 /turf/simulated/wall,
 /area/station/security/prisonlockers)
@@ -15020,16 +14890,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/lobby)
-"bjD" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Primary tool storage"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/public/storage/tools)
 "bjE" = (
 /obj/machinery/bluespace_beacon,
 /turf/simulated/floor/plasteel/dark,
@@ -15619,20 +15479,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
-"blE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/mining,
-/obj/effect/mapping_helpers/airlock/access/any/supply/smith,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/supply/smith_office)
 "blF" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
@@ -17636,23 +17482,6 @@
 /obj/structure/bookcase/sop,
 /turf/simulated/floor/carpet/grimey,
 /area/station/legal/lawoffice)
-"btZ" = (
-/obj/machinery/door/airlock/glass,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/security/doors,
-/obj/effect/mapping_helpers/airlock/access/any/security/court,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Courtroom"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/legal/courtroom)
 "bud" = (
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tiles/department/security/side,
@@ -17673,16 +17502,6 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
-"buh" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison)
 "bun" = (
 /turf/simulated/floor/plasteel,
 /area/station/security/storage)
@@ -17782,6 +17601,31 @@
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/control)
+"buH" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	locked = 1;
+	id_tag = "perma_door_ext";
+	dir = 4
+	},
+/obj/machinery/access_button{
+	autolink_id = "perma_btn_ext";
+	name = "Prison Wing Access Button";
+	req_access = list(2);
+	pixel_x = 23
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Prison Gate";
+	name = "Prison Lockdown Blast Doors"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/tiles/department/security,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/permabrig)
 "buL" = (
 /obj/structure/sign/electricshock,
 /turf/simulated/wall/r_wall,
@@ -18663,17 +18507,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
-"byN" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Access"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore/east)
 "byO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -18686,12 +18519,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/west)
-"byQ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/nw)
 "byS" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -18931,6 +18758,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/equipmentstorage)
+"bzM" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/east)
 "bzN" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/rods,
@@ -19002,7 +18845,7 @@
 	dir = 8;
 	level = 3;
 	name = "Distribution and Waste Monitor";
-	autolink_sensors = list("mair_in_meter"="Mixed Air In","air_sensor"="Mixed Air Supply Tank","mair_out_meter"="Mixed Air Out","dloop_atm_meter"="Distribution Loop","wloop_atm_meter"="Waste Loop")
+	autolink_sensors = list("mair_in_meter" = "Mixed Air In", "air_sensor" = "Mixed Air Supply Tank", "mair_out_meter" = "Mixed Air Out", "dloop_atm_meter" = "Distribution Loop", "wloop_atm_meter" = "Waste Loop")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 4
@@ -19254,6 +19097,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/a)
+"bAZ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/nanotrasen_logo/directional/west,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/department/science/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/science/research)
 "bBc" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -19458,12 +19312,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/surgery/primary)
-"bBW" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fore)
 "bBX" = (
 /obj/structure/table/reinforced,
 /obj/item/analyzer,
@@ -19819,12 +19667,6 @@
 /obj/effect/turf_decal/tiles/department/command/side,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
-"bCM" = (
-/obj/effect/mapping_helpers/airlock/access/all/security/evidence,
-/obj/machinery/door/airlock/security,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/evidence)
 "bCP" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 1;
@@ -21391,12 +21233,6 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
-"bHV" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fsmaint)
 "bHZ" = (
 /turf/simulated/floor/grass/jungle,
 /area/station/maintenance/fsmaint)
@@ -22384,6 +22220,13 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/warden)
+"bLJ" = (
+/obj/structure/mineral_door/wood,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/grimey,
+/area/station/service/library)
 "bLM" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -22442,32 +22285,6 @@
 /obj/machinery/alarm/directional/west,
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/tools)
-"bMa" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Access"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore/east)
-"bMb" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Access"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/department/cargo/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore/east)
 "bMc" = (
 /obj/machinery/camera{
 	c_tag = "Primary Security Hallway North";
@@ -24440,20 +24257,6 @@
 	},
 /turf/simulated/floor/catwalk/black,
 /area/station/aisat)
-"bTt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/airlock/medical/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tiles/department/medical,
-/turf/simulated/floor/plasteel,
-/area/station/medical/storage)
 "bTu" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -24758,15 +24561,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
-"bUt" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fore)
 "bUv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -25783,6 +25577,19 @@
 /obj/machinery/economy/vending/wallmed/directional/north,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
+"bYt" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/research)
 "bYu" = (
 /obj/machinery/status_display{
 	pixel_x = 32
@@ -25837,13 +25644,6 @@
 /area/station/hallway/primary/port/east)
 "bYD" = (
 /turf/simulated/wall,
-/area/station/command/office/captain/bedroom)
-"bYE" = (
-/obj/machinery/door/airlock/silver{
-	name = "Captain's Bathroom"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel/white,
 /area/station/command/office/captain/bedroom)
 "bYF" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -25903,25 +25703,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/legal/magistrate)
-"bYU" = (
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
-/obj/machinery/door/airlock/engineering{
-	name = "Electrical Maintenance"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical/fore_starboard)
-"bZc" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/department/security,
-/turf/simulated/floor/plasteel,
-/area/station/security/storage)
 "bZf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27239,6 +27020,21 @@
 /obj/item/storage/box/donkpockets,
 /turf/simulated/floor/plasteel/dark,
 /area/station/legal/courtroom/gallery)
+"ced" = (
+/obj/effect/mapping_helpers/airlock/access/any/service/chapel_office,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock{
+	name = "Chapel Morgue";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/service/chapel/office)
 "cei" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -27312,27 +27108,6 @@
 /obj/machinery/porta_turret/ai_turret,
 /turf/simulated/floor/bluegrid,
 /area/station/telecomms/chamber)
-"ceQ" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=1";
-	dir = 1;
-	location = "Engineering"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/general,
-/obj/machinery/door/window/classic/reversed{
-	name = "Engineering Delivery"
-	},
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/port)
 "ceT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -29720,17 +29495,6 @@
 "cnP" = (
 /turf/simulated/wall,
 /area/station/public/locker)
-"cnR" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/starboard2)
 "cnV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -29877,14 +29641,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central)
-"coE" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/east)
 "coF" = (
 /obj/machinery/door_control{
 	id = "teleportershutter";
@@ -30074,6 +29830,22 @@
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/engine)
+"cpo" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/genetics,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/genetics)
 "cpq" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the singularity chamber.";
@@ -31109,18 +30881,6 @@
 /obj/machinery/power/emitter,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/secure_storage)
-"csF" = (
-/obj/structure/mineral_door/wood,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet/grimey,
-/area/station/service/library)
-"csG" = (
-/obj/structure/mineral_door/wood,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/carpet/grimey,
-/area/station/service/library)
 "csH" = (
 /obj/machinery/status_display,
 /turf/simulated/wall,
@@ -31786,18 +31546,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard2)
-"cuJ" = (
-/obj/machinery/door/airlock/glass{
-	name = "Cabin"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/public/locker)
 "cuK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -32146,13 +31894,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/rnd)
-"cvV" = (
-/obj/machinery/door/airlock/glass{
-	name = "Cabin"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/public/locker)
 "cvW" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tiles/neutral/corner{
@@ -32513,27 +32254,6 @@
 /area/station/ai_monitored/storage/eva)
 "cxa" = (
 /turf/simulated/wall/r_wall,
-/area/station/science/robotics/showroom)
-"cxb" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "pub_room";
-	name = "Public Meeting Room"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
-/area/station/science/robotics/showroom)
-"cxc" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "pub_room";
-	name = "Public Meeting Room"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
 /area/station/science/robotics/showroom)
 "cxd" = (
 /obj/machinery/hologram/holopad,
@@ -34362,12 +34082,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/public/toilet/lockerroom)
-"cDh" = (
-/obj/machinery/door/airlock{
-	name = "Toilet"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/toilet/lockerroom)
 "cDi" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/alarm/directional/north,
@@ -34624,17 +34338,6 @@
 /obj/item/kirbyplants/large,
 /turf/simulated/floor/plasteel/dark,
 /area/station/ai_monitored/storage/eva)
-"cEt" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/multi_tile/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/carpet/arcade,
-/area/station/public/arcade)
 "cEv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -36082,12 +35785,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/station/science/lobby)
-"cIX" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
-/turf/simulated/floor/plasteel,
-/area/station/science/lobby)
 "cIY" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -36100,11 +35797,6 @@
 "cIZ" = (
 /obj/machinery/status_display,
 /turf/simulated/wall,
-/area/station/science/lobby)
-"cJa" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
-/turf/simulated/floor/plasteel,
 /area/station/science/lobby)
 "cJb" = (
 /obj/structure/sign/directions/engineering{
@@ -36165,21 +35857,10 @@
 	},
 /turf/simulated/wall,
 /area/station/medical/reception)
-"cJh" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
-/turf/simulated/floor/plasteel,
-/area/station/medical/reception)
 "cJi" = (
 /obj/machinery/status_display,
 /turf/simulated/wall,
 /area/station/medical/reception)
-"cJl" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/starboard)
 "cJm" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/turf_decal/delivery/hollow,
@@ -37761,18 +37442,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/port2)
-"cPY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/department/medical/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/barber)
 "cPZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -38026,15 +37695,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/port2)
-"cRc" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Access"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/south)
 "cRd" = (
 /obj/item/kirbyplants/large,
 /obj/effect/turf_decal/tiles/department/science/corner{
@@ -39794,27 +39454,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/starboard)
-"cZk" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Gambling Den"
-	},
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/abandonedbar)
-"cZl" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Gambling Den"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/abandonedbar)
 "cZm" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -39936,6 +39575,19 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/starboard)
+"cZZ" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard2)
 "dab" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tiles/department/medical,
@@ -40075,23 +39727,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
-"dat" = (
-/obj/machinery/smartfridge/medbay,
-/obj/machinery/door/window/classic/reversed,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/chemistry,
-/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "imnotmakingyoulubepissoff";
-	name = "Chemistry Privacy Shutter"
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/chemistry)
 "dau" = (
 /obj/effect/turf_decal/tiles/department/science/corner{
 	dir = 1
@@ -40411,13 +40046,16 @@
 /obj/effect/mapping_helpers/turfs/rust,
 /turf/simulated/wall,
 /area/station/maintenance/port2)
-"dbN" = (
-/obj/machinery/door/airlock/titanium/glass{
-	id_tag = "s_docking_airlock"
+"dbU" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
 	},
-/obj/structure/fans/tiny/invisible,
-/turf/simulated/floor/indestructible/titanium,
-/area/shuttle/arrival/station)
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/maintenance/electrical_shop)
 "dbX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -41197,18 +40835,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/abandonedbar)
-"deF" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/apmaint)
 "deG" = (
 /obj/machinery/alarm/directional/east,
 /turf/simulated/floor/plasteel/dark,
@@ -41358,14 +40984,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/chemistry)
-"dft" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/north)
 "dfu" = (
 /turf/simulated/wall,
 /area/station/hallway/primary/aft/south)
@@ -41375,17 +40993,6 @@
 "dfy" = (
 /turf/simulated/wall,
 /area/station/medical/cloning)
-"dfB" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/north)
 "dfG" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -41655,17 +41262,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass,
 /area/station/medical/medbay)
-"dhh" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/south)
 "dhi" = (
 /obj/effect/spawner/random/fungus/frequent,
 /turf/simulated/wall,
@@ -42465,18 +42061,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
-"dkP" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/abandoned_garden)
 "dkR" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/white,
@@ -42675,14 +42259,6 @@
 /obj/structure/table/wood,
 /turf/simulated/floor/plating,
 /area/station/maintenance/abandonedbar)
-"dlL" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/port2)
 "dlM" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -42704,24 +42280,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"dlU" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "atmos";
-	name = "Atmos Blast Door"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/controlroom)
 "dlV" = (
 /obj/machinery/power/apc/directional/west,
 /obj/item/kirbyplants/large,
@@ -42849,11 +42407,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard)
-"dmK" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plasteel,
-/area/station/public/construction)
 "dmL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -43800,15 +43353,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics/chargebay)
-"drI" = (
-/obj/machinery/door/firedoor,
-/obj/structure/sign/poster/official/nanotrasen_logo/directional/west,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/department/science/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/science/research)
 "drK" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -43819,17 +43363,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/south)
-"drN" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/research)
 "drX" = (
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
@@ -43842,14 +43375,6 @@
 "dsk" = (
 /obj/effect/mapping_helpers/turfs/rust,
 /turf/simulated/wall,
-/area/station/public/construction)
-"dsl" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
 /area/station/public/construction)
 "dsm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -43880,12 +43405,6 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
-"dsu" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/department/science/corner,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/research)
 "dsv" = (
 /obj/structure/closet/secure_closet/rd,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -43918,12 +43437,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/command/office/rd)
-"dsI" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/north)
 "dsJ" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/metal{
@@ -44098,15 +43611,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/construction)
-"dtF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/apmaint)
 "dtJ" = (
 /obj/structure/sign/poster/contraband/random/directional/south,
 /turf/simulated/floor/plating,
@@ -44298,16 +43802,6 @@
 "duk" = (
 /turf/simulated/wall,
 /area/station/medical/morgue)
-"dup" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/virology,
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/fore)
 "duy" = (
 /obj/machinery/iv_drip,
 /turf/simulated/floor/plating,
@@ -44509,6 +44003,19 @@
 /obj/effect/landmark/spawner/rev,
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
+"dvx" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
 "dvG" = (
 /obj/structure/closet/secure_closet/psychiatrist,
 /turf/simulated/floor/wood,
@@ -45213,25 +44720,6 @@
 "dAH" = (
 /turf/simulated/floor/plasteel/airless,
 /area/station/science/toxins/test)
-"dAQ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/classic/normal{
-	dir = 1;
-	name = "Cargo Bay Desk"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/item/desk_bell{
-	anchored = 1;
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/all/supply/general{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/supply/office)
 "dAX" = (
 /obj/structure/computerframe,
 /obj/item/circuitboard/operating,
@@ -45459,17 +44947,6 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
-"dCf" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Morgue Maintenance"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
-/turf/simulated/floor/plasteel/dark,
-/area/station/medical/morgue)
 "dCm" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -45869,28 +45346,6 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"dEl" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/north)
-"dEm" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Access"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/north)
 "dEn" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -46549,29 +46004,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"dIG" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/apmaint)
 "dIH" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/hallway/secondary/exit)
-"dIJ" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Access"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "dIL" = (
 /obj/machinery/camera{
@@ -47150,19 +46588,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass,
 /area/station/medical/medbay)
-"dNn" = (
-/obj/machinery/door/airlock/virology/glass{
-	name = "Isolations"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/virology)
 "dNr" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -47339,15 +46764,6 @@
 	id = "CHAP"
 	},
 /turf/simulated/floor/plating,
-/area/station/service/chapel)
-"dOX" = (
-/obj/effect/mapping_helpers/airlock/access/any/service/chapel_office,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock{
-	name = "Chapel Office"
-	},
-/turf/simulated/floor/carpet/grimey,
 /area/station/service/chapel)
 "dPb" = (
 /obj/machinery/ai_status_display{
@@ -47768,15 +47184,6 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/service/chapel)
-"dRB" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id_tag = "evashutters2";
-	name = "E.V.A. Storage Shutters"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/apmaint)
 "dRD" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/package_wrap,
@@ -47786,27 +47193,6 @@
 /obj/effect/turf_decal/tiles/department/command/side{
 	dir = 9
 	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/apmaint)
-"dRE" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Auxiliary E.V.A."
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/eva,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/apmaint)
-"dRF" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Auxiliary E.V.A."
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/eva,
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/apmaint)
 "dRI" = (
@@ -48336,6 +47722,17 @@
 	icon_state = "cult"
 	},
 /area/station/service/chapel/office)
+"dUO" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Power Monitoring";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/atmos)
 "dUQ" = (
 /obj/machinery/mass_driver{
 	id_tag = "chapelgun"
@@ -48515,15 +47912,6 @@
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
-"dWn" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/port)
 "dWp" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -48629,14 +48017,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
-"dXj" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Access"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/south)
 "dXk" = (
 /obj/machinery/ai_status_display{
 	pixel_x = -32
@@ -49066,6 +48446,15 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/research)
+"dZg" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/landmark/spawner/nukedisc_respawn,
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/fore)
 "dZi" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -49077,12 +48466,6 @@
 	},
 /turf/space,
 /area/space)
-"dZE" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/public/sleep)
 "dZG" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -49168,22 +48551,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
-/area/station/maintenance/fore)
-"eao" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/turf_decal/tiles/neutral/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
 "eaq" = (
 /obj/machinery/door/airlock/maintenance,
@@ -49326,23 +48693,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/north)
-"ecP" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Psych Office"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "psychoffice"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood,
-/area/station/medical/psych)
 "ecX" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -49356,6 +48706,20 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/reception)
+"edL" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Internal Medbay Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/station/medical/surgery)
 "eed" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -49555,25 +48919,23 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/storage)
-"ehC" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"ehz" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "medbayfoyer";
+	name = "Medbay Entrance";
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics Locker Room"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/poddoor/preopen{
-	id_tag = "atmos";
-	name = "Atmos Blast Door"
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
 	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/break_room/secondary)
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/medbay)
 "ehT" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -49628,17 +48990,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/ai_monitored/storage/eva)
-"ejC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/evidence,
-/obj/machinery/door/airlock/security,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/evidence)
 "ejQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -49780,16 +49131,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/equipmentstorage)
-"elK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/obj/machinery/door/airlock/freezer,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/service/kitchen)
 "ema" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -49839,19 +49180,6 @@
 /obj/structure/chair,
 /turf/simulated/floor/plasteel,
 /area/station/security/processing)
-"emC" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	name = "Prisoner Re-education Centre"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/execution)
 "emI" = (
 /obj/machinery/economy/arcade/claw,
 /obj/machinery/firealarm/directional/west,
@@ -50230,6 +49558,20 @@
 /obj/effect/turf_decal/tiles/neutral/side,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
+"esQ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	id_tag = "pub_room";
+	name = "Public Meeting Room";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet,
+/area/station/science/robotics/showroom)
 "esZ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -50340,6 +49682,19 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
+"eun" = (
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/vacant_office)
 "eup" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel/dark,
@@ -50361,6 +49716,20 @@
 /obj/machinery/porta_turret,
 /turf/simulated/floor/bluegrid,
 /area/station/turret_protected/ai_upload)
+"euM" = (
+/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Robotics Maintenance";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/apmaint)
 "evl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -50377,6 +49746,20 @@
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"evv" = (
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison)
 "evX" = (
 /obj/structure/cable/extra_insulated,
 /obj/effect/spawner/window/reinforced/grilled,
@@ -51203,14 +50586,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
-"eNm" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "pub_room";
-	name = "Public Meeting Room"
-	},
-/turf/simulated/floor/carpet,
-/area/station/science/robotics/showroom)
 "eNp" = (
 /obj/structure/table,
 /obj/item/reagent_containers/drinks/mug/med,
@@ -51263,6 +50638,21 @@
 /obj/effect/turf_decal/tiles/department/security/side,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison)
+"eNZ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/department/cargo/corner{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "east bump";
+	pixel_x = 28;
+	dir = 5
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore/east)
 "eOa" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plasteel/dark,
@@ -51427,29 +50817,6 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/aft/south)
-"eQz" = (
-/obj/machinery/access_button{
-	autolink_id = "virolab_btn_ext";
-	layer = 3.6;
-	name = "Virology Lab Access Button";
-	pixel_x = -24;
-	req_access = list(39)
-	},
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	id_tag = "virolab_door_ext";
-	locked = 1;
-	name = "Virology Lab External Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/medbay)
 "eQB" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -51476,17 +50843,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
-"eQZ" = (
-/obj/machinery/door/airlock/medical/glass,
-/obj/machinery/door/firedoor,
+"eRb" = (
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/reception)
 "eRi" = (
@@ -51814,6 +51179,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/north)
+"faA" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
 "fbj" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -51832,6 +51213,24 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
+"fbF" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command{
+	id_tag = "ntrepofficedoor";
+	name = "NT Representative's Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/ntrep,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/station/command/office/ntrep)
 "fbH" = (
 /obj/machinery/power/apc/important/directional/east,
 /obj/effect/turf_decal/stripes/end{
@@ -51873,6 +51272,16 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/nw)
+"fcm" = (
+/obj/machinery/door/airlock/glass{
+	name = "Cabin";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/locker)
 "fct" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -51990,16 +51399,6 @@
 /obj/machinery/requests_console/directional/north,
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/tools)
-"feM" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Science Maintenance"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/medical/genetics,
-/turf/simulated/floor/plasteel/white,
-/area/station/maintenance/port)
 "ffa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -52162,19 +51561,6 @@
 	},
 /turf/space,
 /area/space)
-"fhG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mining/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/supply/mail_sorting,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/supply/sorting)
 "fhO" = (
 /obj/structure/table,
 /obj/item/storage/bag/plants/seed_sorting_tray,
@@ -52353,6 +51739,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"flT" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/control)
 "fmg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -52372,17 +51776,6 @@
 	icon_state = "seadeep"
 	},
 /area/station/public/fitness)
-"fmU" = (
-/obj/machinery/door/airlock/atmos/glass{
-	heat_proof = 1;
-	name = "Supermatter Chamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/engine/supermatter)
 "fmZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
@@ -52405,6 +51798,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/office/ntrep)
+"fng" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/electrical/aft_port)
 "fnH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -52545,6 +51952,27 @@
 /obj/structure/cable/extra_insulated,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"fpV" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "atmos";
+	name = "Atmos Blast Door"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/controlroom)
 "fqa" = (
 /obj/machinery/light{
 	dir = 4
@@ -52569,6 +51997,20 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/south)
+"fqG" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Engineering Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/port)
 "fqS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -52581,6 +52023,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
+"frb" = (
+/obj/machinery/door/airlock/research/glass{
+	autoclose = 0;
+	id_tag = "tox_airlock_exterior";
+	locked = 1;
+	name = "Xenobiology Kill Room";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/xenobiology)
 "frh" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -52625,6 +52084,23 @@
 /obj/effect/turf_decal/tiles/neutral/side,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
+"fsg" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Public Access";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/north)
 "fst" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -52695,17 +52171,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prisonlockers)
-"fun" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/atmos)
 "fuu" = (
 /obj/structure/mirror{
 	pixel_y = 28
@@ -52722,6 +52187,21 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/reception)
+"fuD" = (
+/obj/machinery/door/airlock/medical{
+	name = "Operating Theatre Storage";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/station/medical/surgery)
 "fuE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -52735,6 +52215,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/theatre)
+"fuR" = (
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id_tag = "evashutters2";
+	name = "E.V.A. Storage Shutters"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door_control{
+	id = "evashutters2";
+	name = "Auxilary E.V.A. Storage";
+	pixel_x = 26
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/apmaint)
 "fuY" = (
 /obj/item/radio/intercom{
 	name = "east bump";
@@ -52790,6 +52286,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central)
+"fxe" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/machinery/door/airlock/research/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "rnd"
+	},
+/obj/effect/turf_decal/tiles/department/science,
+/turf/simulated/floor/plasteel,
+/area/station/science/rnd)
 "fxo" = (
 /obj/machinery/bodyscanner{
 	dir = 1
@@ -52866,12 +52380,6 @@
 /obj/effect/landmark/spawner/nukedisc_respawn,
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
-"fyP" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/nw)
 "fza" = (
 /obj/docking_port/mobile/pod{
 	id = "pod2";
@@ -53072,21 +52580,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
-"fCY" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
-	id_tag = "ntrepofficedoor";
-	name = "NT Representative's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/ntrep,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/station/command/office/ntrep)
 "fDa" = (
 /obj/item/radio/intercom{
 	name = "north bump";
@@ -53123,6 +52616,20 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"fDI" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/science/research)
 "fDS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -53208,6 +52715,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/fore)
+"fFr" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint)
 "fFu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -53251,26 +52774,24 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/legal/courtroom)
-"fFT" = (
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
-	dir = 1
+"fFS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
-	dir = 1
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/classic/reversed{
-	dir = 1;
-	name = "Kitchen Delivery"
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/maintenance/fore)
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tiles/department/medical,
+/turf/simulated/floor/plasteel,
+/area/station/medical/storage)
 "fFU" = (
 /obj/structure/rack,
 /obj/item/clothing/gloves/color/latex,
@@ -53371,6 +52892,13 @@
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/wood,
 /area/station/maintenance/library)
+"fHN" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/station/supply/lobby)
 "fIf" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -53394,6 +52922,19 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"fIm" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/starboard2)
 "fIn" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plating,
@@ -53428,11 +52969,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/gravitygenerator)
-"fIE" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "fIU" = (
 /obj/structure/table/reinforced,
 /obj/item/wrench,
@@ -53638,6 +53174,26 @@
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall,
 /area/station/maintenance/starboard2)
+"fMy" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Supermatter Monitoring Room";
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "atmos";
+	name = "Atmos Blast Door"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/controlroom)
 "fMM" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -53658,24 +53214,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
-"fMP" = (
-/obj/machinery/door/airlock/command{
-	id_tag = "cmoofficedoor";
-	name = "CMO's Office"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "CMO"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/dark,
-/area/station/command/office/cmo)
 "fMW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -53685,6 +53223,31 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/apmaint)
+"fNv" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	locked = 1;
+	id_tag = "perma_door_int";
+	dir = 4
+	},
+/obj/machinery/access_button{
+	autolink_id = "perma_btn_int";
+	name = "Prison Wing Access Button";
+	req_access = list(2);
+	pixel_x = -23
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Prison Gate";
+	name = "Prison Lockdown Blast Doors"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/turf_decal/tiles/department/security,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/permabrig)
 "fNF" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/turf_decal/tiles/neutral/corner{
@@ -53707,13 +53270,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/cmo)
-"fNP" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/medical/side{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/cryo)
 "fNS" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
@@ -53781,6 +53337,15 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/misc_lab)
+"fOC" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/structure/barricade/wooden,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/starboard)
 "fON" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
@@ -53935,6 +53500,21 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass,
 /area/station/medical/reception)
+"fQu" = (
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/department/security,
+/turf/simulated/floor/plasteel,
+/area/station/security/storage)
 "fQx" = (
 /obj/machinery/cryopod/right{
 	dir = 8
@@ -54048,6 +53628,21 @@
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/engine,
 /area/station/engineering/controlroom)
+"fSL" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/cargo_bay,
+/obj/effect/mapping_helpers/airlock/access/all/supply/mail_sorting,
+/turf/simulated/floor/plasteel,
+/area/station/supply/warehouse)
 "fTe" = (
 /obj/structure/railing{
 	dir = 1
@@ -54098,15 +53693,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/ne)
-"fTr" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Maintenance"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/supply/cargo_bay,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fore2)
 "fTC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -54153,6 +53739,23 @@
 /obj/item/trash/spentcasing/bullet,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port2)
+"fUc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Cryogenic Dormitories";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/public/sleep)
 "fUf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -54172,33 +53775,44 @@
 /obj/item/storage/backpack/satchel/withwallet,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"fVl" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/science/research)
 "fVG" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"fVR" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/science/xenobiology)
 "fVZ" = (
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/surgery/primary)
+"fWB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tiles/neutral/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint)
 "fWX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -54611,6 +54225,29 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"geD" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/north)
+"gfg" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Funeral Parlour";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/service/chapel)
 "gfq" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-4"
@@ -54677,16 +54314,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
-"ggG" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
-	name = "Teleport Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/command/teleporter)
 "ggW" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /obj/effect/turf_decal/tiles/neutral,
@@ -54740,30 +54367,6 @@
 /obj/effect/landmark/lightsout,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/reception)
-"giE" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/east)
-"giG" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/eftpos/register{
-	dir = 1;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/maintenance/fore)
 "giK" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/transit_tube/curved{
@@ -55042,6 +54645,19 @@
 "goP" = (
 /turf/simulated/wall,
 /area/station/security/processing)
+"gpq" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command{
+	name = "Teleport Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/command/teleporter)
 "gpy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -55060,6 +54676,20 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard)
+"gqa" = (
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Transit Tube";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "transitlock";
+	name = "Transit Tube Lockdown"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/ai_transit_tube)
 "gqm" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -55170,14 +54800,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/warden)
-"gsC" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Warehouse Maintenance"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/supply/cargo_bay,
-/turf/simulated/floor/plasteel,
-/area/station/supply/warehouse)
 "gsI" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/light/small{
@@ -55240,21 +54862,35 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/research)
+"gtV" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/window,
+/obj/effect/mapping_helpers/airlock/windoor/autoname,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen,
+/obj/effect/turf_decal/delivery,
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "kitchenbar";
+	name = "Kitchen Shutters"
+	},
+/obj/item/reagent_containers/condiment/peppermill,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/drinks/britcup{
+	pixel_x = -9
+	},
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/kitchen)
 "gtW" = (
 /obj/machinery/firealarm/directional/east,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/station/service/bar)
-"gtZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external/glass{
-	id_tag = "admin_home"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/north)
 "gua" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/dark,
@@ -55275,6 +54911,20 @@
 "guC" = (
 /turf/simulated/floor/grass/no_creep,
 /area/station/hallway/primary/port/north)
+"guT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "ferry_home";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/north)
 "gvr" = (
 /obj/effect/turf_decal/tiles/neutral/corner{
 	dir = 8
@@ -55291,6 +54941,20 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"gvC" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/supply/office)
 "gvD" = (
 /obj/effect/turf_decal/tiles/department/virology/side{
 	dir = 4
@@ -55387,22 +55051,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/xenobiology)
-"gxo" = (
-/obj/machinery/door/airlock/research/glass{
-	autoclose = 0;
-	id_tag = "tox_airlock_exterior";
-	locked = 1;
-	name = "Xenobiology Kill Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/science/xenobiology)
 "gxu" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -55449,6 +55097,14 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/tech_storage)
+"gyM" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/south)
 "gyR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -55458,17 +55114,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/electrical/aft_port)
-"gyY" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "pub_room";
-	name = "Public Meeting Room"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet,
-/area/station/science/robotics/showroom)
 "gzi" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/plating,
@@ -55516,6 +55161,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/south)
+"gAs" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/department/virology/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore/east)
 "gAN" = (
 /obj/structure/grille/broken,
 /obj/structure/cable/extra_insulated{
@@ -55699,6 +55354,20 @@
 	icon_state = "cult"
 	},
 /area/station/legal/magistrate)
+"gDR" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/virology,
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/fore)
 "gDY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -55728,6 +55397,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
+"gEJ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Primary tool storage";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/public/storage/tools)
 "gER" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/extra_insulated{
@@ -55738,19 +55420,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"gEY" = (
-/obj/machinery/door/airlock/command{
-	name = "Head of Personnel"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/hop,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
-/area/station/command/office/hop)
 "gFa" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
@@ -55836,6 +55505,20 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
+"gHq" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/atmos)
 "gHy" = (
 /obj/machinery/shieldwallgen,
 /turf/simulated/floor/plating,
@@ -55845,17 +55528,6 @@
 /obj/effect/spawner/random/oil/maybe,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"gHE" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/xenobiology)
 "gHG" = (
 /obj/item/stack/cable_coil/yellow,
 /turf/space,
@@ -55963,15 +55635,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/break_room)
-"gKb" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/turf_decal/tiles/neutral/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fore)
 "gKe" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -55987,6 +55650,19 @@
 /obj/structure/disaster_counter/toxins,
 /turf/simulated/wall/r_wall,
 /area/station/science/toxins/launch)
+"gKk" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/lounge)
 "gKm" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/structure/table/reinforced,
@@ -56004,12 +55680,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/control)
-"gKs" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/west)
 "gKF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -56237,6 +55907,27 @@
 /obj/machinery/alarm/directional/north,
 /turf/simulated/floor/wood,
 /area/station/service/theatre)
+"gNU" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Chapel Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/apmaint)
+"gNY" = (
+/obj/machinery/door/airlock/titanium/glass{
+	id_tag = "s_docking_airlock";
+	dir = 4
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/simulated/floor/indestructible/titanium,
+/area/shuttle/arrival/station)
 "gOD" = (
 /obj/machinery/light{
 	dir = 1
@@ -56371,6 +56062,20 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/north)
+"gSt" = (
+/obj/machinery/door/airlock/command{
+	id_tag = "captainofficedoor";
+	name = "Captain's Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/captain,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/command/office/captain/bedroom)
 "gTq" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -56525,19 +56230,6 @@
 /obj/item/storage/fancy/matches,
 /turf/simulated/floor/wood,
 /area/station/maintenance/fore)
-"gWD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external/glass{
-	id_tag = "ferry_home"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/north)
 "gWY" = (
 /obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
@@ -56560,6 +56252,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/abandonedservers)
+"gXE" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/rd,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel/white,
+/area/station/command/office/rd)
 "gXF" = (
 /obj/machinery/atmospherics/trinary/filter{
 	dir = 8
@@ -57130,6 +56844,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central)
+"hlA" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id_tag = "janitorshutters";
+	name = "Janitor Shutters"
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/service/janitor)
 "hlL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -57245,6 +56971,24 @@
 /obj/effect/landmark/start/atmospheric,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
+"hnz" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Power Transmission Laser";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/sign/electricshock{
+	pixel_x = 32
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/neutral/side{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/port)
 "hnE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57494,6 +57238,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/office/cmo)
+"htd" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/port/north)
 "htq" = (
 /obj/structure/sign/science/research,
 /turf/simulated/wall/r_wall,
@@ -57835,6 +57593,27 @@
 	},
 /turf/simulated/wall,
 /area/station/maintenance/fore)
+"hBR" = (
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/doors,
+/obj/effect/mapping_helpers/airlock/access/any/security/court,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Courtroom"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/legal/courtroom)
 "hBU" = (
 /obj/item/radio/intercom/locked/prison{
 	name = "Prison Intercom (General)";
@@ -58034,20 +57813,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/medical/paramedic)
-"hFW" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Electrical Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/electrical/aft_port)
 "hGj" = (
 /obj/machinery/atmospherics/portable/canister/toxins,
 /obj/machinery/ai_status_display{
@@ -58380,17 +58145,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/hydroponics)
-"hPC" = (
-/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Robotics Maintenance"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/apmaint)
 "hPL" = (
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -58482,18 +58236,6 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/space,
 /area/space/nearstation)
-"hRJ" = (
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/station/medical/surgery)
 "hSe" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder,
@@ -58516,6 +58258,16 @@
 /obj/item/storage/box/lights/mixed,
 /turf/simulated/floor/plating,
 /area/station/public/storage/emergency/port)
+"hSH" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/south)
 "hSO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel{
@@ -58561,6 +58313,18 @@
 /obj/effect/turf_decal/tiles/department/security/corner,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison/cell_block/a)
+"hTP" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Internal Medbay Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/coldroom)
 "hTT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -58619,6 +58383,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room/secondary)
+"hUC" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "hUX" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -58745,6 +58516,24 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
+"hWO" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command{
+	id_tag = "blueshieldofficedoor";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/command/blueshield,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/station/command/office/blueshield)
 "hWP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -58968,19 +58757,20 @@
 /obj/machinery/atmospherics/refill_station/nitrogen,
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/port)
-"iaU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
+"iaV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tiles/department/medical/side{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/sleeper)
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "specops_home";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/east)
 "ibb" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
@@ -59145,26 +58935,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"ieX" = (
-/obj/machinery/door/airlock/medical/glass,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/reception)
-"ifj" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Internal Medbay Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/station/medical/surgery)
 "igc" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
@@ -59314,23 +59084,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/surgery/observation)
-"ijN" = (
-/obj/machinery/door/airlock/atmos/glass{
-	heat_proof = 1;
-	name = "Supermatter Chamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/turf/simulated/floor/engine,
-/area/station/engineering/engine/supermatter)
-"ijR" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/turf_decal/tiles/neutral/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fore)
 "ijT" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 5
@@ -59371,6 +59124,18 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
+"ila" = (
+/obj/structure/table/wood,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id_tag = "detective";
+	name = "Detective Office Shutters"
+	},
+/turf/simulated/floor/carpet/black,
+/area/station/security/detective)
 "ile" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -59397,6 +59162,23 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard2)
+"ilI" = (
+/obj/machinery/door/airlock{
+	name = "Auxillary Restrooms";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/public/toilet/unisex)
 "imf" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -59404,6 +59186,20 @@
 /obj/machinery/newscaster/directional/north,
 /turf/simulated/floor/carpet/grimey,
 /area/station/public/vacant_office)
+"imF" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/mining/glass{
+	name = "Supply Break Room";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/break_room)
 "imG" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop{
@@ -59432,18 +59228,6 @@
 /obj/item/clothing/head/stalhelm,
 /turf/simulated/floor/wood,
 /area/station/service/clown)
-"imV" = (
-/obj/effect/mapping_helpers/airlock/access/any/service/chapel_office,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock{
-	name = "Chapel Morgue"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/station/service/chapel/office)
 "imY" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -59487,15 +59271,6 @@
 	},
 /turf/simulated/floor/catwalk/grey,
 /area/station/engineering/gravitygenerator)
-"ino" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison)
 "iny" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -59784,6 +59559,44 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
+"iuq" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/controlroom)
+"iuv" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/port)
+"iuz" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
 "iuB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -60098,14 +59911,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard)
-"iyN" = (
-/obj/machinery/door/airlock{
-	name = "Prison Showers"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/security/permabrig)
 "izj" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
@@ -60126,6 +59931,17 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/apmaint)
+"izE" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Public Access";
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/north)
 "izT" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/l3closet/janitor,
@@ -60271,15 +60087,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
-"iDv" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	name = "E.V.A."
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/eva,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel/dark,
-/area/station/ai_monitored/storage/eva)
 "iDw" = (
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 5
@@ -60322,6 +60129,20 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
+"iEk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/machinery/door/airlock/freezer{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/service/kitchen)
 "iEH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/barsign{
@@ -60345,18 +60166,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
-"iFa" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/port/north)
 "iFl" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/wood,
@@ -60461,6 +60270,20 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/medical/psych)
+"iIo" = (
+/obj/machinery/door/airlock/command{
+	id_tag = "captainofficedoor";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/command/captain,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/station/command/office/captain)
 "iIC" = (
 /obj/machinery/economy/vending/boozeomat,
 /obj/machinery/status_display{
@@ -60522,6 +60345,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
+"iJY" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/public/arcade)
 "iKf" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -60568,6 +60397,20 @@
 /obj/machinery/alarm/directional/south,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/abandonedservers)
+"iKZ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Public Access";
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/department/cargo/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore/east)
 "iLp" = (
 /obj/effect/turf_decal/delivery/partial{
 	dir = 1
@@ -60681,19 +60524,6 @@
 /obj/effect/turf_decal/tiles/neutral/side,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore2)
-"iOv" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/south)
 "iOC" = (
 /obj/machinery/door/window/reinforced/reversed{
 	name = "Toxins Launcher";
@@ -60751,6 +60581,29 @@
 /obj/structure/sign/cargo/dock,
 /turf/simulated/wall,
 /area/station/supply/storage)
+"iPC" = (
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=1";
+	dir = 1;
+	location = "Engineering"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/general,
+/obj/machinery/door/window/classic/reversed{
+	name = "Engineering Delivery"
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/port)
 "iPG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -60967,6 +60820,23 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/command/bridge)
+"iSm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/mining/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/cargo_bay,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/supply/miningdock)
 "iSv" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 8
@@ -61007,6 +60877,19 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/bar)
+"iTF" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Teleporter Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/command/teleporter)
 "iTV" = (
 /obj/structure/gunrack,
 /obj/item/gun/energy/gun,
@@ -61157,21 +61040,6 @@
 "iVX" = (
 /turf/simulated/wall,
 /area/station/maintenance/library)
-"iWd" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Research Division Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/research,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/science/research)
 "iWf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -61280,11 +61148,43 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/station/security/processing)
+"iYn" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "iYu" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/effect/spawner/airlock/e_to_w,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_port)
+"iYL" = (
+/obj/machinery/door/airlock/research/glass{
+	name = "Test Chamber";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/machinery/door/poddoor/preopen{
+	name = "Biohazard Shutter";
+	id_tag = "RnDChem"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/engine,
+/area/station/science/test_chamber)
 "iYM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -61705,14 +61605,6 @@
 /obj/effect/turf_decal/tiles/department/command,
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/storage/secondary)
-"jji" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/department/science/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/science/research)
 "jjp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -61832,18 +61724,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/supply/qm)
-"jls" = (
-/obj/machinery/door/airlock/bananium,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/service/clown,
-/turf/simulated/floor/wood,
-/area/station/service/clown)
 "jlw" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -62002,20 +61882,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
-"jpm" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/north)
 "jpA" = (
 /obj/effect/turf_decal/tiles/department/medical/corner{
 	dir = 1
@@ -62170,6 +62036,28 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/supply_shuttle,
 /turf/simulated/floor/plating,
 /area/station/supply/storage)
+"jsY" = (
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id_tag = "paramedic";
+	name = "Paramedic Garage"
+	},
+/obj/machinery/door_control{
+	id = "paramedic";
+	name = "Garage Door Control";
+	pixel_x = -24;
+	req_access = list(66)
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/medical/paramedic)
 "jtb" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -62185,18 +62073,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/research)
-"jtF" = (
-/obj/machinery/door/airlock/tranquillite,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/any/service/mime,
-/turf/simulated/floor/mineral/tranquillite,
-/area/station/service/mime)
 "jtL" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Power Transmission Laser"
@@ -62354,12 +62230,27 @@
 /obj/effect/spawner/airlock/long/square,
 /turf/simulated/wall,
 /area/station/maintenance/abandonedservers)
+"jwd" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "jwo" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
+"jwY" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/west)
 "jwZ" = (
 /turf/simulated/wall,
 /area/station/public/storage/emergency/port)
@@ -62414,21 +62305,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard2)
-"jAs" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 9
-	},
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Distribution Loop"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/distribution)
 "jAu" = (
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -62648,18 +62524,6 @@
 /obj/machinery/alarm/directional/north,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
-"jHM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/station/maintenance/electrical_shop)
 "jIc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -62919,14 +62783,6 @@
 /obj/machinery/status_display,
 /turf/simulated/wall,
 /area/station/aisat)
-"jMa" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Fabrication"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/engine,
-/area/station/engineering/engine)
 "jMb" = (
 /obj/machinery/door/window{
 	base_state = "right";
@@ -62939,13 +62795,19 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/command/office/captain)
-"jMh" = (
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Turbine Generator Access"
+"jMp" = (
+/obj/machinery/door/airlock/engineering{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/station/engineering/atmos)
+/area/station/maintenance/electrical/aft_starboard)
 "jMD" = (
 /obj/machinery/computer/crew,
 /obj/structure/sign/poster/official/random/directional/north,
@@ -63058,15 +62920,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
-"jPk" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Research Division Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/research,
-/obj/effect/turf_decal/stripes/line,
-/turf/simulated/floor/plasteel,
-/area/station/science/research)
 "jPp" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
@@ -63104,17 +62957,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/supply/sorting)
-"jPF" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Engineering Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/port)
 "jPR" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/small{
@@ -63133,24 +62975,6 @@
 /obj/effect/turf_decal/tiles/department/medical/side,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/surgery/primary)
-"jQb" = (
-/obj/machinery/door/airlock/glass{
-	name = "Internal Affairs Office"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/iaa,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "IAA"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/carpet/grimey,
-/area/station/legal/lawoffice)
 "jQv" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
 /turf/simulated/floor/plasteel{
@@ -63186,6 +63010,17 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
+"jQC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint)
 "jQN" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -63370,6 +63205,23 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
+"jTE" = (
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/reception)
 "jTJ" = (
 /obj/machinery/alarm/directional/east,
 /obj/structure/table,
@@ -63651,17 +63503,6 @@
 /obj/machinery/cooking/stovetop/loaded,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
-"jZo" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard2)
 "kad" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -64148,6 +63989,29 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/station/command/office/hos)
+"kkO" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/permabrig)
 "kkY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -64196,6 +64060,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
+"knu" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison)
 "knL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -64337,6 +64214,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
+"kql" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Mining Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "kqn" = (
 /obj/effect/landmark/start/coroner,
 /obj/effect/turf_decal/tiles/department/command/side,
@@ -64516,6 +64402,19 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/reception)
+"kug" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/south)
 "kuI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -64592,30 +64491,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prisonershuttle)
-"kwm" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Trainer's Office";
-	id_tag = "nct"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "NCT"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/all/procedure/trainer,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/station/procedure/trainer_office)
 "kxe" = (
 /obj/structure/table/reinforced,
 /obj/item/bikehorn/rubberducky,
@@ -64646,6 +64521,26 @@
 /obj/item/pen,
 /turf/simulated/floor/carpet/grimey,
 /area/station/maintenance/starboard)
+"kxs" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door_control{
+	id = "janitorshutters";
+	name = "Janitor Shutters Control";
+	pixel_x = 25;
+	req_access = list(26)
+	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id_tag = "janitorshutters";
+	name = "Janitor Shutters"
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/service/janitor)
 "kxH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -64671,6 +64566,22 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/break_room)
+"kxT" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Gambling Den";
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/abandonedbar)
 "kyk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -64682,6 +64593,20 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/service/kitchen)
+"kyo" = (
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/storage/tools/auxiliary)
 "kyr" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/effect/turf_decal/tiles/department/medical/side,
@@ -64742,6 +64667,14 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/sleeper)
+"kzv" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/north)
 "kzx" = (
 /obj/effect/turf_decal/stripes/white/corner{
 	dir = 8
@@ -64861,12 +64794,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison)
-"kBv" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/wood,
-/area/station/maintenance/library)
 "kBB" = (
 /obj/machinery/power/apc/directional/east,
 /obj/structure/cable{
@@ -64967,12 +64894,6 @@
 	},
 /turf/simulated/floor/transparent/glass,
 /area/station/aisat)
-"kEt" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/south)
 "kED" = (
 /obj/machinery/door/airlock/research{
 	name = "Abandoned Equipment Room"
@@ -65004,6 +64925,23 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/library)
+"kFb" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/side{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/cryo)
+"kFf" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/public/sleep)
 "kFD" = (
 /obj/machinery/power/apc/directional/south,
 /obj/structure/cable,
@@ -65151,19 +65089,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/sleeper)
-"kHT" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/processing)
 "kIa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -65195,21 +65120,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/cmo)
-"kIF" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
-	id_tag = "blueshieldofficedoor"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/command/blueshield,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/station/command/office/blueshield)
 "kIG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -65307,20 +65217,6 @@
 /obj/effect/turf_decal/tiles/department/command/side,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
-"kLR" = (
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Holding Area"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/secondary/exit)
 "kLU" = (
 /obj/structure/girder,
 /obj/effect/turf_decal/tiles/neutral/side,
@@ -65369,6 +65265,13 @@
 /obj/item/reagent_containers/drinks/mug/sci,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/break_room)
+"kMJ" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/east)
 "kMN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -65486,6 +65389,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"kPq" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Break Room";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/break_room)
 "kPt" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light{
@@ -65543,6 +65457,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/east)
+"kPO" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/break_room)
 "kQd" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -66050,17 +65982,22 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
-"kYS" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Research Division Access"
+"kYO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/science/research,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/station/science/research)
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/department/medical/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/barber)
 "kYX" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -66069,6 +66006,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"kYZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
 "kZr" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -66335,6 +66283,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/surgery/observation)
+"lgZ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Public Access";
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/south)
 "lhJ" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
@@ -66384,26 +66344,6 @@
 /obj/effect/turf_decal/tiles/department/security/corner,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison)
-"liC" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id_tag = "paramedic";
-	name = "Paramedic Garage"
-	},
-/obj/machinery/door_control{
-	id = "paramedic";
-	name = "Garage Door Control";
-	pixel_x = -24;
-	req_access = list(66)
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/medical/paramedic)
 "liE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -66687,17 +66627,6 @@
 /obj/structure/sign/medical,
 /turf/simulated/wall,
 /area/station/medical/paramedic)
-"lpL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/south)
 "lpN" = (
 /obj/effect/turf_decal,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -66762,11 +66691,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/permabrig)
-"lqL" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/medical/side,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/surgery/observation)
 "lrh" = (
 /obj/machinery/optable,
 /obj/machinery/light/small{
@@ -66859,6 +66783,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/gambling_den)
+"lsZ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/department/science/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/science/research)
 "lth" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical{
@@ -67024,6 +66958,23 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/research)
+"lwU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/obj/machinery/door/airlock/maintenance/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/abandonedservers)
 "lwY" = (
 /obj/structure/table/glass,
 /obj/item/clothing/neck/stethoscope{
@@ -67070,14 +67021,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/chapel)
-"lyj" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/barricade/wooden,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fore2)
 "lyp" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/delivery,
@@ -67241,35 +67184,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet/red,
 /area/station/command/office/hos)
-"lBa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
-/obj/machinery/door/airlock/maintenance/glass,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/abandonedservers)
-"lBi" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/research/glass{
-	name = "Break Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/research,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/break_room)
 "lBx" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -67318,6 +67232,14 @@
 	},
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/station/maintenance/electrical/aft_port)
+"lCA" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/south)
 "lCO" = (
 /turf/simulated/wall,
 /area/station/supply/break_room)
@@ -67342,6 +67264,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
+"lDb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/north)
 "lDf" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plasteel/dark,
@@ -67482,6 +67417,15 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
+"lFO" = (
+/obj/machinery/door/airlock/atmos/glass{
+	heat_proof = 1;
+	name = "Supermatter Chamber";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/turf/simulated/floor/engine,
+/area/station/engineering/engine/supermatter)
 "lGj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -67570,6 +67514,14 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/research)
+"lIR" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/nw)
 "lIX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/turf_decal/tiles/department/command/side{
@@ -67696,6 +67648,26 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
+"lLw" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=1";
+	dir = 1;
+	location = "Robotics"
+	},
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/science/robotics,
+/obj/machinery/door/window/classic/reversed{
+	name = "Robotics Delivery"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint)
 "lLN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -68027,6 +67999,21 @@
 /obj/effect/turf_decal/tiles/department/security/checker,
 /turf/simulated/floor/plasteel,
 /area/station/medical/break_room)
+"lTz" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "E.V.A.";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/eva,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel/dark,
+/area/station/ai_monitored/storage/eva)
 "lUd" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -68168,6 +68155,16 @@
 /obj/machinery/economy/atm/directional/north,
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/abandonedbar)
+"lYn" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/toilet/lockerroom)
 "lYp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -68412,6 +68409,17 @@
 /obj/effect/turf_decal/tiles/department/virology/side,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
+"mdu" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Public Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/exit)
 "mdx" = (
 /obj/structure/chair/stool{
 	dir = 4
@@ -68429,6 +68437,22 @@
 /obj/item/robotanalyzer,
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics)
+"med" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/abandoned_garden)
 "mej" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
@@ -68620,6 +68644,21 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
+"miI" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	id_tag = "pub_room";
+	name = "Public Meeting Room";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/wood,
+/area/station/science/robotics/showroom)
 "miJ" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/turf_decal/delivery/hollow,
@@ -68688,6 +68727,26 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/transmission_laser)
+"mjF" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Bay Maintenance";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/supply/cargo_bay,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore2)
+"mjO" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/construction)
 "mjS" = (
 /obj/effect/turf_decal/tiles/dark/side,
 /obj/machinery/camera{
@@ -68850,19 +68909,6 @@
 /obj/effect/turf_decal/tiles/department/science/side,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/break_room)
-"mmw" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/warden)
 "mmC" = (
 /obj/effect/spawner/random/dirt/frequent,
 /obj/effect/turf_decal/tiles/neutral/side{
@@ -68886,6 +68932,26 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/break_room)
+"mnL" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Psych Office";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "psychoffice"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/station/medical/psych)
 "mnT" = (
 /obj/machinery/shower/directional/west,
 /turf/simulated/floor/plasteel{
@@ -68959,6 +69025,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/processing)
+"mpp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Public Access";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/south)
 "mpw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -69147,6 +69229,16 @@
 /obj/effect/turf_decal/tiles/department/security/side,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison)
+"msj" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/engineering/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/port/north)
 "mss" = (
 /obj/structure/table/wood,
 /obj/item/folder,
@@ -69294,18 +69386,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison)
-"muB" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/genetics,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/genetics)
 "muI" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/railing,
@@ -69394,24 +69474,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"mxK" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=1";
-	dir = 1;
-	location = "Robotics"
-	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/science/robotics,
-/obj/machinery/door/window/classic/reversed{
-	name = "Robotics Delivery"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/apmaint)
 "mxU" = (
 /obj/item/cultivator/rake,
 /turf/simulated/floor/grass,
@@ -69421,17 +69483,6 @@
 /obj/item/bedsheet/hos,
 /turf/simulated/floor/carpet/red,
 /area/station/command/office/hos)
-"myn" = (
-/obj/machinery/door/airlock/engineering,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/electrical/aft_starboard)
 "myx" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -69557,6 +69608,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
+"mAz" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "mAC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -69569,19 +69631,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
-"mAH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/research,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/tox,
-/obj/machinery/door/firedoor/heavy,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/toxins/mixing)
 "mAS" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -69644,12 +69693,41 @@
 /obj/effect/landmark/spawner/nukedisc_respawn,
 /turf/simulated/floor/carpet/grimey,
 /area/station/maintenance/gambling_den)
+"mDa" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/north)
 "mDe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"mDk" = (
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/paramedic,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/paramedic)
 "mDm" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/tracks/mapped{
@@ -69677,9 +69755,39 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/public/storage/tools/auxiliary)
+"mEp" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/service/janitor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/service/janitor)
 "mEG" = (
 /turf/simulated/floor/wood,
 /area/station/security/detective)
+"mEU" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/turf_decal/tiles/neutral/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
 "mFj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -69745,6 +69853,18 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
+"mHe" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	id_tag = "pub_room";
+	name = "Public Meeting Room";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/station/science/robotics/showroom)
 "mHV" = (
 /obj/effect/spawner/random/barrier/possibly_welded_airlock,
 /turf/simulated/floor/plating,
@@ -69958,14 +70078,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/east)
-"mNM" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/south)
 "mNS" = (
 /obj/structure/chair{
 	dir = 8
@@ -70226,6 +70338,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
+"mSD" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "mSF" = (
 /obj/effect/turf_decal{
 	dir = 1
@@ -70267,18 +70389,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/expedition)
-"mSZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Access"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/exit)
 "mTd" = (
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xeno5";
@@ -70504,18 +70614,6 @@
 /obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/plasteel,
 /area/station/supply/expedition)
-"mWz" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/neutral/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/east)
 "mWC" = (
 /obj/structure/table/glass,
 /obj/item/seeds/tower,
@@ -70549,6 +70647,24 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"mWP" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
 "mWS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -70840,6 +70956,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/storage)
+"nak" = (
+/obj/machinery/door/airlock/engineering{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/electrical/aft_port)
 "naA" = (
 /obj/effect/spawner/random/barrier/wall_probably,
 /turf/simulated/floor/plating,
@@ -70892,6 +71024,22 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
+"ncC" = (
+/obj/machinery/door/airlock/command{
+	name = "Head of Personnel";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/hop,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/wood,
+/area/station/command/office/hop)
 "ncT" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/cargo{
@@ -71034,17 +71182,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prisonershuttle)
-"ngZ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Supply Break Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/general,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/supply/break_room)
 "nhh" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -71133,6 +71270,21 @@
 /obj/item/clothing/mask/gas,
 /turf/simulated/floor/engine,
 /area/station/science/test_chamber)
+"nhW" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/controlroom)
 "nij" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tiles/department/science/side{
@@ -71150,15 +71302,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat)
-"njk" = (
-/obj/machinery/door/airlock{
-	name = "Unisex Restrooms"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/toilet/lockerroom)
 "njo" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -71272,19 +71415,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/chemistry)
-"nlA" = (
-/obj/machinery/door/airlock/command{
-	id_tag = "captainofficedoor"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/command/captain,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/station/command/office/captain)
 "nlB" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/turf_decal/delivery/red/hollow,
@@ -71300,6 +71430,22 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/electrical_shop)
+"nlW" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/west)
 "nlY" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -71329,17 +71475,6 @@
 "nmp" = (
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat)
-"nmr" = (
-/obj/machinery/door/airlock/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/vacant_office)
 "nmt" = (
 /obj/effect/turf_decal/tiles/neutral/corner{
 	dir = 4
@@ -71383,33 +71518,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/north)
-"nnD" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prison Cafeteria"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
-"nnP" = (
-/obj/machinery/door/window,
-/obj/effect/mapping_helpers/airlock/windoor/autoname,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id_tag = "kitchenbar";
-	name = "Kitchen Shutters"
-	},
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/kitchen)
 "nnU" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -71683,12 +71791,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
-"ntZ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/west)
 "nui" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
@@ -71733,6 +71835,28 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/library)
+"nuU" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Power Monitoring";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "atmos";
+	name = "Atmos Blast Door"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "atmos";
+	name = "Atmos Blast Door"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/controlroom)
 "nvc" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -71761,6 +71885,24 @@
 /obj/effect/spawner/random/blood,
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/apmaint)
+"nvS" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command{
+	id_tag = "hopofficedoor";
+	name = "Head of Personnel";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/hop,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/station/command/office/hop)
 "nvZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -71828,28 +71970,6 @@
 /obj/structure/sink/directional/north,
 /turf/simulated/floor/grass,
 /area/station/science/genetics)
-"nxX" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/delivery,
-/obj/item/desk_bell{
-	anchored = 1;
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "rnd"
-	},
-/obj/machinery/door/window/classic/normal,
-/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id_tag = "researchdesk1";
-	name = "Research and Development Front Desk Shutters"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/science/tox,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/rnd)
 "nyr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/mounted/frame/apc_frame,
@@ -71872,13 +71992,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/toxins/launch)
-"nyH" = (
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/abandoned_garden)
 "nyK" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance,
@@ -72102,21 +72215,6 @@
 /obj/structure/flora/grass/jungle,
 /turf/simulated/floor/grass,
 /area/station/security/permabrig)
-"nEk" = (
-/obj/machinery/door/airlock/research{
-	name = "Research Division Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
-/obj/effect/mapping_helpers/airlock/access/any/science/research,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/research)
 "nEo" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/security/doors,
@@ -72137,19 +72235,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/south)
-"nEq" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Transit Tube"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "transitlock";
-	name = "Transit Tube Lockdown"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/ai_transit_tube)
 "nEu" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/engine,
@@ -72158,20 +72243,6 @@
 /obj/effect/turf_decal/tiles/neutral/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/south)
-"nEx" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/control)
 "nEK" = (
 /obj/item/stack/package_wrap,
 /obj/item/hand_labeler,
@@ -72295,6 +72366,16 @@
 /obj/effect/turf_decal/tiles/department/security/corner,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison)
+"nHM" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
 "nHY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -72344,6 +72425,22 @@
 	icon_state = "seadeep"
 	},
 /area/station/public/fitness)
+"nIZ" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Auxiliary E.V.A.";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/eva,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/apmaint)
 "nKa" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -72488,19 +72585,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
-"nNK" = (
-/obj/machinery/door/airlock,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/service/janitor,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/service/janitor)
 "nNL" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -72564,6 +72648,14 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/wood,
 /area/station/maintenance/library)
+"nPe" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line,
+/turf/simulated/floor/plasteel,
+/area/station/science/lobby)
 "nPF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -72727,6 +72819,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
+"nTB" = (
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/department/security,
+/turf/simulated/floor/plasteel,
+/area/station/security/storage)
 "nTF" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -72845,6 +72954,22 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"nWa" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/east)
 "nWg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/spawner/random/barrier/grille_often,
@@ -72892,41 +73017,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/permabrig)
-"nWF" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	locked = 1;
-	id_tag = "perma_door_int"
-	},
-/obj/machinery/access_button{
-	autolink_id = "perma_btn_int";
-	name = "Prison Wing Access Button";
-	req_access = list(2);
-	pixel_x = 23
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/tiles/department/security,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/permabrig)
-"nWR" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/department/security,
-/turf/simulated/floor/plasteel,
-/area/station/security/storage)
 "nWU" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -73092,6 +73182,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"oac" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Electrical Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/electrical/aft_port)
 "oao" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm/directional/east,
@@ -73287,6 +73394,18 @@
 /obj/effect/turf_decal/tiles/department/security/checker,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
+"oeQ" = (
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/department/security,
+/turf/simulated/floor/plasteel,
+/area/station/security/storage)
 "oeS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -73326,6 +73445,28 @@
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"ofK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Locker Room";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "atmos";
+	name = "Atmos Blast Door"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/break_room/secondary)
 "ofS" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1
@@ -73343,7 +73484,7 @@
 	dir = 4
 	},
 /obj/machinery/computer/general_air_control{
-	autolink_sensors = list("burn_sensor"="Burn Mix");
+	autolink_sensors = list("burn_sensor" = "Burn Mix");
 	dir = 4;
 	name = "Bomb Mix Monitor"
 	},
@@ -73508,20 +73649,6 @@
 /obj/effect/turf_decal/tiles/department/security,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
-"oll" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/multi_tile/glass{
-	name = "Cryogenic Dormitories"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/public/sleep)
 "olm" = (
 /obj/structure/table/wood,
 /obj/item/gavelblock,
@@ -73874,13 +74001,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/simulated/floor/plasteel,
 /area/station/supply/warehouse)
-"oqD" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/effect/landmark/spawner/nukedisc_respawn,
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/maintenance/fore)
 "oqH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -73921,12 +74041,6 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
-"orG" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/lounge)
 "orL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -73972,6 +74086,23 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/xenobiology)
+"osh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/mining/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/supply/mail_sorting,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/supply/sorting)
 "osk" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -74079,6 +74210,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/storage)
+"osU" = (
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Holding Area";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/secondary/exit)
 "oth" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -74104,6 +74252,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
+"otI" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command{
+	id_tag = "captainofficedoor";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/command/captain,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/station/command/office/captain)
 "otJ" = (
 /obj/machinery/camera{
 	c_tag = "Mining Dock";
@@ -74193,6 +74359,21 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"ovz" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Public Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/exit)
 "ovF" = (
 /obj/machinery/power/apc/directional/east,
 /obj/structure/cable{
@@ -74455,17 +74636,6 @@
 /obj/machinery/alarm/directional/north,
 /turf/simulated/floor/wood,
 /area/station/maintenance/electrical_shop)
-"ozS" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Bay"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/supply/office)
 "ozX" = (
 /obj/structure/railing{
 	dir = 1
@@ -74491,18 +74661,35 @@
 	icon_regular_floor = "yellowsiding"
 	},
 /area/station/service/theatre)
-"oAm" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/east)
 "oAx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/surgery/secondary)
+"oAE" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "medbayfoyer";
+	name = "Medbay Entrance";
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/medbay)
 "oAO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -74618,6 +74805,27 @@
 	dir = 1
 	},
 /area/station/security/main)
+"oEK" = (
+/obj/machinery/door/airlock/command{
+	id_tag = "cmoofficedoor";
+	name = "CMO's Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "CMO"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/office/cmo)
 "oFa" = (
 /obj/structure/toilet/directional/east,
 /obj/machinery/newscaster/directional/north,
@@ -74704,28 +74912,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/expedition)
-"oHk" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window,
-/obj/effect/mapping_helpers/airlock/windoor/autoname,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen,
-/obj/effect/turf_decal/delivery,
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id_tag = "kitchenbar";
-	name = "Kitchen Shutters"
-	},
-/obj/item/reagent_containers/condiment/peppermill,
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = 8
-	},
-/obj/item/reagent_containers/drinks/britcup{
-	pixel_x = -9
-	},
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/kitchen)
 "oHl" = (
 /obj/machinery/flasher{
 	id = "Execution";
@@ -74741,9 +74927,14 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/public/sleep)
-"oHy" = (
-/turf/simulated/wall/indestructible/titanium,
-/area/shuttle/arrival/station)
+"oHP" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/lounge)
 "oHR" = (
 /turf/simulated/floor/plating/airless,
 /area/station/hallway/secondary/exit)
@@ -74790,20 +74981,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
-"oIT" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/east)
 "oJi" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/delivery/blue/hollow,
@@ -74870,6 +75047,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"oKG" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/east)
 "oKH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -74937,18 +75124,6 @@
 "oLR" = (
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/apmaint)
-"oMd" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/department/medical/side{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/cryo)
 "oMh" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -75040,6 +75215,20 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics/chargebay)
+"oNP" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Maintenance";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/electrical/aft_port)
 "oNV" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -75072,6 +75261,32 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
+"oOr" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Bay Warehouse Maintenance";
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/supply/cargo_bay,
+/turf/simulated/floor/plasteel,
+/area/station/supply/warehouse)
+"oOv" = (
+/obj/machinery/door/airlock/virology/glass{
+	name = "Workstation";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/virology)
 "oOF" = (
 /obj/machinery/atmospherics/portable/canister/sleeping_agent,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -75205,15 +75420,6 @@
 /obj/structure/sign/cargo/mining,
 /turf/simulated/wall,
 /area/station/supply/miningdock)
-"oRx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/research{
-	name = "Abandoned Equipment Room"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/science/research,
-/turf/simulated/floor/plasteel/white,
-/area/station/maintenance/apmaint)
 "oRy" = (
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tiles/neutral/corner,
@@ -75254,6 +75460,28 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
+"oRS" = (
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/classic/reversed{
+	dir = 1;
+	name = "Kitchen Delivery"
+	},
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/maintenance/fore)
 "oRX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -75309,14 +75537,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating/airless,
 /area/station/medical/virology)
-"oTS" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/kitchen)
 "oUw" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -75356,6 +75576,17 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
 /area/station/hallway/secondary/exit)
+"oVG" = (
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/warden)
 "oVH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -75531,20 +75762,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/apmaint)
-"oYX" = (
-/obj/machinery/door/airlock/virology{
-	name = "Virology Lobby"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/medbay)
 "oZf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -75607,30 +75824,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
-"paC" = (
-/obj/machinery/door/airlock/command{
-	id_tag = "captainofficedoor";
-	name = "Captain's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/captain,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/command/office/captain/bedroom)
-"paF" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Access"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/department/virology/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore/east)
 "paO" = (
 /obj/machinery/camera{
 	c_tag = "Power Transmission Laser";
@@ -75668,14 +75861,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
-"pbr" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Mining Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fsmaint)
 "pbM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable{
@@ -75748,6 +75933,22 @@
 /obj/machinery/newscaster/directional/north,
 /obj/effect/turf_decal/tiles/department/virology/corner{
 	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/north)
+"pdv" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/north)
@@ -75877,6 +76078,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/south)
+"pgi" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/east)
 "pgj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -75948,6 +76157,13 @@
 /obj/item/storage/secure/briefcase,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"phE" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "phF" = (
 /obj/structure/closet/secure_closet/iaa,
 /obj/item/push_broom,
@@ -75959,6 +76175,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/transmission_laser)
+"phK" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/research/glass{
+	name = "Break Room";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/research,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/break_room)
 "pit" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -76030,6 +76263,23 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/north)
+"pjZ" = (
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/processing)
 "pkg" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/turf_decal/tiles/department/medical,
@@ -76054,6 +76304,15 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
+"pkH" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Fabrication";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/engine,
+/area/station/engineering/engine)
 "pla" = (
 /obj/effect/spawner/random/barrier/wall_probably,
 /turf/simulated/floor/plating,
@@ -76067,6 +76326,26 @@
 /obj/effect/turf_decal/tiles/neutral/corner,
 /turf/simulated/floor/plasteel,
 /area/station/public/fitness)
+"pln" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/turf_decal/tiles/neutral/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
 "plr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -76086,28 +76365,6 @@
 /obj/item/kirbyplants/large,
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat)
-"plR" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/rd,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/science/server)
 "plY" = (
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/effect/turf_decal/tiles/department/engineering/side{
@@ -76130,16 +76387,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
-"pmI" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Funeral Parlour"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/service/chapel)
 "pmO" = (
 /obj/structure/table/glass,
 /obj/item/roller,
@@ -76157,6 +76404,17 @@
 	},
 /turf/simulated/floor/grass/jungle,
 /area/station/maintenance/fsmaint)
+"pmR" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison)
 "pmT" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -76250,6 +76508,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
+"poz" = (
+/obj/machinery/door/airlock/tranquillite{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/any/service/mime,
+/turf/simulated/floor/mineral/tranquillite,
+/area/station/service/mime)
 "poH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -76266,6 +76540,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
+"poI" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "robo"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/robotics)
 "poQ" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -76290,15 +76581,6 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/fore)
-"ppr" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/medical/reception)
 "ppu" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -76594,6 +76876,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/armory/secure)
+"pvr" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/wood,
+/area/station/maintenance/library)
 "pvv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/reinforced/normal,
@@ -76628,14 +76920,22 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/south)
-"pwd" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Science Maintenance"
+"pwB" = (
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/science/research,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Supermatter Monitoring Room";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/atmos)
 "pwQ" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -77156,14 +77456,6 @@
 /obj/item/kirbyplants/large,
 /turf/simulated/floor/indestructible/titanium,
 /area/shuttle/arrival/station)
-"pHr" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
 "pHx" = (
 /obj/effect/spawner/random/blood/often,
 /turf/simulated/floor/plating,
@@ -77267,6 +77559,18 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/north)
+"pJQ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/effect/turf_decal/stripes/line,
+/turf/simulated/floor/plasteel,
+/area/station/science/research)
 "pJY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -77322,6 +77626,21 @@
 	},
 /turf/simulated/floor/transparent/glass,
 /area/station/aisat)
+"pLh" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/carpet/arcade,
+/area/station/public/arcade)
 "pLq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -77365,6 +77684,21 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
+"pLV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tiles/department/medical/side{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/sleeper)
 "pMd" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -77384,20 +77718,6 @@
 /obj/effect/turf_decal/tiles/department/cargo/side,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/east)
-"pMx" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
-	name = "Conference Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood,
-/area/station/command/meeting_room)
 "pMI" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/transit_tube/curved/flipped{
@@ -77440,10 +77760,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/a)
-"pNl" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/carpet/arcade,
-/area/station/public/arcade)
 "pNo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -77564,6 +77880,17 @@
 /obj/structure/flora/bush,
 /turf/simulated/floor/grass,
 /area/station/science/lobby)
+"pPH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "admin_home";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/north)
 "pPJ" = (
 /mob/living/basic/bear{
 	dir = 1
@@ -77587,6 +77914,23 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/public/pet_store)
+"pQq" = (
+/obj/machinery/door/window,
+/obj/effect/mapping_helpers/airlock/windoor/autoname,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "kitchenbar";
+	name = "Kitchen Shutters"
+	},
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/kitchen)
 "pQv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -77681,6 +78025,32 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"pTe" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore/east)
+"pTl" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/department/medical/side,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/surgery/observation)
 "pTp" = (
 /obj/structure/chair{
 	dir = 1
@@ -77934,6 +78304,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"pXR" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
 "pXV" = (
 /obj/machinery/light/floor,
 /obj/effect/turf_decal/tiles/neutral,
@@ -78141,16 +78521,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
-"qdb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/catwalk/black,
-/area/station/aisat)
 "qdq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -78317,20 +78687,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
-"qhL" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/neutral/side{
+"qhR" = (
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner,
 /turf/simulated/floor/plasteel,
-/area/station/maintenance/fore)
+/area/station/hallway/primary/aft/north)
 "qhX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -78357,17 +78721,6 @@
 /obj/structure/sign/electricshock,
 /turf/simulated/wall/r_wall,
 /area/station/science/robotics/showroom)
-"qiB" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/electrical/aft_port)
 "qiP" = (
 /obj/effect/turf_decal/tiles/department/virology/side{
 	dir = 4
@@ -78465,28 +78818,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/storage/secondary)
-"qlH" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	locked = 1;
-	id_tag = "perma_door_int"
-	},
-/obj/machinery/access_button{
-	autolink_id = "perma_btn_int";
-	name = "Prison Wing Access Button";
-	req_access = list(2);
-	pixel_x = -23
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/tiles/department/security,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/permabrig)
 "qlL" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/simulated/floor/plasteel/dark,
@@ -78514,6 +78845,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonershuttle)
+"qmi" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security{
+	name = "Prisoner Re-education Centre";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/execution)
 "qmB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -78535,6 +78882,21 @@
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard2)
+"qmZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/theatre,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white{
+	icon_regular_floor = "yellowsiding"
+	},
+/area/station/maintenance/fore)
 "qnx" = (
 /obj/machinery/status_display{
 	pixel_x = -32
@@ -78662,6 +79024,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
+"qrS" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Security Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore2)
 "qrT" = (
 /turf/simulated/wall/r_wall,
 /area/station/telecomms/chamber)
@@ -78803,20 +79173,6 @@
 	},
 /turf/simulated/floor/catwalk/black,
 /area/station/engineering/engine)
-"quu" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/west)
 "quv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/disposalpipe/segment{
@@ -79098,6 +79454,20 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/equipmentstorage)
+"qzX" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Public Access";
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/department/virology/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore/east)
 "qAd" = (
 /obj/effect/turf_decal/tiles/department/virology/side{
 	dir = 8
@@ -79111,23 +79481,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/cryo)
-"qAx" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Research Division Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/research,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/science/research)
 "qAz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -79180,6 +79533,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"qBa" = (
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/warden)
 "qBh" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/turf_decal/tiles/neutral,
@@ -79265,23 +79635,19 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
-"qDE" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+"qCL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Supermatter Monitoring Room"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Access";
+	dir = 4
 	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "atmos";
-	name = "Atmos Blast Door"
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/controlroom)
+/turf/simulated/floor/catwalk/black,
+/area/station/aisat)
 "qEh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -79722,6 +80088,29 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison/cell_block/a)
+"qNT" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Operating Theatre 1";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "sr1"
+	},
+/obj/machinery/holosign/surgery{
+	id = "surgery1"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/surgery/primary)
 "qOd" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -79839,13 +80228,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/abandonedservers)
-"qQK" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/processing)
 "qQS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/turf_decal/tiles/white/corner{
@@ -79912,6 +80294,18 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
+"qRF" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "E.V.A.";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/eva,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel/dark,
+/area/station/ai_monitored/storage/eva)
 "qSp" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -80053,6 +80447,33 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/gravitygenerator)
+"qUj" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Trainer's Office";
+	id_tag = "nct";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "NCT"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/all/procedure/trainer,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/procedure/trainer_office)
 "qUR" = (
 /obj/machinery/atmospherics/unary/tank/air,
 /turf/simulated/floor/plating,
@@ -80101,6 +80522,17 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/virology)
+"qVB" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/medical/reception)
 "qVE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80225,6 +80657,17 @@
 /obj/machinery/atmospherics/unary/portables_connector,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/execution)
+"qXP" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	id_tag = "pub_room";
+	name = "Public Meeting Room";
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/station/science/robotics/showroom)
 "qXW" = (
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
@@ -80313,6 +80756,14 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
+"qZi" = (
+/obj/effect/mapping_helpers/airlock/access/all/security/evidence,
+/obj/machinery/door/airlock/security{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/evidence)
 "qZj" = (
 /obj/effect/turf_decal/tiles/department/security/corner,
 /turf/simulated/floor/plasteel/dark,
@@ -80372,6 +80823,27 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
+"qZT" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/classic/normal{
+	dir = 1;
+	name = "Cargo Bay Desk"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/item/desk_bell{
+	anchored = 1;
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/all/supply/general{
+	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/supply/office)
 "qZV" = (
 /obj/structure/chair/comfy/teal,
 /turf/simulated/floor/plasteel/white,
@@ -80426,13 +80898,14 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/service/chapel)
-"ray" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 8
+"raH" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison)
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "raU" = (
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison)
@@ -80529,6 +81002,21 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/chapel)
+"rcR" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/xenobiology)
 "rcS" = (
 /obj/structure/cable,
 /obj/effect/spawner/window/reinforced/polarized/grilled{
@@ -80536,6 +81024,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/office/ntrep)
+"rdm" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard2)
 "rdA" = (
 /obj/structure/table/glass,
 /obj/item/storage/fancy/donut_box{
@@ -80558,6 +81053,15 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
+"rdJ" = (
+/obj/effect/mapping_helpers/airlock/access/all/security/forensics,
+/obj/machinery/door/airlock/maintenance{
+	name = "Detective Maintenance";
+	security_level = 1;
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard2)
 "rdK" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/junglebush,
@@ -80662,19 +81166,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
-"reW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external/glass{
-	id_tag = "specops_home"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/east)
 "rfa" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -80743,14 +81234,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet/black,
 /area/station/service/chapel)
-"rhi" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering Break Room"
+"rhl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/break_room)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/south)
 "rhX" = (
 /obj/machinery/economy/vending/snack,
 /obj/effect/turf_decal/delivery/hollow,
@@ -80845,13 +81341,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/electrical/aft_starboard)
-"rjy" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/warden)
 "rjE" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable/extra_insulated{
@@ -80977,14 +81466,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/electrical/aft_starboard)
-"rlv" = (
-/obj/effect/mapping_helpers/airlock/access/all/security/forensics,
-/obj/machinery/door/airlock/maintenance{
-	name = "Detective Maintenance";
-	security_level = 1
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard2)
 "rly" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -80999,25 +81480,6 @@
 /obj/item/kirbyplants/large,
 /turf/simulated/floor/plating,
 /area/station/maintenance/abandonedbar)
-"rlO" = (
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/airlock/highsecurity{
-	name = "Secure Tech Storage"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/tech_storage)
 "rlS" = (
 /obj/machinery/economy/vending/cola,
 /obj/effect/turf_decal/tiles/department/engineering/corner{
@@ -81113,18 +81575,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet,
 /area/station/legal/courtroom)
-"rnp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Bay"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/cargo_bay,
-/obj/effect/mapping_helpers/airlock/access/all/supply/mail_sorting,
-/turf/simulated/floor/plasteel,
-/area/station/supply/warehouse)
 "rnx" = (
 /obj/effect/turf_decal/tiles/department/science/corner{
 	dir = 8
@@ -81147,6 +81597,23 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
+"rnC" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command{
+	name = "Conference Room";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/station/command/meeting_room)
 "rnO" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable/yellow,
@@ -81256,11 +81723,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/apmaint)
-"rrn" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard2)
 "rrv" = (
 /obj/effect/landmark/start/coroner,
 /obj/structure/chair,
@@ -81418,25 +81880,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
-"rtU" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Power Monitoring"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "atmos";
-	name = "Atmos Blast Door"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "atmos";
-	name = "Atmos Blast Door"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/controlroom)
 "rup" = (
 /obj/effect/spawner/random/engineering/toolbox,
 /obj/structure/rack,
@@ -81608,26 +82051,6 @@
 /obj/effect/turf_decal/tiles/department/medical/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/hallway/secondary/entry/north)
-"rwZ" = (
-/obj/structure/table/reinforced,
-/obj/item/desk_bell{
-	anchored = 1
-	},
-/obj/machinery/door/window/classic/reversed,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/chemistry,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "imnotmakingyoulubepissoff";
-	name = "Chemistry Privacy Shutter"
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/chemistry)
 "rxb" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/newscaster/security_unit/directional/north,
@@ -81669,16 +82092,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/abandonedbar)
-"rxD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/storage/emergency/port)
 "rxO" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable,
@@ -81767,6 +82180,23 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/maintenance/fore)
+"rzh" = (
+/obj/machinery/door/airlock/virology{
+	name = "Virology Lobby";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/medbay)
 "rzs" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/camera{
@@ -81828,6 +82258,18 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/apmaint)
+"rAS" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
+/obj/machinery/door/airlock/engineering{
+	name = "Electrical Maintenance";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/electrical/fore_starboard)
 "rBb" = (
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall,
@@ -81906,16 +82348,24 @@
 /obj/effect/turf_decal/tiles/department/virology,
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/hydroponics)
-"rCJ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/light{
-	dir = 8
+"rCM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 8
+/obj/machinery/door/airlock/mining{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
+/obj/effect/mapping_helpers/airlock/access/any/supply/smith,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/smith_office)
 "rDd" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -82301,6 +82751,24 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating/airless,
 /area/station/science/toxins/test)
+"rLH" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos)
 "rLN" = (
 /obj/machinery/requests_console/directional/south,
 /turf/simulated/floor/carpet/black,
@@ -82511,28 +82979,6 @@
 	},
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/fore)
-"rQI" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/security/forensics,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Detective"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/wood,
-/area/station/security/detective)
 "rQS" = (
 /obj/effect/turf_decal/tiles/white/corner{
 	dir = 4
@@ -82644,6 +83090,22 @@
 /obj/effect/turf_decal/tiles/department/security/side,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison)
+"rTT" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/expedition,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/mining{
+	name = "Expedition Headquarters";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/expedition)
 "rTU" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
@@ -82858,6 +83320,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_port)
+"rXC" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/starboard)
 "rXO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -82874,27 +83344,6 @@
 /obj/effect/turf_decal/tiles/department/virology/side,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
-"rYb" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Supermatter Monitoring Room"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/atmos)
-"rYd" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "rYe" = (
 /obj/machinery/suit_storage_unit/cmo/sec_storage/secure,
 /obj/effect/turf_decal/tiles/department/command/corner{
@@ -82954,6 +83403,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/fitness)
+"rZJ" = (
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Transit Tube";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/ai_transit_tube)
 "rZT" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
@@ -83140,6 +83604,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
+"scu" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/simulated/floor/plasteel,
+/area/station/medical/reception)
 "scA" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -83313,14 +83784,6 @@
 /obj/effect/turf_decal/tiles/department/security,
 /turf/simulated/floor/plasteel,
 /area/station/security/range)
-"sgM" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Internal Medbay Maintenance"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft2)
 "sgZ" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -83517,6 +83980,20 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/toxins/mixing)
+"skn" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/department/medical/side{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/cryo)
 "skw" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/camera/autoname{
@@ -83620,6 +84097,15 @@
 /obj/effect/turf_decal/tiles/department/security/checker,
 /turf/simulated/floor/plasteel,
 /area/station/medical/break_room)
+"slI" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Internal Medbay Maintenance";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft2)
 "slK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/cable{
@@ -83656,6 +84142,19 @@
 /obj/effect/turf_decal/tiles/department/science/side,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/misc_lab)
+"smy" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint)
 "smC" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -83686,21 +84185,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
-"snn" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/break_room)
 "snE" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass,
@@ -83805,19 +84289,6 @@
 /obj/machinery/atmospherics/trinary/tvalve/digital,
 /turf/simulated/floor/engine,
 /area/station/science/toxins/mixing)
-"soA" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "robo"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/science/robotics)
 "soV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -83837,6 +84308,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
+"spH" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/simulated/floor/plasteel,
+/area/station/science/lobby)
 "spI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
@@ -83884,20 +84362,6 @@
 /obj/effect/turf_decal/tiles/department/security,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/permabrig)
-"sqj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tiles/neutral/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/apmaint)
 "sqk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -84086,6 +84550,24 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/security/permabrig)
+"stp" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Public Access";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore/east)
 "str" = (
 /obj/structure/table,
 /obj/item/reagent_containers/condiment/peppermill{
@@ -84200,6 +84682,14 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/surgery/observation)
+"swD" = (
+/obj/machinery/door/airlock/silver{
+	name = "Captain's Bathroom";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel/white,
+/area/station/command/office/captain/bedroom)
 "swS" = (
 /obj/machinery/economy/vending/genedrobe,
 /obj/effect/turf_decal/tiles/department/science/side{
@@ -84435,6 +84925,48 @@
 /obj/effect/landmark/start/chaplain,
 /turf/simulated/floor/carpet/black,
 /area/station/service/chapel)
+"sBo" = (
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Secure Tech Storage";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/tech_storage)
+"sBq" = (
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prisonlockers)
 "sBE" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/firealarm/directional/west,
@@ -84473,6 +85005,32 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/public/fitness)
+"sCD" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/rd,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/server)
 "sCK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -84512,22 +85070,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/medical/cloning)
-"sDO" = (
-/obj/item/storage/fancy/donut_box,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window,
-/obj/effect/mapping_helpers/airlock/windoor/autoname,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen,
-/obj/effect/turf_decal/delivery,
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id_tag = "kitchenbar";
-	name = "Kitchen Shutters"
-	},
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/kitchen)
 "sEf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -84544,18 +85086,6 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
-"sEA" = (
-/obj/machinery/door/airlock/engineering,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/electrical/aft_port)
 "sEN" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
@@ -84584,14 +85114,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/tools)
-"sFH" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/north)
 "sFK" = (
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 10
@@ -84755,18 +85277,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonershuttle)
-"sJs" = (
-/obj/machinery/door/airlock/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/storage/tools/auxiliary)
 "sJA" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -84985,6 +85495,29 @@
 /obj/effect/turf_decal/tiles/department/medical,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
+"sMM" = (
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/department/security,
+/turf/simulated/floor/plasteel,
+/area/station/security/storage)
 "sMV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/large,
@@ -85051,6 +85584,18 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/hydroponics)
+"sOO" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/kitchen)
 "sOP" = (
 /obj/machinery/light_switch{
 	dir = 1;
@@ -85192,22 +85737,6 @@
 "sRd" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/electrical/aft_port)
-"sRf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/highsecurity{
-	name = "Telecommunications"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/flasher{
-	pixel_x = 24
-	},
-/turf/simulated/floor/catwalk/black,
-/area/station/telecomms/chamber)
 "sRh" = (
 /obj/effect/turf_decal/tiles/department/command/side{
 	dir = 1
@@ -85288,6 +85817,16 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/controlroom)
+"sSo" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/engineering/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/port/north)
 "sSy" = (
 /obj/structure/machine_frame,
 /obj/effect/decal/cleanable/dirt,
@@ -85348,6 +85887,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/legal/courtroom/gallery)
+"sTk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "sTm" = (
 /obj/item/kirbyplants/large,
 /obj/item/radio/intercom{
@@ -85445,6 +85994,23 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
+"sVY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/research{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/tox,
+/obj/machinery/door/firedoor/heavy{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/science/toxins/mixing)
 "sWd" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -85713,16 +86279,6 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
-"taP" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison)
 "taY" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/small{
@@ -85855,6 +86411,18 @@
 /mob/living/basic/mouse/brown/tom,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/vault)
+"tdz" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/item/eftpos/register{
+	dir = 1;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/fore)
 "tdA" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -85911,17 +86479,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/expedition)
-"tep" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/delivery,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/science/research)
 "teD" = (
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/station/maintenance/port2)
@@ -86064,14 +86621,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
-"thl" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/engineering/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/port/north)
 "thm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -86153,17 +86702,6 @@
 /obj/item/bedsheet/black,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"tiQ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/south)
 "tjB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -86494,6 +87032,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
+"trw" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Morgue Maintenance";
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/turf/simulated/floor/plasteel/dark,
+/area/station/medical/morgue)
 "trJ" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -86660,13 +87210,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"tvs" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fore2)
 "tvu" = (
 /obj/machinery/computer/security/mining{
 	dir = 8
@@ -86857,28 +87400,6 @@
 /obj/machinery/newscaster/directional/south,
 /turf/simulated/floor/plasteel,
 /area/station/public/toilet/lockerroom)
-"tyi" = (
-/obj/machinery/door/airlock/engineering/glass{
-	autoclose = 0;
-	id_tag = "engsm_door_int";
-	locked = 1;
-	name = "Reactor Interior Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/access_button{
-	autolink_id = "engsm_btn_int";
-	name = "Reactor Access Button";
-	pixel_y = 1;
-	req_access = list(10);
-	pixel_x = 25
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/engine)
 "tyF" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -86886,19 +87407,6 @@
 	},
 /turf/space,
 /area/space/nearstation)
-"tyN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/mining/glass,
-/obj/effect/mapping_helpers/airlock/access/all/supply/cargo_bay,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/supply/miningdock)
 "tyQ" = (
 /obj/machinery/economy/vending/medical,
 /obj/effect/turf_decal/tiles/department/medical/side{
@@ -87533,6 +88041,25 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/tools)
+"tKN" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "Telecommunications";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/flasher{
+	pixel_x = 24
+	},
+/turf/simulated/floor/catwalk/black,
+/area/station/telecomms/chamber)
 "tKX" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable,
@@ -87576,6 +88103,31 @@
 "tMo" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/fsmaint)
+"tMG" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	locked = 1;
+	id_tag = "perma_door_int";
+	dir = 4
+	},
+/obj/machinery/access_button{
+	autolink_id = "perma_btn_int";
+	name = "Prison Wing Access Button";
+	req_access = list(2);
+	pixel_x = 23
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Prison Gate";
+	name = "Prison Lockdown Blast Doors"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/tiles/department/security,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/permabrig)
 "tMJ" = (
 /obj/machinery/shower/directional/west,
 /obj/effect/turf_decal/delivery/white/hollow,
@@ -87760,18 +88312,6 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/south)
-"tQl" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	name = "E.V.A."
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/eva,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/dark,
-/area/station/ai_monitored/storage/eva)
 "tQT" = (
 /obj/machinery/camera{
 	c_tag = "Medbay West Hallway";
@@ -88098,6 +88638,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard)
+"tVo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/nw)
 "tVq" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/item/radio/intercom{
@@ -88106,11 +88661,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/controlroom)
-"tVy" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "tVz" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -88394,25 +88944,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central)
-"uaV" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/department/security,
-/turf/simulated/floor/plasteel,
-/area/station/security/storage)
 "uaW" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt,
@@ -88427,6 +88958,24 @@
 	},
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/port)
+"ubj" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 9
+	},
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Distribution Loop";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos/distribution)
 "ubn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -88746,28 +89295,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
-"ufM" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/engineering/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/port/north)
-"ugy" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/research,
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "rnd"
-	},
-/obj/effect/turf_decal/tiles/department/science,
-/turf/simulated/floor/plasteel,
-/area/station/science/rnd)
 "ugz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -88896,6 +89423,22 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/surgery/observation)
+"uji" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/west)
 "ujq" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=hall9e";
@@ -89043,20 +89586,22 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
-"ulG" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id_tag = "evashutters2";
-	name = "E.V.A. Storage Shutters"
+"ulH" = (
+/obj/machinery/door/airlock/virology/glass{
+	name = "Isolations";
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door_control{
-	id = "evashutters2";
-	name = "Auxilary E.V.A. Storage";
-	pixel_x = 26
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/apmaint)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/virology)
 "uma" = (
 /obj/structure/sign/radiation/rad_area,
 /turf/simulated/wall,
@@ -89068,6 +89613,17 @@
 /obj/effect/turf_decal/tiles/department/security/checker,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
+"unk" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Auxiliary E.V.A.";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/eva,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/apmaint)
 "unn" = (
 /obj/machinery/door_timer/cell_3{
 	pixel_y = -32
@@ -89335,6 +89891,20 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
+"urS" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/east)
 "urW" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -89817,21 +90387,6 @@
 /obj/effect/landmark/start/doctor,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/surgery/primary)
-"uEq" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
-	id_tag = "hopofficedoor";
-	name = "Head of Personnel"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/hop,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood,
-/area/station/command/office/hop)
 "uEx" = (
 /obj/effect/turf_decal/tiles/neutral/corner,
 /obj/structure/cable,
@@ -89844,6 +90399,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/north)
+"uEV" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/port2)
 "uEX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/extra_insulated{
@@ -89882,6 +90449,32 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
+"uFw" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/security/forensics,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Detective"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/wood,
+/area/station/security/detective)
 "uFH" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -90021,6 +90614,15 @@
 /obj/machinery/economy/vending/suitdispenser,
 /turf/simulated/floor/plasteel/dark,
 /area/station/public/locker)
+"uHs" = (
+/obj/structure/mineral_door/wood,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet/grimey,
+/area/station/service/library)
 "uHI" = (
 /turf/simulated/floor/grass,
 /area/station/science/genetics)
@@ -90114,16 +90716,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/electrical/aft_port)
-"uKP" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Chapel Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/apmaint)
 "uKT" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/blue,
@@ -90186,13 +90778,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/fore)
-"uLH" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fore)
+"uLV" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/department/science/corner,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/research)
 "uLW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -90240,6 +90833,32 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"uMA" = (
+/obj/machinery/access_button{
+	autolink_id = "virolab_btn_ext";
+	layer = 3.6;
+	name = "Virology Lab Access Button";
+	pixel_x = -24;
+	req_access = list(39)
+	},
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	id_tag = "virolab_door_ext";
+	locked = 1;
+	name = "Virology Lab External Airlock";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/medbay)
 "uMB" = (
 /obj/machinery/alarm/directional/east,
 /obj/structure/chair{
@@ -90302,6 +90921,14 @@
 /obj/effect/turf_decal/tiles/neutral/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
+"uOH" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/nw)
 "uOS" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -90376,17 +91003,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"uQq" = (
-/obj/machinery/door/firedoor,
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison)
 "uQW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -90426,6 +91042,14 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel,
 /area/station/science/storage)
+"uRZ" = (
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Turbine Generator Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos)
 "uSe" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -90478,19 +91102,6 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/command/customs)
-"uSO" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/machinery/power/apc/directional/east,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/east)
 "uTb" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/welding,
@@ -90777,19 +91388,6 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
-"uZj" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Tech Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/tech_storage)
 "uZp" = (
 /obj/structure/chair/sofa/right{
 	color = "#6ae226"
@@ -90872,20 +91470,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
-"vcb" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/west)
 "vcs" = (
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 5
@@ -90982,6 +91566,20 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/storage)
+"veo" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Public Access";
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore/east)
 "veH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -91031,6 +91629,17 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/surgery/observation)
+"vfs" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "admin_home";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/north)
 "vfv" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 8
@@ -91045,17 +91654,6 @@
 /obj/effect/turf_decal/tiles/department/science/side,
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/port2)
-"vfD" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Maintenance"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/electrical/aft_port)
 "vfH" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/public/cryo,
@@ -91235,6 +91833,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
+"vjE" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/north)
 "vjJ" = (
 /obj/machinery/atmospherics/portable/scrubber,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -91255,6 +91863,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/permabrig)
+"vjQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/evidence,
+/obj/machinery/door/airlock/security{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/evidence)
 "vjT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -91460,6 +92081,24 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
+"voc" = (
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
+/obj/effect/mapping_helpers/airlock/access/any/science/research,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/research)
 "vom" = (
 /obj/effect/turf_decal/alphanumeric/air{
 	dir = 8
@@ -91521,6 +92160,19 @@
 /mob/living/carbon/human/monkey,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
+"vqi" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Prison Cafeteria";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
 "vqs" = (
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/atmospherics/binary/volume_pump{
@@ -91695,18 +92347,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/public/toilet/unisex)
-"vtx" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/engineering/controlroom)
 "vtH" = (
 /obj/machinery/economy/vending/medical,
 /obj/effect/turf_decal/tiles/department/medical/side{
@@ -91718,6 +92358,16 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/station/service/hydroponics)
+"vue" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/barricade/wooden,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore2)
 "vuu" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -92004,13 +92654,6 @@
 /obj/effect/turf_decal/tiles/department/security/side,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
-"vBu" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/medical/side{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/sleeper)
 "vBB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -92034,6 +92677,20 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/east)
+"vBO" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison)
 "vBX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -92528,18 +93185,6 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/security/permabrig)
-"vKF" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fore)
 "vKU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -92652,6 +93297,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"vMP" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/science/research)
 "vNb" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -92689,6 +93352,30 @@
 /obj/effect/turf_decal/tiles/department/security,
 /turf/simulated/floor/plasteel,
 /area/station/security/processing)
+"vNU" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/delivery,
+/obj/item/desk_bell{
+	anchored = 1;
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "rnd"
+	},
+/obj/machinery/door/window/classic/normal,
+/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "researchdesk1";
+	name = "Research and Development Front Desk Shutters"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/science/tox,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/rnd)
 "vNV" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tiles/department/engineering/side{
@@ -92829,16 +93516,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/virology)
-"vQm" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/department/medical/side,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/surgery/observation)
 "vQS" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -92922,23 +93599,30 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
-"vSm" = (
-/obj/machinery/door/airlock/research/glass{
-	name = "Test Chamber"
+"vRR" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Science Maintenance";
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/science/research,
-/obj/machinery/door/poddoor/preopen{
-	name = "Biohazard Shutter";
-	id_tag = "RnDChem"
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/mapping_helpers/airlock/access/all/medical/genetics,
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/port)
+"vSr" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Gambling Den";
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/engine,
-/area/station/science/test_chamber)
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/abandonedbar)
 "vSv" = (
 /obj/structure/table,
 /obj/effect/spawner/random/plushies,
@@ -92987,20 +93671,6 @@
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
-"vTs" = (
-/obj/machinery/door/airlock/virology/glass{
-	name = "Workstation"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/virology)
 "vTw" = (
 /obj/structure/chair/sofa/bench/left,
 /obj/effect/turf_decal/tiles/department/medical/checker,
@@ -93070,21 +93740,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"vVF" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos)
 "vVU" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -93156,6 +93811,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"vXs" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/side{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/sleeper)
 "vXI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tiles/neutral/side,
@@ -93379,6 +94043,17 @@
 /obj/machinery/atmospherics/portable/canister/carbon_dioxide,
 /turf/simulated/floor/plasteel,
 /area/station/science/storage)
+"wce" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Science Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "wcu" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
 /obj/effect/turf_decal/tiles/department/medical/side{
@@ -93547,6 +94222,18 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
+"wgv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/research{
+	name = "Abandoned Equipment Room";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/research,
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/apmaint)
 "wgx" = (
 /obj/structure/table/wood,
 /obj/item/deck/cards{
@@ -93696,14 +94383,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/toxins/launch)
-"wjY" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Power Monitoring"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/atmos)
 "wka" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -93746,13 +94425,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/storage/secondary)
-"wkG" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Auxiliary Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/starboard2)
 "wkJ" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel,
@@ -93944,6 +94616,24 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
+"wnA" = (
+/obj/item/storage/fancy/donut_box,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/window,
+/obj/effect/mapping_helpers/airlock/windoor/autoname,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen,
+/obj/effect/turf_decal/delivery,
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "kitchenbar";
+	name = "Kitchen Shutters"
+	},
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/kitchen)
 "wob" = (
 /obj/effect/turf_decal/tiles/department/medical/side{
 	dir = 5
@@ -94012,26 +94702,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/station/engineering/engine/supermatter)
-"wpJ" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Operating Theatre 1"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "sr1"
-	},
-/obj/machinery/holosign/surgery{
-	id = "surgery1"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/surgery/primary)
 "wqd" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/camera{
@@ -94084,18 +94754,6 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/supply/sorting)
-"wrm" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Teleporter Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/command/teleporter)
 "wro" = (
 /obj/item/kirbyplants/large,
 /obj/effect/turf_decal/tiles/department/virology/side{
@@ -94145,6 +94803,13 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
+"wsw" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/side,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/surgery/observation)
 "wsx" = (
 /obj/item/storage/pill_bottle/random_drug_bottle{
 	pixel_x = -3
@@ -94226,46 +94891,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/station/maintenance/library)
-"wtO" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
-	id_tag = "captainofficedoor"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/command/captain,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood,
-/area/station/command/office/captain)
 "wtU" = (
 /obj/effect/spawner/random/blood/maybe,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/wood,
 /area/station/maintenance/apmaint)
-"wuc" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "medbayfoyer";
-	name = "Medbay Entrance"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/medbay)
 "wud" = (
 /obj/machinery/light{
 	dir = 4
@@ -94404,6 +95034,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
+"wwQ" = (
+/obj/machinery/door/airlock{
+	name = "Prison Showers";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/security/permabrig)
 "wwX" = (
 /obj/structure/closet/lasertag/red,
 /obj/effect/turf_decal/tiles/neutral/side,
@@ -94431,6 +95070,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/office/cmo)
+"wye" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "wyk" = (
 /obj/effect/turf_decal/delivery/red/partial{
 	dir = 1
@@ -94450,20 +95099,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/bar)
-"wyn" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "medbayfoyer";
-	name = "Medbay Entrance"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/medbay)
 "wyA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass,
@@ -94654,6 +95289,20 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/reception)
+"wAY" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Public Access";
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore/east)
 "wBm" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -94678,6 +95327,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/east)
+"wBN" = (
+/obj/machinery/door/airlock/bananium{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/clown,
+/turf/simulated/floor/wood,
+/area/station/service/clown)
 "wBO" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -94986,6 +95651,19 @@
 /obj/machinery/newscaster/security_unit/directional/west,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
+"wGO" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/port)
 "wGT" = (
 /obj/machinery/bodyscanner{
 	dir = 4
@@ -95045,6 +95723,14 @@
 	},
 /turf/simulated/floor/grass/jungle,
 /area/station/maintenance/fsmaint)
+"wIl" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/west)
 "wIw" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -95182,6 +95868,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/station/service/bar)
+"wLK" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison)
 "wLR" = (
 /obj/structure/morgue,
 /obj/effect/landmark/spawner/rev,
@@ -95375,6 +96070,31 @@
 /obj/machinery/alarm/directional/east,
 /turf/simulated/floor/plasteel,
 /area/station/supply/sorting)
+"wQh" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	locked = 1;
+	id_tag = "perma_door_ext";
+	dir = 4
+	},
+/obj/machinery/access_button{
+	autolink_id = "perma_btn_ext";
+	name = "Prison Wing Access Button";
+	req_access = list(2);
+	pixel_x = -23
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Prison Gate";
+	name = "Prison Lockdown Blast Doors"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/turf_decal/tiles/department/security,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/permabrig)
 "wQi" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/turf_decal/delivery/red/hollow,
@@ -95511,20 +96231,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/library)
-"wTi" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Transit Tube"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/ai_transit_tube)
 "wTL" = (
 /obj/machinery/economy/vending/clothing,
 /obj/structure/sign/public/restroom{
@@ -95532,15 +96238,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/public/locker)
-"wTS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "wUc" = (
 /obj/machinery/alarm/directional/east,
 /turf/simulated/floor/plasteel/dark,
@@ -95789,6 +96486,26 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/station/public/storage/emergency/port)
+"wYv" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/science/research)
 "wYx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -95841,6 +96558,22 @@
 "wYY" = (
 /turf/simulated/wall/r_wall,
 /area/station/engineering/break_room/secondary)
+"wYZ" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Tech Storage";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/tech_storage)
 "wZb" = (
 /obj/structure/morgue,
 /obj/structure/window/reinforced{
@@ -95860,17 +96593,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
-"wZK" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Internal Medbay Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/turf/simulated/floor/plating,
-/area/station/medical/coldroom)
 "xag" = (
 /obj/machinery/light,
 /turf/simulated/floor/plating,
@@ -96091,6 +96813,17 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/cmo)
+"xec" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
 "xeB" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1
@@ -96181,24 +96914,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/station/engineering/atmos)
-"xgH" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/rd,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/white,
-/area/station/command/office/rd)
 "xhf" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 8
@@ -96278,47 +96993,6 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/service/chapel)
-"xib" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Cloning"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/unres,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/medical/cloning)
-"xid" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
-"xie" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "AI-door";
-	name = "AI Chamber Blast Doors";
-	opacity = 0
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Chamber Observation"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/flasher{
-	pixel_x = 24
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/turret_protected/aisat)
 "xij" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -96404,18 +97078,6 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
-"xjD" = (
-/obj/machinery/door/airlock/medical/glass,
-/obj/effect/mapping_helpers/airlock/access/all/medical/paramedic,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/paramedic)
 "xjE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -96531,13 +97193,6 @@
 "xlP" = (
 /turf/simulated/floor/wood,
 /area/station/hallway/secondary/entry/east)
-"xlS" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/barricade/wooden,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/starboard)
 "xme" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
@@ -96555,6 +97210,17 @@
 /obj/effect/turf_decal/tiles/department/science/side,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/lobby)
+"xmw" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Fore-Port Atmospherics Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "xmE" = (
 /obj/structure/cable,
 /obj/effect/spawner/window/reinforced/grilled,
@@ -96792,6 +97458,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/electrical_shop)
+"xrP" = (
+/obj/effect/mapping_helpers/airlock/access/any/service/chapel_office,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock{
+	name = "Chapel Office";
+	dir = 4
+	},
+/turf/simulated/floor/carpet/grimey,
+/area/station/service/chapel)
 "xrW" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -96823,6 +97501,14 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/medical/chemistry)
+"xso" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Auxiliary Storage";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/starboard2)
 "xsz" = (
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 5
@@ -96913,6 +97599,28 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/virology)
+"xtN" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/science/xenobiology)
 "xtU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -97095,6 +97803,17 @@
 "xyH" = (
 /turf/simulated/wall/r_wall,
 /area/station/turret_protected/ai_upload)
+"xyX" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/abandoned_garden)
 "xze" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/status_display{
@@ -97329,21 +98048,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
-"xEL" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Power Transmission Laser"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/sign/electricshock{
-	pixel_x = 32
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/neutral/side{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/port)
 "xES" = (
 /obj/machinery/smartfridge/secure/chemistry/virology/preloaded,
 /obj/structure/reagent_dispensers/virusfood{
@@ -97355,19 +98059,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
-"xFp" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/supply/expedition,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/mining{
-	name = "Expedition Headquarters"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/supply/expedition)
 "xFq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -97526,11 +98217,6 @@
 "xHp" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/range)
-"xHN" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/east)
 "xIm" = (
 /obj/structure/closet/walllocker/emerglocker/directional/west,
 /obj/effect/turf_decal/tiles/department/medical/corner{
@@ -97626,6 +98312,25 @@
 /obj/effect/turf_decal/tiles/department/security/side,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"xJY" = (
+/obj/machinery/smartfridge/medbay,
+/obj/machinery/door/window/classic/reversed,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/chemistry,
+/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "imnotmakingyoulubepissoff";
+	name = "Chemistry Privacy Shutter"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/chemistry)
 "xKd" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plating,
@@ -97769,20 +98474,19 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/engine)
+"xNp" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/service/library)
 "xNC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
-/area/station/maintenance/fore)
-"xNH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/service/theatre,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white{
-	icon_regular_floor = "yellowsiding"
-	},
 /area/station/maintenance/fore)
 "xNN" = (
 /obj/machinery/door/firedoor,
@@ -97953,6 +98657,14 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics)
+"xQq" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/lounge)
 "xQB" = (
 /obj/item/chesspiece/wking,
 /obj/effect/decal/cleanable/dirt,
@@ -98043,6 +98755,38 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
+"xSK" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Public Access";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore/east)
+"xSW" = (
+/obj/machinery/door/airlock/glass{
+	name = "Cabin";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/locker)
 "xTc" = (
 /obj/structure/sign/radiation/rad_area,
 /turf/simulated/wall/r_wall,
@@ -98234,6 +98978,44 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/office/hos)
+"xYU" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/power/apc/directional/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/east)
+"xYV" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "AI-door";
+	name = "AI Chamber Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Chamber Observation";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/flasher{
+	pixel_x = 24
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/turret_protected/aisat)
 "xYX" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	autolink_id = "tox_in";
@@ -98285,6 +99067,19 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"yah" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/south)
 "yal" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -98362,6 +99157,28 @@
 /obj/effect/spawner/random/blood/maybe,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"ycY" = (
+/obj/structure/table/reinforced,
+/obj/item/desk_bell{
+	anchored = 1
+	},
+/obj/machinery/door/window/classic/reversed,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/chemistry,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "imnotmakingyoulubepissoff";
+	name = "Chemistry Privacy Shutter"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/chemistry)
 "yde" = (
 /obj/machinery/atmospherics/reactor_chamber,
 /turf/simulated/floor/engine,
@@ -98639,6 +99456,13 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/port2)
+"yiS" = (
+/obj/machinery/door/airlock{
+	name = "Toilet";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/toilet/lockerroom)
 "yjj" = (
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/structure/fans/tiny,
@@ -98738,28 +99562,6 @@
 /obj/structure/sign/service/custodian,
 /turf/simulated/wall,
 /area/station/service/janitor)
-"ylA" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	locked = 1;
-	id_tag = "perma_door_ext"
-	},
-/obj/machinery/access_button{
-	autolink_id = "perma_btn_ext";
-	name = "Prison Wing Access Button";
-	req_access = list(2);
-	pixel_x = -23
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/tiles/department/security,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/permabrig)
 "ylC" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/simulated/floor/grass,
@@ -107887,13 +108689,13 @@ btd
 bIj
 bJU
 biX
-xie
+xYV
 bPL
 bRB
 bTD
 bVR
 bXJ
-sRf
+tKN
 caX
 boh
 cgu
@@ -110976,7 +111778,7 @@ gFb
 gbo
 bTO
 grH
-qdb
+qCL
 gNA
 gNA
 cpe
@@ -118198,7 +119000,7 @@ cXX
 czF
 drn
 vjZ
-xEL
+hnz
 gIF
 uBY
 czb
@@ -119671,7 +120473,7 @@ aIy
 aJP
 aLg
 tEt
-jMh
+uRZ
 aPH
 aQT
 aSB
@@ -120716,7 +121518,7 @@ ban
 bnE
 tzW
 iJK
-jAs
+ubj
 nMT
 ouE
 kyZ
@@ -120767,7 +121569,7 @@ tnJ
 vMH
 cFR
 cFO
-vfD
+oNP
 uKG
 cLD
 cQx
@@ -120775,7 +121577,7 @@ juT
 cQx
 cLD
 cJR
-qiB
+fng
 cWp
 bUr
 xPn
@@ -120991,11 +121793,11 @@ bBt
 rcq
 bEN
 bGy
-wTi
+rZJ
 bKb
 bMe
 iTz
-nEq
+gqa
 bRU
 bUe
 wOE
@@ -121467,10 +122269,10 @@ aHc
 aEn
 aHe
 aIC
-dlU
+fpV
 aLo
 aMM
-fun
+gHq
 tOj
 tOj
 aSE
@@ -121710,7 +122512,7 @@ nKa
 bSC
 ipb
 rXw
-auF
+iuq
 avB
 awR
 axL
@@ -122746,16 +123548,16 @@ nEu
 aAa
 aBX
 aAa
-ijN
+lFO
 sdP
-fmU
+bhj
 aFX
 aGi
 aIH
-qDE
+fMy
 xBP
 aMQ
-rYb
+pwB
 qSy
 qSy
 aSH
@@ -122777,13 +123579,13 @@ jgX
 eQM
 mtk
 bmw
-vVF
+rLH
 hUs
 tdP
 jYE
 tdP
 bvG
-ehC
+ofK
 byp
 rgS
 qLm
@@ -122823,7 +123625,7 @@ cDz
 dmq
 cFW
 dWg
-hFW
+oac
 cJX
 cLK
 cNc
@@ -122831,7 +123633,7 @@ cOE
 cQB
 cRJ
 cjH
-sEA
+nak
 cXS
 jby
 irt
@@ -123063,13 +123865,13 @@ tFc
 qNa
 qNa
 jyw
-tyi
+acl
 csq
 cod
 cpl
 cqR
 cmR
-jMa
+pkH
 ixn
 cib
 vYi
@@ -123091,7 +123893,7 @@ gbp
 cIx
 pAM
 wWU
-cZk
+kxT
 dal
 dhC
 dcU
@@ -123348,7 +124150,7 @@ fZY
 cIx
 oZv
 wIA
-cZl
+vSr
 dnH
 xxX
 drb
@@ -123766,7 +124568,7 @@ smc
 jko
 jOt
 mQl
-vtx
+nhW
 qTA
 abc
 iqV
@@ -124037,10 +124839,10 @@ aFV
 aGb
 aHn
 pmT
-rtU
+nuU
 aLw
 aMT
-wjY
+dUO
 aPH
 aPH
 aXw
@@ -124362,7 +125164,7 @@ cAC
 cdk
 cbl
 cDD
-ceQ
+iPC
 iwU
 cHq
 dhG
@@ -125133,7 +125935,7 @@ bos
 cAG
 cCp
 jwo
-jPF
+fqG
 kZr
 drn
 drn
@@ -125156,7 +125958,7 @@ deJ
 cyc
 cCn
 cHX
-dlL
+uEV
 cLY
 cOl
 dYB
@@ -125363,12 +126165,12 @@ uJP
 bIC
 nhh
 bMt
-snn
+kPO
 bQA
 bSh
 bUs
 cbR
-nEx
+flT
 wCn
 cbn
 kJU
@@ -126139,7 +126941,7 @@ bOn
 bQt
 bUv
 bWu
-rhi
+kPq
 gDY
 cbt
 ceT
@@ -126866,7 +127668,7 @@ vdR
 azb
 iBx
 aor
-ijR
+mEU
 aor
 azb
 kmu
@@ -126937,7 +127739,7 @@ cGh
 dmq
 cIJ
 cKm
-gHE
+rcR
 wJP
 cON
 cQH
@@ -127629,7 +128431,7 @@ awX
 auX
 kOE
 aor
-aya
+xmw
 aor
 aAk
 cMw
@@ -127670,7 +128472,7 @@ akN
 byF
 vIY
 bfE
-thl
+sSo
 bty
 bGO
 uEO
@@ -127763,7 +128565,7 @@ osk
 uEX
 qGm
 mMT
-lBa
+lwU
 ffB
 qQJ
 uIg
@@ -127927,7 +128729,7 @@ bxf
 byG
 rFk
 bBO
-iFa
+htd
 bDC
 bGQ
 bOo
@@ -127939,7 +128741,7 @@ blX
 bUB
 bWA
 bYf
-dWn
+wGO
 cdg
 cHy
 cAS
@@ -128184,7 +128986,7 @@ bGR
 byH
 brV
 brV
-ufM
+msj
 brV
 vOO
 bGR
@@ -128417,7 +129219,7 @@ wCx
 aor
 aor
 aEt
-gKb
+dvx
 aor
 sWB
 aor
@@ -128667,7 +129469,7 @@ aEq
 aFn
 aGl
 utf
-dkP
+med
 yfB
 aor
 aor
@@ -128924,7 +129726,7 @@ aEq
 aHD
 upZ
 qdq
-nyH
+xyX
 aKc
 iBx
 aMV
@@ -128966,7 +129768,7 @@ brW
 bjU
 kIG
 bWE
-gIG
+iuv
 drn
 cHr
 drn
@@ -129167,7 +129969,7 @@ arr
 pNN
 ars
 arr
-auk
+dbU
 azb
 mqk
 awX
@@ -129202,7 +130004,7 @@ aor
 nag
 lKO
 ryd
-vKF
+faA
 ttQ
 aor
 ayC
@@ -129269,7 +130071,7 @@ dng
 epi
 mcM
 weO
-vSm
+iYL
 nXr
 rDQ
 pjk
@@ -129469,14 +130271,14 @@ abj
 tBk
 bAj
 sOU
-rlO
+sBo
 ouF
 bBS
 dGB
 bIP
 bIP
 bOs
-uZj
+wYZ
 bSv
 bQQ
 bWG
@@ -129556,7 +130358,7 @@ day
 iwr
 eZe
 thL
-kBv
+pvr
 dOO
 rBi
 tFT
@@ -129680,7 +130482,7 @@ hSy
 arr
 art
 xrC
-jHM
+bgr
 oKD
 pUg
 avP
@@ -129816,7 +130618,7 @@ thL
 iVX
 dSc
 dPw
-dRB
+bab
 dRQ
 nQM
 dSG
@@ -130073,7 +130875,7 @@ thL
 iVX
 dOO
 dRj
-ulG
+fuR
 dRQ
 dOO
 dSO
@@ -130251,7 +131053,7 @@ brW
 fGs
 pSW
 bWH
-ctU
+xNp
 bZL
 cdz
 cdz
@@ -130264,7 +131066,7 @@ cnj
 bso
 bwo
 bso
-csF
+uHs
 bso
 cvi
 cwG
@@ -130293,7 +131095,7 @@ cKr
 hYv
 cPn
 cPn
-jji
+lsZ
 hdu
 hnH
 ojf
@@ -130465,7 +131267,7 @@ kWc
 jrc
 jrc
 jrc
-giG
+tdz
 vdR
 xVp
 aLA
@@ -130508,7 +131310,7 @@ awX
 cWa
 vHe
 bWH
-ctU
+xNp
 bZM
 crn
 crn
@@ -130521,7 +131323,7 @@ crn
 crn
 bZM
 crn
-csG
+bLJ
 crn
 cvj
 cwH
@@ -130550,18 +131352,18 @@ cKr
 gtR
 hqk
 lID
-tep
+fVl
 row
 ubB
 sQG
 hmr
 lwS
 lwS
-nEk
+voc
 vKf
 hXw
 eFJ
-mAH
+sVY
 qBt
 mNc
 mpV
@@ -130587,7 +131389,7 @@ thL
 xdd
 dOP
 dRk
-dRE
+nIZ
 djZ
 dRK
 dSW
@@ -130722,14 +131524,14 @@ mXP
 jrc
 jrc
 jrc
-oqD
+dZg
 vdR
 xVp
 azb
 eKL
 pjF
 aEt
-ijR
+mEU
 aor
 udF
 fxZ
@@ -130761,7 +131563,7 @@ apU
 apU
 bMF
 bMF
-bUt
+iuz
 bSx
 oRi
 nmf
@@ -130807,7 +131609,7 @@ mod
 dau
 dbX
 cSt
-dsu
+uLV
 pAO
 uLW
 iWz
@@ -130844,7 +131646,7 @@ fHD
 iVX
 dOP
 kvZ
-dRF
+unk
 oLR
 oLR
 oLR
@@ -131307,7 +132109,7 @@ dmq
 wKL
 exC
 mek
-gxo
+frb
 cOX
 cQS
 cSe
@@ -131315,7 +132117,7 @@ cTE
 cVg
 cWJ
 cpE
-fVR
+xtN
 ctm
 wsl
 cMm
@@ -131341,7 +132143,7 @@ ddv
 dOO
 ieW
 lnn
-dtF
+jQC
 ddv
 dOO
 dOO
@@ -131598,7 +132400,7 @@ vJn
 mMb
 xjE
 jPD
-sqj
+fWB
 xjE
 gER
 fqS
@@ -131862,7 +132664,7 @@ srv
 wQW
 wQW
 ddW
-deF
+fFr
 bjX
 deY
 mtB
@@ -132002,7 +132804,7 @@ eQB
 usL
 tRJ
 usL
-qhL
+mWP
 qlU
 qlU
 eQB
@@ -132014,7 +132816,7 @@ bfd
 qEs
 bla
 enm
-eao
+pln
 cSU
 qWW
 pgO
@@ -132244,14 +133046,14 @@ aAr
 urr
 nEp
 anJ
-rxD
+adi
 apJ
 apI
 hWb
 arI
 arN
 ato
-auq
+kYZ
 auQ
 avV
 vrY
@@ -132294,7 +133096,7 @@ gNi
 awX
 gDq
 axd
-bBW
+nHM
 bCb
 bOz
 kva
@@ -132303,7 +133105,7 @@ bIS
 biW
 bOB
 bOB
-bjD
+gEJ
 bUa
 bUG
 bWJ
@@ -132616,7 +133418,7 @@ dbw
 qyi
 dbp
 eYL
-oRx
+wgv
 dOO
 eYL
 eYL
@@ -132630,7 +133432,7 @@ tWj
 dIy
 dCU
 dKX
-uKP
+gNU
 ddY
 ddY
 dKI
@@ -132789,7 +133591,7 @@ awX
 poH
 tSw
 mdn
-dup
+gDR
 bpZ
 bjh
 aTd
@@ -132852,7 +133654,7 @@ cDW
 sWC
 qJo
 qJo
-feM
+vRR
 yem
 yem
 wQl
@@ -132993,9 +133795,9 @@ aaa
 aaa
 aaa
 xgt
-gWD
+guT
 oKR
-gWD
+guT
 ueF
 qGl
 mFy
@@ -133037,7 +133839,7 @@ hKI
 vdR
 nNA
 rFv
-xNH
+qmZ
 wDI
 bvJ
 nuC
@@ -133160,7 +133962,7 @@ eLO
 ssO
 ugz
 ssO
-imV
+ced
 dTo
 dUb
 dUL
@@ -133371,7 +134173,7 @@ pxi
 rwE
 ukr
 onj
-muB
+cpo
 ctm
 sFm
 cPn
@@ -133560,7 +134362,7 @@ awX
 emp
 wyP
 iLp
-fFT
+oRS
 lhJ
 aYZ
 jbc
@@ -133578,7 +134380,7 @@ fOV
 ssu
 uFJ
 bxl
-baG
+tVo
 hNh
 bEa
 jok
@@ -133588,7 +134390,7 @@ bJd
 bDR
 bDR
 bOD
-vcb
+uji
 byO
 bUK
 chc
@@ -133602,7 +134404,7 @@ eVz
 bOW
 twX
 bOW
-quu
+nlW
 tVa
 bsf
 bsf
@@ -133835,7 +134637,7 @@ npJ
 fcl
 fcl
 sPx
-fyP
+uOH
 fcl
 bCf
 fcl
@@ -133845,7 +134647,7 @@ fcl
 fcl
 fcl
 fcl
-gKs
+wIl
 hzo
 bUL
 hzo
@@ -133859,7 +134661,7 @@ hzo
 hzo
 reu
 hzo
-gKs
+wIl
 cpN
 crq
 vji
@@ -133897,7 +134699,7 @@ dkS
 dmb
 dnp
 doM
-xgH
+gXE
 drA
 dsE
 dtZ
@@ -133924,7 +134726,7 @@ srq
 mGN
 tcA
 dMT
-dOX
+xrP
 rvb
 dQk
 dQX
@@ -134092,7 +134894,7 @@ xGb
 iXC
 iXC
 iXC
-byQ
+lIR
 keo
 bDG
 keo
@@ -134102,7 +134904,7 @@ iXC
 iXC
 iXC
 iXC
-ntZ
+jwY
 nTR
 bUM
 bWM
@@ -134116,7 +134918,7 @@ bHi
 ckm
 oQO
 eVW
-ntZ
+jwY
 bqp
 rqv
 wud
@@ -134161,7 +134963,7 @@ dua
 pCD
 dwk
 dxt
-plR
+sCD
 dzQ
 dBe
 wJr
@@ -134315,7 +135117,7 @@ ouM
 bzl
 rSQ
 aCx
-nNK
+mEp
 qdO
 aEx
 aFA
@@ -134427,7 +135229,7 @@ kxJ
 noW
 ykJ
 ozw
-pwd
+wce
 oZR
 dKZ
 ddy
@@ -134550,14 +135352,14 @@ alv
 agE
 alv
 alv
-oHy
+agE
 agE
 aaa
 dGS
 uAk
 ala
 alm
-nmr
+eun
 apQ
 apQ
 aqP
@@ -134593,7 +135395,7 @@ uvp
 hdh
 bcq
 bdL
-elK
+iEk
 xSx
 xHc
 puy
@@ -134800,15 +135602,15 @@ blc
 jWY
 doS
 abj
-oHy
+agE
 agE
 agF
 agF
-oHy
+agE
 agF
 agF
 agE
-oHy
+agE
 abj
 dGS
 wOh
@@ -134829,7 +135631,7 @@ fys
 azk
 aAw
 aBy
-aLD
+hlA
 vqx
 kcj
 aFA
@@ -134909,11 +135711,11 @@ cMf
 cPo
 aKC
 cSn
-iWd
+vMP
 cUY
 cVs
 cXc
-qAx
+wYv
 daE
 vjm
 qAH
@@ -134925,7 +135727,7 @@ dkV
 cPn
 cPn
 cPn
-drI
+bAZ
 cPn
 cPn
 dkV
@@ -134952,7 +135754,7 @@ hsn
 rax
 fBo
 fBo
-pmI
+gfg
 fBo
 ppH
 tHk
@@ -135086,7 +135888,7 @@ ayo
 tTk
 wzq
 aCn
-aPP
+kxs
 aUv
 qbI
 aFA
@@ -135147,7 +135949,7 @@ ciB
 bSE
 qzr
 vKr
-tQl
+lTz
 cvv
 cwS
 cyf
@@ -135159,7 +135961,7 @@ csK
 sUV
 ckv
 cHE
-cIX
+nPe
 cMe
 xpu
 xme
@@ -135182,7 +135984,7 @@ dkW
 dyL
 dyL
 dyL
-drN
+bYt
 dyL
 kSr
 dyL
@@ -135192,7 +135994,7 @@ tDR
 tAt
 xxv
 fOS
-lBi
+phK
 qhX
 mnr
 gJW
@@ -135311,10 +136113,10 @@ oMA
 ktI
 qGl
 blc
-afb
+lDb
 mUk
-afb
-dbN
+lDb
+gNY
 ahB
 ahB
 ahB
@@ -135322,10 +136124,10 @@ ahB
 ahB
 ahB
 ahB
-dbN
-lpL
+gNY
+rhl
 lfH
-lpL
+rhl
 anT
 afc
 aoo
@@ -135416,18 +136218,18 @@ cEQ
 cIT
 ckv
 cHG
-cJa
+spH
 rAk
 cKD
 cNF
 cPq
 kWO
 mxh
-jPk
+pJQ
 dje
 dfR
 djD
-kYS
+fDI
 cKF
 dbX
 cSt
@@ -135439,7 +136241,7 @@ dkX
 cSt
 cSt
 dIi
-dsu
+uLV
 geq
 cSt
 cSt
@@ -135842,7 +136644,7 @@ dGS
 ahQ
 anT
 anO
-bkH
+pXR
 aoq
 mXH
 mIR
@@ -135857,7 +136659,7 @@ ayp
 azn
 aAy
 aGq
-uLH
+xec
 aHi
 qbI
 aFA
@@ -135876,7 +136678,7 @@ aOG
 aOG
 aOG
 aOG
-oTS
+sOO
 bdQ
 bdQ
 mem
@@ -136153,13 +136955,13 @@ aos
 bCn
 bDZ
 bCL
-pMx
+rnC
 ptz
 bKL
 bMS
 bOJ
 bQJ
-gEY
+ncC
 bOL
 clO
 bOY
@@ -136172,10 +136974,10 @@ bSG
 clO
 cru
 cns
-uEq
+nvS
 wbm
 crx
-iDv
+qRF
 cvy
 cwX
 cyf
@@ -136219,7 +137021,7 @@ sqX
 sqX
 sqX
 dEn
-hPC
+euM
 cMk
 dCV
 dbC
@@ -136228,7 +137030,7 @@ dFt
 dGg
 dbI
 dHM
-dIG
+smy
 syw
 pZR
 dKn
@@ -136390,7 +137192,7 @@ aWg
 aUo
 aOG
 aTp
-nnP
+pQq
 bdQ
 bdQ
 aui
@@ -136590,10 +137392,10 @@ aaa
 aaa
 aaa
 rJk
-gtZ
+vfs
 llM
 anU
-gtZ
+vfs
 fMh
 blc
 ahA
@@ -136647,7 +137449,7 @@ aWh
 aUw
 aOG
 aVQ
-oHk
+gtV
 bdQ
 bdQ
 xSH
@@ -136733,7 +137535,7 @@ dyO
 ccR
 fGV
 dtN
-mxK
+lLw
 lmg
 dbB
 ddy
@@ -136847,10 +137649,10 @@ aaa
 aaa
 aaa
 aaa
-ahg
+pPH
 aFB
 vwH
-ahg
+pPH
 ktI
 blc
 ovL
@@ -136904,7 +137706,7 @@ aWi
 aUB
 aOG
 jYO
-sDO
+wnA
 bdQ
 bgv
 sMx
@@ -136958,7 +137760,7 @@ csK
 cEU
 ckv
 cHG
-cJa
+spH
 pgJ
 cSr
 cNJ
@@ -136973,7 +137775,7 @@ cZB
 daL
 dcb
 ddG
-ugy
+fxe
 dir
 dip
 fzN
@@ -136999,7 +137801,7 @@ dFv
 dFa
 dcV
 dHT
-dIJ
+mdu
 dUT
 cYk
 gkk
@@ -137110,10 +137912,10 @@ doS
 ovL
 aeP
 blc
-afb
+lDb
 oOV
-afb
-dbN
+lDb
+gNY
 ahB
 ahB
 ahB
@@ -137121,10 +137923,10 @@ ahB
 ahB
 ahB
 ahB
-dbN
-lpL
+gNY
+rhl
 xty
-lpL
+rhl
 anT
 anY
 qtd
@@ -137142,7 +137944,7 @@ awX
 azs
 aAC
 aCw
-aFQ
+ilI
 bck
 ohu
 aFA
@@ -137161,7 +137963,7 @@ rnA
 aXI
 aOG
 jYO
-nnP
+pQq
 bdQ
 bdQ
 bli
@@ -137215,14 +138017,14 @@ tzC
 czY
 ckv
 cHG
-cJa
+spH
 pgJ
 ffi
 pML
 vJs
 ffi
 xKn
-nxX
+vNU
 cVw
 cWQ
 cYn
@@ -137238,7 +138040,7 @@ cIq
 vNV
 doX
 drD
-soA
+poI
 dwr
 dvm
 dyR
@@ -137256,7 +138058,7 @@ dVx
 dGl
 dcV
 dHT
-dIJ
+mdu
 dUT
 cYk
 dKo
@@ -137385,13 +138187,13 @@ aAr
 adu
 anQ
 aou
-aeJ
+lCA
 aqU
 aqU
 asA
 neb
 asY
-awh
+aiq
 gxU
 awi
 wyS
@@ -137418,7 +138220,7 @@ aOG
 aOG
 aOG
 qKm
-nnP
+pQq
 bdQ
 bdQ
 nbo
@@ -137513,7 +138315,7 @@ dFx
 dFa
 dcV
 dHQ
-mSZ
+ovz
 xCy
 ikD
 vxk
@@ -137642,13 +138444,13 @@ uci
 anl
 oTa
 oTa
-dhh
+yah
 aqX
 asB
 asi
 asB
 asD
-apu
+gKk
 bpn
 awj
 pit
@@ -137711,7 +138513,7 @@ cdL
 cfI
 chm
 ciI
-fCY
+fbF
 clQ
 coD
 bac
@@ -137720,12 +138522,12 @@ fwX
 csO
 cua
 cvD
-cxb
+miI
 cyj
 czL
 cyk
 cyk
-gyY
+esQ
 cEV
 dLT
 gPh
@@ -138166,7 +138968,7 @@ wKI
 axF
 awl
 ayx
-byN
+wAY
 bhO
 bhO
 bhO
@@ -138189,14 +138991,14 @@ bhO
 bhO
 aZd
 bsi
-bfp
+gAs
 mVs
 bjA
 bhO
 bhO
 bhO
 bsi
-paF
+qzX
 sqk
 npJ
 hBw
@@ -138243,7 +139045,7 @@ jdz
 czY
 ckv
 cHI
-dEm
+izE
 wkV
 wkV
 cNN
@@ -138258,7 +139060,7 @@ wkV
 wkV
 wkV
 wkV
-dft
+geD
 dgC
 diu
 dnC
@@ -138266,7 +139068,7 @@ dnC
 dnC
 yal
 dgC
-mNM
+hSH
 cVA
 cVA
 cVA
@@ -138278,7 +139080,7 @@ dHT
 dHT
 urW
 dDb
-dXj
+apD
 dHT
 vvy
 dcV
@@ -138423,7 +139225,7 @@ wKI
 juJ
 awm
 gmY
-aBj
+xSK
 azv
 aAG
 mzs
@@ -138446,14 +139248,14 @@ seH
 seH
 bvg
 bvg
-bgw
+pTe
 byW
 oWT
 bvg
 bhP
 bar
 bar
-bMa
+stp
 bot
 bqt
 bsl
@@ -138500,7 +139302,7 @@ uPh
 cEW
 cGA
 cHJ
-dEl
+fsg
 jBj
 jBj
 cNO
@@ -138515,7 +139317,7 @@ jBj
 jBj
 jBj
 jBj
-dfB
+mDa
 jBj
 jBj
 jBj
@@ -138523,7 +139325,7 @@ cnV
 jBj
 jBj
 jBj
-tiQ
+kug
 pIn
 tQi
 neQ
@@ -138535,13 +139337,13 @@ prT
 pIn
 lAW
 dDc
-iOv
+mpp
 dEZ
 loM
 moN
 ewH
 cUv
-kLR
+osU
 vSW
 vSW
 vSW
@@ -138680,7 +139482,7 @@ wKI
 roR
 awn
 sAB
-aBU
+veo
 bhY
 bwh
 bhY
@@ -138703,14 +139505,14 @@ bhY
 oWc
 bhY
 wzH
-bgx
+eNZ
 gVm
 bhY
 bhY
 blq
 bhY
 bhY
-bMb
+iKZ
 bov
 hgo
 hBw
@@ -138757,7 +139559,7 @@ siG
 csW
 cGB
 cHK
-dEm
+izE
 cKz
 cRh
 cNP
@@ -138772,7 +139574,7 @@ cJY
 cJY
 cJY
 oRy
-dsI
+qhR
 dle
 cJY
 cJY
@@ -138780,7 +139582,7 @@ psT
 cJY
 dmh
 cJY
-kEt
+gyM
 dpa
 dpa
 dpa
@@ -138792,7 +139594,7 @@ ovF
 eNA
 dBQ
 dnD
-cRc
+lgZ
 dnD
 dGo
 dGo
@@ -139184,13 +139986,13 @@ age
 upw
 uQW
 eDE
-aeJ
+lCA
 aea
 aea
 ask
 aea
 aea
-orG
+xQq
 xcx
 awo
 tBo
@@ -139253,7 +140055,7 @@ cdP
 cfM
 chq
 ciO
-kIF
+hWO
 clV
 cny
 bbE
@@ -139262,12 +140064,12 @@ hQk
 csU
 cug
 cvH
-cxc
+mHe
 cyo
 czR
 cBo
 cBo
-eNm
+qXP
 csW
 ckv
 cHK
@@ -139301,7 +140103,7 @@ dEo
 dEo
 jcP
 uOV
-xid
+jwd
 dDk
 dDh
 dQs
@@ -139441,13 +140243,13 @@ adZ
 anT
 rrZ
 aoB
-aeJ
+lCA
 aqZ
 aqZ
 asW
 asZ
 asZ
-axi
+oHP
 avh
 awp
 aow
@@ -139536,7 +140338,7 @@ kts
 ktT
 nQF
 mTs
-rwZ
+ycY
 cZF
 cXg
 dbd
@@ -139725,20 +140527,20 @@ aUV
 wre
 aQg
 aRN
-fhG
+osh
 aUP
 aWp
 aUE
 aZi
 baX
-ozS
+gvC
 bdX
 kDv
 bft
 bec
 lUp
 blu
-bhU
+fHN
 bov
 hgo
 uGT
@@ -139785,7 +140587,7 @@ tzC
 csW
 ckv
 cHK
-cJh
+scu
 rQz
 eAi
 cPD
@@ -139793,7 +140595,7 @@ cPD
 uFH
 nQF
 mTs
-dat
+xJY
 cZF
 cXg
 cXg
@@ -139973,7 +140775,7 @@ jkv
 wnt
 eOG
 aFF
-rnp
+fSL
 uJC
 ibg
 aKy
@@ -139995,7 +140797,7 @@ bfu
 bhW
 bfu
 blu
-bhU
+fHN
 bov
 hgo
 uGT
@@ -140042,7 +140844,7 @@ cyv
 cEY
 ckv
 cHK
-cJh
+scu
 rQz
 rqw
 cNU
@@ -140218,11 +141020,11 @@ arb
 arS
 asC
 atH
-tvs
+qrS
 avj
 aws
 uTx
-gsC
+oOr
 jUb
 aAM
 xLJ
@@ -140330,7 +141132,7 @@ dEo
 aNB
 ntG
 myx
-wZK
+hTP
 dDh
 qLt
 dCb
@@ -140446,9 +141248,9 @@ aaa
 aaa
 aaa
 agh
-reW
+iaV
 alt
-reW
+iaV
 afh
 pGg
 wRJ
@@ -140458,7 +141260,7 @@ alG
 alG
 alG
 alG
-xHN
+kMJ
 alG
 alG
 alG
@@ -140509,7 +141311,7 @@ bea
 aYc
 bfu
 blu
-bhU
+fHN
 bov
 hgo
 uGT
@@ -140715,7 +141517,7 @@ vcE
 vcE
 vcE
 vcE
-giE
+nWa
 kLd
 vcE
 vcE
@@ -140766,7 +141568,7 @@ bfu
 aYc
 bfu
 blu
-bhU
+fHN
 box
 bqx
 uGT
@@ -140779,7 +141581,7 @@ aos
 bCy
 bEl
 bCL
-wtO
+otI
 bJl
 bLa
 bNc
@@ -140787,7 +141589,7 @@ bOX
 wAC
 bSQ
 bUX
-nlA
+iIo
 bYz
 can
 cci
@@ -140798,10 +141600,10 @@ cgQ
 ckz
 clX
 cnz
-ggG
+gpq
 cqh
 crN
-xFp
+rTT
 cum
 cvM
 cxf
@@ -140972,7 +141774,7 @@ rVD
 bld
 kPM
 akb
-uSO
+xYU
 inH
 eOg
 eOg
@@ -141267,13 +142069,13 @@ aNr
 aOP
 ohK
 aRR
-ngZ
+imF
 fvQ
 mpA
 aNm
 aNm
 bbc
-dAQ
+qZT
 bcC
 bfu
 bgG
@@ -141306,7 +142108,7 @@ cbz
 cap
 cck
 cdW
-paC
+gSt
 csL
 ciS
 ckB
@@ -141334,7 +142136,7 @@ oyG
 oAd
 iQz
 rMG
-wyn
+ehz
 cMq
 cMq
 bqy
@@ -141343,7 +142145,7 @@ bqy
 hbt
 oMI
 diC
-vBu
+vXs
 dWP
 dWP
 dWP
@@ -141351,7 +142153,7 @@ oiF
 fWX
 eEf
 hZH
-xib
+aCt
 sDN
 xdN
 tWK
@@ -141584,14 +142386,14 @@ wwx
 jdr
 dLT
 njU
-cJh
+scu
 nCu
 rqw
 fQt
 cPI
 haj
 oZf
-wuc
+oAE
 cYO
 cYO
 dvV
@@ -141600,7 +142402,7 @@ sbz
 utn
 mZL
 kho
-iaU
+pLV
 kHJ
 kHJ
 oqo
@@ -141822,7 +142624,7 @@ etC
 cdY
 bYD
 chy
-wrm
+iTF
 cjY
 cmb
 cnD
@@ -141841,7 +142643,7 @@ wOM
 csW
 ckv
 jfG
-ppr
+qVB
 hdI
 rsV
 gIn
@@ -141857,7 +142659,7 @@ cMq
 cMq
 lDF
 cSA
-vBu
+vXs
 dWP
 dWP
 dWP
@@ -142073,7 +142875,7 @@ bQT
 bYD
 bVa
 bWY
-bYE
+swD
 cas
 ccn
 cdZ
@@ -142094,7 +142896,7 @@ cuB
 cAb
 cBD
 cDc
-kwm
+qUj
 kWp
 fFu
 bug
@@ -142114,7 +142916,7 @@ cMq
 cMq
 hbt
 cSA
-vBu
+vXs
 dWP
 dWP
 dWP
@@ -142557,11 +143359,11 @@ aSG
 aWx
 nQX
 nQX
-tyN
+iSm
 iWf
 pTK
 bfz
-blE
+rCM
 bic
 tAo
 blN
@@ -142790,7 +143592,7 @@ auu
 atP
 axf
 axf
-lyj
+vue
 aBN
 ayD
 azL
@@ -142826,7 +143628,7 @@ mwl
 bov
 hgo
 uGT
-sFH
+vjE
 pSh
 pSh
 pSh
@@ -142840,7 +143642,7 @@ pSh
 pSh
 pSh
 dLL
-coE
+oKG
 wBx
 bVc
 txj
@@ -142854,7 +143656,7 @@ ciV
 wBx
 wBx
 wBx
-coE
+oKG
 scp
 pLA
 epO
@@ -143049,7 +143851,7 @@ auu
 avp
 are
 axv
-fTr
+mjF
 azK
 aAW
 aBS
@@ -143083,7 +143885,7 @@ oeE
 jjp
 dog
 npJ
-kEN
+kzv
 uHV
 uHV
 uhI
@@ -143097,7 +143899,7 @@ uHV
 uHV
 uHV
 uHV
-oAm
+pgi
 lmQ
 bVd
 lmQ
@@ -143111,7 +143913,7 @@ nYW
 lmQ
 lmQ
 lmQ
-oAm
+pgi
 wvz
 crS
 nAC
@@ -143126,7 +143928,7 @@ hIZ
 hIZ
 cGD
 kCi
-liC
+jsY
 omT
 cMv
 cNY
@@ -143142,7 +143944,7 @@ ppu
 cKO
 hbt
 cSA
-fNP
+kFb
 rod
 dGm
 rod
@@ -143340,7 +144142,7 @@ oeE
 dBI
 bqA
 qOr
-jpm
+pdv
 uLr
 uLr
 bxz
@@ -143354,7 +144156,7 @@ uLr
 qjT
 uLr
 bPc
-oIT
+bzM
 bSU
 bVe
 bXa
@@ -143368,7 +144170,7 @@ cnC
 iJi
 pOw
 ccO
-mWz
+urS
 cqp
 crT
 efA
@@ -143395,11 +144197,11 @@ eKP
 vsw
 nQF
 npp
-ieX
+eRb
 cKO
 kPl
 hrX
-oMd
+skn
 mzT
 dld
 dlv
@@ -143407,7 +144209,7 @@ qtJ
 hsp
 pZM
 xIH
-sgM
+slI
 irJ
 kgC
 duk
@@ -143652,7 +144454,7 @@ lUd
 eHZ
 tEL
 mtg
-eQZ
+jTE
 mUB
 lYp
 bIW
@@ -143901,7 +144703,7 @@ dfv
 xLC
 iIY
 cOa
-xjD
+mDk
 hZO
 vEY
 vZa
@@ -143930,7 +144732,7 @@ mAC
 rNO
 xzp
 tfY
-dCf
+trw
 mbh
 dDh
 dEo
@@ -144107,7 +144909,7 @@ bgR
 bii
 hXL
 bjM
-pbr
+kql
 bQg
 eNt
 aaa
@@ -144378,11 +145180,11 @@ btL
 abj
 bgs
 ctc
-wkG
+xso
 bLk
 bNk
 bPf
-sJs
+kyo
 bSY
 xLe
 iRk
@@ -144649,7 +145451,7 @@ awM
 hIn
 gQU
 pfl
-btZ
+hBR
 fFQ
 cHD
 flb
@@ -144680,13 +145482,13 @@ nEb
 pqM
 tYQ
 sCK
-fMP
+oEK
 tpM
 tKj
 dkL
 lnN
 kJJ
-ecP
+mnL
 dls
 uXP
 hon
@@ -145173,13 +145975,13 @@ bYH
 bwL
 bxe
 bsh
-njk
+lYn
 jvM
 cAg
 cDg
 cDg
 cDg
-cJl
+rXC
 fPx
 cTa
 cUM
@@ -145691,7 +146493,7 @@ cxn
 czU
 bBu
 cAf
-cDh
+yiS
 cEo
 cxn
 mUz
@@ -145728,7 +146530,7 @@ cki
 kxH
 cSH
 cSH
-oYX
+rzh
 qqE
 dDv
 aKE
@@ -145736,7 +146538,7 @@ aKE
 tzg
 aKE
 auO
-eQz
+uMA
 dNu
 nZk
 gLq
@@ -145892,7 +146694,7 @@ aaa
 eNt
 llR
 tcJ
-bYU
+rAS
 sHd
 bqK
 lKI
@@ -146205,7 +147007,7 @@ cxn
 bAd
 cAi
 cBL
-cDh
+yiS
 cEq
 cDe
 mUz
@@ -146442,7 +147244,7 @@ eNt
 bbK
 dJF
 hUX
-jQb
+axc
 ndS
 ccv
 fMd
@@ -146483,7 +147285,7 @@ dwG
 bYs
 hbt
 cSF
-lqL
+wsw
 doj
 dkl
 doj
@@ -146719,7 +147521,7 @@ cxn
 puH
 cAj
 cAf
-cDh
+yiS
 cFb
 cFg
 ltY
@@ -146740,7 +147542,7 @@ cSA
 cKO
 sln
 sXV
-vQm
+pTl
 ijt
 crC
 nhy
@@ -146750,7 +147552,7 @@ qRe
 qZr
 udE
 dWY
-wpJ
+qNT
 xAK
 dWR
 pWz
@@ -146759,7 +147561,7 @@ jPY
 cXJ
 cSY
 wnk
-myn
+jMp
 sUX
 xKS
 lBL
@@ -146989,7 +147791,7 @@ jIz
 iwu
 lJc
 rLr
-bTt
+fFS
 cSH
 cSH
 dcE
@@ -146997,7 +147799,7 @@ cSH
 cSH
 uXN
 cSF
-lqL
+wsw
 doj
 doj
 doj
@@ -147209,7 +148011,7 @@ ahh
 hKx
 hps
 wUn
-rYd
+mSD
 pqL
 uZG
 pgK
@@ -147254,7 +148056,7 @@ cSF
 cSF
 esf
 cSF
-lqL
+wsw
 xhf
 nhv
 eMB
@@ -147457,7 +148259,7 @@ uQZ
 yfo
 pmP
 pYb
-rYd
+mSD
 wUn
 wUn
 fXd
@@ -147470,7 +148272,7 @@ eNt
 rOn
 lMX
 qJl
-jZo
+cZZ
 bVB
 szn
 bTh
@@ -147803,7 +148605,7 @@ arQ
 tTf
 xHg
 tTg
-dNn
+ulH
 wYx
 mXf
 tOS
@@ -147993,7 +148795,7 @@ oIy
 hhw
 cJn
 brM
-rrn
+rdm
 cqw
 cqw
 crX
@@ -148035,7 +148837,7 @@ oAx
 hXE
 gMe
 ffa
-hRJ
+fuD
 hiT
 lwo
 rRw
@@ -148553,7 +149355,7 @@ dlz
 wMS
 ebi
 nvr
-ifj
+edL
 boG
 cSY
 cSY
@@ -148573,7 +149375,7 @@ mcy
 xTt
 qsg
 mJU
-vTs
+oOv
 gfJ
 miC
 ipg
@@ -148734,7 +149536,7 @@ eNt
 gsI
 ftn
 mni
-wTS
+sTk
 gDp
 uPW
 eNt
@@ -148742,7 +149544,7 @@ cjs
 qgy
 qgy
 qgy
-bHV
+raH
 swZ
 swZ
 bLy
@@ -148776,7 +149578,7 @@ cyQ
 cAl
 cBS
 cDn
-cuJ
+xSW
 cFm
 cGQ
 ujq
@@ -149270,7 +150072,7 @@ bAN
 bVq
 sUE
 bsG
-bhf
+ila
 ccF
 gGA
 cgh
@@ -149290,7 +150092,7 @@ cyS
 cAm
 cYh
 hZL
-cvV
+fcm
 cGS
 cHa
 cWh
@@ -149527,7 +150329,7 @@ cwx
 bVq
 sUE
 pYm
-bhf
+ila
 leC
 hOL
 rLN
@@ -149784,7 +150586,7 @@ hzD
 bVq
 sUE
 bsG
-bhf
+ila
 jWU
 ccG
 rIo
@@ -150045,11 +150847,11 @@ bLn
 bLt
 dtD
 leC
-rlv
+rdJ
 cjq
 ckZ
 gGu
-cnR
+fIm
 gGu
 cqD
 bTg
@@ -150061,11 +150863,11 @@ cyU
 cBW
 cEv
 lah
-cEt
+pLh
 cIg
 rkJ
 hcU
-jls
+wBN
 aGr
 aHB
 cOq
@@ -150276,7 +151078,7 @@ mxn
 cgr
 kaM
 juN
-ejC
+vjQ
 aft
 tse
 goP
@@ -150318,7 +151120,7 @@ cyV
 cIk
 cIj
 cIk
-pNl
+iJY
 fNF
 tbn
 cIh
@@ -150327,7 +151129,7 @@ cLo
 cMM
 aHQ
 cQf
-fIE
+hUC
 boG
 dDy
 bng
@@ -150346,7 +151148,7 @@ dmH
 diT
 diS
 dtB
-dmK
+aWa
 dtz
 cjn
 dvS
@@ -150533,7 +151335,7 @@ aRX
 cgr
 fCB
 ceF
-bCM
+qZi
 mpE
 bFU
 mpl
@@ -150554,7 +151356,7 @@ vOc
 bAN
 xfr
 fnH
-rQI
+uFw
 eXs
 rCd
 fgB
@@ -150860,7 +151662,7 @@ diS
 diS
 diR
 dtE
-dsl
+mjO
 dty
 cUM
 oqS
@@ -151093,7 +151895,7 @@ bmW
 xSg
 sCx
 aFs
-jtF
+poz
 aHA
 cMO
 aKh
@@ -151355,7 +152157,7 @@ cLq
 aHC
 aKi
 cQh
-fIE
+hUC
 cSY
 dDD
 bng
@@ -151572,7 +152374,7 @@ uiw
 naG
 chO
 tQg
-qQK
+aQH
 aPx
 ick
 vOc
@@ -151603,7 +152405,7 @@ cAo
 cAs
 cAs
 rqO
-oll
+fUc
 cFu
 pMQ
 vJt
@@ -151811,17 +152613,17 @@ eud
 vis
 elp
 sxD
-emC
+qmi
 qwp
 qNE
-biy
+sBq
 bkh
 fTf
 ddp
 boU
 lyH
 bFU
-kHT
+pjZ
 tQg
 naG
 emz
@@ -151860,7 +152662,7 @@ cyY
 cyY
 cyY
 why
-dZE
+kFf
 dwH
 dTF
 cIl
@@ -152051,7 +152853,7 @@ ygH
 szP
 amp
 szP
-iyN
+wwQ
 qeq
 lFo
 foD
@@ -152121,7 +152923,7 @@ bmW
 tvI
 vzs
 plm
-cPY
+kYO
 sOo
 pEn
 tsc
@@ -152610,7 +153412,7 @@ vOc
 fDa
 xhz
 ihi
-aaT
+fQu
 gho
 pgj
 wyk
@@ -152662,7 +153464,7 @@ bng
 iBK
 oTo
 nZN
-xlS
+fOC
 dym
 dym
 fou
@@ -152834,22 +153636,22 @@ rTU
 aVw
 vVn
 iUE
-qlH
+fNv
 cMi
 uCD
-ylA
+wQh
 xZf
 mux
 sve
 mXG
 dLl
-ray
+wLK
 hiS
 lHN
 mux
 sve
 lGj
-buh
+evv
 xsH
 qAK
 gnW
@@ -152857,7 +153659,7 @@ mRz
 whi
 whi
 moB
-rCJ
+iYn
 jSd
 ufv
 qnx
@@ -152867,7 +153669,7 @@ yjx
 ncZ
 icC
 bTj
-uaV
+sMM
 nah
 jbf
 wvg
@@ -153100,7 +153902,7 @@ reb
 xaS
 bNI
 xaS
-ino
+pmR
 hkW
 xaS
 iNl
@@ -153114,7 +153916,7 @@ mbY
 jTm
 vHR
 jTm
-aAL
+mAz
 xhp
 oqH
 mPL
@@ -153336,7 +154138,7 @@ jau
 bwA
 bwA
 bwA
-tVy
+phE
 wdd
 aVw
 aVw
@@ -153348,22 +154150,22 @@ aVw
 aVw
 tWB
 rtx
-nWF
+tMG
 baS
 kAQ
-aTJ
+buH
 axU
 etf
 mpE
 dLO
 nGQ
-uQq
+knu
 mpE
 raU
 sXb
 xjq
 lTc
-taP
+vBO
 xkr
 uHg
 nXf
@@ -153371,7 +154173,7 @@ oao
 hra
 upe
 hra
-pHr
+wye
 kjA
 xuI
 osI
@@ -153386,7 +154188,7 @@ pEJ
 mpR
 rRd
 osu
-nWR
+nTB
 iuB
 tvJ
 aqq
@@ -153643,7 +154445,7 @@ mQo
 mpR
 bun
 bud
-bZc
+oeQ
 rfV
 xxz
 aVt
@@ -154138,7 +154940,7 @@ cnL
 uBL
 bXl
 lMs
-rjy
+oVG
 bPu
 oIB
 oxS
@@ -154381,7 +155183,7 @@ bJN
 pYi
 aSp
 pMd
-aPb
+kkO
 uee
 lqB
 wsZ
@@ -154404,7 +155206,7 @@ fMj
 gka
 uhy
 jtR
-mmw
+qBa
 bTr
 jWD
 gBB
@@ -155139,7 +155941,7 @@ ijX
 ijX
 cBH
 tYf
-nnD
+vqi
 rIi
 vJL
 sQe

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -165,24 +165,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/warden)
-"acI" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Delivery Office"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/any/supply/mail_sorting,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/supply/general,
-/obj/structure/sign/cargo/mail{
-	pixel_x = 32
-	},
-/turf/simulated/floor/plasteel,
-/area/station/supply/sorting)
 "acQ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -258,24 +240,6 @@
 /obj/effect/mapping_helpers/turfs/rust/maybe,
 /turf/simulated/wall,
 /area/station/maintenance/dorms/starboard)
-"aer" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Escape Shuttle Cell"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/security/doors,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/exit)
-"aeu" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft)
 "aeB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
@@ -616,11 +580,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
-"aiP" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/medical,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/sleeper)
 "aiS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -715,6 +674,29 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/hop)
+"ajT" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Warden's Office";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/warden)
 "akg" = (
 /obj/effect/spawner/random/blood/maybe,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -722,6 +704,20 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/aft2)
+"akj" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/public/toilet/unisex)
 "akk" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
@@ -1079,20 +1075,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
-"anm" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/classic/normal{
-	dir = 1;
-	name = "Kitchen Desk"
-	},
-/obj/machinery/door/window/classic/normal,
-/obj/effect/mapping_helpers/airlock/windoor/access/all/service/kitchen{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/all/service/hydroponics,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/service/hydroponics)
 "ano" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/extra_insulated{
@@ -1140,20 +1122,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/virology/lab)
-"anP" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "AI Upload Access"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/science,
-/turf/simulated/floor/plasteel/white,
-/area/station/turret_protected/ai_upload)
 "anS" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 4
@@ -1273,6 +1241,29 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
+"aoL" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	id = "Cell 3";
+	name = "Cell 3"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison/cell_block)
 "aoM" = (
 /obj/structure/sink/directional/north,
 /obj/machinery/camera/autoname{
@@ -1642,6 +1633,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/range)
+"arN" = (
+/obj/machinery/door/airlock/virology/glass{
+	name = "Monkey Pen";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/grass/no_creep,
+/area/station/medical/virology)
 "arO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1962,6 +1966,18 @@
 /obj/effect/turf_decal/tiles/department/security/side,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
+"avc" = (
+/obj/structure/barricade/wooden/crude,
+/obj/machinery/door/airlock/science/glass{
+	welded = 1;
+	locked = 1;
+	name = "Abandoned Airlock";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "ave" = (
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
@@ -2182,6 +2198,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
+"axh" = (
+/obj/machinery/door/airlock/medical{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/morgue,
+/obj/effect/mapping_helpers/airlock/access/any/security/forensics,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/medical/morgue)
 "axi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2222,27 +2254,6 @@
 "axH" = (
 /turf/simulated/wall,
 /area/station/public/construction)
-"axS" = (
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	id_tag = "viro_door_ext";
-	locked = 1;
-	name = "Virology Lab External Airlock"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/machinery/door/firedoor,
-/obj/machinery/access_button{
-	autolink_id = "viro_btn_ext";
-	name = "Virology Lab Access Button";
-	pixel_x = -24;
-	req_access = list(39)
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/virology)
 "ayj" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -2675,6 +2686,19 @@
 /obj/effect/turf_decal/tiles/dark/corner,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
+"aDI" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance";
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "aDK" = (
 /obj/structure/table,
 /obj/item/rpd,
@@ -3080,15 +3104,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
-"aIf" = (
-/obj/machinery/door/airlock{
-	name = "Unit 3"
+"aIh" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/station/public/toilet/lockerroom)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint2)
 "aIj" = (
 /turf/simulated/wall,
 /area/station/maintenance/aft2)
@@ -3598,6 +3623,22 @@
 /obj/item/food/chips,
 /turf/simulated/floor/wood,
 /area/station/public/vacant_office)
+"aNC" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Messaging Server";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/science/rd,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/command/server)
 "aNH" = (
 /obj/item/beach_ball{
 	desc = "The simple beach ball is one of Nanotrasen's most popular products. 'Why do we make beach balls? Because we can! (TM)' - Nanotrasen";
@@ -3796,13 +3837,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
-"aPC" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/security/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
 "aPG" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/sop_command{
@@ -3818,17 +3852,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/hop)
-"aQe" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "aQf" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/evaguide,
@@ -3880,10 +3903,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
-"aQD" = (
-/obj/machinery/door/airlock/engineering,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint2)
 "aQT" = (
 /obj/structure/chair/comfy/teal{
 	dir = 8
@@ -4252,19 +4271,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/aft_port)
-"aUA" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Incinerator Access"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/turf/simulated/floor/plating,
-/area/station/maintenance/incinerator)
 "aUC" = (
 /obj/structure/sign/nosmoking/alt{
 	pixel_y = 32
@@ -4333,16 +4339,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
-"aVv" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/starboard/south)
 "aVA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5094,6 +5090,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_port)
+"bbx" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Brig Atmospherics Maintenance";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/turf/simulated/floor/plating,
+/area/station/maintenance/security/aft_starboard)
 "bbz" = (
 /obj/structure/rack,
 /obj/item/storage/box/handcuffs,
@@ -5150,6 +5155,24 @@
 /obj/effect/spawner/random/cobweb/left/rare,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"bco" = (
+/obj/machinery/door/airlock/research{
+	name = "Test Lab";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
+/obj/effect/mapping_helpers/airlock/access/any/science/tox,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/misc_lab)
 "bcs" = (
 /turf/simulated/wall,
 /area/station/supply/smith_office)
@@ -5162,18 +5185,6 @@
 /obj/effect/turf_decal/tiles/department/science/side,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/electrical/aft_starboard)
-"bcC" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
 "bcK" = (
 /turf/space,
 /area/station/engineering/atmos/asteroid)
@@ -5535,6 +5546,16 @@
 /obj/machinery/newscaster/directional/east,
 /turf/simulated/floor/wood,
 /area/station/service/bar)
+"bho" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/south)
 "bhp" = (
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall,
@@ -5732,6 +5753,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/service/hydroponics)
+"bjL" = (
+/obj/machinery/door/airlock/medical{
+	name = "Operating Theatre Storage";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/station/medical/surgery/secondary)
 "bjM" = (
 /obj/item/radio/intercom{
 	name = "south bump";
@@ -5756,6 +5795,13 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/hallway/secondary/entry/lounge)
+"bkh" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/security/corner,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "bki" = (
 /obj/structure/chair/stool/bar{
 	dir = 8
@@ -5990,18 +6036,6 @@
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/station/service/chapel/funeral)
-"bmg" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "MiniSat Maintenance"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/turf/simulated/floor/plating,
-/area/station/aisat/hall)
 "bmi" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -6030,19 +6064,6 @@
 /obj/machinery/power/emitter,
 /turf/simulated/floor/plating,
 /area/station/engineering/secure_storage)
-"bmG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/medical/genetics,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/science/genetics)
 "bmK" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin/nanotrasen,
@@ -6055,11 +6076,6 @@
 	icon_state = "cult"
 	},
 /area/station/legal/magistrate)
-"bmP" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/dorms/port)
 "bmQ" = (
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
@@ -6367,14 +6383,6 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dorms/port)
-"bpR" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/west)
 "bpS" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -6611,6 +6619,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard)
+"bsp" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Bay Warehouse Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/cargo_bay,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint2)
 "bsr" = (
 /obj/effect/mapping_helpers/turfs/rust/maybe,
 /turf/simulated/wall,
@@ -6699,6 +6715,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/ai_monitored/storage/eva)
+"btj" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/black,
+/area/station/service/chapel)
 "btk" = (
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/atmospherics/refill_station/nitrogen,
@@ -7223,6 +7252,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
+"bxL" = (
+/obj/machinery/door/airlock/public/glass{
+	autoclose = 0;
+	heat_proof = 1;
+	id_tag = "incinerator_door_int";
+	locked = 1;
+	name = "Mixing Room Interior Airlock";
+	dir = 4
+	},
+/obj/machinery/access_button{
+	autolink_id = "incinerator_btn_int";
+	name = "Incinerator Airlock Control";
+	pixel_x = 23
+	},
+/turf/simulated/floor/engine,
+/area/station/maintenance/incinerator)
 "bxN" = (
 /obj/structure/closet/coffin,
 /turf/simulated/floor/plasteel{
@@ -7238,14 +7283,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/supply/qm)
-"bxY" = (
-/obj/machinery/door/airlock/external/glass{
-	id_tag = "trader_home";
-	name = "Docking Port 4"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/secondary/entry/west)
 "byd" = (
 /obj/machinery/firealarm/directional/west,
 /obj/structure/cable/extra_insulated{
@@ -7482,16 +7519,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
-"bAo" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/station_engineer,
-/obj/machinery/door/airlock/engineering{
-	name = "Power Transmission Laser"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/engine/reactor)
 "bAr" = (
 /obj/machinery/flasher/portable,
 /obj/item/radio/intercom/department/security{
@@ -7620,18 +7647,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/cmo)
-"bAL" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Checkpoint"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical/aft_starboard)
 "bAR" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8
@@ -7718,12 +7733,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
-"bBN" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/carpet,
-/area/station/service/library)
 "bBS" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 4
@@ -7742,6 +7751,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"bCa" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/department/cargo/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/lobby)
 "bCh" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -7869,6 +7892,20 @@
 /obj/machinery/economy/vending/cola,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison)
+"bDt" = (
+/obj/machinery/door/airlock{
+	name = "Court";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/security/court,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/legal/courtroom)
 "bDv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -7969,17 +8006,15 @@
 	},
 /turf/simulated/floor/engine/asteroid,
 /area/station/engineering/atmos/asteroid_core)
-"bEg" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
+"bEa" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/department/cargo/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/supply/lobby)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/dorms/port)
 "bEh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -8060,25 +8095,6 @@
 /obj/item/kirbyplants/large,
 /turf/simulated/floor/wood,
 /area/station/security/permabrig)
-"bFc" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id_tag = "paramedic";
-	name = "Paramedic Garage"
-	},
-/obj/machinery/door_control{
-	id = "paramedic";
-	name = "Garage Door Control";
-	pixel_x = 24;
-	req_access = list(66)
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/medical/paramedic)
 "bFj" = (
 /obj/effect/spawner/random/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -8727,20 +8743,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/aft_starboard)
-"bLq" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Atmospherics Maintenance"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Engineering";
-	name = "Engineering Security Doors"
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/break_room)
 "bLu" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -8824,6 +8826,19 @@
 	icon_state = "cult"
 	},
 /area/station/legal/magistrate)
+"bMt" = (
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock";
+	name = "Escape Pod Hatch";
+	dir = 4
+	},
+/obj/docking_port/mobile/pod{
+	id = "pod1";
+	name = "escape pod 1";
+	dir = 2
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/pod_1)
 "bMD" = (
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "bridge blast north";
@@ -8918,6 +8933,13 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay2)
+"bNg" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/sleeper)
 "bNr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9188,16 +9210,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/asteroid_filtering)
-"bPJ" = (
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/station/medical/surgery/primary)
 "bPP" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
@@ -9453,11 +9465,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
-"bSb" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/public/dorms)
 "bSe" = (
 /obj/machinery/ai_status_display{
 	pixel_y = -32
@@ -9540,6 +9547,23 @@
 	},
 /turf/simulated/floor/engine/co2,
 /area/station/engineering/atmos)
+"bSJ" = (
+/obj/machinery/door/airlock/command{
+	name = "Teleport Access";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/any/command/teleporter,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/command/teleporter)
 "bSW" = (
 /obj/structure/railing{
 	dir = 1
@@ -9609,17 +9633,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/aft_port)
-"bTC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/medical/genetics,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/science/genetics)
 "bTM" = (
 /obj/machinery/alarm/directional/north,
 /obj/structure/cable{
@@ -9702,16 +9715,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"bUF" = (
-/obj/machinery/door/airlock{
-	name = "Crematorium"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/crematorium,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/station/service/chapel/office)
 "bUG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/sign/directions/engineering{
@@ -9958,6 +9961,19 @@
 /obj/structure/closet/secure_closet/cmo,
 /turf/simulated/floor/wood,
 /area/station/command/office/cmo)
+"bWC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "bWE" = (
 /obj/structure/railing{
 	dir = 1
@@ -10301,6 +10317,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/asteroid_filtering)
+"cay" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "caz" = (
 /obj/item/weldingtool/mini,
 /turf/simulated/floor/plating,
@@ -10314,18 +10338,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/office/rd)
-"caL" = (
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock";
-	name = "Escape Pod Hatch"
-	},
-/obj/docking_port/mobile/pod{
-	id = "pod1";
-	name = "escape pod 1";
-	dir = 2
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/pod_1)
 "caS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10513,6 +10525,19 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/ai)
+"cct" = (
+/obj/machinery/door/airlock/medical{
+	name = "Operating Theatre Storage";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/station/medical/surgery/primary)
 "ccx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
@@ -10532,6 +10557,29 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"ccJ" = (
+/obj/machinery/door/window/classic/reversed{
+	name = "Medical Reception";
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/desk_bell{
+	pixel_x = 7;
+	pixel_y = 6;
+	anchored = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/all/medical/general{
+	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/medical/reception)
 "ccY" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -11042,6 +11090,18 @@
 /obj/effect/turf_decal/tiles/department/security/checker,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
+"cij" = (
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Teleporter Room";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
+/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/turret_protected/aisat/interior)
 "cim" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door_control{
@@ -11424,12 +11484,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"cmK" = (
-/obj/machinery/door/airlock/freezer,
-/obj/structure/barricade/wooden,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/asmaint)
 "cmQ" = (
 /obj/machinery/atmospherics/portable/scrubber/huge,
 /obj/effect/turf_decal/stripes/line,
@@ -11467,19 +11521,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/abandonedbar)
-"cna" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/mining,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/supply/smith,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/supply/smith_office)
 "cni" = (
 /obj/structure/table,
 /obj/item/storage/box/monkeycubes/neaeracubes,
@@ -11594,16 +11635,22 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/grass,
 /area/station/medical/medbay2)
-"cph" = (
-/obj/machinery/door/airlock/command{
-	name = "Research Director's Office"
+"cpg" = (
+/obj/machinery/door/airlock/public{
+	name = "Dorms Storefront 2";
+	id_tag = "shopdoor2";
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/science/rd,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/station/command/office/rd)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/chemistry,
+/obj/effect/turf_decal/tiles/department/security/checker,
+/turf/simulated/floor/plasteel,
+/area/station/public/shops)
 "cpq" = (
 /obj/structure/table/wood/poker,
 /obj/machinery/camera{
@@ -11858,13 +11905,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/maintenance/asmaint)
-"crT" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint2)
 "crW" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -11882,18 +11922,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/command/office/ce)
-"csf" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Aft Secondary Atmospherics Maintenance"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft2)
 "csg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -12085,6 +12113,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
+"cuv" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/dorms/fore)
 "cuz" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -12725,6 +12763,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
+"cBc" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "cBd" = (
 /obj/structure/table,
 /obj/item/storage/bag/money,
@@ -12913,15 +12961,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/station/public/sleep)
-"cDj" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Teleporter Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/turret_protected/aisat/interior)
 "cDl" = (
 /obj/item/shard,
 /obj/effect/decal/cleanable/dirt,
@@ -13013,6 +13052,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"cEy" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/dorms/starboard)
 "cEK" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 1;
@@ -13127,11 +13174,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/public/fitness)
-"cFP" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/titanium/glass,
-/turf/simulated/floor/indestructible/titanium,
-/area/shuttle/arrival/station)
+"cFO" = (
+/obj/machinery/door/airlock{
+	name = "Prison Toilets";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/security/permabrig)
 "cFS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -13228,6 +13279,18 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/aft2)
+"cGw" = (
+/obj/machinery/door/airlock/mining{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/supply/miningdock)
 "cGA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -13818,6 +13881,27 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
+"cMa" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Break Room";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Engineering";
+	name = "Engineering Security Doors"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/break_room)
 "cMe" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/item/radio/intercom{
@@ -14012,19 +14096,6 @@
 /obj/item/stack/cable_coil,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
-"cOJ" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Atmospherics"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/aisat/atmos)
 "cOU" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -14119,21 +14190,6 @@
 /obj/effect/spawner/random/cobweb/left/frequent,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint2)
-"cPN" = (
-/obj/machinery/door/airlock/research{
-	name = "Research Division Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/science/research,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/science/research)
 "cPS" = (
 /obj/effect/spawner/random/barrier/grille_maybe,
 /obj/effect/decal/cleanable/dirt,
@@ -14247,18 +14303,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/toxins/launch)
-"cRc" = (
-/obj/machinery/door/airlock/medical,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/morgue,
-/obj/effect/mapping_helpers/airlock/access/any/security/forensics,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/medical/morgue)
 "cRi" = (
 /turf/simulated/wall,
 /area/station/security/main)
@@ -14315,11 +14359,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
-"cRJ" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint)
 "cRS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -14388,16 +14427,6 @@
 /obj/item/shard,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
-"cTe" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Mr. Chang's"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/mrchangs)
 "cTf" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -14511,6 +14540,27 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/command/office/ce)
+"cTP" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Storage";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Engineering";
+	name = "Engineering Security Doors"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/equipmentstorage)
 "cTR" = (
 /obj/machinery/atmospherics/binary/pump{
 	name = "Tank to Mix";
@@ -14856,6 +14906,26 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/server/coldroom)
+"cXB" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Psych Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "psychoffice"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/psych)
 "cXC" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -14892,6 +14962,28 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/station/command/office/ce)
+"cXU" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "AI Core";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/turf/simulated/floor/plasteel/dark,
+/area/station/turret_protected/ai)
 "cXZ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -14901,6 +14993,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
+"cYh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "cYl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -14978,6 +15085,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/north)
+"cZE" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft2)
 "cZM" = (
 /obj/structure/sink/kitchen/directional/west,
 /obj/effect/turf_decal/tiles/dark/checker,
@@ -15218,25 +15335,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
-"dcn" = (
-/obj/machinery/door/airlock/command/glass,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "qm"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/qm,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/supply/qm)
 "dcw" = (
 /obj/effect/turf_decal/delivery/hollow/left,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -15826,6 +15924,15 @@
 /obj/structure/sign/command/head,
 /turf/simulated/wall/r_wall,
 /area/station/command/office/hop)
+"die" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Fabrication";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/engine,
+/area/station/engineering/engine)
 "dil" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -15922,6 +16029,16 @@
 /obj/item/hand_labeler,
 /turf/simulated/floor/carpet/grimey,
 /area/station/security/detective)
+"dju" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fpmaint)
 "djB" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
@@ -16485,6 +16602,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"doG" = (
+/obj/machinery/door/airlock/command{
+	name = "Chief Engineer's Bedroom";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/command/office/ce)
 "doI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
@@ -16510,30 +16640,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/captain)
-"doR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry)
-"doV" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Messaging Server"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/science/rd,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/engine,
-/area/station/command/server)
 "doY" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -16577,13 +16683,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/aft_starboard)
-"dpp" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/neutral/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
 "dpq" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /obj/structure/cable/extra_insulated{
@@ -16723,6 +16822,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"drw" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random/directional/west,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/neutral/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/shops)
 "drz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel/dark,
@@ -16763,6 +16876,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
+"drT" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/ne)
 "drU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 4
@@ -17049,24 +17173,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore)
-"duh" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prisonlockers)
 "duj" = (
 /obj/structure/transit_tube,
 /obj/machinery/light{
@@ -17839,7 +17945,7 @@
 	},
 /obj/machinery/computer/general_air_control{
 	name = "Bomb Mix Monitor";
-	autolink_sensors = list("burn_sensor"="Burn Mix");
+	autolink_sensors = list("burn_sensor" = "Burn Mix");
 	dir = 8
 	},
 /obj/effect/turf_decal/tiles/department/science/side{
@@ -18039,6 +18145,29 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
+"dEr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Operating Theatre 1";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Surgery 1"
+	},
+/obj/machinery/holosign/surgery{
+	id = "surgery1"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/surgery/primary)
 "dEs" = (
 /obj/machinery/economy/atm/directional/north,
 /obj/effect/turf_decal/tiles/department/cargo/corner{
@@ -18342,6 +18471,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
+"dHz" = (
+/obj/machinery/door/airlock/security{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison)
 "dHC" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -18439,6 +18584,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint2)
+"dIA" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/department/medical/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/barber)
 "dIH" = (
 /obj/item/decorations/sticky_decorations/flammable/spiderweb{
 	pixel_y = 20
@@ -18517,23 +18676,23 @@
 	},
 /turf/simulated/floor/carpet/grimey,
 /area/station/hallway/secondary/entry/lounge)
-"dJy" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Chamber Observation"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/aisat/hall)
 "dJU" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
 /area/station/aisat/service)
+"dJY" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "dKa" = (
 /obj/structure/railing{
 	dir = 8
@@ -19179,15 +19338,6 @@
 /obj/item/stack/rods,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/aft_starboard)
-"dRc" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/turf/simulated/floor/plating,
-/area/station/maintenance/security/aft_port)
 "dRn" = (
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 8
@@ -19461,14 +19611,6 @@
 /obj/effect/turf_decal/tiles/department/security/corner,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"dUQ" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Escape Shuttle Cell"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/security/doors,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/exit)
 "dVe" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -19582,6 +19724,16 @@
 /obj/structure/bookcase/manuals,
 /turf/simulated/floor/wood,
 /area/station/maintenance/apmaint2)
+"dWG" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/engineering/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/sw)
 "dWH" = (
 /obj/structure/bookcase{
 	name = "bookcase (Reference)"
@@ -19677,6 +19829,21 @@
 "dYs" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel/dark,
+/area/station/legal/courtroom/gallery)
+"dYx" = (
+/obj/machinery/door/airlock{
+	name = "Jury";
+	id_tag = "Jury entrance";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/security/court,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
 /area/station/legal/courtroom/gallery)
 "dYy" = (
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
@@ -19858,17 +20025,6 @@
 "ear" = (
 /turf/simulated/wall,
 /area/station/medical/cloning)
-"eax" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "eaB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -20011,14 +20167,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/electrical/aft_starboard)
-"ebO" = (
-/obj/machinery/door/airlock/maintenance{
-	electrified_until = -1;
-	locked = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/security/fore)
 "eca" = (
 /obj/item/radio/intercom{
 	name = "west bump";
@@ -20232,14 +20380,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
-"edG" = (
-/obj/machinery/door/airlock{
-	name = "Prison Toilets"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/security/permabrig)
 "edM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -20288,22 +20428,29 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos/storage)
+"eec" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Foyer";
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/lobby)
 "eeg" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/electrical/aft_port)
-"eeh" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Aft-Port Atmospherics Maintenance"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint2)
 "eex" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -20398,18 +20545,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/gravitygenerator)
-"efJ" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel,
-/area/station/public/park)
 "efL" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -20542,6 +20677,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat/breakroom)
+"ehc" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/public/glass{
+	name = "Security Space Bridge";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/security/south)
 "ehg" = (
 /turf/simulated/floor/engine,
 /area/station/science/misc_lab)
@@ -20556,6 +20707,19 @@
 /obj/effect/turf_decal/tiles/department/security/checker,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
+"ehA" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Prison Forestry";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
 "ehK" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/wood,
@@ -20715,13 +20879,6 @@
 "eju" = (
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
-"ejB" = (
-/obj/machinery/door/airlock/external/glass{
-	id_tag = "ferry_home"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/west)
 "ejD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20786,6 +20943,16 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/command/office/cmo)
+"eke" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Security Space Bridge";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/security/south)
 "ekg" = (
 /obj/structure/plasmageyser,
 /turf/simulated/floor/lava/plasma/fuming,
@@ -20917,17 +21084,6 @@
 /obj/effect/turf_decal/tiles/department/cargo/corner,
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
-"elw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
 "elA" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -21077,13 +21233,6 @@
 /obj/item/clothing/mask/cigarette,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
-"emz" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/carpet/orange,
-/area/station/service/kitchen)
 "emE" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/railing{
@@ -21111,25 +21260,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/sorting)
-"emN" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "AI Core"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
-/turf/simulated/floor/plasteel/dark,
-/area/station/turret_protected/ai)
 "emQ" = (
 /obj/effect/landmark/spawner/xeno,
 /turf/simulated/floor/plating,
@@ -21161,16 +21291,6 @@
 /obj/effect/landmark/spawner/nukedisc_respawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/assembly_line)
-"eny" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft)
 "enL" = (
 /turf/simulated/wall,
 /area/station/engineering/hardsuitstorage)
@@ -21556,6 +21676,19 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/sleeper)
+"erY" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Mr. Chang's";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/mrchangs)
 "esd" = (
 /obj/machinery/light{
 	dir = 8
@@ -22023,16 +22156,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dorms/port)
-"ewp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft)
 "ewq" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door_control{
@@ -22459,6 +22582,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"eAh" = (
+/obj/machinery/door/airlock/public/glass{
+	autoclose = 0;
+	heat_proof = 1;
+	id_tag = "turbine_door_int";
+	name = "Turbine Interior Airlock";
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/engine,
+/area/station/engineering/atmos/asteroid_filtering)
 "eAm" = (
 /obj/structure/chair{
 	dir = 8
@@ -22609,14 +22747,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/carpet,
 /area/station/public/dorms)
-"eBM" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Tool Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint2)
 "eBV" = (
 /obj/effect/decal/cleanable/ash,
 /obj/structure/cable/extra_insulated{
@@ -23258,6 +23388,22 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/legal/courtroom)
+"eIO" = (
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Chamber Observation";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/aisat/hall)
 "eIQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -23663,6 +23809,25 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/east)
+"eNy" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Prison Library";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/wood,
+/area/station/security/permabrig)
 "eNB" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -23913,6 +24078,15 @@
 /obj/item/kitchen/knife/plastic,
 /turf/simulated/floor/plasteel/white,
 /area/station/security/permabrig)
+"ePC" = (
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "trader_home";
+	name = "Docking Port 4";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/secondary/entry/west)
 "ePR" = (
 /obj/effect/turf_decal/alphanumeric/mix,
 /turf/simulated/floor/engine/airless/nodecay,
@@ -23929,14 +24103,6 @@
 	},
 /turf/space,
 /area/station/engineering/solar/fore_starboard)
-"ePX" = (
-/obj/structure/table/reinforced,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/genetics,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/classic/reversed,
-/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/genetics)
 "ePY" = (
 /obj/machinery/power/apc/directional/south,
 /obj/structure/cable{
@@ -24009,14 +24175,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
-"eRc" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/dorms/fore)
 "eRh" = (
 /obj/effect/turf_decal/arrows/black{
 	dir = 1;
@@ -24150,6 +24308,19 @@
 "eSN" = (
 /turf/simulated/floor/plasteel,
 /area/station/service/theatre)
+"eSZ" = (
+/obj/effect/mapping_helpers/airlock/access/all/service/janitor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock{
+	name = "Janitorial Supplies";
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fpmaint)
 "eTc" = (
 /obj/machinery/hydroponics/constructable{
 	desc = "These are connected with an irrigation tube. You see a little pipe connecting the trays.";
@@ -24272,6 +24443,13 @@
 "eUC" = (
 /turf/simulated/wall,
 /area/station/public/arcade)
+"eUF" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/dorms/starboard)
 "eUL" = (
 /obj/machinery/computer/supplycomp,
 /obj/machinery/camera{
@@ -24581,18 +24759,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"eWX" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Aft-Port Atmospherics Maintenance"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint2)
 "eXi" = (
 /obj/machinery/light{
 	dir = 4
@@ -25318,14 +25484,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
-"fdO" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
 "fdQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -25698,6 +25856,22 @@
 /obj/effect/turf_decal/tiles/dark/corner,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
+"fgZ" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/public/shops)
 "fha" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25923,29 +26097,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
-"fjY" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Chief Engineer's Office"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "CE"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/command/office/ce)
 "fkc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/oil/maybe,
@@ -26110,6 +26261,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/break_room)
+"flH" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Atmospherics Maintenance";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Engineering";
+	name = "Engineering Security Doors"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/break_room)
 "flP" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
@@ -26255,6 +26421,30 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/hallway/spacebridge/security/west)
+"fna" = (
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "BS"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/blueshield,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "blueshieldofficedoor";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/wood,
+/area/station/command/office/blueshield)
 "fnd" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical,
@@ -27005,6 +27195,20 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/aft_starboard)
+"ftL" = (
+/obj/machinery/door/airlock/wood{
+	name = "Back Stage Entrance";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/service/theatre)
 "ftN" = (
 /obj/machinery/ignition_switch{
 	id = "gasturbine";
@@ -27232,15 +27436,6 @@
 /obj/effect/landmark/spawner/nukedisc_respawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
-"fvA" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/effect/turf_decal/tiles/department/engineering/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/sw)
 "fvK" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /turf/simulated/floor/plasteel,
@@ -27325,6 +27520,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/expedition)
+"fwG" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint2)
 "fwH" = (
 /turf/simulated/wall,
 /area/station/maintenance/dorms/port)
@@ -27390,13 +27592,6 @@
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
-"fxo" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft2)
 "fxs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 4
@@ -27491,25 +27686,16 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"fyd" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/sw)
 "fyf" = (
 /turf/simulated/floor/beach/away/sand,
 /area/station/public/dorms)
-"fyk" = (
-/obj/machinery/door/airlock/research/glass{
-	name = "Break Room"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
-/obj/effect/mapping_helpers/airlock/access/any/science/research,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel,
-/area/station/science/break_room)
 "fyl" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency,
@@ -27981,22 +28167,6 @@
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/station/science/toxins/test)
-"fDj" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Staff Entrance"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/medbay2)
 "fDk" = (
 /obj/machinery/status_display{
 	pixel_x = -32
@@ -28122,6 +28292,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block)
+"fER" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Courtroom Maintenance";
+	security_level = 1;
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/security/court,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fpmaint)
 "fFb" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/supply/supply_shuttle,
@@ -28181,13 +28363,6 @@
 /obj/effect/turf_decal/tiles/department/security/checker,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
-"fFY" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Court gallery"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/legal/courtroom/gallery)
 "fGb" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -28248,6 +28423,59 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison/cell_block)
+"fGn" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Prisoner Oversight";
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Prison Gate";
+	name = "Prison Lockdown Blast Doors"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison)
+"fGr" = (
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "hosofficedoor";
+	name = "Head of Security";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/security/hos,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "HoS"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/office/hos)
 "fGw" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -28359,6 +28587,15 @@
 "fHi" = (
 /turf/simulated/wall/r_wall,
 /area/station/engineering/tech_storage)
+"fHu" = (
+/obj/machinery/door/airlock/wood{
+	name = "Private Residence";
+	desc = "No solicitors please.";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/wood,
+/area/station/maintenance/fsmaint)
 "fHE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -28664,15 +28901,6 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel,
 /area/station/medical/break_room)
-"fKf" = (
-/obj/machinery/door/poddoor{
-	id_tag = "Secure Storage";
-	name = "Secure Storage Blast Doors"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/secure_storage)
 "fKn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -28710,6 +28938,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/station/public/vacant_office)
+"fKQ" = (
+/obj/machinery/door/airlock/multi_tile{
+	name = "maintenance access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint2)
 "fKS" = (
 /obj/effect/spawner/random/barrier/grille_maybe,
 /obj/structure/disposalpipe/segment{
@@ -28751,11 +28987,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dorms/starboard)
-"fLg" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/medical/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore/north)
 "fLj" = (
 /obj/effect/spawner/random/blood/maybe,
 /obj/structure/cable/extra_insulated{
@@ -29363,6 +29594,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/station/command/office/ntrep)
+"fQt" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Tool Storage";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint2)
 "fQw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -29616,6 +29856,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/ne)
+"fTp" = (
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Atmospherics";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/aisat/atmos)
 "fTr" = (
 /obj/machinery/economy/vending/wallmed/directional/east,
 /obj/structure/cable{
@@ -29766,6 +30022,18 @@
 /obj/item/pen/multi,
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/ai)
+"fVF" = (
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/research,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/research)
 "fVN" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
@@ -29781,16 +30049,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/surgery/secondary)
-"fVX" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medical Supplies"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/medical,
-/turf/simulated/floor/plasteel,
-/area/station/medical/storage)
 "fWa" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -30080,6 +30338,32 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
+"gan" = (
+/obj/machinery/door/window/classic/reversed{
+	desc = "You have the public fridge, pal, lube off.";
+	name = "Security Shield"
+	},
+/obj/machinery/door/window/classic/reversed{
+	desc = "You have the public fridge, pal, lube off.";
+	name = "Security Shield";
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id_tag = "viroshutters";
+	name = "Privacy Shutters";
+	dir = 2
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/general{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/virology,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/virology,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/virology/lab)
 "gaA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -30101,14 +30385,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/asteroid_filtering)
-"gaK" = (
-/obj/structure/curtain/open,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/patients_rooms_secondary)
 "gaT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -30365,24 +30641,6 @@
 /obj/effect/turf_decal/tiles/department/security,
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/storage/secondary)
-"gcQ" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Perma Cell 3"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/effect/turf_decal/tiles/department/security,
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
 "gcT" = (
 /obj/machinery/atmospherics/refill_station/plasma,
 /turf/simulated/floor/plasteel/white,
@@ -30539,6 +30797,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
+"gew" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Escape Pod 1 Airlock";
+	id_tag = "emergency_home";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/west)
 "gez" = (
 /obj/effect/spawner/random/barrier/grille_maybe,
 /obj/effect/decal/cleanable/generic,
@@ -32164,6 +32430,16 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/ai_transit_tube)
+"guP" = (
+/obj/effect/mapping_helpers/airlock/access/any/command/hop,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/command{
+	id_tag = "hopofficedoor";
+	name = "Head of Personnel";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/command/office/hop)
 "guW" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -32268,6 +32544,27 @@
 /obj/item/storage/box/monkeycubes/wolpincubes,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"gwD" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Cloning";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/medical/cloning)
 "gwF" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal{
@@ -32372,6 +32669,19 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"gxM" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/sw)
 "gxN" = (
 /obj/machinery/status_display{
 	pixel_y = 32
@@ -32446,14 +32756,6 @@
 /obj/effect/spawner/random/blood/maybe,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/aft_starboard)
-"gzv" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering Suit Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/station_engineer,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/control)
 "gzx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32507,15 +32809,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
-"gAm" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/machinery/door/airlock/maintenance{
-	name = "Atmospherics Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage)
 "gAs" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -32754,14 +33047,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft)
-"gCX" = (
-/obj/machinery/door/airlock/security{
-	name = "Evidence Storage"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/evidence,
-/turf/simulated/floor/plasteel,
-/area/station/security/processing)
 "gDm" = (
 /obj/machinery/camera{
 	c_tag = "Chapel North"
@@ -32785,27 +33070,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore)
-"gDu" = (
-/obj/machinery/door/airlock/engineering/glass{
-	autoclose = 0;
-	id_tag = "engsm_door_int";
-	locked = 1;
-	name = "Reactor Interior Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/access_button{
-	autolink_id = "engsm_btn_int";
-	name = "Reactor Access Button";
-	pixel_y = 1;
-	req_access = list(10);
-	pixel_x = 25
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/engine)
 "gDA" = (
 /obj/effect/spawner/random/oil/maybe,
 /obj/structure/cable/extra_insulated{
@@ -33136,29 +33400,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology/lab)
-"gGv" = (
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	id_tag = "viro_door_int";
-	locked = 1;
-	name = "Virology Lab Internal Airlock"
-	},
-/obj/machinery/access_button{
-	autolink_id = "viro_btn_int";
-	name = "Virology Lab Access Button";
-	pixel_x = -24;
-	req_access = list(39)
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/virology,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/virology)
 "gGy" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -33592,6 +33833,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/tools)
+"gKZ" = (
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "specops_home";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/east)
 "gLc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -33738,24 +33987,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/office/rd)
-"gNe" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Vault Storage"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/command/vault)
 "gNo" = (
 /obj/structure/rack,
 /obj/item/gun/projectile/shotgun/riot{
@@ -33938,6 +34169,17 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
+"gPw" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "E.V.A. Maintenance";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/command/eva,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint2)
 "gPx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -34132,6 +34374,22 @@
 /obj/effect/turf_decal/tiles/department/security/checker,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/storage)
+"gRR" = (
+/obj/machinery/door/airlock/public{
+	name = "Dorms Storefront 1";
+	id_tag = "shopdoor1";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/chemistry,
+/obj/effect/turf_decal/tiles/department/security/checker,
+/turf/simulated/floor/plasteel,
+/area/station/public/shops)
 "gSd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -34149,6 +34407,18 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"gSj" = (
+/obj/machinery/door/airlock/wood{
+	name = "Back Stage Entrance";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/fakestairs{
+	dir = 1
+	},
+/area/station/service/theatre)
 "gSn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -34361,12 +34631,6 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
-"gUH" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/public/glass,
-/turf/simulated/floor/carpet/black,
-/area/station/service/chapel)
 "gUJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/oil/maybe,
@@ -34773,6 +35037,23 @@
 /obj/effect/spawner/random/barrier/possibly_welded_airlock,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"gYF" = (
+/obj/machinery/door/airlock/glass{
+	name = "Prison";
+	id_tag = "Prison Perma Cell 2";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/security,
+/turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
 "gYK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -34941,19 +35222,6 @@
 	},
 /turf/space,
 /area/station/engineering/solar/aft_port)
-"hae" = (
-/obj/machinery/door/airlock/tranquillite,
-/obj/effect/mapping_helpers/airlock/access/all/service/mime,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white{
-	icon_regular_floor = "yellowsiding"
-	},
-/area/station/service/mime)
 "hai" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -35082,6 +35350,25 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
+"hbu" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Prison Library";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/wood,
+/area/station/security/permabrig)
 "hbD" = (
 /obj/effect/spawner/random/trash,
 /turf/simulated/floor/wood,
@@ -35461,6 +35748,22 @@
 /obj/effect/spawner/window/reinforced/plasma/grilled,
 /turf/simulated/floor/plating,
 /area/station/science/toxins/launch)
+"heT" = (
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Service Bay";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/aisat/service)
 "hfp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -35600,13 +35903,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint2)
-"hgZ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Security Space Bridge"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/security/south)
 "hha" = (
 /obj/effect/turf_decal/delivery/partial{
 	dir = 4
@@ -35880,24 +36176,6 @@
 /obj/effect/turf_decal/tiles/department/security/side,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/warden)
-"hjl" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prison Library"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/wood,
-/area/station/security/permabrig)
 "hjs" = (
 /obj/machinery/light{
 	dir = 1
@@ -36095,6 +36373,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard)
+"hlb" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "hld" = (
 /obj/machinery/door/airlock/public/glass{
 	locked = 1;
@@ -36153,6 +36443,19 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/genetics)
+"hmd" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tiles/department/medical,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/cryo)
 "hmo" = (
 /obj/effect/spawner/random/blood/maybe,
 /turf/simulated/floor/plating,
@@ -36372,24 +36675,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/ai_monitored/storage/eva)
-"hoq" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prison Library"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/wood,
-/area/station/security/permabrig)
 "hou" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -36658,6 +36943,26 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
+"hqV" = (
+/obj/machinery/door/window/brigdoor{
+	id = "Cell 4";
+	name = "Cell 4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison/cell_block)
 "hrd" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 0;
@@ -36785,18 +37090,6 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
-"hsM" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/sw)
 "hsN" = (
 /obj/structure/chair{
 	dir = 4
@@ -37281,6 +37574,24 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
+"hxi" = (
+/obj/machinery/door/airlock/research{
+	name = "Research Storage";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
+/obj/effect/mapping_helpers/airlock/access/any/science/research,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel,
+/area/station/science/break_room)
 "hxs" = (
 /obj/machinery/shieldwallgen,
 /obj/structure/window/reinforced{
@@ -37525,6 +37836,19 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/aft_starboard)
+"hzn" = (
+/obj/machinery/door/airlock/maintenance{
+	locked = 1;
+	dir = 4
+	},
+/obj/structure/barricade/wooden,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/abandoned_office)
 "hzA" = (
 /obj/structure/girder,
 /turf/simulated/floor/plasteel,
@@ -37738,6 +38062,31 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/science/robotics)
+"hBe" = (
+/obj/machinery/access_button{
+	autolink_id = "xeno_btn_int";
+	name = "Xenobiology Access Button";
+	pixel_x = -24;
+	req_access = list(55)
+	},
+/obj/machinery/door/airlock/research{
+	autoclose = 0;
+	id_tag = "xeno_door_int";
+	locked = 1;
+	name = "Xenobiology Internal Airlock";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/science/xenobiology)
 "hBf" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hos,
@@ -37837,6 +38186,23 @@
 	},
 /turf/simulated/floor/grass/jungle,
 /area/station/maintenance/aft)
+"hBJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/medical/morgue)
 "hBP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -38056,6 +38422,24 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/abandoned_office)
+"hDQ" = (
+/obj/machinery/door/airlock/wood{
+	name = "Back Stage Entrance";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/fakestairs{
+	dir = 1
+	},
+/area/station/service/theatre)
 "hEb" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/chair{
@@ -38092,15 +38476,6 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/plasma,
 /area/station/engineering/atmos/asteroid_core)
-"hEp" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/neutral/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/shops)
 "hEr" = (
 /obj/structure/chair{
 	dir = 1
@@ -38209,23 +38584,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/station/hallway/secondary/entry/east)
-"hFF" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Psych Office"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "psychoffice"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/psych)
 "hFG" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-4"
@@ -38333,13 +38691,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/east)
-"hGJ" = (
-/obj/machinery/door/airlock/security{
-	name = "Firing Range Storage"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/range)
 "hGR" = (
 /obj/docking_port/stationary{
 	dwidth = 2;
@@ -38536,13 +38887,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
-"hIZ" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/dorms/port)
 "hJb" = (
 /obj/structure/sign/poster/official/random/directional/east,
 /obj/machinery/tcomms/core/station,
@@ -39107,6 +39451,25 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/captain)
+"hQx" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medical Supplies";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical,
+/turf/simulated/floor/plasteel,
+/area/station/medical/storage)
 "hQy" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -39133,19 +39496,6 @@
 "hQU" = (
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fpmaint)
-"hQX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry)
 "hRl" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel/dark,
@@ -39224,16 +39574,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/office/ntrep)
-"hSF" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry)
 "hSG" = (
 /obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/tiles/department/security/corner{
@@ -39333,6 +39673,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint2)
+"hTJ" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Staff Entrance";
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/medbay2)
 "hUd" = (
 /obj/effect/turf_decal/tiles/neutral/side,
 /obj/structure/sign/poster/official/random/directional/north,
@@ -39460,18 +39816,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/south)
-"hVF" = (
-/obj/machinery/door/airlock{
-	name = "Jury";
-	id_tag = "Jury entrance"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/security/court,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/station/legal/courtroom/gallery)
 "hVI" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -39722,18 +40066,6 @@
 /obj/machinery/shieldgen,
 /turf/simulated/floor/plating,
 /area/station/engineering/secure_storage)
-"hYx" = (
-/obj/machinery/door/airlock/maintenance{
-	locked = 1
-	},
-/obj/structure/barricade/wooden,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/abandoned_office)
 "hYB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
 	dir = 4
@@ -39868,14 +40200,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/asteroid_filtering)
-"hZO" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/cargo_bay,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "hZV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -39886,6 +40210,17 @@
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"iaj" = (
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "mining_home";
+	name = "Mining Dock Airlock";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/plating,
+/area/station/supply/miningdock)
 "iak" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -40205,9 +40540,6 @@
 /obj/item/stack/tile/wood,
 /turf/simulated/floor/plating,
 /area/station/maintenance/abandonedbar)
-"idk" = (
-/turf/simulated/wall/indestructible/titanium,
-/area/shuttle/arrival/station)
 "idq" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -40293,13 +40625,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/storage)
-"iek" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Escape Pod 3 Airlock";
-	id_tag = "emergency_home"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage)
 "iep" = (
 /obj/structure/chair/stool{
 	dir = 8
@@ -40860,16 +41185,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
-"ijM" = (
-/obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
-/obj/machinery/door/airlock/external/glass{
-	id_tag = "mining_home";
-	name = "Mining Dock Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plating,
-/area/station/supply/miningdock)
 "ijS" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/cleaner{
@@ -40974,6 +41289,18 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/public/toilet/unisex)
+"ilf" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Checkpoint";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/electrical/fore_starboard)
 "ilh" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/effect/decal/cleanable/dirt,
@@ -41132,6 +41459,17 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/doors,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison/cell_block)
+"imF" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/airlock/engineering{
+	name = "Aft Port Solar Access";
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/solar_maintenance/aft_port)
 "imI" = (
 /obj/machinery/light{
 	dir = 4
@@ -41353,6 +41691,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
+"ipc" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/west)
 "ipp" = (
 /turf/simulated/wall,
 /area/station/supply/sorting)
@@ -41391,6 +41740,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft2)
+"ipK" = (
+/obj/machinery/door/airlock/glass{
+	name = "Prison";
+	id_tag = "Prison Perma Cell 3";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/security,
+/turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
 "ipM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/extra_insulated{
@@ -41432,19 +41798,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/lobby)
-"iqk" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Maintenance"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "iqs" = (
 /obj/structure/reagent_dispensers/spacecleanertank{
 	pixel_y = 30
@@ -41693,6 +42046,18 @@
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall,
 /area/station/maintenance/dorms/fore)
+"itf" = (
+/obj/machinery/door/airlock/multi_tile{
+	name = "maintenance access";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "ith" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41719,6 +42084,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"itM" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/science/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/south)
 "itP" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet,
@@ -42100,14 +42474,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint2)
-"ixs" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Fabrication"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/engine,
-/area/station/engineering/engine)
 "ixE" = (
 /obj/machinery/firealarm/directional/south,
 /obj/structure/chair{
@@ -42230,26 +42596,6 @@
 /obj/effect/turf_decal/tiles/department/cargo/corner,
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
-"iyv" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/service/mime,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
-"iyw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/airlock/public/glass{
-	name = "Prison Forestry"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
 "iyz" = (
 /obj/item/radio/intercom{
 	name = "north bump";
@@ -42464,6 +42810,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
+"iAq" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/carpet/orange,
+/area/station/service/kitchen)
 "iAv" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -42485,6 +42842,29 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
+"iAC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/any/command/hop,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command{
+	name = "Head of Personnel's Private Quarters";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/command/office/hop)
+"iAG" = (
+/obj/machinery/door/airlock/glass{
+	name = "Primary tool storage";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/storage/tools)
 "iAQ" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 1;
@@ -42557,16 +42937,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"iBy" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Fore Starboard Solar Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/solar_maintenance/fore_starboard)
 "iBG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -42588,16 +42958,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard)
-"iBL" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
 "iBN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/spawner/xeno,
@@ -42621,6 +42981,15 @@
 /obj/machinery/alarm/directional/east,
 /turf/simulated/floor/plasteel,
 /area/station/ai_monitored/storage/eva)
+"iCb" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/sign/barber{
+	pixel_x = -17
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft)
 "iCi" = (
 /turf/simulated/wall,
 /area/station/science/testrange)
@@ -42670,11 +43039,6 @@
 /obj/item/beacon,
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
-"iCI" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/security/corner,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
 "iCN" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
@@ -42778,13 +43142,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/station/public/toilet/lockerroom)
-"iDV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry)
 "iEf" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -43433,15 +43790,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
-"iKd" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/department/cargo/corner,
-/turf/simulated/floor/plasteel,
-/area/station/supply/lobby)
 "iKk" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/machinery/status_display{
@@ -43871,22 +44219,6 @@
 /obj/effect/turf_decal/tiles/department/security/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/north)
-"iOp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Foyer"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/lobby)
 "iOs" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Mining Maintenance"
@@ -44118,27 +44450,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/abandoned_office)
-"iQU" = (
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "NTR"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/ntrep,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	id_tag = "ntrepofficedoor";
-	name = "NT Representative's Office"
-	},
-/turf/simulated/floor/wood,
-/area/station/command/office/ntrep)
 "iQX" = (
 /obj/effect/turf_decal/tiles/neutral/side{
 	dir = 4
@@ -44907,6 +45218,31 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
+"iYo" = (
+/obj/machinery/door/airlock/engineering/glass{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "gravity"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/station_engineer,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/gravitygenerator)
 "iYE" = (
 /turf/simulated/wall,
 /area/station/public/storage/office)
@@ -45445,20 +45781,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/evidence)
-"jej" = (
-/obj/machinery/door/airlock/glass{
-	name = "Prison";
-	id_tag = "Prison Perma Cell 2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/security,
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
 "jey" = (
 /obj/effect/spawner/random/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -45598,6 +45920,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/gravitygenerator)
+"jfC" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/neutral/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/shops)
 "jfE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -46260,27 +46595,6 @@
 /obj/item/toy/figure/crew/explorer,
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
-"jne" = (
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	id = "Cell 3";
-	name = "Cell 3"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison/cell_block)
 "jni" = (
 /obj/machinery/newscaster/directional/south,
 /obj/structure/disposalpipe/segment{
@@ -46561,28 +46875,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/science/storage)
-"jqV" = (
-/obj/machinery/access_button{
-	autolink_id = "xeno_btn_int";
-	name = "Xenobiology Access Button";
-	pixel_x = -24;
-	req_access = list(55)
-	},
-/obj/machinery/door/airlock/research{
-	autoclose = 0;
-	id_tag = "xeno_door_int";
-	locked = 1;
-	name = "Xenobiology Internal Airlock"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/xenobiology)
 "jqW" = (
 /obj/machinery/door/airlock,
 /obj/machinery/door/poddoor/preopen{
@@ -46654,6 +46946,16 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/office)
+"jsa" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/carpet,
+/area/station/service/library)
 "jsc" = (
 /obj/machinery/economy/slot_machine,
 /turf/simulated/floor/wood,
@@ -46721,16 +47023,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/asteroid_filtering)
-"jsL" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Escape Pod Airlock"
-	},
-/obj/docking_port/mobile/pod{
-	id = "pod3";
-	name = "escape pod 3"
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/pod_3)
 "jsM" = (
 /obj/machinery/light,
 /obj/machinery/hydroponics/constructable,
@@ -46841,25 +47133,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/south)
-"juh" = (
-/obj/machinery/door/window/reinforced/normal{
-	name = "Accused"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/all/security/brig,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/legal/courtroom)
 "juk" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /turf/simulated/floor/plasteel,
@@ -47565,19 +47838,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
-"jBn" = (
-/obj/machinery/door/airlock/security{
-	name = "Prisoner Re-education Centre"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/execution)
 "jBr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
@@ -47659,6 +47919,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"jCg" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Secure Tech Storage";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/tech_storage)
 "jCk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -47870,27 +48145,6 @@
 /obj/machinery/alarm/directional/east,
 /turf/simulated/floor/engine,
 /area/station/science/test_chamber)
-"jEA" = (
-/obj/machinery/door/airlock/command/glass{
-	id_tag = "rdofficedoor";
-	name = "Research Director's Office"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/rd,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "rd"
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/command/office/rd)
 "jEE" = (
 /obj/structure/machine_frame,
 /obj/machinery/alarm/directional/north,
@@ -48065,6 +48319,22 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/storage)
+"jFI" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "jFM" = (
 /obj/effect/spawner/random/barrier/grille_maybe,
 /obj/structure/cable/extra_insulated{
@@ -48395,6 +48665,16 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard)
+"jIL" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/service/mime,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "jIQ" = (
 /obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/plating,
@@ -48543,6 +48823,17 @@
 	},
 /turf/space,
 /area/station/engineering/solar/fore_port)
+"jKB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/abandonedservers)
 "jKH" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
 /turf/simulated/floor/plasteel{
@@ -48765,19 +49056,6 @@
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plasteel,
 /area/station/ai_monitored/storage/eva)
-"jMI" = (
-/obj/machinery/door/airlock/research/glass{
-	name = "Toxins Storage"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/science/tox_storage,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/storage)
 "jMJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -48933,16 +49211,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/bridge)
-"jOy" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Office Maintenance"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/service/bar,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft2)
 "jOF" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -49532,6 +49800,22 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"jTN" = (
+/obj/machinery/door/airlock/security{
+	name = "Prisoner Re-education Centre";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/execution)
 "jTU" = (
 /obj/structure/railing{
 	dir = 5
@@ -49550,6 +49834,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
+"jUi" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Aft Secondary Atmospherics Maintenance";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft2)
 "jUr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -49585,6 +49882,19 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
+"jUZ" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "jVe" = (
 /obj/structure/rack,
 /obj/item/latexballon,
@@ -49719,19 +50029,6 @@
 /obj/structure/closet/crate/can,
 /turf/simulated/floor/carpet/orange,
 /area/station/service/kitchen)
-"jWo" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Maintenance"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/supply/cargo_bay,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint2)
 "jWu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -49876,6 +50173,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/aft_port)
+"jYs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/airlock/public/glass{
+	name = "Prison Forestry";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
 "jYC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/random/directional/north,
@@ -49925,24 +50235,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/ai)
-"jZs" = (
-/obj/machinery/door/window/brigdoor{
-	id = "Cell 2";
-	name = "Cell 2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison/cell_block)
 "jZv" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -50145,6 +50437,33 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"kbv" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/classic/normal{
+	name = "Head of Personnel's Desk"
+	},
+/obj/machinery/door/window/classic/normal{
+	name = "Head of Personnel's Desk";
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id_tag = "hop";
+	name = "Privacy Shutters";
+	dir = 2
+	},
+/obj/item/desk_bell{
+	pixel_x = -6;
+	pixel_y = 3;
+	anchored = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/all/command/hop{
+	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/command/office/hop)
 "kbG" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -50528,6 +50847,20 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/expedition)
+"kfe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Checkpoint";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/electrical/fore_starboard)
 "kfi" = (
 /obj/effect/turf_decal/tiles/dark/corner{
 	dir = 1
@@ -50547,6 +50880,29 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/station/security/permabrig)
+"kfv" = (
+/obj/machinery/door/airlock/security{
+	name = "Equipment Storage";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/storage)
 "kfC" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -50803,25 +51159,6 @@
 /obj/item/trash/candle,
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/chapel)
-"kiq" = (
-/obj/machinery/door/airlock/wood{
-	name = "Back Stage Entrance"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/station/service/theatre)
-"kix" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Brig Atmospherics Maintenance"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/turf/simulated/floor/plating,
-/area/station/maintenance/security/aft_starboard)
 "kiy" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/beanie/rasta,
@@ -50923,6 +51260,20 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/asteroid_filtering)
+"kjq" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Sanitarium";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison)
 "kjE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -51098,15 +51449,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"klW" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/ne)
 "kmd" = (
 /obj/machinery/chem_dispenser,
 /turf/simulated/floor/engine,
@@ -51217,6 +51559,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
+"knu" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Escape Shuttle Cell";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/doors,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/exit)
 "knw" = (
 /obj/structure/table,
 /obj/item/trash/tray,
@@ -51248,19 +51601,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/carpet/black,
 /area/station/command/meeting_room)
-"knO" = (
-/obj/machinery/door/airlock/glass{
-	name = "Primary tool storage"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/public/storage/tools)
 "knP" = (
 /obj/machinery/door/airlock/security/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -51494,6 +51834,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/medical/storage)
+"kqy" = (
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Chamber Hallway";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/turret_protected/aisat/interior)
 "kqz" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -51537,6 +51888,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"kqG" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/ne)
 "kqI" = (
 /obj/effect/spawner/random/oil/maybe,
 /obj/effect/decal/cleanable/dirt,
@@ -51736,6 +52094,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/fore)
+"ksA" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Aft Starboard Solar Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/solar_maintenance/aft_starboard)
 "ksB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -51803,6 +52173,35 @@
 "ksW" = (
 /turf/simulated/floor/plasteel/white,
 /area/station/science/lobby)
+"ksY" = (
+/obj/machinery/door/airlock/research{
+	autoclose = 0;
+	id_tag = "xeno_door_ext";
+	locked = 1;
+	name = "Xenobiology External Airlock";
+	dir = 4
+	},
+/obj/machinery/access_button{
+	autolink_id = "xeno_btn_ext";
+	name = "Xenobiology Access Button";
+	pixel_x = -24;
+	req_access = list(55)
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/science/xenobiology)
 "ktc" = (
 /obj/item/cigbutt/roach,
 /turf/simulated/floor/wood,
@@ -52087,19 +52486,20 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/science/robotics)
-"kwq" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Staff Entrance"
+"kwp" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Foyer";
+	dir = 4
 	},
 /obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/unres,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/medbay2)
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/lobby)
 "kws" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -52161,6 +52561,22 @@
 /obj/effect/turf_decal/tiles/department/medical/side,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard)
+"kxd" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Upload";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/turret_protected/ai_upload)
 "kxn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -52291,16 +52707,16 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"kyS" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/airlock/engineering{
-	name = "Aft Port Solar Access"
+"kzh" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
 	},
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/station/maintenance/solar_maintenance/aft_port)
+/area/station/maintenance/dorms/starboard)
 "kzl" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel/white,
@@ -52553,19 +52969,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/security/processing)
-"kBr" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/classic/normal,
-/obj/effect/mapping_helpers/airlock/windoor/access/all/service/kitchen,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/windoor/autoname,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id_tag = "kitchendiner";
-	name = "Kitchen Shutters"
-	},
-/turf/simulated/floor/carpet/orange,
-/area/station/service/kitchen)
 "kBy" = (
 /obj/effect/spawner/random/blood/maybe,
 /obj/item/radio/intercom/department/security{
@@ -52827,11 +53230,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
-"kEW" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint2)
 "kFe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -52933,6 +53331,22 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/public/toilet/unisex)
+"kGO" = (
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id_tag = "qm_warehouse";
+	name = "Warehouse Shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/warehouse)
 "kGW" = (
 /obj/machinery/light{
 	dir = 1
@@ -53071,6 +53485,18 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
+"kIn" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/department/cargo/corner,
+/turf/simulated/floor/plasteel,
+/area/station/supply/lobby)
 "kIp" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -53147,12 +53573,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
-"kJl" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/sw)
 "kJn" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes/cigpack_shadyjims,
@@ -53290,6 +53710,24 @@
 /obj/effect/turf_decal/tiles/department/security/checker,
 /turf/simulated/floor/plasteel,
 /area/station/public/shops)
+"kKG" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Asteroid Access";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/storage)
 "kKJ" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance,
@@ -53789,19 +54227,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/simulated/floor/wood,
 /area/station/service/library)
-"kOC" = (
-/obj/machinery/door/airlock/vault{
-	locked = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/any/supply/vault,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/command/vault)
 "kOU" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -53839,6 +54264,19 @@
 /obj/item/paper,
 /turf/simulated/floor/wood,
 /area/station/maintenance/abandoned_office)
+"kPK" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint)
 "kPL" = (
 /obj/item/radio/intercom{
 	name = "north bump";
@@ -53880,15 +54318,6 @@
 /obj/item/pen,
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
-"kPV" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/black,
-/area/station/service/chapel)
 "kQc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/turfs/damage,
@@ -54205,13 +54634,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
-"kTd" = (
-/obj/machinery/door/airlock/wood{
-	name = "The Grey Tide"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint2)
 "kTf" = (
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall,
@@ -54231,6 +54653,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/equipmentstorage)
+"kTr" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/spacebridge/security/west)
 "kTs" = (
 /obj/effect/spawner/random/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -54415,17 +54852,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
-"kVJ" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Funeral Services"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/grimey,
-/area/station/service/chapel/funeral)
 "kVQ" = (
 /obj/structure/chair/comfy/black,
 /obj/structure/cable{
@@ -54639,21 +55065,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
-"kYt" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/public/construction)
 "kYy" = (
 /obj/structure/dresser,
 /obj/item/toy/figure/crew/ce{
@@ -54892,20 +55303,6 @@
 /obj/structure/table/wood/fancy/blue,
 /turf/simulated/floor/carpet,
 /area/station/legal/courtroom)
-"lbA" = (
-/obj/machinery/door/airlock/public/glass{
-	autoclose = 0;
-	heat_proof = 1;
-	id_tag = "turbine_door_int";
-	name = "Turbine Interior Airlock"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/engine,
-/area/station/engineering/atmos/asteroid_filtering)
 "lbP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/catwalk/black,
@@ -54972,6 +55369,30 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard)
+"lcT" = (
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	id_tag = "viro_door_ext";
+	locked = 1;
+	name = "Virology Lab External Airlock";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/access_button{
+	autolink_id = "viro_btn_ext";
+	name = "Virology Lab Access Button";
+	pixel_x = -24;
+	req_access = list(39)
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/virology)
 "lcY" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tiles/department/medical,
@@ -54993,6 +55414,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"ldg" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint2)
+"ldj" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "ldt" = (
 /obj/effect/decal/cleanable/vomit,
 /obj/effect/decal/cleanable/dirt,
@@ -55474,14 +55915,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"liu" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft2)
 "lix" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/newscaster/directional/west,
@@ -55501,19 +55934,6 @@
 /obj/item/paper/maintengine,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"liL" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Service Bay"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/aisat/service)
 "lja" = (
 /turf/simulated/floor/carpet/grimey,
 /area/station/service/chapel/funeral)
@@ -55528,21 +55948,6 @@
 /obj/effect/turf_decal/tiles/department/command/side,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/cmo)
-"ljn" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/lobby)
 "ljp" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -55942,6 +56347,13 @@
 /obj/item/plant_analyzer,
 /turf/simulated/floor/grass,
 /area/station/security/permabrig)
+"loo" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "lor" = (
 /obj/machinery/atmospherics/portable/scrubber,
 /obj/machinery/camera{
@@ -55992,13 +56404,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"loH" = (
-/obj/machinery/door/airlock/external/glass{
-	id_tag = "admin_home"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/east)
 "loI" = (
 /obj/structure/table,
 /obj/item/crowbar,
@@ -56071,31 +56476,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/dorms/fore)
-"loX" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	dir = 1;
-	id_tag = "robotics_surgery";
-	name = "Robotics Surgery Center"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/science/robotics)
-"loY" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Gravity Generator Foyer"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/any/science/rd,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/station_engineering,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/gravitygenerator)
 "loZ" = (
 /obj/machinery/biogenerator,
 /obj/structure/cable{
@@ -56108,6 +56488,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint2)
+"lpi" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/black,
+/area/station/service/chapel)
 "lpk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/flora/junglebush,
@@ -56591,27 +56981,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/aisat/breakroom)
-"ltL" = (
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "BS"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/blueshield,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	id_tag = "blueshieldofficedoor"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/wood,
-/area/station/command/office/blueshield)
 "ltR" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/sign/public/arrivals{
@@ -56635,13 +57004,6 @@
 /obj/effect/turf_decal/tiles/department/virology,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
-"luf" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Escape Pod 4 Airlock";
-	id_tag = "emergency_home"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/security/fore)
 "luo" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/spawner/random/oil/maybe,
@@ -56746,6 +57108,22 @@
 	icon_state = "cult"
 	},
 /area/station/service/library)
+"lvr" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/public/park)
 "lvy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash,
@@ -56871,46 +57249,10 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
-"lwn" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	dir = 1;
-	location = "Research Division"
-	},
-/obj/machinery/door/window/classic/reversed{
-	name = "Research Division Delivery"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/science/research,
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/science/rnd)
 "lwp" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/science/toxins/launch)
-"lwr" = (
-/obj/machinery/door/airlock/command{
-	name = "Teleport Access"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/any/command/teleporter,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/command/teleporter)
 "lwv" = (
 /obj/machinery/atmospherics/portable/pump,
 /turf/simulated/floor/plating,
@@ -56999,6 +57341,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/dorms/port)
+"lxy" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Delivery Office";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/any/supply/mail_sorting,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/structure/sign/cargo/mail{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/sorting)
 "lxE" = (
 /obj/structure/bed/roller,
 /obj/item/reagent_containers/iv_bag/blood/o_minus,
@@ -57080,6 +57443,27 @@
 "lyp" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/prisonlockers)
+"lyq" = (
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id_tag = "paramedic";
+	name = "Paramedic Garage"
+	},
+/obj/machinery/door_control{
+	id = "paramedic";
+	name = "Garage Door Control";
+	pixel_x = 24;
+	req_access = list(66)
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/medical/paramedic)
 "lys" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -57740,6 +58124,16 @@
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics/chargebay)
+"lEI" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "lES" = (
 /obj/machinery/atmospherics/portable/canister/oxygen,
 /obj/effect/turf_decal/delivery/blue/hollow,
@@ -57859,21 +58253,6 @@
 /obj/effect/turf_decal/tiles/department/medical/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/security/permabrig)
-"lGw" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Perma Cell 4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/effect/turf_decal/tiles/department/security,
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
 "lGB" = (
 /obj/item/kirbyplants/large,
 /obj/effect/turf_decal/tiles/neutral/side{
@@ -57975,10 +58354,6 @@
 /obj/item/flag/nt,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/north)
-"lIl" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/west)
 "lIm" = (
 /obj/machinery/status_display{
 	pixel_x = 32
@@ -58001,6 +58376,38 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
+"lIS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
+"lIW" = (
+/obj/machinery/door/window/brigdoor{
+	id = "Cell 2";
+	name = "Cell 2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison/cell_block)
 "lIY" = (
 /obj/machinery/ai_status_display{
 	pixel_x = -32;
@@ -58028,6 +58435,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
+"lJy" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "lJz" = (
 /obj/structure/sink/directional/east,
 /obj/effect/turf_decal/delivery/hollow,
@@ -58203,18 +58621,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
-"lLL" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prison Forestry"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
 "lLM" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -58486,6 +58892,27 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/misc_lab)
+"lOm" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Perma Cell 2";
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Prison Gate";
+	name = "Prison Lockdown Blast Doors"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/turf_decal/tiles/department/security,
+/turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
 "lOv" = (
 /obj/structure/closet/emcloset,
 /obj/effect/spawner/random/maintenance,
@@ -58808,15 +59235,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/lobby)
-"lSu" = (
-/obj/machinery/door/airlock{
-	name = "Private Restroom"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/command/office/captain/bedroom)
 "lSA" = (
 /obj/effect/spawner/random/barrier/grille_maybe,
 /obj/effect/decal/cleanable/dirt,
@@ -59238,16 +59656,6 @@
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/simulated/floor/carpet,
 /area/station/maintenance/aft2)
-"lXm" = (
-/obj/machinery/door/airlock/security,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/security/checkpoint/secondary)
 "lXt" = (
 /obj/machinery/economy/vending/wallmed/directional/west,
 /obj/effect/turf_decal/tiles/department/security/side{
@@ -59501,6 +59909,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/processing)
+"lZY" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Court gallery";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/legal/courtroom/gallery)
 "maa" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -59521,15 +59939,6 @@
 	icon_state = "chapel"
 	},
 /area/station/service/chapel)
-"maf" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id_tag = "qm_warehouse";
-	name = "Warehouse Shutters"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/supply/warehouse)
 "mat" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -59631,6 +60040,19 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
+"mbO" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "MiniSat Maintenance";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/turf/simulated/floor/plating,
+/area/station/aisat/service)
 "mcn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/barrier/grille_often,
@@ -59748,6 +60170,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_port)
+"mdy" = (
+/obj/machinery/door/airlock/security{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/security/checkpoint/secondary)
 "mdC" = (
 /obj/effect/spawner/window/reinforced/polarized/grilled{
 	id = "Interrogation"
@@ -59834,6 +60270,17 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"mei" = (
+/obj/machinery/door/airlock/security{
+	name = "Evidence Storage";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/evidence,
+/turf/simulated/floor/plasteel,
+/area/station/security/processing)
 "mel" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
@@ -59874,15 +60321,6 @@
 /obj/machinery/economy/atm/directional/north,
 /turf/simulated/floor/wood,
 /area/station/service/bar)
-"mff" = (
-/obj/machinery/door/airlock/maintenance{
-	locked = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "mfk" = (
 /obj/structure/chair{
 	dir = 4
@@ -60134,21 +60572,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/range)
-"mhS" = (
-/obj/machinery/door/airlock/research{
-	name = "Research Storage"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
-/obj/effect/mapping_helpers/airlock/access/any/science/research,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel,
-/area/station/science/break_room)
 "mhT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -60421,13 +60844,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/captain)
-"mlh" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/dorms/fore)
 "mll" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -60567,14 +60983,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/electrical/aft_starboard)
-"mmp" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Chamber Hallway"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/turret_protected/aisat/interior)
 "mmr" = (
 /obj/machinery/economy/vending/snack,
 /turf/simulated/floor/wood,
@@ -61020,19 +61428,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
-"mri" = (
-/obj/machinery/door/airlock/medical/glass,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/medical/paramedic,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/paramedic)
 "mrk" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -61197,6 +61592,20 @@
 	icon_state = "chapel"
 	},
 /area/station/service/chapel)
+"msL" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Maintenance";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "msM" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/carpet/grimey,
@@ -61764,6 +62173,16 @@
 /obj/effect/turf_decal/tiles/department/science/side,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
+"mzJ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/public/sleep)
 "mzN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -61854,6 +62273,28 @@
 /obj/effect/spawner/random/oil/maybe,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
+"mBc" = (
+/obj/machinery/door/airlock/engineering/glass{
+	autoclose = 0;
+	id_tag = "engsm_door_int";
+	locked = 1;
+	name = "Reactor Interior Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/access_button{
+	autolink_id = "engsm_btn_int";
+	name = "Reactor Access Button";
+	pixel_y = 1;
+	req_access = list(10);
+	pixel_x = 25
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/engine)
 "mBq" = (
 /obj/machinery/power/apc/directional/west,
 /obj/structure/cable{
@@ -61963,15 +62404,6 @@
 	},
 /turf/simulated/wall,
 /area/station/maintenance/abandoned_garden)
-"mBW" = (
-/obj/effect/mapping_helpers/airlock/access/any/command/hop,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/command{
-	id_tag = "hopofficedoor";
-	name = "Head of Personnel"
-	},
-/turf/simulated/floor/wood,
-/area/station/command/office/hop)
 "mBX" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
@@ -62246,19 +62678,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/electrical/fore_starboard)
-"mEn" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "AI Upload"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/turret_protected/ai_upload)
 "mEq" = (
 /obj/structure/table/wood,
 /obj/item/ashtray/bronze,
@@ -62491,6 +62910,19 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
+"mHM" = (
+/obj/machinery/door/airlock{
+	name = "Crematorium";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/crematorium,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/service/chapel/office)
 "mHW" = (
 /turf/simulated/wall,
 /area/station/supply/qm)
@@ -62641,6 +63073,14 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"mKf" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Escape Pod 4 Airlock";
+	id_tag = "emergency_home";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/security/fore)
 "mKj" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/effect/decal/cleanable/dirt,
@@ -62839,16 +63279,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/abandoned_office)
-"mLL" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/ne)
 "mLQ" = (
 /turf/simulated/floor/plating/asteroid/ancient/airless,
 /area/station/engineering/atmos/asteroid)
@@ -63069,6 +63499,27 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room/secondary)
+"mOB" = (
+/obj/machinery/door/window/reinforced/normal{
+	name = "Accused"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/all/security/brig,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/legal/courtroom)
 "mOI" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -63475,6 +63926,18 @@
 /obj/machinery/alarm/directional/south,
 /turf/simulated/floor/wood,
 /area/station/command/meeting_room)
+"mSv" = (
+/obj/machinery/door/airlock/glass{
+	name = "Prison";
+	id_tag = "Prison Perma Cell 1";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/security,
+/turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
 "mSw" = (
 /obj/machinery/computer/prisoner{
 	dir = 1
@@ -63795,13 +64258,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/testrange)
-"mVF" = (
-/obj/machinery/door/airlock/external/glass{
-	id_tag = "specops_home"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/east)
 "mVK" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Storage"
@@ -63819,14 +64275,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/equipmentstorage)
-"mVL" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "mVN" = (
 /obj/effect/turf_decal/trimline/misc/toxins/arrow_cw{
 	dir = 1
@@ -64020,19 +64468,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/carpet/grimey,
 /area/station/command/office/hop)
-"mWY" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Telecommunications Access"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/telecomms/computer)
 "mXh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64129,19 +64564,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/incinerator)
-"mXW" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Sanitarium"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison)
 "mYb" = (
 /obj/structure/table,
 /obj/item/paicard,
@@ -64419,11 +64841,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/aft_port)
-"nbw" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/asmaint)
 "nbP" = (
 /obj/structure/rack,
 /obj/item/storage/fancy/crayons,
@@ -64443,6 +64860,40 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/sorting)
+"nck" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Vault Storage";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/command/vault)
+"ncm" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "MiniSat Maintenance";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/turf/simulated/floor/plating,
+/area/station/aisat/hall)
 "nco" = (
 /obj/item/kirbyplants/large,
 /obj/machinery/light,
@@ -64474,18 +64925,6 @@
 /obj/effect/mapping_helpers/turfs/rust,
 /turf/simulated/wall,
 /area/station/maintenance/security/aft_starboard)
-"ncH" = (
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Courtroom"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/court,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Courtroom";
-	id_tag = "courtentrance"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/legal/courtroom)
 "ncL" = (
 /obj/machinery/power/apc/directional/east,
 /obj/structure/cable,
@@ -64638,6 +65077,20 @@
 /obj/effect/turf_decal/tiles/department/security/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/spacebridge/security/south)
+"nec" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/janitor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/service/janitor)
 "neo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -64822,13 +65275,6 @@
 	},
 /turf/simulated/floor/lava/plasma/fuming,
 /area/station/engineering/atmos/asteroid_core)
-"nfr" = (
-/obj/machinery/door/airlock/mining,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/supply/smith,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/supply/miningdock)
 "nfM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/turf_decal/tiles/department/virology/side{
@@ -64840,15 +65286,6 @@
 /obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
-"nfV" = (
-/obj/machinery/door/airlock/wood{
-	name = "Back Stage Entrance"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/fakestairs{
-	dir = 1
-	},
-/area/station/service/theatre)
 "nfX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -64878,17 +65315,6 @@
 /obj/effect/spawner/random/barrier/grille_maybe,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
-"ngi" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "E.V.A."
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/eva,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/ai_monitored/storage/eva)
 "ngk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -64899,26 +65325,21 @@
 	icon_state = "showroomfloor"
 	},
 /area/station/medical/surgery)
-"ngp" = (
+"ngl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/medical/genetics,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Operating Theatre 2"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Surgery 2"
-	},
-/obj/machinery/holosign/surgery{
-	id = "surgery2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel/white,
-/area/station/medical/surgery/secondary)
+/area/station/science/genetics)
 "ngr" = (
 /turf/simulated/wall,
 /area/station/medical/morgue)
@@ -64930,6 +65351,16 @@
 /obj/structure/closet/l3closet/security,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
+"ngE" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/machinery/door/airlock/maintenance{
+	name = "Atmospherics Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage)
 "ngF" = (
 /obj/structure/window/reinforced,
 /obj/structure/cable{
@@ -64945,6 +65376,23 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/ai)
+"ngM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/medical/genetics,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/science/genetics)
 "ngO" = (
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/simulated/floor/plating,
@@ -65036,6 +65484,31 @@
 /obj/effect/landmark/spawner/nukedisc_respawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/aft_port)
+"nht" = (
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/research,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/asmaint)
 "nhy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm/directional/south,
@@ -65147,19 +65620,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/fore)
-"nib" = (
-/obj/machinery/door/airlock/multi_tile/glass,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/public/sleep)
 "nif" = (
 /obj/structure/sign/vacuum{
 	pixel_x = 32
 	},
 /turf/simulated/floor/plating,
 /area/station/aisat/hall)
+"nig" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Incinerator Access";
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/plating,
+/area/station/maintenance/incinerator)
 "niO" = (
 /obj/effect/mapping_helpers/turfs/rust,
 /turf/simulated/wall,
@@ -65404,6 +65884,30 @@
 /obj/item/clothing/neck/stethoscope,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"nlG" = (
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "rdofficedoor";
+	name = "Research Director's Office";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/rd,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "rd"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/command/office/rd)
 "nlH" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -65854,6 +66358,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
+"npS" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod Airlock";
+	dir = 4
+	},
+/obj/docking_port/mobile/pod{
+	id = "pod3";
+	name = "escape pod 3"
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/pod_3)
 "npU" = (
 /obj/structure/table,
 /obj/item/mounted/frame/alarm_frame,
@@ -66261,11 +66776,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"ntR" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/science/tox,
+"ntT" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Aft-Port Atmospherics Maintenance";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/apmaint2)
 "nua" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -66555,6 +67078,21 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay2)
+"nxm" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/south)
 "nxq" = (
 /obj/structure/chair/stool{
 	dir = 4
@@ -66773,13 +67311,6 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
-"nyY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/station/public/dorms)
 "nzl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -66876,6 +67407,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
+"nzU" = (
+/obj/machinery/door/airlock/command/glass{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "bridge blast entrance";
+	name = "Bridge Blast Doors"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/command/bridge)
 "nAc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -66930,6 +67477,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/service/chapel)
+"nAF" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plating,
+/area/station/public/storage/emergency)
 "nAH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -67332,27 +67893,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/atmos/asteroid_filtering)
-"nEv" = (
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	id = "Cell 1";
-	name = "Cell 1"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison/cell_block)
 "nEy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -67497,24 +68037,6 @@
 /obj/effect/turf_decal/tiles/department/security,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"nFU" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Cloning"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/medical/cloning)
 "nFW" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -67799,6 +68321,17 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos/transit)
+"nIe" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/turf/simulated/floor/plating,
+/area/station/maintenance/security/aft_port)
 "nIf" = (
 /turf/simulated/wall,
 /area/station/security/brig)
@@ -68151,19 +68684,6 @@
 	icon_state = "solarpanel"
 	},
 /area/station/engineering/solar/aft_starboard)
-"nMe" = (
-/obj/machinery/door/airlock/public{
-	name = "Dorms Storefront 2";
-	id_tag = "shopdoor2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/chemistry,
-/obj/effect/turf_decal/tiles/department/security/checker,
-/turf/simulated/floor/plasteel,
-/area/station/public/shops)
 "nMf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -68249,6 +68769,17 @@
 /obj/structure/disposalpipe/junction/reversed,
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
+"nMz" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/public/sleep)
 "nMB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -68291,21 +68822,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/electrical/aft_starboard)
-"nMN" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Asteroid Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/storage)
 "nMO" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 8
@@ -68466,11 +68982,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
-"nOk" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/neutral/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/ne)
 "nOr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -68509,6 +69020,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
+"nOt" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/public/arcade)
 "nOu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -68939,24 +69463,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
-"nTi" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering Storage"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Engineering";
-	name = "Engineering Security Doors"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/equipmentstorage)
 "nTk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -68986,17 +69492,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/control)
-"nTC" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel,
-/area/station/public/storage/tools/auxiliary)
 "nTD" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/effect/spawner/airlock,
@@ -69053,6 +69548,29 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/hallway/primary/central/west)
+"nUj" = (
+/obj/machinery/door/airlock/command/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "qm"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/qm,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/supply/qm)
 "nUk" = (
 /obj/machinery/status_display/supply_display,
 /turf/simulated/wall,
@@ -69468,17 +69986,6 @@
 /obj/machinery/economy/vending/wallmed/directional/south,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/equipmentstorage)
-"nYF" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tiles/department/medical,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/sleeper)
 "nYM" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -69492,6 +69999,16 @@
 /obj/structure/sign/poster/official/random/directional/east,
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat/breakroom)
+"nYO" = (
+/obj/machinery/door/airlock/security{
+	name = "Firing Range Storage";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/range)
 "nYQ" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
@@ -69572,18 +70089,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/hos)
-"nZE" = (
-/obj/machinery/door/airlock/research,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/science/tox,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel,
-/area/station/science/toxins/launch)
 "nZG" = (
 /obj/machinery/computer/security/wooden_tv,
 /obj/item/toy/figure/crew/detective{
@@ -69632,26 +70137,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
-"nZR" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Operating Theatre 1"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Surgery 1"
-	},
-/obj/machinery/holosign/surgery{
-	id = "surgery1"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/surgery/primary)
 "nZS" = (
 /obj/effect/turf_decal/tiles/department/medical/side,
 /turf/simulated/floor/plasteel/white,
@@ -69840,6 +70325,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
+"obA" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	dir = 1;
+	location = "Research Division"
+	},
+/obj/machinery/door/window/classic/reversed{
+	name = "Research Division Delivery"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/science/research,
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/science/rnd)
 "obK" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -69891,6 +70400,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/break_room)
+"obZ" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Checkpoint";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/electrical/aft_starboard)
 "och" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -69920,13 +70442,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
-"ocI" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Escape Pod 1 Airlock";
-	id_tag = "emergency_home"
+"ocC" = (
+/obj/structure/curtain/open,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/west)
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/patients_rooms_secondary)
 "ocN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -69987,6 +70512,13 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
+"ocW" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fpmaint)
 "ocY" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/cobweb/right/rare,
@@ -70197,19 +70729,6 @@
 /obj/structure/bookcase/manuals/engineering,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
-"ofe" = (
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/mapping_helpers/airlock/access/all/science/tox,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel,
-/area/station/science/testrange)
 "ofj" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -70239,15 +70758,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"ofz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/abandonedservers)
 "ofA" = (
 /obj/effect/turf_decal/tiles/department/medical/corner{
 	dir = 8
@@ -70493,6 +71003,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room/secondary)
+"ohJ" = (
+/obj/machinery/door/airlock{
+	name = "Unit 1";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/station/public/toilet/lockerroom)
 "ohK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -70534,20 +71056,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos/storage)
-"oid" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Teleporter Room"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/turret_protected/aisat/interior)
 "oih" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt,
@@ -70566,6 +71074,29 @@
 	icon_regular_floor = "yellowsiding"
 	},
 /area/station/service/mime)
+"oim" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	id = "Cell 1";
+	name = "Cell 1"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison/cell_block)
 "oip" = (
 /obj/structure/closet/crate/trashcart{
 	desc = "A heavy, metal laundrycart with wheels.";
@@ -70991,11 +71522,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/aft_port)
-"omq" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fsmaint2)
 "omt" = (
 /obj/machinery/power/apc/directional/west,
 /obj/structure/cable{
@@ -71313,18 +71839,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
-"opA" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel,
-/area/station/public/pet_store)
 "opF" = (
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/effect/turf_decal/tiles/neutral/side{
@@ -71440,15 +71954,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prisonershuttle)
-"oqr" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/ne)
 "oqC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -71773,30 +72278,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
-"otv" = (
-/obj/machinery/door/airlock/command/glass{
-	id_tag = "hosofficedoor";
-	name = "Head of Security"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/security/hos,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "HoS"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/command/office/hos)
 "otB" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -72261,6 +72742,15 @@
 "ozB" = (
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics/chargebay)
+"ozU" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "ozW" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -72330,6 +72820,12 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prisonershuttle)
+"oAG" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/west)
 "oAI" = (
 /obj/effect/turf_decal/tiles/white/corner{
 	dir = 8
@@ -72793,16 +73289,6 @@
 /obj/effect/turf_decal/tiles/department/security/checker,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
-"oFy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/any/command/hop,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
-	name = "Head of Personnel's Private Quarters"
-	},
-/turf/simulated/floor/wood,
-/area/station/command/office/hop)
 "oFC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -72889,6 +73375,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"oGF" = (
+/obj/machinery/door/airlock/maintenance{
+	electrified_until = -1;
+	locked = 1;
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/security/fore)
 "oGN" = (
 /turf/simulated/wall/r_wall,
 /area/space)
@@ -73039,11 +73534,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prisonershuttle)
-"oIR" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/smartfridge/food/chef,
-/turf/simulated/floor/plasteel,
-/area/station/service/hydroponics)
 "oIU" = (
 /obj/structure/rack,
 /obj/item/soap,
@@ -73659,6 +74149,13 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
+"oOd" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/smartfridge/food/chef,
+/turf/simulated/floor/plasteel,
+/area/station/service/hydroponics)
 "oOg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
@@ -74005,17 +74502,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
-"oRk" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tiles/department/medical,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/cryo)
 "oRn" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
@@ -74291,6 +74777,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/asteroid_maint)
+"oUn" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Upload Access";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/science,
+/turf/simulated/floor/plasteel/white,
+/area/station/turret_protected/ai_upload)
 "oUo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -74375,27 +74878,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
-"oUY" = (
-/obj/machinery/door/airlock/engineering/glass,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "gravity"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/station_engineer,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/gravitygenerator)
 "oVc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -74680,6 +75162,25 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
+"oXN" = (
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/lobby)
 "oXO" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -75493,6 +75994,19 @@
 /obj/effect/turf_decal/tiles/department/science/corner,
 /turf/simulated/floor/plasteel,
 /area/station/science/toxins/mixing)
+"pft" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medical Supplies";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical,
+/turf/simulated/floor/plasteel,
+/area/station/medical/storage)
 "pfA" = (
 /obj/structure/closet/secure_closet/reagents,
 /obj/effect/turf_decal/stripes/line{
@@ -75997,6 +76511,33 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/plasma,
 /area/station/engineering/atmos/asteroid_core)
+"pjF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/command/glass{
+	name = "Trainer's Office";
+	id_tag = "nct";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/procedure/trainer,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "NCT"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/procedure/trainer_office)
 "pjL" = (
 /obj/item/clipboard,
 /obj/item/pen,
@@ -76288,6 +76829,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
+"pnc" = (
+/obj/machinery/door/airlock/command{
+	id_tag = "hopofficedoor";
+	name = "Head of Personnel";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/any/command/hop,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/command/office/hop)
 "pno" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -76419,16 +76977,6 @@
 /obj/item/chair/stool/bar,
 /turf/simulated/floor/wood,
 /area/station/maintenance/abandonedbar)
-"poL" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Security Space Bridge"
-	},
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/security/south)
 "poN" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel/white,
@@ -76515,6 +77063,26 @@
 /obj/structure/table,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/robotics)
+"ppm" = (
+/obj/machinery/door/airlock/command/glass{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "bridge blast entrance";
+	name = "Bridge Blast Doors"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/command/bridge)
 "pps" = (
 /obj/machinery/light{
 	dir = 4
@@ -76538,6 +77106,15 @@
 "ppu" = (
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft)
+"ppy" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/dorms/fore)
 "ppB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
@@ -76755,6 +77332,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"prv" = (
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/medical/paramedic,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/paramedic)
 "prz" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -76859,6 +77453,17 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/ai_monitored/storage/eva)
+"pst" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/station_engineer,
+/obj/machinery/door/airlock/engineering{
+	name = "Power Transmission Laser";
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/engine/reactor)
 "psz" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/camera{
@@ -76913,14 +77518,6 @@
 /obj/structure/table,
 /turf/simulated/floor/plasteel,
 /area/station/security/processing)
-"ptC" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry)
 "ptH" = (
 /obj/effect/spawner/window/reinforced/polarized/grilled{
 	id = "Detective"
@@ -76928,28 +77525,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/security/detective)
-"ptQ" = (
-/obj/machinery/door/airlock/research{
-	name = "Research Division Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/research,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/asmaint)
 "pud" = (
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/structure/fans/tiny,
@@ -77070,6 +77645,21 @@
 /obj/effect/turf_decal/tiles/department/security/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/north)
+"pvn" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/public/storage/tools/auxiliary)
 "pvv" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -77635,17 +78225,6 @@
 /obj/effect/spawner/random/glowstick,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
-"pCe" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Checkpoint"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical/aft_port)
 "pCt" = (
 /obj/machinery/light_switch{
 	name = "north bump";
@@ -78141,14 +78720,15 @@
 	},
 /turf/simulated/floor/engine/asteroid,
 /area/station/engineering/atmos/asteroid_core)
-"pGV" = (
+"pHg" = (
 /obj/machinery/door/airlock/engineering{
-	name = "Engineering Checkpoint"
+	name = "Engineering Checkpoint";
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable{
+/obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -78441,20 +79021,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
-"pJu" = (
-/obj/machinery/door/airlock/glass{
-	name = "Prison";
-	id_tag = "Prison Perma Cell 3"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/security,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
 "pJD" = (
@@ -78761,6 +79327,18 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/east)
+"pLX" = (
+/obj/machinery/door/airlock{
+	name = "Unit 3";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/station/public/toilet/lockerroom)
 "pMe" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 9
@@ -78793,6 +79371,18 @@
 	},
 /turf/simulated/floor/catwalk/black,
 /area/station/turret_protected/aisat/interior)
+"pMG" = (
+/obj/machinery/door/airlock/glass{
+	name = "Prison";
+	id_tag = "Prison Perma Cell 4";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/security,
+/turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
 "pMM" = (
 /obj/effect/spawner/random/barrier/grille_maybe,
 /obj/effect/decal/cleanable/dirt,
@@ -78920,6 +79510,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/asteroid_filtering)
+"pOr" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/titanium/glass{
+	dir = 4
+	},
+/turf/simulated/floor/indestructible/titanium,
+/area/shuttle/arrival/station)
 "pOy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -78988,18 +79585,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
-"pPL" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/north)
 "pPN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -79107,7 +79692,7 @@
 /obj/machinery/computer/general_air_control{
 	dir = 1;
 	name = "Tank Monitor";
-	autolink_sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous Oxide","waste_sensor"="Gas Mix Tank")
+	autolink_sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous Oxide", "waste_sensor" = "Gas Mix Tank")
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/control)
@@ -79120,6 +79705,23 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/secure_storage)
+"pRc" = (
+/obj/machinery/door/airlock/tranquillite{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/mime,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white{
+	icon_regular_floor = "yellowsiding"
+	},
+/area/station/service/mime)
 "pRo" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -79622,6 +80224,16 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"pWT" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/public/park)
 "pWV" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt,
@@ -79858,6 +80470,19 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
+"pZv" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tiles/department/medical,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/sleeper)
 "pZy" = (
 /obj/structure/sign/poster/contraband/random/directional/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -80023,6 +80648,17 @@
 /obj/effect/spawner/random/barrier/obstruction,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/aft_port)
+"qbV" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Fore Starboard Solar Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/solar_maintenance/fore_starboard)
 "qbZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -80215,6 +80851,30 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics/chargebay)
+"qdl" = (
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "NTR"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/ntrep,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "ntrepofficedoor";
+	name = "NT Representative's Office";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/command/office/ntrep)
 "qdt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -80501,7 +81161,7 @@
 /obj/machinery/computer/general_air_control{
 	level = 3;
 	name = "Distribution and Waste Monitor";
-	autolink_sensors = list("mair_in_meter"="Mixed Air In","air_sensor"="Mixed Air Supply Tank","mair_out_meter"="Mixed Air Out","dloop_atm_meter"="Distribution Loop","wloop_atm_meter"="Waste Loop")
+	autolink_sensors = list("mair_in_meter" = "Mixed Air In", "air_sensor" = "Mixed Air Supply Tank", "mair_out_meter" = "Mixed Air Out", "dloop_atm_meter" = "Distribution Loop", "wloop_atm_meter" = "Waste Loop")
 	},
 /obj/effect/turf_decal/tiles/department/engineering/side{
 	dir = 5
@@ -80677,6 +81337,15 @@
 /obj/effect/turf_decal/tiles/department/command,
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/storage/secondary)
+"qin" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft2)
 "qiq" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -80822,6 +81491,15 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/command/office/captain/bedroom)
+"qjW" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/security/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "qkb" = (
 /obj/structure/sink/directional/north,
 /obj/item/reagent_containers/glass/bucket,
@@ -80894,16 +81572,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/misc_lab)
-"qkM" = (
-/obj/machinery/door/airlock,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plating,
-/area/station/public/storage/emergency)
 "qkV" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -81033,6 +81701,24 @@
 /obj/effect/spawner/random/trash,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dorms/port)
+"qmM" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/public/construction)
 "qna" = (
 /obj/structure/table,
 /obj/item/vending_refill/coffee,
@@ -81445,6 +82131,22 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/lobby)
+"qrN" = (
+/obj/machinery/door/poddoor{
+	id_tag = "Secure Storage";
+	name = "Secure Storage Blast Doors"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/secure_storage)
 "qrO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door_control{
@@ -81492,6 +82194,22 @@
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall/r_wall,
 /area/station/hallway/spacebridge/security/south)
+"qrX" = (
+/obj/machinery/access_button{
+	autolink_id = "incinerator_btn_ext";
+	name = "Incinerator Airlock Control";
+	pixel_x = 23
+	},
+/obj/machinery/door/airlock/public/glass{
+	autoclose = 0;
+	heat_proof = 1;
+	id_tag = "incinerator_door_ext";
+	locked = 1;
+	name = "Mixing Room Exterior Airlock";
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/maintenance/incinerator)
 "qrZ" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/drinks/britcup,
@@ -81862,6 +82580,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"qxo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/public/dorms)
 "qxt" = (
 /obj/effect/spawner/random/trash,
 /obj/structure/cable/extra_insulated{
@@ -82077,6 +82804,22 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"qzh" = (
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Desk";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "atmos";
+	name = "Atmos Blast Door"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos/control)
 "qzt" = (
 /obj/effect/turf_decal{
 	dir = 8
@@ -82090,15 +82833,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/simulated/floor/wood,
 /area/station/command/office/rd)
-"qzz" = (
-/obj/machinery/door/airlock{
-	name = "Unit 1"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/station/public/toilet/lockerroom)
 "qzJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -82331,15 +83065,6 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/command/meeting_room)
-"qCh" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/apmaint)
 "qCm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
@@ -82505,16 +83230,6 @@
 /obj/item/toy/russian_revolver,
 /turf/simulated/floor/wood,
 /area/station/maintenance/dorms/starboard)
-"qDZ" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/structure/sign/poster/official/random/directional/west,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/neutral/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/shops)
 "qEb" = (
 /obj/structure/table/wood,
 /obj/item/dice/d20,
@@ -82696,6 +83411,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/toxins/mixing)
+"qFK" = (
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Teleporter Room";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
+/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/turret_protected/aisat/interior)
 "qFP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
@@ -82807,6 +83539,14 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology/lab)
+"qHc" = (
+/obj/machinery/door/airlock/freezer{
+	dir = 4
+	},
+/obj/structure/barricade/wooden,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint)
 "qHd" = (
 /turf/simulated/floor/plasteel,
 /area/station/science/toxins/mixing)
@@ -83521,21 +84261,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dorms/fore)
-"qPb" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Psych Office"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "psychoffice"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/station/medical/psych)
 "qPg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -83576,19 +84301,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/testrange)
-"qPB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/medical/glass,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/medical/morgue)
 "qPE" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-8"
@@ -83666,6 +84378,14 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
+"qQh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "qQn" = (
 /obj/structure/rack,
 /obj/item/stack/cable_coil{
@@ -83809,17 +84529,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
-"qRI" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/asmaint)
 "qRO" = (
 /obj/structure/extinguisher_cabinet{
 	name = "south bump";
@@ -83870,6 +84579,16 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/security/permabrig)
+"qSx" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/west)
 "qSC" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -83909,18 +84628,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
-"qTj" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/wood,
-/area/station/public/vacant_office)
 "qTm" = (
 /obj/structure/chair/comfy/beige{
 	dir = 4
@@ -83936,6 +84643,17 @@
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall,
 /area/station/maintenance/aft)
+"qTE" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/ne)
 "qTH" = (
 /obj/effect/spawner/random/barrier/grille_maybe,
 /turf/simulated/floor/plating,
@@ -84037,6 +84755,19 @@
 /obj/machinery/cooking/stovetop/loaded,
 /turf/simulated/floor/plasteel/white,
 /area/station/security/permabrig)
+"qUw" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Aft-Port Atmospherics Maintenance";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/supply,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint2)
 "qUz" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -84126,6 +84857,18 @@
 /obj/effect/turf_decal/tiles/department/cargo/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
+"qVl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft)
 "qVn" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/grass/jungle,
@@ -84483,6 +85226,23 @@
 /obj/machinery/firealarm/directional/east,
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/ai_upload)
+"qYH" = (
+/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "robo"
+	},
+/obj/machinery/door/airlock/research/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/robotics)
 "qYK" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs{
@@ -85044,6 +85804,26 @@
 /obj/effect/turf_decal/tiles/department/science/side,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
+"rdx" = (
+/obj/machinery/door/poddoor/preopen{
+	name = "Biohazard Shutter";
+	id_tag = "RnDChem"
+	},
+/obj/machinery/door/airlock/research/glass{
+	name = "Test Chamber";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/tox,
+/obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
+/turf/simulated/floor/engine,
+/area/station/science/misc_lab)
 "rdB" = (
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
@@ -85231,21 +86011,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
-"rfC" = (
-/obj/machinery/access_button{
-	autolink_id = "incinerator_btn_ext";
-	name = "Incinerator Airlock Control";
-	pixel_x = 23
-	},
-/obj/machinery/door/airlock/public/glass{
-	autoclose = 0;
-	heat_proof = 1;
-	id_tag = "incinerator_door_ext";
-	locked = 1;
-	name = "Mixing Room Exterior Airlock"
-	},
-/turf/simulated/floor/engine,
-/area/station/maintenance/incinerator)
 "rfG" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door_control{
@@ -85309,6 +86074,32 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/expedition)
+"rgz" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Chief Engineer's Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "CE"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/command/office/ce)
 "rgD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -85682,18 +86473,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
-"rjf" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/public/shops)
 "rjg" = (
 /obj/machinery/light{
 	dir = 1
@@ -85826,16 +86605,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/public/construction)
-"rkg" = (
-/obj/machinery/door/airlock/virology/glass{
-	name = "Monkey Pen"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/grass/no_creep,
-/area/station/medical/virology)
 "rkB" = (
 /obj/structure/sign/directions/security{
 	dir = 4;
@@ -86419,10 +87188,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"rqR" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/station/public/dorms)
 "rqT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
@@ -86455,14 +87220,6 @@
 /obj/structure/sign/poster/official/random/directional/east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
-"rrm" = (
-/obj/machinery/door/airlock/wood{
-	name = "Private Residence";
-	desc = "No solicitors please."
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/wood,
-/area/station/maintenance/fsmaint)
 "rrn" = (
 /obj/item/shard,
 /turf/simulated/floor/plating,
@@ -86783,24 +87540,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"ruT" = (
-/obj/machinery/door/window/brigdoor{
-	id = "Cell 4";
-	name = "Cell 4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison/cell_block)
 "ruV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	autolink_id = "cstm_outlet_scrubber"
@@ -87029,14 +87768,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/fitness)
-"rxN" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint)
 "rxP" = (
 /obj/structure/sign/cargo/materials,
 /turf/simulated/wall,
@@ -87104,6 +87835,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
+"ryL" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Suit Storage";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/station_engineer,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/control)
 "ryO" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -87261,6 +88003,25 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/science/xenobiology)
+"rzI" = (
+/obj/machinery/door/airlock/glass{
+	name = "Internal Affairs Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/iaa,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "IAA"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/legal/lawoffice)
 "rzL" = (
 /obj/structure/table,
 /obj/item/camera,
@@ -87988,6 +88749,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/nw)
+"rHP" = (
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/public/dorms)
 "rHS" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -88201,6 +88969,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
+"rJm" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Security Space Bridge";
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/spacebridge/security/south)
 "rJq" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/maintenance,
@@ -88357,6 +89138,19 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/grimey,
 /area/station/service/bar)
+"rKA" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/machinery/door/airlock/atmos{
+	name = "Security Maintenance Atmospherics control";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/security/aft_port)
 "rKG" = (
 /obj/structure/bed/roller,
 /obj/item/bedsheet/medical,
@@ -88546,14 +89340,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/telecomms/computer)
-"rMg" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint)
 "rMi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/extra_insulated{
@@ -88607,30 +89393,6 @@
 /obj/machinery/economy/atm/directional/west,
 /turf/simulated/floor/wood,
 /area/station/maintenance/dorms/starboard)
-"rMy" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
-"rMz" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel,
-/area/station/supply/lobby)
 "rME" = (
 /obj/machinery/economy/atm/directional/east,
 /obj/effect/turf_decal/tiles/department/science/corner{
@@ -88646,6 +89408,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/electrical/aft_starboard)
+"rMT" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fpmaint)
 "rMU" = (
 /obj/effect/decal/cleanable/blood/gibs/robot,
 /obj/effect/decal/cleanable/blood/oil,
@@ -88696,14 +89468,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
-"rNm" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/dorms/port)
 "rNn" = (
 /obj/machinery/alarm/directional/north,
 /turf/simulated/floor/bluegrid,
@@ -88752,22 +89516,6 @@
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/simulated/floor/plasteel,
 /area/station/security/interrogation)
-"rNB" = (
-/obj/machinery/door/airlock/glass{
-	name = "Internal Affairs Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/iaa,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "IAA"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/station/legal/lawoffice)
 "rNI" = (
 /obj/item/flag/nt,
 /obj/effect/turf_decal/woodsiding{
@@ -89041,35 +89789,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/xenobiology)
-"rQM" = (
-/obj/machinery/door/airlock/public/glass{
-	autoclose = 0;
-	heat_proof = 1;
-	id_tag = "incinerator_door_int";
-	locked = 1;
-	name = "Mixing Room Interior Airlock"
+"rQQ" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Perma Cell 3";
+	dir = 4
 	},
-/obj/machinery/access_button{
-	autolink_id = "incinerator_btn_int";
-	name = "Incinerator Airlock Control";
-	pixel_x = 23
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Prison Gate";
+	name = "Prison Lockdown Blast Doors"
 	},
-/turf/simulated/floor/engine,
-/area/station/maintenance/incinerator)
-"rQO" = (
-/obj/machinery/door/airlock/public/glass{
-	autoclose = 0;
-	heat_proof = 1;
-	id_tag = "turbine_door_ext";
-	name = "Turbine Exterior Airlock"
-	},
-/obj/structure/cable/yellow{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/engine,
-/area/station/engineering/atmos/asteroid_filtering)
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/turf_decal/tiles/department/security,
+/turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
 "rQU" = (
 /turf/simulated/wall,
 /area/station/medical/paramedic)
@@ -89432,20 +90172,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
-"rUv" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id_tag = "qm_warehouse";
-	name = "Warehouse Shutters"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/supply/warehouse)
 "rUx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -89494,30 +90220,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/nw)
-"rUQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/command/glass{
-	name = "Trainer's Office";
-	id_tag = "nct"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/procedure/trainer,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "NCT"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/procedure/trainer_office)
 "rUU" = (
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/simulated/floor/plasteel,
@@ -89608,6 +90310,17 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/maintenance/incinerator)
+"rVT" = (
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id_tag = "qm_warehouse";
+	name = "Warehouse Shutters"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/warehouse)
 "rVU" = (
 /obj/item/radio/intercom{
 	name = "east bump";
@@ -89643,31 +90356,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/service/library)
-"rWf" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/classic/normal{
-	name = "Head of Personnel's Desk"
-	},
-/obj/machinery/door/window/classic/normal{
-	name = "Head of Personnel's Desk";
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id_tag = "hop";
-	name = "Privacy Shutters";
-	dir = 2
-	},
-/obj/item/desk_bell{
-	pixel_x = -6;
-	pixel_y = 3;
-	anchored = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/all/command/hop{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/station/command/office/hop)
 "rWj" = (
 /obj/effect/spawner/random/oil/maybe,
 /obj/effect/spawner/random/trash,
@@ -89681,15 +90369,6 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prisonlockers)
-"rWs" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/public/arcade)
 "rWt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/turf_decal/stripes/line{
@@ -89863,6 +90542,15 @@
 /obj/item/toy/figure/crew/syndie,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/fore)
+"rXD" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore/north)
 "rXG" = (
 /obj/effect/turf_decal/tiles/department/medical/side,
 /turf/simulated/floor/plasteel,
@@ -90057,6 +90745,29 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/lobby)
+"rZw" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/classic/reversed,
+/obj/item/desk_bell{
+	pixel_y = 8;
+	anchored = 1
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	name = "Research and Development Lab Shutters";
+	id_tag = "rndlab2"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/science/tox,
+/turf/simulated/floor/plasteel,
+/area/station/science/rnd)
 "rZB" = (
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
@@ -90810,22 +91521,6 @@
 /obj/item/hand_labeler,
 /turf/simulated/floor/engine,
 /area/station/medical/chemistry)
-"sic" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Engineering Maintenance"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Engineering";
-	name = "Engineering Security Doors"
-	},
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "sih" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -90971,13 +91666,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/carpet/orange,
 /area/station/service/kitchen)
-"sjG" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft2)
 "sjH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -91418,24 +92106,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
-"soN" = (
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/ne)
-"soQ" = (
-/obj/machinery/door/airlock/research{
-	name = "Test Lab"
+"soK" = (
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Antechamber";
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
-/obj/effect/mapping_helpers/airlock/access/any/science/tox,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/misc_lab)
+/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/turret_protected/aisat/interior)
+"soN" = (
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/ne)
 "soR" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tiles/white/corner{
@@ -91449,17 +92138,6 @@
 /obj/effect/mapping_helpers/turfs/burn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
-"soV" = (
-/obj/machinery/door/airlock/multi_tile{
-	name = "maintenance access"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "soW" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -91862,6 +92540,25 @@
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/asteroid_filtering)
+"stJ" = (
+/obj/machinery/door/airlock/research/glass{
+	name = "Break Room";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
+/obj/effect/mapping_helpers/airlock/access/any/science/research,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel,
+/area/station/science/break_room)
 "stK" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -91994,6 +92691,18 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/service/library)
+"suL" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "suS" = (
 /obj/effect/landmark/lightsout,
 /turf/simulated/floor/plasteel,
@@ -92009,19 +92718,6 @@
 /obj/item/kirbyplants/medium,
 /turf/simulated/floor/plasteel,
 /area/station/supply/lobby)
-"svl" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Antechamber"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/turret_protected/aisat/interior)
 "svn" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/cable/extra_insulated{
@@ -92237,6 +92933,19 @@
 /obj/item/clothing/mask/breath,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/engine/reactor)
+"sxL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "sxN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -92356,12 +93065,38 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/aft_port)
+"syQ" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/supply/lobby)
 "syR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
+"syU" = (
+/obj/structure/table/reinforced,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/genetics,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/window/classic/reversed,
+/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/genetics)
 "syW" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -92442,32 +93177,6 @@
 /obj/item/kirbyplants/large,
 /turf/simulated/floor/wood,
 /area/station/hallway/secondary/exit)
-"szH" = (
-/obj/machinery/door/airlock/research{
-	autoclose = 0;
-	id_tag = "xeno_door_ext";
-	locked = 1;
-	name = "Xenobiology External Airlock"
-	},
-/obj/machinery/access_button{
-	autolink_id = "xeno_btn_ext";
-	name = "Xenobiology Access Button";
-	pixel_x = -24;
-	req_access = list(55)
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/science/xenobiology)
 "szO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -92480,19 +93189,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
-"szQ" = (
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics Desk"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "atmos";
-	name = "Atmos Blast Door"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/control)
 "szR" = (
 /obj/machinery/atmospherics/binary/pump,
 /obj/item/radio/intercom{
@@ -92597,14 +93293,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
-"sAK" = (
-/obj/machinery/door/airlock/mining,
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel,
-/area/station/supply/miningdock)
 "sAL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -92646,24 +93334,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
-"sBe" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/range)
 "sBh" = (
 /obj/effect/turf_decal/tiles/dark/checker,
 /obj/structure/sink/kitchen/old/directional/west,
@@ -92692,6 +93362,13 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating/airless,
 /area/station/aisat/breakroom)
+"sBQ" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/tox,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "sBR" = (
 /obj/effect/spawner/random/blood/maybe,
 /obj/effect/decal/cleanable/dirt,
@@ -92939,6 +93616,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/grass,
 /area/station/maintenance/abandoned_garden)
+"sEi" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/north)
 "sEw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -92949,19 +93636,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"sEA" = (
-/obj/machinery/door/airlock/public{
-	name = "Dorms Storefront 1";
-	id_tag = "shopdoor1"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/chemistry,
-/obj/effect/turf_decal/tiles/department/security/checker,
-/turf/simulated/floor/plasteel,
-/area/station/public/shops)
 "sEM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -93138,22 +93812,6 @@
 /obj/structure/sign/poster/official/cleanliness/directional/east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"sGo" = (
-/obj/machinery/door/airlock/command/glass,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge blast entrance";
-	name = "Bridge Blast Doors"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/command/bridge)
 "sGx" = (
 /obj/machinery/alarm/directional/east,
 /obj/structure/chair{
@@ -93303,6 +93961,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
+"sHi" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/security/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "sHm" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -93319,21 +93986,6 @@
 /obj/structure/sign/poster/contraband/random/directional/south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint2)
-"sHD" = (
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "robo"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/science/robotics/chargebay)
 "sHG" = (
 /obj/structure/bed/dogbed,
 /obj/effect/turf_decal/tiles/department/cargo/side,
@@ -93420,6 +94072,15 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/fore)
+"sJb" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint2)
 "sJx" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/machinery/door/poddoor/preopen{
@@ -93493,18 +94154,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/grass,
 /area/station/public/park)
-"sKh" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prisonlockers)
 "sKk" = (
 /obj/structure/rack{
 	dir = 1
@@ -93859,12 +94508,6 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
 /area/station/medical/storage)
-"sNT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry)
 "sOp" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/drinks/cans/bottler/glass_bottle{
@@ -93959,15 +94602,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/rd)
-"sPK" = (
-/obj/machinery/door/airlock/glass{
-	name = "Prison";
-	id_tag = "Prison Perma Cell 1"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/security,
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
 "sPL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/syndicatebomb/training,
@@ -94012,17 +94646,6 @@
 /obj/effect/spawner/random/blood/often,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dorms/starboard)
-"sQn" = (
-/obj/structure/barricade/wooden/crude,
-/obj/machinery/door/airlock/science/glass{
-	welded = 1;
-	locked = 1;
-	name = "Abandoned Airlock"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
 "sQp" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -94237,14 +94860,6 @@
 	icon_state = "cult"
 	},
 /area/station/legal/lawoffice)
-"sSv" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	locked = 1
-	},
-/obj/structure/barricade/wooden,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/abandoned_garden)
 "sSy" = (
 /obj/structure/table/reinforced,
 /obj/item/bikehorn/rubberducky,
@@ -94278,11 +94893,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"sTg" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/medical,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/cryo)
 "sTk" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/drinks/cans/cola{
@@ -94486,6 +95096,15 @@
 /obj/effect/decal/cleanable/glass,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/aft_starboard)
+"sVm" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Bay Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/cargo_bay,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "sVq" = (
 /obj/structure/girder,
 /obj/structure/cable/extra_insulated{
@@ -94886,6 +95505,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dorms/port)
+"sYi" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Engineering Maintenance";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Engineering";
+	name = "Engineering Security Doors"
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "sYm" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/white,
@@ -94938,18 +95574,6 @@
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/security/aft_port)
-"sZi" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Secure Tech Storage"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/tech_storage)
 "sZl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -94983,6 +95607,22 @@
 /obj/item/stack/cable_coil,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"sZO" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/classic/normal{
+	dir = 1;
+	name = "Kitchen Desk"
+	},
+/obj/machinery/door/window/classic/normal,
+/obj/effect/mapping_helpers/airlock/windoor/access/all/service/kitchen{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/all/service/hydroponics,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/service/hydroponics)
 "sZP" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/machinery/light{
@@ -95120,6 +95760,12 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/legal/courtroom)
+"tbe" = (
+/obj/machinery/door/airlock/engineering{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint2)
 "tbi" = (
 /obj/machinery/economy/atm/directional/north,
 /obj/effect/turf_decal/tiles/white/corner{
@@ -95270,18 +95916,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
-"tcz" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/obj/machinery/door/airlock/atmos{
-	name = "Security Maintenance Atmospherics control"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/security/aft_port)
 "tcB" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
@@ -95379,6 +96013,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/south)
+"tdL" = (
+/obj/machinery/door/airlock/research{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/science/tox,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/science/toxins/launch)
 "tdN" = (
 /obj/structure/sign/nosmoking{
 	pixel_y = 30
@@ -95476,24 +96126,6 @@
 /obj/item/reagent_containers/glass/bottle/facid,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/execution)
-"teC" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Conference Room";
-	id_tag = "conference"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "conference"
-	},
-/turf/simulated/floor/wood,
-/area/station/command/meeting_room)
 "teD" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -95700,6 +96332,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/vault)
+"tgr" = (
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "robo"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/robotics/chargebay)
 "tgv" = (
 /obj/structure/extinguisher_cabinet{
 	name = "south bump";
@@ -96439,18 +97090,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/public/park)
-"tnt" = (
-/obj/machinery/door/airlock/command/glass,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge blast entrance";
-	name = "Bridge Blast Doors"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel,
-/area/station/command/bridge)
 "tnv" = (
 /obj/structure/table/wood,
 /obj/item/megaphone,
@@ -96786,6 +97425,29 @@
 /obj/effect/spawner/random/trash,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
+"tqp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Operating Theatre 2";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Surgery 2"
+	},
+/obj/machinery/holosign/surgery{
+	id = "surgery2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/surgery/secondary)
 "tqq" = (
 /obj/structure/table,
 /obj/item/radio{
@@ -97023,21 +97685,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/processing)
-"tsy" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Perma Cell 1"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/effect/turf_decal/tiles/department/security,
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
 "tsJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/extra_insulated{
@@ -97073,6 +97720,18 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"tsW" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Funeral Services";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/grimey,
+/area/station/service/chapel/funeral)
 "ttc" = (
 /obj/structure/machine_frame,
 /obj/effect/decal/cleanable/dirt,
@@ -97122,24 +97781,6 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"ttC" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Perma Cell 2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/effect/turf_decal/tiles/department/security,
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
 "ttG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -97246,6 +97887,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint2)
+"tul" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore/north)
 "tuC" = (
 /obj/effect/spawner/random/barrier/grille_maybe,
 /obj/effect/decal/cleanable/dirt,
@@ -97313,20 +97966,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/science/robotics)
-"tvv" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos)
 "tvx" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/soft/cargo,
@@ -97580,6 +98219,25 @@
 /obj/item/camera,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
+"tyC" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Staff Entrance";
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/medbay2)
 "tyE" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/turf_decal/tiles/department/science/side,
@@ -98030,6 +98688,15 @@
 	temperature = 80
 	},
 /area/station/science/xenobiology)
+"tEf" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "tEg" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -98308,17 +98975,6 @@
 /obj/structure/sign/public/cryo,
 /turf/simulated/wall,
 /area/station/public/sleep)
-"tHj" = (
-/obj/machinery/door/airlock{
-	name = "Court"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/security/court,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/legal/courtroom)
 "tHm" = (
 /obj/structure/flora/rock/jungle,
 /obj/structure/railing{
@@ -98571,6 +99227,28 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
+"tKc" = (
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/range)
 "tKe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -98865,6 +99543,22 @@
 /obj/item/eftpos/register,
 /turf/simulated/floor/plasteel,
 /area/station/supply/smith_office)
+"tMA" = (
+/obj/machinery/door/airlock/vault{
+	locked = 1;
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/any/supply/vault,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/command/vault)
 "tMD" = (
 /obj/effect/turf_decal/tiles/department/security/corner{
 	dir = 1
@@ -98990,28 +99684,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay2)
-"tNp" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Medbay Maintenance"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
-"tNq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore/north)
 "tNr" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tiles/department/medical/side,
@@ -99061,6 +99733,24 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/west)
+"tOr" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Perma Cell 1";
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Prison Gate";
+	name = "Prison Lockdown Blast Doors"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/turf_decal/tiles/department/security,
+/turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
 "tOs" = (
 /obj/item/stack/tile/carpet,
 /obj/effect/mapping_helpers/turfs/burn,
@@ -99106,6 +99796,20 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
+"tPD" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "E.V.A.";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/eva,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/ai_monitored/storage/eva)
 "tPJ" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/engineering_guide{
@@ -99397,6 +100101,20 @@
 /obj/machinery/economy/vending/wallmed/directional/west,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/range)
+"tSX" = (
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prisonlockers)
 "tTh" = (
 /obj/structure/railing{
 	dir = 5
@@ -99512,6 +100230,21 @@
 	icon_regular_floor = "yellowsiding"
 	},
 /area/station/service/mime)
+"tTX" = (
+/obj/machinery/door/airlock/public/glass{
+	autoclose = 0;
+	heat_proof = 1;
+	id_tag = "turbine_door_ext";
+	name = "Turbine Exterior Airlock";
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/engine,
+/area/station/engineering/atmos/asteroid_filtering)
 "tTY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/barrier/grille_maybe,
@@ -99711,26 +100444,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/sleeper)
-"tWs" = (
-/obj/machinery/door/airlock/security{
-	name = "Equipment Storage"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/storage)
 "tWz" = (
 /obj/structure/table/reinforced,
 /obj/item/screwdriver,
@@ -100497,6 +101210,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
+"udm" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Break Room";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel,
+/area/station/security/main)
 "udv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -100546,6 +101277,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"udW" = (
+/obj/machinery/door/airlock/wood{
+	name = "The Grey Tide";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint2)
 "udY" = (
 /obj/structure/transit_tube/diagonal/topleft{
 	dir = 1
@@ -100689,6 +101428,13 @@
 "ufG" = (
 /turf/simulated/floor/wood,
 /area/station/supply/qm)
+"ufP" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "ufS" = (
 /obj/effect/turf_decal/tiles/white/side{
 	dir = 5
@@ -100768,6 +101514,13 @@
 /obj/item/clothing/head/hardhat/pumpkinhead,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"ugG" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore/north)
 "ugO" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -100870,22 +101623,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/lobby)
-"uhY" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medical Supplies"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/medical,
-/turf/simulated/floor/plasteel,
-/area/station/medical/storage)
 "uia" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -100899,6 +101636,23 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
+"uiE" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Escape Shuttle Cell";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/doors,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/exit)
 "uiH" = (
 /obj/structure/chair/sofa/corner{
 	dir = 1;
@@ -101587,6 +102341,14 @@
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/station/security/range)
+"uqm" = (
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "ferry_home";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/west)
 "uqp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -101632,17 +102394,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/storage/secondary)
-"uqY" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint2)
 "urb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -101987,16 +102738,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"uuD" = (
-/obj/machinery/door/airlock/command{
-	name = "Chief Engineer's Bedroom"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/station/command/office/ce)
 "uuF" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -102120,6 +102861,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/clown)
+"uvz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft)
 "uvJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -102393,20 +103146,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/shops)
-"uyB" = (
-/obj/machinery/door/poddoor{
-	id_tag = "Secure Storage";
-	name = "Secure Storage Blast Doors"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/secure_storage)
 "uyG" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel,
@@ -102861,15 +103600,6 @@
 /obj/structure/sign/poster/contraband/random/directional/south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/fore)
-"uCX" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/west)
 "uDa" = (
 /obj/effect/spawner/random/oil/maybe,
 /obj/effect/decal/cleanable/dirt,
@@ -103087,30 +103817,6 @@
 /obj/effect/spawner/random/barrier/grille_maybe,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
-"uFC" = (
-/obj/machinery/door/window/classic/reversed{
-	desc = "You have the public fridge, pal, lube off.";
-	name = "Security Shield"
-	},
-/obj/machinery/door/window/classic/reversed{
-	desc = "You have the public fridge, pal, lube off.";
-	name = "Security Shield";
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id_tag = "viroshutters";
-	name = "Privacy Shutters";
-	dir = 2
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/general{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/virology,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/virology,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/virology/lab)
 "uFD" = (
 /obj/machinery/autolathe,
 /obj/machinery/requests_console/directional/south,
@@ -103157,6 +103863,21 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
+"uFT" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/north)
 "uFV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -103408,17 +104129,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/security/permabrig)
-"uHS" = (
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock";
-	name = "Escape Pod Hatch"
-	},
-/obj/docking_port/mobile/pod{
-	id = "pod4";
-	name = "escape pod 4"
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/pod_4)
 "uHT" = (
 /obj/structure/flora/junglebush,
 /obj/structure/cable{
@@ -103554,13 +104264,6 @@
 /obj/machinery/porta_turret/ai_turret,
 /turf/simulated/floor/bluegrid,
 /area/station/telecomms/computer)
-"uJn" = (
-/obj/machinery/door/airlock/multi_tile{
-	name = "maintenance access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint2)
 "uJr" = (
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/chapel)
@@ -103622,22 +104325,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/atmos/asteroid_filtering)
-"uJY" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Processing"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/processing)
 "uKf" = (
 /obj/structure/chair,
 /obj/effect/spawner/random/cobweb/left/rare,
@@ -103656,6 +104343,13 @@
 /obj/machinery/alarm/directional/east,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/vault)
+"uKG" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/cryo)
 "uKH" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9
@@ -103742,6 +104436,14 @@
 /obj/item/target,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/range)
+"uLM" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Escape Pod 3 Airlock";
+	id_tag = "emergency_home";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage)
 "uLN" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/secure_data/laptop{
@@ -103806,15 +104508,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/station/medical/psych)
-"uMh" = (
-/obj/machinery/door/airlock/glass{
-	name = "Prison";
-	id_tag = "Prison Perma Cell 4"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/security,
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
 "uMw" = (
 /obj/structure/table/wood,
 /obj/structure/extinguisher_cabinet{
@@ -103841,20 +104534,6 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/east)
-"uMQ" = (
-/obj/machinery/door/airlock/command{
-	id_tag = "hopofficedoor";
-	name = "Head of Personnel"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/any/command/hop,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/station/command/office/hop)
 "uMR" = (
 /obj/machinery/atmospherics/portable/canister/air,
 /obj/machinery/atmospherics/unary/portables_connector,
@@ -104123,6 +104802,18 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"uPR" = (
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock";
+	name = "Escape Pod Hatch";
+	dir = 4
+	},
+/obj/docking_port/mobile/pod{
+	id = "pod4";
+	name = "escape pod 4"
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/pod_4)
 "uQd" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
@@ -104228,13 +104919,6 @@
 /obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
-"uQI" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/neutral/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
 "uQO" = (
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
@@ -104613,26 +105297,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/doors,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison/cell_block)
-"uUr" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Warden's Office"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/warden)
 "uUB" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/cardboard{
@@ -104695,6 +105359,26 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/surgery/primary)
+"uVd" = (
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Processing"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/processing)
 "uVq" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -105089,19 +105773,6 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
-"vaq" = (
-/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "robo"
-	},
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/robotics)
 "vav" = (
 /obj/structure/table,
 /obj/item/storage/box/monkeycubes/farwacubes,
@@ -105153,24 +105824,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fpmaint)
-"vbb" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering Break Room"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Engineering";
-	name = "Engineering Security Doors"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/break_room)
 "vbd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -105511,6 +106164,20 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/misc_lab)
+"vff" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Bay Maintenance";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/supply/cargo_bay,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint2)
 "vfi" = (
 /obj/structure/table,
 /obj/item/reagent_containers/drinks/mug/sci{
@@ -105638,6 +106305,23 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/fore)
+"vgk" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator Foyer";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/any/science/rd,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/station_engineering,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/gravitygenerator)
 "vgm" = (
 /obj/machinery/status_display{
 	pixel_x = 32;
@@ -105651,6 +106335,22 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/engine)
+"vgr" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/wood,
+/area/station/public/vacant_office)
 "vgt" = (
 /obj/machinery/power/apc/directional/north,
 /obj/structure/cable{
@@ -105686,6 +106386,28 @@
 /obj/machinery/firealarm/directional/east,
 /turf/simulated/floor/plasteel/dark,
 /area/station/legal/courtroom/gallery)
+"vgL" = (
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "admin_home";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/east)
+"vgR" = (
+/obj/effect/mapping_helpers/airlock/access/all/supply/expedition,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/mining/glass{
+	name = "Expedition Headquarters";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/expedition)
 "vha" = (
 /obj/structure/table/glass,
 /obj/item/crowbar,
@@ -106003,6 +106725,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
+"vkM" = (
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Courtroom"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/court,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Courtroom";
+	id_tag = "courtentrance";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/legal/courtroom)
 "vkO" = (
 /obj/structure/table/glass/reinforced,
 /obj/structure/window/reinforced,
@@ -106043,21 +106780,6 @@
 /obj/structure/sign/electricshock,
 /turf/simulated/floor/plating,
 /area/station/engineering/gravitygenerator)
-"vlh" = (
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre Storage"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/station/medical/surgery/secondary)
 "vli" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -106388,6 +107110,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"vox" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/science/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/south)
 "voE" = (
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
@@ -107093,6 +107824,19 @@
 /obj/machinery/newscaster/directional/east,
 /turf/simulated/floor/carpet/grimey,
 /area/station/service/chapel/office)
+"vwc" = (
+/obj/machinery/door/airlock/command{
+	name = "Research Director's Office";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/science/rd,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/command/office/rd)
 "vwe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -107308,11 +108052,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/science/storage)
-"vys" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
 "vyC" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tiles/dark/checker,
@@ -107355,6 +108094,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"vyR" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Office Maintenance";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft2)
 "vyV" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/fyellow,
@@ -107829,15 +108579,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/asteroid_filtering)
-"vDF" = (
-/obj/machinery/door/airlock/research{
-	name = "Research Division Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/science/research,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/research)
 "vDH" = (
 /obj/item/radio/intercom{
 	name = "west bump";
@@ -108642,6 +109383,18 @@
 /obj/effect/turf_decal/tiles/department/medical/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/public/locker)
+"vLA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/south)
 "vLB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -108798,6 +109551,27 @@
 /obj/item/book/manual/wiki/sop_service,
 /turf/simulated/floor/carpet/grimey,
 /area/station/service/bar)
+"vMB" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Conference Room";
+	id_tag = "conference";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "conference"
+	},
+/turf/simulated/floor/wood,
+/area/station/command/meeting_room)
 "vMF" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -109076,6 +109850,16 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prisonlockers)
+"vPj" = (
+/obj/machinery/door/airlock/maintenance{
+	locked = 1;
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "vPk" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -109209,17 +109993,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/garden)
-"vQe" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Courtroom Maintenance";
-	security_level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/security/court,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint)
 "vQv" = (
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/asteroid_filtering)
@@ -109296,6 +110069,13 @@
 /obj/item/clothing/mask/breath,
 /turf/simulated/floor/plating,
 /area/station/public/storage/emergency)
+"vRg" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/dorms/port)
 "vRh" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/machinery/light{
@@ -109691,18 +110471,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/equipmentstorage)
-"vVy" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/south)
 "vVz" = (
 /obj/structure/sink/directional/west,
 /turf/simulated/floor/plating,
@@ -109881,6 +110649,13 @@
 /obj/effect/landmark/spawner/nukedisc_respawn,
 /turf/simulated/floor/wood,
 /area/station/command/office/captain/bedroom)
+"vXq" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint)
 "vXr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -110181,11 +110956,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard)
-"wap" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "waq" = (
 /turf/simulated/floor/engine/co2,
 /area/station/engineering/atmos)
@@ -110706,18 +111476,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/north)
-"wfX" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "MiniSat Maintenance"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/turf/simulated/floor/plating,
-/area/station/aisat/service)
 "wgs" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -110756,6 +111514,22 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
+"wgA" = (
+/obj/machinery/door/airlock/glass{
+	name = "Primary tool storage";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/storage/tools)
 "wgJ" = (
 /obj/item/radio/intercom{
 	name = "north bump";
@@ -110900,6 +111674,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
+"whY" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/classic/normal,
+/obj/effect/mapping_helpers/airlock/windoor/access/all/service/kitchen,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/autoname,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "kitchendiner";
+	name = "Kitchen Shutters"
+	},
+/turf/simulated/floor/carpet/orange,
+/area/station/service/kitchen)
 "whZ" = (
 /obj/effect/decal/cleanable/molten_object/large,
 /obj/effect/spawner/random/oil/maybe,
@@ -110907,27 +111696,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
-"wid" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/classic/reversed,
-/obj/item/desk_bell{
-	pixel_y = 8;
-	anchored = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	name = "Research and Development Lab Shutters";
-	id_tag = "rndlab2"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/science/tox,
-/turf/simulated/floor/plasteel,
-/area/station/science/rnd)
 "wih" = (
 /obj/structure/extinguisher_cabinet{
 	name = "north bump";
@@ -111396,6 +112164,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet/grimey,
 /area/station/service/bar)
+"wni" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/ne)
 "wno" = (
 /obj/effect/spawner/random/barrier/grille_maybe,
 /obj/effect/decal/cleanable/dirt,
@@ -111433,21 +112213,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/nw)
-"wnQ" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Break Room"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel,
-/area/station/security/main)
 "wnS" = (
 /obj/machinery/atmospherics/binary/pump{
 	name = "Mix to Distro"
@@ -111678,6 +112443,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/tools)
+"wpA" = (
+/obj/machinery/door/poddoor{
+	id_tag = "Secure Storage";
+	name = "Secure Storage Blast Doors"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/secure_storage)
 "wpJ" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 4
@@ -111770,6 +112546,12 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prisonershuttle)
+"wqD" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/ne)
 "wqN" = (
 /obj/structure/table,
 /obj/item/food/sosjerky,
@@ -111851,13 +112633,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"wsp" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Warehouse Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/cargo_bay,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint2)
 "wst" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil,
@@ -112047,6 +112822,19 @@
 /obj/effect/turf_decal/tiles/white/side,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
+"wus" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/security/aft_port)
 "wux" = (
 /obj/machinery/computer/aiupload{
 	dir = 4
@@ -112110,6 +112898,22 @@
 /obj/item/cartridge/iaa,
 /turf/simulated/floor/carpet,
 /area/station/legal/lawoffice)
+"wvr" = (
+/obj/machinery/door/airlock/research/glass{
+	name = "Toxins Storage";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/science/tox_storage,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/science/storage)
 "wvE" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/carpet/orange,
@@ -112121,35 +112925,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
-"wvN" = (
-/obj/machinery/door/airlock{
-	name = "Crematorium"
+"wvQ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/all/service/crematorium,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	name = "Robotics Lab Shutters";
+	id_tag = "mechbay_inner"
 	},
-/area/station/service/chapel/office)
-"wvS" = (
-/obj/machinery/door/poddoor/preopen{
-	name = "Biohazard Shutter";
-	id_tag = "RnDChem"
-	},
-/obj/machinery/door/airlock/research/glass{
-	name = "Test Chamber"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/science/tox,
-/obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
-/turf/simulated/floor/engine,
-/area/station/science/misc_lab)
+/turf/simulated/floor/plasteel,
+/area/station/science/robotics)
 "wvT" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tiles/department/medical/corner,
@@ -112235,6 +113022,24 @@
 /obj/effect/spawner/window/reinforced/plasma/grilled,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine/reactor)
+"wwB" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Perma Cell 4";
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Prison Gate";
+	name = "Prison Lockdown Blast Doors"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/turf_decal/tiles/department/security,
+/turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
 "wwG" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/cyan,
 /turf/simulated/floor/plasteel,
@@ -112260,6 +113065,16 @@
 /obj/effect/spawner/random/cobweb/left/rare,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"wwS" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/dorms/port)
 "wwT" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
@@ -112614,16 +113429,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"wBc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
 "wBd" = (
 /obj/machinery/economy/atm/directional/east,
 /obj/effect/turf_decal/tiles/white/corner{
@@ -112808,6 +113613,15 @@
 /obj/effect/mapping_helpers/turfs/rust,
 /turf/simulated/wall,
 /area/station/maintenance/aft)
+"wDU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "wDW" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
@@ -112990,6 +113804,39 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison)
+"wGg" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint)
+"wGj" = (
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prisonlockers)
 "wGv" = (
 /obj/structure/table,
 /obj/machinery/light/small,
@@ -113360,6 +114207,18 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/medical/chemistry)
+"wKO" = (
+/obj/machinery/door/airlock{
+	name = "Private Restroom";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/command/office/captain/bedroom)
 "wKP" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	autolink_id = "tox_outlet_scrubber"
@@ -113395,6 +114254,18 @@
 /obj/effect/landmark/start/assistant,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/nw)
+"wLm" = (
+/obj/machinery/door/airlock{
+	name = "Unit 2";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/station/public/toilet/lockerroom)
 "wLn" = (
 /obj/structure/extinguisher_cabinet{
 	name = "east bump";
@@ -113510,17 +114381,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/ne)
-"wMn" = (
-/obj/effect/mapping_helpers/airlock/access/all/supply/expedition,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Expedition Headquarters"
+"wMo" = (
+/obj/machinery/door/airlock/mining{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/supply/smith,
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/station/supply/expedition)
+/area/station/supply/miningdock)
 "wMr" = (
 /obj/structure/table/wood,
 /obj/item/storage/briefcase,
@@ -113535,6 +114406,22 @@
 /obj/machinery/light,
 /turf/simulated/floor/plasteel/dark,
 /area/station/legal/courtroom/gallery)
+"wMA" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/public/pet_store)
 "wME" = (
 /obj/structure/chair/sofa/bamboo/right,
 /obj/item/radio/intercom{
@@ -113552,18 +114439,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/legal/courtroom)
-"wNj" = (
-/obj/effect/mapping_helpers/airlock/access/all/service/janitor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock{
-	name = "Janitorial Supplies"
-	},
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fpmaint)
 "wNy" = (
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/dirt,
@@ -114099,6 +114974,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/sorting)
+"wSF" = (
+/obj/machinery/door/airlock{
+	name = "Crematorium";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/all/service/crematorium,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/service/chapel/office)
 "wSH" = (
 /obj/effect/turf_decal/tiles/dark/checker,
 /obj/item/radio/intercom/locked/prison{
@@ -114198,13 +115088,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/assembly_line)
-"wTS" = (
-/obj/machinery/door/firedoor,
-/obj/structure/sign/barber{
-	pixel_x = -17
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft)
 "wUa" = (
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 1
@@ -114281,21 +115164,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room/secondary)
-"wUL" = (
-/obj/machinery/door/airlock/wood{
-	name = "Back Stage Entrance"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/fakestairs{
-	dir = 1
-	},
-/area/station/service/theatre)
 "wVd" = (
 /obj/machinery/bookbinder,
 /obj/item/radio/intercom{
@@ -114594,6 +115462,32 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
+"wYp" = (
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	id_tag = "viro_door_int";
+	locked = 1;
+	name = "Virology Lab Internal Airlock";
+	dir = 4
+	},
+/obj/machinery/access_button{
+	autolink_id = "viro_btn_int";
+	name = "Virology Lab Access Button";
+	pixel_x = -24;
+	req_access = list(39)
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/virology,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/virology)
 "wYs" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 8
@@ -114676,29 +115570,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/hallway/secondary/exit)
-"wZR" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prisoner Oversight"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison)
 "wZZ" = (
 /turf/simulated/floor/bluegrid,
 /area/station/turret_protected/ai_upload)
@@ -114899,17 +115770,6 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel,
 /area/station/science/break_room)
-"xcB" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Foyer"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/lobby)
 "xcQ" = (
 /turf/simulated/wall,
 /area/station/security/warden)
@@ -114951,18 +115811,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/west)
-"xdi" = (
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/public/toilet/unisex)
 "xdw" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced{
@@ -114995,6 +115843,16 @@
 	},
 /turf/simulated/floor/carpet/grimey,
 /area/station/command/office/hop)
+"xdH" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "xdJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -115062,15 +115920,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
-"xer" = (
-/obj/machinery/door/airlock{
-	name = "Unit 2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/station/public/toilet/lockerroom)
 "xes" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 2
@@ -115136,6 +115985,23 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/public/vacant_office)
+"xfi" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/mining{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/supply/smith,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/smith_office)
 "xfp" = (
 /obj/machinery/power/apc/directional/north,
 /obj/structure/cable{
@@ -115312,19 +116178,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage)
-"xgT" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/spacebridge/security/west)
 "xgU" = (
 /obj/structure/table,
 /obj/item/ashtray/glass,
@@ -115723,6 +116576,15 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/command/office/hos)
+"xlo" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft2)
 "xls" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -115791,6 +116653,12 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
+"xmd" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/public/dorms)
 "xme" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -115831,19 +116699,6 @@
 /obj/item/trash/twimsts,
 /turf/simulated/floor/plating,
 /area/station/maintenance/electrical/aft_starboard)
-"xmq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Checkpoint"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical/fore_starboard)
 "xmr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -116078,16 +116933,6 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
-"xoR" = (
-/obj/machinery/door/airlock,
-/obj/effect/mapping_helpers/airlock/access/all/service/janitor,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/service/janitor)
 "xpa" = (
 /obj/structure/grille/broken,
 /obj/item/stack/rods,
@@ -116151,13 +116996,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
-"xpo" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/science/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/starboard/south)
 "xpt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -116206,27 +117044,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass,
 /area/station/public/park)
-"xpY" = (
-/obj/machinery/door/window/classic/reversed{
-	name = "Medical Reception";
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/item/desk_bell{
-	pixel_x = 7;
-	pixel_y = 6;
-	anchored = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/all/medical/general{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/medical/reception)
 "xqc" = (
 /obj/machinery/camera{
 	c_tag = "Perma A South";
@@ -116309,17 +117126,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay2)
-"xqC" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Aft Starboard Solar Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/solar_maintenance/aft_starboard)
 "xqG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -116347,6 +117153,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/south)
+"xqN" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Psych Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "psychoffice"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/medical/psych)
 "xqT" = (
 /obj/structure/chair/stool{
 	dir = 4
@@ -116556,6 +117380,19 @@
 /obj/effect/turf_decal/tiles/department/security/side,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
+"xsi" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 1;
+	id_tag = "robotics_surgery";
+	name = "Robotics Surgery Center"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/station/science/robotics)
 "xsl" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /obj/effect/spawner/random/maintenance,
@@ -116579,14 +117416,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"xsw" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint2)
 "xsy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -116619,6 +117448,23 @@
 /obj/structure/sign/poster/official/random/directional/east,
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
+"xsT" = (
+/obj/machinery/door/airlock/research/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/tox,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/science/testrange)
 "xsW" = (
 /obj/structure/chair/sofa{
 	dir = 8
@@ -116846,6 +117692,15 @@
 /obj/effect/spawner/random/cobweb/left/rare,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
+"xvU" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	locked = 1;
+	dir = 4
+	},
+/obj/structure/barricade/wooden,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/abandoned_garden)
 "xvW" = (
 /obj/structure/railing{
 	dir = 1
@@ -116936,19 +117791,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/gravitygenerator)
-"xxc" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/public/glass{
-	name = "Security Space Bridge"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/spacebridge/security/south)
 "xxe" = (
 /obj/structure/closet/emcloset,
 /obj/item/wrench,
@@ -117198,6 +118040,15 @@
 	icon_regular_floor = "yellowsiding"
 	},
 /area/station/service/mime)
+"xzi" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "xzk" = (
 /obj/structure/dresser,
 /turf/simulated/floor/wood,
@@ -117834,17 +118685,6 @@
 "xGq" = (
 /turf/simulated/wall/r_wall,
 /area/station/science/server)
-"xGv" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/security/aft_port)
 "xGF" = (
 /obj/structure/table,
 /obj/item/reagent_containers/iv_bag/salglu,
@@ -118066,6 +118906,12 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plasteel,
 /area/station/ai_monitored/storage/eva)
+"xJj" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft)
 "xJl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -118353,12 +119199,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/station/supply/storage)
-"xLK" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/dorms/starboard)
 "xLP" = (
 /obj/machinery/economy/vending/coffee,
 /obj/machinery/camera{
@@ -118371,13 +119211,6 @@
 /obj/item/trash/pistachios,
 /turf/simulated/floor/wood,
 /area/station/maintenance/apmaint2)
-"xMb" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
 "xMe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -118494,18 +119327,22 @@
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/security/aft_starboard)
+"xNO" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Checkpoint";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plating,
+/area/station/maintenance/electrical/aft_port)
 "xNP" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet,
 /area/station/legal/courtroom)
-"xNS" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/dorms/starboard)
 "xNV" = (
 /obj/machinery/light{
 	dir = 1
@@ -119169,16 +120006,6 @@
 "xVg" = (
 /turf/simulated/floor/plasteel,
 /area/station/science/testrange)
-"xVh" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	name = "Robotics Lab Shutters";
-	id_tag = "mechbay_inner"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/science/robotics)
 "xVj" = (
 /obj/item/circuitboard/secure_data,
 /obj/effect/decal/cleanable/dirt,
@@ -119245,18 +120072,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/research)
-"xVP" = (
-/obj/machinery/door/airlock/security,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison)
 "xVW" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/effect/decal/cleanable/dirt,
@@ -119398,16 +120213,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
-"xXu" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/department/medical/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/barber)
 "xXD" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -119429,6 +120234,23 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dorms/starboard)
+"xYn" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos)
 "xYw" = (
 /mob/living/basic/pig,
 /turf/simulated/floor/grass,
@@ -119595,14 +120417,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/aft_starboard)
-"yat" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/public/sleep)
 "yau" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/turfs/burn,
@@ -119699,17 +120513,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
-"ybr" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Checkpoint"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical/fore_starboard)
 "ybx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -120016,6 +120819,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
+"yeB" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Telecommunications Access";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/telecomms/computer)
 "yeE" = (
 /obj/effect/decal/cleanable/glass,
 /turf/simulated/floor/plating,
@@ -120113,6 +120932,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/lava/plasma/fuming,
 /area/station/engineering/atmos/asteroid_core)
+"yfm" = (
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/research,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/science/research)
 "yfv" = (
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo";
@@ -120434,6 +121271,19 @@
 	},
 /turf/simulated/floor/carpet/cyan,
 /area/station/security/prison/cell_block)
+"yiU" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint2)
 "yiV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weldingtool/mini,
@@ -120604,16 +121454,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
-"ykH" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "E.V.A. Maintenance"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/command/eva,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint2)
 "ykK" = (
 /obj/machinery/camera{
 	c_tag = "Departure Lounge South East";
@@ -129389,7 +130229,7 @@ gTi
 ghK
 trM
 qWK
-aQe
+dJY
 jTc
 kNt
 ldt
@@ -129654,7 +130494,7 @@ ddq
 cKS
 jWh
 bSC
-kEW
+fwG
 dGS
 dGS
 ohp
@@ -130424,7 +131264,7 @@ mRL
 ehy
 eiF
 tUl
-crT
+sJb
 uug
 cXp
 mKP
@@ -132152,7 +132992,7 @@ xnC
 iLz
 eaB
 skA
-bAo
+pst
 bZD
 bZD
 aYw
@@ -132452,7 +133292,7 @@ vGF
 pbx
 sfP
 iVu
-qCh
+wGg
 tSu
 ifZ
 pGI
@@ -132488,7 +133328,7 @@ rKO
 opq
 uQO
 kRb
-kTd
+udW
 jfl
 cuh
 jOG
@@ -133258,7 +134098,7 @@ uCh
 gid
 opq
 opq
-uJn
+fKQ
 fMB
 fMB
 vSD
@@ -133437,7 +134277,7 @@ vbN
 kCQ
 djZ
 xUn
-gAm
+ngE
 lCF
 wtb
 orn
@@ -133705,13 +134545,13 @@ xiT
 oyI
 oyI
 oYa
-gDu
+mBc
 sUc
 fgO
 fgO
 evI
 ftQ
-ixs
+die
 hmq
 erp
 rKn
@@ -134165,9 +135005,9 @@ gHv
 gHv
 wwI
 xdD
-lbA
+eAh
 tob
-rQO
+tTX
 cqO
 vKu
 qbd
@@ -134714,9 +135554,9 @@ jnP
 eNa
 ety
 uuH
-uHS
+uPR
 kTG
-iek
+uLM
 fcb
 eJg
 sZB
@@ -135257,7 +136097,7 @@ uQd
 rsz
 kws
 mPW
-sic
+sYi
 pru
 fGG
 bfI
@@ -136012,7 +136852,7 @@ eLZ
 pRa
 pRa
 pRa
-uyB
+qrN
 asS
 avt
 xFr
@@ -136269,7 +137109,7 @@ ceG
 gCz
 gCz
 gCz
-fKf
+wpA
 bbP
 bbP
 jQC
@@ -136285,7 +137125,7 @@ bvG
 scb
 bbP
 bbP
-gzv
+ryL
 oYM
 oYM
 oYM
@@ -136772,7 +137612,7 @@ fpO
 jyH
 oIZ
 wPK
-nMN
+kKG
 eiK
 dPS
 boC
@@ -137827,7 +138667,7 @@ tGz
 tGz
 jfx
 tea
-vbb
+cMa
 tGz
 kaF
 aln
@@ -137838,7 +138678,7 @@ tGz
 rar
 uWB
 tGz
-kYt
+qmM
 nxw
 lqc
 xBt
@@ -138073,7 +138913,7 @@ ilx
 pIh
 ilx
 ilx
-bLq
+flH
 uPA
 bvg
 sjT
@@ -138370,7 +139210,7 @@ oQf
 ttv
 usU
 juL
-hZO
+sVm
 xSw
 iRc
 azE
@@ -138665,7 +139505,7 @@ fMB
 lUy
 eJa
 sqB
-kyS
+imF
 aZt
 kLR
 rnS
@@ -138898,7 +139738,7 @@ xpt
 sYH
 deb
 fGj
-rUv
+kGO
 fpM
 fpM
 mUg
@@ -139097,11 +139937,11 @@ bUx
 aVB
 gWH
 qOq
-oUY
+iYo
 nZH
 pDx
 vPu
-loY
+vgk
 tst
 qiV
 dGu
@@ -139116,7 +139956,7 @@ eFc
 dFR
 asu
 fxO
-fjY
+rgz
 srS
 fGb
 bbY
@@ -139155,14 +139995,14 @@ ave
 ave
 ave
 iwz
-maf
+rVT
 jpi
 aSp
 pba
 eIQ
 oLF
 aSp
-wsp
+bsp
 dGS
 ipM
 vMb
@@ -139365,7 +140205,7 @@ doC
 doC
 qdM
 lBh
-nTi
+cTP
 vPy
 hIf
 jRA
@@ -139382,7 +140222,7 @@ sKy
 rok
 rok
 uhx
-uuD
+doG
 cXT
 lDT
 sZS
@@ -139939,13 +140779,13 @@ qrg
 hiu
 qgf
 wTz
-eWX
+qUw
 tkI
 bHB
 jrd
 mBw
 xDw
-eeh
+ntT
 aeO
 aeO
 iPS
@@ -140184,7 +141024,7 @@ jON
 jON
 ojo
 jON
-jWo
+vff
 gLc
 dAe
 nMV
@@ -140383,7 +141223,7 @@ fQT
 jtR
 jYf
 gce
-tvv
+xYn
 toe
 toe
 toe
@@ -140708,7 +141548,7 @@ ipp
 eyo
 jPU
 pra
-pCe
+xNO
 tKv
 qII
 jvQ
@@ -140942,7 +141782,7 @@ nEQ
 oqC
 swx
 uqE
-dcn
+nUj
 aDb
 nIR
 hTl
@@ -140965,7 +141805,7 @@ ipp
 vSD
 tfO
 wRf
-xmq
+kfe
 fDc
 wEs
 qpG
@@ -141721,7 +142561,7 @@ uHE
 oKD
 bEO
 rfe
-acI
+lxy
 tto
 ugW
 tfs
@@ -142211,7 +143051,7 @@ cLj
 bLQ
 wiP
 efj
-sZi
+jCg
 uXt
 cmq
 rzm
@@ -143473,11 +144313,11 @@ mdF
 wst
 uph
 cTt
-szQ
+qzh
 tWK
 bsg
 eIL
-fvA
+dWG
 qxY
 cXZ
 ndE
@@ -143516,7 +144356,7 @@ ter
 tuQ
 yez
 eEd
-bEg
+bCa
 uhS
 qTV
 jUQ
@@ -143525,7 +144365,7 @@ nqX
 eHo
 bMP
 gve
-sAK
+cGw
 jjX
 goL
 rat
@@ -143734,7 +144574,7 @@ qUl
 eFf
 jFv
 sMz
-hsM
+gxM
 rTi
 qRy
 wbn
@@ -143773,7 +144613,7 @@ nai
 mhk
 mhk
 mhk
-rMz
+syQ
 lWE
 xnG
 xOO
@@ -143821,9 +144661,9 @@ dPe
 dPe
 dPe
 dPe
-bxY
+ePC
 xHF
-bxY
+ePC
 xNo
 jnP
 jnP
@@ -143991,7 +144831,7 @@ qUl
 dVV
 cKN
 xQv
-kJl
+fyd
 sJK
 snX
 snX
@@ -144030,7 +144870,7 @@ djg
 snX
 qVi
 qVi
-iKd
+kIn
 rGN
 rGN
 ubi
@@ -144078,9 +144918,9 @@ dPe
 dPe
 dPe
 dPe
-bxY
+ePC
 nzE
-bxY
+ePC
 jnP
 jnP
 jnP
@@ -144292,7 +145132,7 @@ vOh
 vKf
 cGZ
 sKV
-cna
+xfi
 nzM
 sao
 tMy
@@ -144308,7 +145148,7 @@ csH
 rWt
 tUj
 jUS
-ijM
+iaj
 xrJ
 jnP
 jnP
@@ -144501,7 +145341,7 @@ uyf
 lfn
 lCl
 qIC
-rMg
+dju
 hCZ
 ddv
 pdm
@@ -144775,7 +145615,7 @@ arS
 pHl
 gbv
 dWJ
-rNm
+wwS
 cId
 ivF
 pgN
@@ -144811,7 +145651,7 @@ kiY
 llQ
 fGP
 dMp
-nfr
+wMo
 kSm
 uFx
 tbw
@@ -145028,7 +145868,7 @@ vUH
 fIK
 fIK
 fIK
-kiq
+ftL
 ncz
 qVx
 rnT
@@ -145046,7 +145886,7 @@ frI
 nuG
 bmR
 vLw
-xdi
+akj
 nqr
 pnG
 jYc
@@ -145307,7 +146147,7 @@ frI
 lQI
 bCU
 rxd
-eFM
+pWT
 sem
 sem
 sem
@@ -145489,7 +146329,7 @@ dXx
 oJh
 vWJ
 muu
-wNj
+eSZ
 ixX
 ixX
 ixX
@@ -145528,7 +146368,7 @@ bvh
 fDk
 wnP
 jLc
-lIl
+oAG
 fGF
 fGF
 kpe
@@ -145564,7 +146404,7 @@ frI
 jcN
 tiX
 wrU
-efJ
+lvr
 qnI
 qnI
 qnI
@@ -145765,7 +146605,7 @@ hmM
 vfJ
 mGp
 vWJ
-cRJ
+ocW
 bvh
 glw
 aQy
@@ -145785,7 +146625,7 @@ dZP
 dZP
 bQX
 tKx
-uCX
+ipc
 xZz
 xZz
 ohC
@@ -145864,7 +146704,7 @@ eps
 rPT
 puz
 xrs
-vys
+loo
 xrs
 fyo
 fZM
@@ -146042,7 +146882,7 @@ dLC
 fGW
 dLC
 rHO
-bpR
+qSx
 ewM
 nPr
 mrv
@@ -146057,7 +146897,7 @@ wAw
 rQw
 izS
 igh
-nfV
+gSj
 iff
 rnT
 arS
@@ -146385,9 +147225,9 @@ fZM
 aGf
 bpq
 dPe
-ocI
+gew
 lic
-caL
+bMt
 bHO
 heG
 xvF
@@ -146792,7 +147632,7 @@ pap
 lQW
 aVP
 aVP
-hVF
+dYx
 uwM
 uvf
 eeK
@@ -146895,7 +147735,7 @@ mCS
 cbp
 vyP
 lbb
-xMb
+xzi
 iHH
 mXG
 lZF
@@ -147084,7 +147924,7 @@ hZf
 aME
 fYC
 fYC
-wUL
+hDQ
 dkF
 tky
 eSN
@@ -147286,7 +148126,7 @@ iPs
 buP
 vqN
 dNw
-rMg
+dju
 jxf
 vIy
 lSA
@@ -147311,7 +148151,7 @@ kjO
 aVh
 lcu
 aVh
-fFY
+lZY
 bvh
 nmP
 mUY
@@ -147363,7 +148203,7 @@ xmm
 rfk
 oBq
 cYl
-wMn
+vgR
 nMB
 fwD
 frH
@@ -147651,7 +148491,7 @@ lri
 dNP
 rUE
 qSL
-sQn
+avc
 keK
 goV
 xOo
@@ -147842,7 +148682,7 @@ xaT
 xaT
 wvW
 xaT
-gUH
+lpi
 giS
 mbN
 mDa
@@ -147928,9 +148768,9 @@ yiN
 kgB
 dPe
 oPx
-ejB
+uqm
 lic
-ejB
+uqm
 dWe
 jnP
 jnP
@@ -148069,7 +148909,7 @@ nkO
 mYr
 tgZ
 oyT
-juh
+mOB
 jwn
 ijt
 aLN
@@ -148310,11 +149150,11 @@ iPs
 jSa
 tXb
 xEx
-rUQ
+pjF
 hoM
 pdn
 dat
-lwr
+bSJ
 mZC
 krh
 jdb
@@ -148356,7 +149196,7 @@ bBG
 bBG
 qKL
 bBG
-kPV
+btj
 iQb
 nyO
 njI
@@ -148380,7 +149220,7 @@ iQX
 dDr
 fhq
 tAW
-sEA
+gRR
 ufy
 dsL
 ecU
@@ -148591,7 +149431,7 @@ mBy
 wsf
 wQX
 wQX
-ncH
+vkM
 aVh
 aVh
 oLU
@@ -148630,7 +149470,7 @@ rpb
 tlu
 eUn
 eUn
-qDZ
+drw
 awT
 nhN
 osR
@@ -148887,14 +149727,14 @@ kgg
 kgg
 kgg
 kgg
-rjf
+fgZ
 oat
 exw
 rvu
 rfK
 rpN
 qgz
-rNm
+wwS
 vDr
 qAY
 odP
@@ -148905,7 +149745,7 @@ xmm
 rxd
 dJp
 ffC
-xMb
+xzi
 kqp
 wdy
 elI
@@ -148951,7 +149791,7 @@ eCX
 sro
 qCu
 dZa
-nTC
+pvn
 pYu
 oLM
 soR
@@ -149093,7 +149933,7 @@ bGn
 tnk
 tpV
 jnX
-vQe
+fER
 gip
 xHx
 wQm
@@ -149110,7 +149950,7 @@ kjO
 kjO
 amW
 aVh
-fFY
+lZY
 bvh
 nmP
 bvh
@@ -149144,7 +149984,7 @@ nXh
 nXh
 nXh
 cto
-hEp
+jfC
 anV
 omx
 fPl
@@ -149212,7 +150052,7 @@ cPY
 fhX
 jaj
 ofA
-hSF
+hlb
 mNw
 sWB
 gaT
@@ -149336,7 +150176,7 @@ ugb
 jJH
 jJH
 veL
-rWf
+kbv
 qfp
 bFT
 huq
@@ -149354,7 +150194,7 @@ kHg
 iJI
 eIM
 gip
-tHj
+bDt
 mPv
 mPv
 ulh
@@ -149408,7 +150248,7 @@ nDB
 qir
 mks
 nrK
-nMe
+cpg
 rPq
 dsL
 ecU
@@ -149469,7 +150309,7 @@ jiG
 wdV
 sgm
 tVn
-sNT
+qQh
 tVn
 vMw
 cXs
@@ -149587,7 +150427,7 @@ jnP
 uQi
 ioK
 rbm
-oFy
+iAC
 qLy
 qLy
 sQW
@@ -149726,7 +150566,7 @@ jiG
 gcm
 jaj
 dkT
-doR
+sxL
 geL
 tTL
 iTx
@@ -150113,7 +150953,7 @@ pfY
 eNi
 xtt
 dat
-ltL
+fna
 oYj
 vBv
 uIt
@@ -150498,9 +151338,9 @@ wdV
 jaj
 bQO
 iYm
-idk
-idk
-idk
+cJq
+cJq
+cJq
 iYm
 tls
 iYm
@@ -150634,7 +151474,7 @@ nAt
 fUW
 kYe
 nqK
-rxN
+rMT
 grM
 vKy
 kzQ
@@ -150664,7 +151504,7 @@ sRr
 koX
 fIy
 qAl
-wvN
+wSF
 sQc
 irq
 rAG
@@ -150750,7 +151590,7 @@ mhj
 eyf
 ugc
 ugc
-qTj
+vgr
 fDH
 jkt
 bQO
@@ -150758,15 +151598,15 @@ iYm
 kbY
 cJq
 cJq
-idk
+cJq
 nYn
-idk
+cJq
 wAh
 wAh
-idk
+cJq
 sgc
-idk
-idk
+cJq
+cJq
 aZS
 aZS
 aZS
@@ -150873,7 +151713,7 @@ jxN
 hkw
 ibk
 tXF
-uMQ
+pnc
 cxp
 dQj
 xgy
@@ -150909,7 +151749,7 @@ oRZ
 iRx
 qHl
 qHl
-rNB
+rzI
 jbD
 ujf
 bvh
@@ -150926,7 +151766,7 @@ ggT
 iqF
 vGW
 vGW
-bUF
+mHM
 bvA
 qQg
 sRm
@@ -150963,7 +151803,7 @@ hBy
 rxd
 lQF
 fyO
-emz
+iAq
 odE
 odE
 pZs
@@ -150985,7 +151825,7 @@ wJM
 byy
 vhN
 tiw
-iyv
+jIL
 pfc
 eCC
 wzh
@@ -151024,7 +151864,7 @@ jNB
 asq
 heu
 cJq
-idk
+cJq
 wAh
 wAh
 aZS
@@ -151201,7 +152041,7 @@ dMv
 skb
 hqh
 skb
-rNm
+wwS
 mzN
 sQR
 fzX
@@ -151214,7 +152054,7 @@ fNv
 luN
 csg
 bJA
-bmP
+vRg
 ykL
 iSc
 rxd
@@ -151248,11 +152088,11 @@ eLb
 fkz
 oqV
 oqV
-hae
+pRc
 pOY
 gGF
 nHw
-vys
+loo
 iYn
 qTZ
 gIg
@@ -151280,7 +152120,7 @@ asq
 asq
 asq
 bLd
-idk
+cJq
 bIo
 vVR
 wAh
@@ -151394,7 +152234,7 @@ cyc
 kQM
 pwP
 rkN
-mBW
+guP
 mQN
 hxY
 fCl
@@ -151486,7 +152326,7 @@ odE
 odE
 fDp
 odE
-oIR
+oOd
 jLm
 mlc
 iuq
@@ -151537,7 +152377,7 @@ kaD
 kaD
 xUl
 asq
-cFP
+pOr
 asq
 asq
 urE
@@ -151743,7 +152583,7 @@ odE
 gJF
 tVa
 hsD
-anm
+sZO
 jLm
 dcA
 jIp
@@ -151766,7 +152606,7 @@ uxI
 gDI
 rSh
 pWd
-lXm
+mdy
 oYG
 cwk
 bWX
@@ -151794,7 +152634,7 @@ asq
 asq
 asq
 bdf
-idk
+cJq
 okY
 pzy
 wAh
@@ -151992,7 +152832,7 @@ ffC
 oVC
 jzD
 kBU
-kBr
+whY
 odE
 odE
 dkD
@@ -152052,7 +152892,7 @@ cOV
 asq
 uHu
 cJq
-idk
+cJq
 wAh
 wAh
 aZS
@@ -152219,7 +153059,7 @@ giS
 giS
 qQg
 giS
-nib
+nMz
 bSD
 bPX
 mKH
@@ -152227,7 +153067,7 @@ btK
 emS
 cJa
 eoO
-hIZ
+bEa
 bXf
 sZl
 gje
@@ -152300,15 +153140,15 @@ iYm
 kbY
 cJq
 cJq
-idk
+cJq
 nYn
-idk
+cJq
 wAh
 wAh
-idk
+cJq
 sgc
-idk
-idk
+cJq
+cJq
 aZS
 aZS
 aZS
@@ -152422,13 +153262,13 @@ sFz
 sFz
 sFz
 mPl
-tnt
+nzU
 xSi
 akO
 huq
 huq
 qLn
-aji
+rXD
 iJo
 iJo
 iJo
@@ -152449,7 +153289,7 @@ mYU
 mYU
 mYU
 mYU
-pdw
+sEi
 ckv
 nEU
 jvR
@@ -152476,7 +153316,7 @@ amG
 giS
 hSX
 diB
-yat
+mzJ
 btW
 lVx
 dzR
@@ -152527,13 +153367,13 @@ lhT
 byy
 uFX
 uMY
-fdO
+cBc
 hdI
 iaG
 fNd
 sFB
 gqQ
-xXu
+dIA
 pOY
 vNc
 nHw
@@ -152554,9 +153394,9 @@ dvh
 jaj
 bQO
 iYm
-idk
-idk
-idk
+cJq
+cJq
+cJq
 iYm
 tls
 iYm
@@ -152679,13 +153519,13 @@ gdX
 gdX
 gdX
 gtz
-sGo
+ppm
 cZD
 pIi
 sCU
 sCU
 sCU
-tNq
+tul
 srv
 srv
 srv
@@ -152706,14 +153546,14 @@ iMO
 iMO
 iMO
 iMO
-pPL
+uFT
 qVM
 qVM
 xyE
 uGt
 qOu
 oGg
-mlh
+ppy
 nYZ
 vAZ
 qUn
@@ -152721,7 +153561,7 @@ aAt
 dwn
 tVG
 gtu
-rqR
+xmd
 giS
 qQg
 giS
@@ -152936,13 +153776,13 @@ nMx
 sFz
 sFz
 tDy
-tnt
+nzU
 xSi
 lBm
 huq
 huq
 huq
-fLg
+ugG
 mJS
 mJS
 mJS
@@ -152963,7 +153803,7 @@ mYU
 mYU
 seI
 mYU
-pdw
+sEi
 ckv
 hME
 xIF
@@ -152978,7 +153818,7 @@ tNl
 tNl
 rHL
 tlW
-nyY
+qxo
 rmI
 xrc
 giS
@@ -153235,7 +154075,7 @@ kpy
 dwn
 qrP
 scU
-rqR
+xmd
 giS
 mbN
 giS
@@ -153248,7 +154088,7 @@ giS
 qQg
 tqe
 eUn
-dpp
+tEf
 eUn
 eUn
 eUn
@@ -153268,7 +154108,7 @@ eUn
 xjx
 tfk
 szl
-gch
+lJy
 rxd
 rxd
 dFY
@@ -153276,7 +154116,7 @@ hBy
 rxd
 rxd
 rxd
-obN
+bho
 ppu
 ppu
 vfQ
@@ -153304,7 +154144,7 @@ pDe
 ppu
 dqB
 ppu
-wTS
+iCb
 ppu
 fYt
 ppu
@@ -153320,11 +154160,11 @@ ppu
 ppu
 vfQ
 ndW
-aeu
+xJj
 eju
 jaj
 rSP
-hQX
+cYh
 qkY
 kJc
 rts
@@ -153492,7 +154332,7 @@ mEq
 rgS
 gtu
 ojd
-bSb
+rHP
 bvA
 mbN
 giS
@@ -153505,7 +154345,7 @@ giS
 oVc
 nuI
 nuI
-elw
+bWC
 nuI
 nuI
 nuI
@@ -153525,7 +154365,7 @@ kgg
 kgg
 kgg
 kgg
-bcC
+jFI
 nqr
 nqr
 pOR
@@ -153533,7 +154373,7 @@ xCl
 suw
 jmI
 jmI
-vVy
+nxm
 nsy
 nsy
 rIC
@@ -153561,7 +154401,7 @@ gCR
 gCR
 gCR
 gCR
-ewp
+uvz
 gCR
 bHp
 gCR
@@ -153577,11 +154417,11 @@ aMz
 aMz
 xsy
 prT
-eny
+qVl
 nvB
 ryO
 wou
-iDV
+wDU
 wou
 gYK
 cNi
@@ -153723,12 +154563,12 @@ nHE
 iMd
 dHw
 fps
-xsw
+aIh
 pBl
 fXt
 tKl
 dGC
-ykH
+gPw
 hNj
 nHr
 oGv
@@ -153762,7 +154602,7 @@ giS
 mbN
 iAy
 nXh
-uQI
+ozU
 nXh
 nXh
 iuw
@@ -153782,7 +154622,7 @@ iUr
 gYS
 nXh
 nXh
-gch
+lJy
 rxd
 rxd
 rfk
@@ -153790,7 +154630,7 @@ ezY
 rxd
 rxd
 rxd
-obN
+bho
 ppu
 ppu
 ppu
@@ -153818,7 +154658,7 @@ ppu
 tUs
 ppu
 vZw
-aeu
+xJj
 wQP
 lKt
 asC
@@ -153834,11 +154674,11 @@ ppu
 ppu
 ppu
 ixj
-aeu
+xJj
 eju
 nnO
 fRS
-ptC
+xdH
 iRX
 fPc
 uEY
@@ -154263,7 +155103,7 @@ wlY
 nOG
 xfs
 pBp
-eRc
+cuv
 aeL
 gPx
 iVX
@@ -154471,7 +155311,7 @@ jxN
 fJx
 cIG
 lWW
-teC
+vMB
 kia
 pOO
 cdA
@@ -154823,7 +155663,7 @@ rzW
 iDm
 uPx
 uPx
-liu
+cZE
 uCv
 hyT
 vKF
@@ -155051,7 +155891,7 @@ fKX
 aLQ
 duK
 xnJ
-xNS
+kzh
 ssZ
 qdt
 vAZ
@@ -155073,7 +155913,7 @@ xmm
 cCH
 jwz
 qMg
-cTe
+erY
 xMe
 xKf
 adp
@@ -155124,9 +155964,9 @@ eNt
 ejD
 cOU
 vEk
-mVF
+gKZ
 coA
-mVF
+gKZ
 nYA
 jnP
 jnP
@@ -155253,7 +156093,7 @@ lsf
 buP
 xtt
 dat
-iQU
+qdl
 bjm
 ncL
 aVK
@@ -155262,7 +156102,7 @@ uRn
 rNe
 wRn
 coS
-aQD
+tbe
 ixq
 pIZ
 iSo
@@ -155326,7 +156166,7 @@ vAZ
 wdw
 rHN
 xjZ
-xYm
+eUF
 fOu
 iSc
 rxd
@@ -155550,7 +156390,7 @@ wSv
 wSv
 oeq
 aRB
-rWs
+nOt
 iQb
 qNC
 njI
@@ -155792,7 +156632,7 @@ oGn
 vtr
 hoi
 oqJ
-ngi
+tPD
 auy
 xfC
 soN
@@ -155890,7 +156730,7 @@ sGN
 rmj
 wKX
 cMm
-sjG
+qin
 jDl
 okS
 usF
@@ -156133,7 +156973,7 @@ nOr
 wJP
 mEj
 mEj
-bBN
+jsa
 cFf
 cFf
 qEv
@@ -156141,7 +156981,7 @@ jOF
 kZs
 pJW
 oFG
-liu
+cZE
 szz
 iIf
 ctv
@@ -156390,7 +157230,7 @@ iGw
 vKs
 mEj
 mEj
-bBN
+jsa
 cFf
 cFf
 nSD
@@ -156421,10 +157261,10 @@ lDr
 vEk
 vEk
 biv
-loH
+vgL
 vEk
 hGB
-loH
+vgL
 jnP
 jnP
 jnP
@@ -156570,7 +157410,7 @@ wMj
 syn
 uQp
 tCr
-eRc
+cuv
 eSI
 eSI
 eSI
@@ -156615,7 +157455,7 @@ xmm
 akP
 fXo
 qMg
-xoR
+nec
 mNB
 jQk
 aNr
@@ -156678,10 +157518,10 @@ fac
 ggj
 vCo
 fVs
-loH
+vgL
 vEk
 vEk
-loH
+vgL
 kNG
 jnP
 jnP
@@ -157052,10 +157892,10 @@ gZS
 svs
 kAZ
 xop
-gNe
+nck
 puU
 igA
-kOC
+tMA
 tgg
 ybL
 hWU
@@ -157069,7 +157909,7 @@ uZS
 kkD
 qaY
 nqd
-hYx
+hzn
 uOM
 lki
 wxY
@@ -157168,7 +158008,7 @@ rGF
 ojL
 mpT
 ajf
-qzz
+ohJ
 cLp
 mpT
 lRd
@@ -157682,7 +158522,7 @@ nwE
 mpT
 nsC
 ajf
-xer
+wLm
 cLp
 mmI
 pod
@@ -157900,7 +158740,7 @@ oBS
 dZB
 dJp
 ffC
-fxo
+xlo
 bMQ
 gSd
 sVz
@@ -158069,7 +158909,7 @@ aZS
 exL
 jXg
 dva
-lSu
+wKO
 oJl
 oDv
 mjP
@@ -158145,7 +158985,7 @@ fRA
 fpF
 bfb
 bfb
-xLK
+cEy
 eTZ
 eTZ
 qBJ
@@ -158196,7 +159036,7 @@ apl
 mpT
 nsC
 uLT
-aIf
+pLX
 cLp
 hmw
 vlY
@@ -158362,7 +159202,7 @@ aYl
 ixq
 pIZ
 pIZ
-omq
+ldg
 soN
 dlV
 soN
@@ -158671,7 +159511,7 @@ pWN
 jOu
 wKu
 pfg
-loX
+xsi
 kwn
 kgG
 hHm
@@ -158686,7 +159526,7 @@ apl
 dsZ
 oqR
 szz
-jOy
+vyR
 gRL
 quG
 tEA
@@ -158876,7 +159716,7 @@ wYM
 xbE
 soN
 soN
-uLC
+wqD
 nuk
 njw
 soN
@@ -158890,7 +159730,7 @@ mez
 eca
 bWW
 eVt
-mLL
+wni
 dsP
 nnA
 bQB
@@ -159133,7 +159973,7 @@ sqT
 gfj
 fLX
 fLX
-klW
+drT
 fLX
 rcn
 fLX
@@ -159147,7 +159987,7 @@ fLX
 fLX
 fTk
 fLX
-oqr
+qTE
 nST
 vrS
 cRD
@@ -159390,7 +160230,7 @@ brq
 ejN
 bwi
 uBv
-nOk
+kqG
 oWo
 koI
 aby
@@ -159404,7 +160244,7 @@ nhc
 nhc
 sXO
 soN
-uLC
+wqD
 jOu
 pVt
 xIG
@@ -159486,7 +160326,7 @@ oOg
 whW
 lqB
 kiE
-csf
+jUi
 ecH
 xsl
 aIj
@@ -159624,10 +160464,10 @@ iNH
 ciw
 aTT
 srx
-uqY
+yiU
 oMd
 eFX
-ybr
+ilf
 bFw
 dXL
 sKl
@@ -160157,7 +160997,7 @@ rDz
 rDz
 kUP
 rDz
-mVL
+lEI
 eBV
 dER
 qub
@@ -160421,7 +161261,7 @@ oOO
 tLi
 yeE
 sov
-wap
+ufP
 kYa
 bHK
 rSC
@@ -160479,7 +161319,7 @@ oks
 stF
 fRD
 phf
-sHD
+tgr
 jtK
 lsy
 grX
@@ -160513,7 +161353,7 @@ oaV
 sUj
 eKZ
 hzV
-aUA
+nig
 rLH
 cyP
 jCU
@@ -160631,7 +161471,7 @@ bBn
 mVu
 sgr
 wmi
-iBy
+qbV
 gbl
 oei
 iXk
@@ -160690,16 +161530,16 @@ gWB
 uiT
 teF
 bsH
-knO
+wgA
 nIN
 fVm
 kyA
-bFc
+lyq
 fum
 bwP
 iRP
 gcy
-mri
+prv
 qni
 fcR
 bOT
@@ -160708,7 +161548,7 @@ bok
 pWD
 eoo
 iVc
-xpY
+ccJ
 uuK
 hpO
 ufS
@@ -160727,7 +161567,7 @@ xCB
 oFi
 hdJ
 wEc
-vaq
+qYH
 oUz
 mrn
 efL
@@ -160736,7 +161576,7 @@ lxR
 xWu
 pif
 dga
-xVh
+wvQ
 bRf
 gZd
 bRf
@@ -160947,7 +161787,7 @@ foD
 nIE
 wpv
 tAF
-mIy
+iAG
 kyA
 uci
 kyA
@@ -160993,7 +161833,7 @@ mYb
 qdU
 arm
 qdU
-xVh
+wvQ
 bRf
 uxG
 ofs
@@ -161250,7 +162090,7 @@ xxh
 lNy
 hFr
 ouh
-xVh
+wvQ
 bRf
 uxG
 xEY
@@ -161289,9 +162129,9 @@ mLj
 hTg
 mXU
 jDP
-rQM
+bxL
 bIX
-rfC
+qrX
 lEy
 quB
 jnP
@@ -161659,7 +162499,7 @@ cwI
 jxV
 hJf
 cbz
-ebO
+oGF
 mBS
 oVl
 aAq
@@ -161727,7 +162567,7 @@ ajq
 aNu
 nRd
 dft
-hFF
+cXB
 nOu
 mjR
 xXt
@@ -161834,7 +162674,7 @@ uQw
 kCu
 qry
 oiZ
-cOJ
+fTp
 qLe
 fRO
 lQo
@@ -161842,7 +162682,7 @@ acd
 imp
 vWg
 mkI
-cOJ
+fTp
 eha
 eha
 eha
@@ -161951,7 +162791,7 @@ hFc
 kZE
 cBK
 coS
-eBM
+fQt
 ixq
 iMP
 nxL
@@ -162288,7 +163128,7 @@ aqy
 hiT
 wwV
 cQM
-xpo
+itM
 iWE
 glQ
 iWE
@@ -162443,7 +163283,7 @@ xMW
 hRp
 nwx
 plQ
-xgT
+kTr
 jsi
 ghD
 fSs
@@ -162489,7 +163329,7 @@ qib
 jDS
 kHi
 scq
-wap
+ufP
 mPD
 nSN
 avn
@@ -162519,7 +163359,7 @@ erV
 kzl
 kZD
 sfT
-gaK
+ocC
 gCm
 pBv
 cHG
@@ -162545,7 +163385,7 @@ fRW
 tMv
 oCW
 tMv
-aVv
+vLA
 tMv
 pGf
 tMv
@@ -162708,7 +163548,7 @@ cbU
 jrm
 rPG
 kVV
-xGv
+wus
 lNV
 xxK
 qyi
@@ -162802,7 +163642,7 @@ izY
 foi
 muy
 lXM
-fMg
+vox
 pJV
 muy
 muy
@@ -163499,7 +164339,7 @@ dgx
 cbq
 gyi
 hoa
-xGv
+wus
 cgy
 qwi
 hFc
@@ -163517,11 +164357,11 @@ hNM
 eJV
 dXR
 hWf
-opA
+wMA
 nIN
 fVm
 kyA
-qPb
+xqN
 jDm
 jDm
 jDm
@@ -163573,7 +164413,7 @@ chp
 lSp
 uUj
 qhc
-wid
+rZw
 nHz
 oll
 iQo
@@ -163589,7 +164429,7 @@ vjE
 ehO
 vpr
 uMS
-nbw
+vXq
 hzR
 sHf
 pkj
@@ -163730,7 +164570,7 @@ evV
 vOa
 pHH
 dxI
-jBn
+jTN
 iFe
 aCc
 eJL
@@ -163798,14 +164638,14 @@ rGD
 eyS
 oXT
 wxB
-aiP
+bNg
 efX
 lem
 fYp
 jke
 tfP
 efX
-sTg
+uKG
 wPL
 myb
 iKS
@@ -163819,9 +164659,9 @@ boG
 pro
 auI
 nUP
-mEn
+kxd
 yeJ
-anP
+oUn
 gKo
 vuN
 bgp
@@ -163878,7 +164718,7 @@ iFN
 xap
 drz
 ffp
-liL
+heT
 qry
 dIX
 gzl
@@ -163991,7 +164831,7 @@ jSs
 rLn
 jox
 wKo
-sBe
+tKc
 tTt
 beu
 uBo
@@ -164055,14 +164895,14 @@ ear
 tdN
 tFz
 wGx
-nYF
+pZv
 ybW
 ykm
 ybW
 mSf
 ybW
 ybW
-oRk
+hmd
 bEz
 hvF
 eVD
@@ -164256,7 +165096,7 @@ aTF
 ktJ
 mYI
 aio
-hGJ
+nYO
 arJ
 gvK
 oKy
@@ -164312,14 +165152,14 @@ ear
 peJ
 oXT
 wxB
-aiP
+bNg
 efX
 nMh
 aRt
 kAu
 kdG
 efX
-sTg
+uKG
 wPL
 kBS
 iKS
@@ -164393,7 +165233,7 @@ nCP
 ayj
 rUc
 bgr
-wfX
+mbO
 dtW
 dtW
 dDm
@@ -164484,9 +165324,9 @@ jnP
 mQZ
 nVF
 sXH
-jsL
+npS
 xNB
-luf
+mKf
 xNB
 xoy
 gjn
@@ -164565,7 +165405,7 @@ fsn
 qvr
 afe
 afe
-nFU
+gwD
 vWf
 dJj
 wxB
@@ -164607,7 +165447,7 @@ mXO
 pjc
 pjc
 jWF
-lwn
+obA
 mxJ
 suS
 tIk
@@ -164787,7 +165627,7 @@ gyi
 nhr
 uTq
 qfH
-tcz
+rKA
 xjP
 nMO
 vmK
@@ -165063,7 +165903,7 @@ iro
 kyA
 ylh
 ePd
-qkM
+nAF
 bHJ
 oqa
 nRH
@@ -165281,7 +166121,7 @@ dis
 dis
 dis
 bvz
-aUl
+qjW
 upm
 vNd
 unI
@@ -165297,7 +166137,7 @@ tfI
 ubl
 lvl
 lvl
-dRc
+nIe
 diW
 uaV
 kRC
@@ -165313,7 +166153,7 @@ pXS
 tql
 hbD
 fhm
-rrm
+fHu
 xvD
 bPF
 iro
@@ -165370,7 +166210,7 @@ mxc
 xor
 vKa
 gbT
-vDF
+fVF
 xhg
 wxD
 rDg
@@ -165538,7 +166378,7 @@ iFe
 iFe
 qYr
 tfI
-wBc
+lIS
 tfI
 tfI
 tfI
@@ -165627,14 +166467,14 @@ aog
 hBa
 hhr
 bue
-cPN
+yfm
 iBu
 wUe
 hIq
 uWH
 iaw
 ixY
-bmG
+ngM
 fve
 kuM
 ghZ
@@ -165672,12 +166512,12 @@ jLp
 qyt
 jkd
 kmM
-svl
+soK
 jzw
 tbu
 lih
 xRU
-mmp
+kqy
 tPW
 tPW
 lbP
@@ -165685,10 +166525,10 @@ mzf
 pPT
 vBi
 gdk
-dJy
+eIO
 rjb
 rjb
-emN
+cXU
 uYY
 ndf
 klp
@@ -165795,7 +166635,7 @@ tZY
 tZY
 wgz
 bcW
-iCI
+bkh
 aCx
 bcW
 bcW
@@ -165834,7 +166674,7 @@ iro
 lcQ
 uci
 rXG
-kwq
+hTJ
 slA
 slA
 tyR
@@ -165897,7 +166737,7 @@ xnm
 lyl
 jHP
 seE
-bTC
+ngl
 raV
 ooa
 dZj
@@ -166091,7 +166931,7 @@ iro
 rMo
 abB
 kxa
-fDj
+tyC
 xSL
 xSL
 xSL
@@ -166114,7 +166954,7 @@ nZS
 jcs
 voZ
 ghI
-nZR
+dEr
 wef
 svU
 tdu
@@ -166148,7 +166988,7 @@ ueN
 uwB
 iBG
 xhg
-ePX
+syU
 aKP
 bLL
 aeP
@@ -166282,7 +167122,7 @@ fjJ
 pzW
 tua
 hfE
-edG
+cFO
 mct
 hcc
 fjJ
@@ -166377,7 +167217,7 @@ uUX
 aqz
 buB
 tMX
-bPJ
+cct
 qXG
 qXG
 xSj
@@ -166700,7 +167540,7 @@ xxl
 hLb
 bEB
 bEB
-cDj
+cij
 lXv
 eKF
 pMu
@@ -166796,7 +167636,7 @@ qes
 hfE
 hfE
 hfE
-edG
+cFO
 mct
 hsh
 fjJ
@@ -166963,7 +167803,7 @@ bEB
 jhL
 fPO
 fPO
-bmg
+ncm
 nMX
 nMX
 nGz
@@ -167124,7 +167964,7 @@ xtX
 gEv
 aQB
 wVg
-qPB
+hBJ
 dzf
 wkg
 byS
@@ -167337,7 +168177,7 @@ sVN
 kWw
 ePg
 tfI
-tWs
+kfv
 nmF
 soY
 aQs
@@ -167405,7 +168245,7 @@ cZW
 kgw
 qWm
 jfE
-vlh
+bjL
 ngk
 jPE
 aRw
@@ -167476,7 +168316,7 @@ iJa
 gkv
 mdq
 teV
-oid
+qFK
 lBH
 ogW
 oyW
@@ -167590,7 +168430,7 @@ kCl
 teT
 kCl
 kCl
-otv
+fGr
 tfI
 uge
 eJL
@@ -167604,7 +168444,7 @@ dpx
 uLS
 kXZ
 oXp
-ljn
+oXN
 pxs
 vAx
 nab
@@ -167656,7 +168496,7 @@ nZS
 vrA
 nff
 fbE
-ngp
+tqp
 bQG
 aZQ
 itF
@@ -167869,7 +168709,7 @@ mMe
 mMe
 lOR
 mMe
-xcB
+kwp
 mnI
 fth
 lxc
@@ -167886,7 +168726,7 @@ fXw
 lxc
 vJF
 fYu
-hgZ
+eke
 rcU
 uci
 bVe
@@ -167906,7 +168746,7 @@ ltB
 tpW
 iIW
 iIW
-fVX
+pft
 oWm
 ivo
 nZS
@@ -168126,7 +168966,7 @@ qMj
 elG
 kIU
 vzf
-iOp
+eec
 aRe
 eSD
 cPL
@@ -168143,7 +168983,7 @@ mrW
 cPL
 fmN
 sxj
-xxc
+ehc
 mgl
 lNL
 diP
@@ -168163,7 +169003,7 @@ euh
 sVU
 lmv
 cHN
-uhY
+hQx
 vHN
 tEG
 nZS
@@ -168195,16 +169035,16 @@ jcy
 jcy
 mXw
 gRv
-ntR
+sBQ
 qPt
 eVE
 xiz
 dtb
-ofe
+xsT
 mbv
 wXF
 nxN
-jEA
+nlG
 quF
 qTK
 iep
@@ -168225,7 +169065,7 @@ kTf
 nuJ
 crR
 rqw
-cmK
+qHc
 rPe
 xPt
 xUy
@@ -168338,7 +169178,7 @@ unt
 rnM
 jRV
 bRb
-hoq
+eNy
 rWK
 uqp
 jZP
@@ -168383,7 +169223,7 @@ mMe
 mMe
 ibR
 mMe
-xcB
+kwp
 xZT
 jNt
 lxc
@@ -168400,7 +169240,7 @@ mXj
 lxc
 dmT
 foG
-poL
+rJm
 txh
 iqv
 ejP
@@ -168466,7 +169306,7 @@ lQC
 uRh
 xlS
 mAj
-cph
+vwc
 hrs
 qFr
 pHE
@@ -168618,7 +169458,7 @@ mTC
 qcW
 dwN
 oag
-wnQ
+udm
 pJc
 blo
 dis
@@ -169175,7 +170015,7 @@ osi
 wLE
 uci
 wmc
-cRc
+axh
 pfT
 pfT
 jAG
@@ -169359,7 +170199,7 @@ sgq
 cix
 wqY
 bbR
-iyw
+jYs
 bbR
 wAR
 iKE
@@ -169368,10 +170208,10 @@ uNI
 rnM
 rnM
 sMk
-sPK
+mSv
 nFO
 taP
-tsy
+tOr
 led
 tfV
 bDs
@@ -169468,7 +170308,7 @@ sto
 whI
 whI
 whI
-tNp
+aDI
 mXw
 mXw
 mXw
@@ -169485,7 +170325,7 @@ eOe
 vdJ
 lNX
 tIH
-soQ
+bco
 gkT
 nYY
 oVs
@@ -169504,15 +170344,15 @@ oVs
 mdU
 jMJ
 nxN
-ptQ
+nht
 yhz
 bqr
 pHy
-szH
+ksY
 tUo
 par
 wea
-jqV
+hBe
 fPX
 par
 uFM
@@ -169544,7 +170384,7 @@ jwL
 wcu
 lBH
 lBH
-mWY
+yeB
 kFe
 aFV
 wiB
@@ -169552,7 +170392,7 @@ ihK
 qbZ
 igE
 kFe
-mWY
+yeB
 eha
 eha
 tYX
@@ -169737,7 +170577,7 @@ kMJ
 qpw
 gIp
 tMa
-wvS
+rdx
 vDP
 ukh
 jDY
@@ -169907,7 +170747,7 @@ lav
 tMD
 vMc
 tfI
-uUr
+ajT
 gmq
 vuO
 goR
@@ -169918,10 +170758,10 @@ hhE
 yiS
 bhY
 dYz
-nEv
+oim
 bpY
 bij
-jZs
+lIW
 jRK
 jFe
 rmi
@@ -169966,7 +170806,7 @@ oTr
 nfM
 irx
 fMZ
-uFC
+gan
 rjG
 pKE
 sYm
@@ -170145,7 +170985,7 @@ vHR
 fjJ
 sGU
 oiX
-mXW
+kjq
 bkj
 kBy
 sxU
@@ -170396,10 +171236,10 @@ roQ
 xaM
 aXL
 rKW
-jej
+gYF
 fOx
 vKI
-ttC
+lOm
 qqz
 tfV
 vdU
@@ -170408,7 +171248,7 @@ jZa
 sxU
 iPQ
 omV
-sKh
+tSX
 kcw
 vPa
 vdh
@@ -170417,7 +171257,7 @@ tfB
 cpO
 cQk
 vww
-duh
+wGj
 iFe
 bog
 dis
@@ -170432,10 +171272,10 @@ hhE
 hxU
 vIm
 syJ
-jne
+aoL
 bpY
 prJ
-ruT
+hqV
 hdK
 iDu
 cri
@@ -170776,14 +171616,14 @@ hHM
 bPc
 lea
 uFV
-fyk
+stJ
 mtc
 mXD
 prr
 nCd
 bTN
 vML
-mhS
+hxi
 dMO
 svY
 muR
@@ -170974,7 +171814,7 @@ iro
 kyA
 ejd
 qYL
-rMy
+ldj
 fuo
 gZF
 mqJ
@@ -171006,7 +171846,7 @@ swY
 fgd
 dAs
 sth
-rkg
+arN
 pIA
 pag
 vav
@@ -171203,7 +172043,7 @@ unI
 dis
 dis
 dis
-aUl
+qjW
 anw
 xrK
 eBi
@@ -171250,11 +172090,11 @@ uuF
 vGE
 oYc
 dHC
-axS
+lcT
 ocz
 oiH
 aVA
-gGv
+wYp
 yee
 eXU
 usg
@@ -171427,12 +172267,12 @@ rRk
 kOj
 kMS
 emp
-wZR
+fGn
 khL
 wGe
 wFz
 wFz
-xVP
+dHz
 iFe
 kQF
 lvl
@@ -171460,7 +172300,7 @@ tfI
 lnd
 tfI
 tfI
-iBL
+suL
 fGm
 sxR
 dSf
@@ -171555,7 +172395,7 @@ cPe
 lWz
 dlx
 iwh
-doV
+aNC
 edM
 ukG
 uYo
@@ -171717,7 +172557,7 @@ snW
 dGn
 snW
 tZY
-aPC
+sHi
 let
 qAo
 fEL
@@ -172056,12 +172896,12 @@ vGd
 vMJ
 uJw
 aiN
-eax
+jUZ
 dJl
 dJl
 lWa
 dJl
-qRI
+kPK
 ylY
 pfR
 bVs
@@ -172452,10 +173292,10 @@ onB
 pJn
 ehR
 rKW
-pJu
+ipK
 fOx
 vKI
-gcQ
+rQQ
 bRN
 pFz
 tsa
@@ -172791,7 +173631,7 @@ jcy
 rXb
 cUP
 wxx
-iqk
+msL
 qVN
 mfn
 tUb
@@ -173090,7 +173930,7 @@ sgh
 vBg
 eki
 gti
-nZE
+tdL
 mPd
 oFZ
 wqn
@@ -173259,7 +174099,7 @@ fYj
 lZX
 vMs
 leQ
-uJY
+uVd
 stV
 dHW
 ipw
@@ -173339,7 +174179,7 @@ ask
 rKb
 qza
 mhT
-jMI
+wvr
 gxr
 poX
 poX
@@ -173471,7 +174311,7 @@ rFX
 ksT
 iVN
 bbR
-lLL
+ehA
 uHN
 dCE
 jkq
@@ -173480,10 +174320,10 @@ uNI
 rnM
 rnM
 sMk
-uMh
+pMG
 nFO
 taP
-lGw
+wwB
 hua
 brr
 tsa
@@ -173569,13 +174409,13 @@ ejo
 sKI
 qKQ
 iZn
-pGV
+obZ
 sRJ
 hqA
 ofq
 uwG
 tqO
-bAL
+pHg
 dgm
 uTQ
 jFM
@@ -173767,7 +174607,7 @@ poU
 rKH
 rKH
 ibo
-gCX
+mei
 leQ
 fYj
 rCl
@@ -174094,10 +174934,10 @@ fIk
 jcy
 dso
 mXw
-gLv
+cay
 mXw
 gRv
-gLv
+cay
 nxB
 caq
 caq
@@ -174506,7 +175346,7 @@ unt
 rnM
 xXa
 dUP
-hjl
+hbu
 rWK
 mfV
 sBC
@@ -174564,7 +175404,7 @@ lIu
 irr
 xTk
 bNS
-dUQ
+knu
 jgL
 cbK
 xFM
@@ -174580,7 +175420,7 @@ xFM
 fGO
 lIu
 jBZ
-kVJ
+tsW
 hxZ
 hxZ
 hxZ
@@ -174611,7 +175451,7 @@ szh
 caq
 hmX
 sGl
-mff
+vPj
 lix
 caq
 jnP
@@ -174821,7 +175661,7 @@ dXC
 oZF
 wZD
 eKR
-aer
+uiE
 vHl
 gTY
 xFM
@@ -175064,7 +175904,7 @@ kcF
 aWy
 gzf
 xWb
-kix
+bbx
 bEF
 rJc
 sfE
@@ -175364,7 +176204,7 @@ jSu
 uCm
 iID
 xDg
-sSv
+xvU
 gRv
 bVE
 wzk
@@ -175688,7 +176528,7 @@ gDA
 xVG
 qKM
 sVI
-xqC
+ksA
 gyJ
 hVe
 iSU
@@ -175932,7 +176772,7 @@ dlM
 anS
 fbU
 ojS
-ofz
+jKB
 cyF
 rZc
 vkZ
@@ -176048,7 +176888,7 @@ qes
 hfE
 hfE
 hfE
-edG
+cFO
 mct
 hsh
 fjJ
@@ -176146,7 +176986,7 @@ vjP
 eaQ
 eaQ
 bpT
-soV
+itf
 bpT
 vHU
 pKK
@@ -176562,7 +177402,7 @@ fjJ
 jMs
 jMs
 hfE
-edG
+cFO
 mct
 hcc
 fjJ

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -561,17 +561,6 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/station/engineering/solar/fore_port)
-"agR" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/starboard)
 "ahd" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plating,
@@ -794,6 +783,26 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/hardsuitstorage)
+"ajV" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "bridge blast";
+	name = "Bridge Blast Doors"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/bridge)
 "ajW" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/portable/canister/toxins,
@@ -1189,13 +1198,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
-"anB" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/theatre)
 "anD" = (
 /obj/structure/chair/office,
 /obj/machinery/computer/security/telescreen{
@@ -1264,6 +1266,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"aov" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/classic/reversed,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/all/service/kitchen,
+/obj/item/food/pie,
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/kitchen)
 "aoA" = (
 /obj/structure/chair{
 	dir = 8
@@ -1318,17 +1337,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"ape" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/east)
 "apl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1401,6 +1409,23 @@
 /obj/machinery/prize_counter,
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
+"apS" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command{
+	name = "Research Division Server Room";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/rd,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/department/science,
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/server)
 "apW" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel/dark,
@@ -1425,10 +1450,65 @@
 /obj/effect/turf_decal/tiles/neutral/corner,
 /turf/simulated/floor/plasteel,
 /area/station/public/fitness)
+"aqc" = (
+/obj/structure/table/reinforced,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/armory{
+	dir = 1
+	},
+/obj/machinery/door/window/classic/normal{
+	name = "Reception Window"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Lockdown Blast Doors"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/item/desk_bell{
+	pixel_x = 7;
+	pixel_y = 7;
+	anchored = 1
+	},
+/obj/machinery/door/window/reinforced/normal{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/autoname/desk{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
+/turf/simulated/floor/plasteel,
+/area/station/security/lobby)
 "aqh" = (
 /obj/machinery/gravity_generator/main/station,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/gravitygenerator)
+"aqj" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/sign/directions/medical{
+	pixel_x = -32;
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/science{
+	pixel_x = -32;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/evac{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/nw)
 "aqk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1641,21 +1721,6 @@
 "arS" = (
 /turf/simulated/wall,
 /area/station/service/pasture)
-"asa" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/command/magistrate,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Magistrate"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/glass,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Lockdown Blast Doors"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/legal/magistrate)
 "asj" = (
 /obj/machinery/mineral/ore_redemption{
 	input_dir = 8;
@@ -2076,23 +2141,22 @@
 "avc" = (
 /turf/simulated/wall,
 /area/station/command/office/hos)
-"avd" = (
-/obj/machinery/door/firedoor,
+"ave" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Telecoms Server Room";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/iaa,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "IAA"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/station/legal/lawoffice)
+/turf/simulated/floor/plasteel/dark,
+/area/station/telecomms/chamber)
 "avr" = (
 /turf/simulated/wall,
 /area/station/public/mrchangs)
@@ -2361,6 +2425,17 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/lobby)
+"axC" = (
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/machinery/door/airlock{
+	name = "Abandoned Hydroponics Backroom";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/starboard2)
 "axG" = (
 /obj/item/storage/box/lights/mixed,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -2800,22 +2875,6 @@
 	},
 /turf/simulated/floor/mineral/tranquillite,
 /area/station/service/mime)
-"aBy" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock{
-	name = "Recreation Area"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
 "aBD" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/suit_storage_unit/industrial/engine/secure,
@@ -2945,16 +3004,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/engine_foyer)
-"aCe" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Recreation Area"
-	},
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
 "aCf" = (
 /obj/machinery/light{
 	dir = 1
@@ -2978,34 +3027,6 @@
 "aCn" = (
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/west)
-"aCo" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	location = "Atmospherics"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/machinery/door/window/classic/reversed{
-	name = "Atmospherics Access";
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/atmos{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery/hollow,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/purple,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/control)
 "aCr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -3111,22 +3132,6 @@
 /obj/effect/turf_decal/tiles/neutral/corner,
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
-"aDb" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Gravity Generator Foyer"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Engineering";
-	name = "Engineering Security Doors"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/engine_foyer)
 "aDi" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/cable/extra_insulated/pre_connect{
@@ -3486,25 +3491,6 @@
 /obj/machinery/requests_console/directional/north,
 /turf/simulated/floor/carpet,
 /area/station/legal/magistrate)
-"aFe" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/door/airlock/security/glass,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel,
-/area/station/security/storage)
 "aFj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -3532,12 +3518,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
-"aFy" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
 "aFD" = (
 /obj/structure/chair{
 	dir = 4
@@ -3686,16 +3666,6 @@
 /obj/structure/chair/comfy/black,
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
-"aGM" = (
-/obj/machinery/door/airlock{
-	name = "Dormitories"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
 "aGO" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel,
@@ -3800,19 +3770,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"aHB" = (
-/obj/machinery/door/airlock/vault{
-	locked = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/supply/vault,
-/turf/simulated/floor/plasteel/dark,
-/area/station/command/vault)
 "aHE" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 0;
@@ -4179,18 +4136,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/checkpoint/secondary)
-"aIP" = (
-/obj/machinery/door/airlock/hatch,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/telecomms/computer)
 "aIS" = (
 /obj/item/stack/sheet/plasteel{
 	amount = 10;
@@ -4285,20 +4230,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tiles/department/virology,
-/turf/simulated/floor/plasteel/white,
-/area/station/public/sleep)
-"aJA" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/department/virology/side{
-	dir = 1
-	},
 /turf/simulated/floor/plasteel/white,
 /area/station/public/sleep)
 "aJB" = (
@@ -4800,19 +4731,6 @@
 "aMk" = (
 /turf/simulated/wall,
 /area/station/legal/courtroom)
-"aMm" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Lockdown Blast Doors"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/station/legal/courtroom)
 "aMn" = (
 /turf/simulated/wall,
 /area/station/legal/lawoffice)
@@ -5162,15 +5080,6 @@
 /obj/effect/spawner/random/blood/often,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
-"aOa" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
-/turf/simulated/floor/engine,
-/area/station/engineering/engine/reactor)
 "aOg" = (
 /obj/machinery/computer/security/telescreen/engine{
 	dir = 8;
@@ -5223,28 +5132,6 @@
 "aOB" = (
 /turf/simulated/wall,
 /area/station/maintenance/fpmaint)
-"aOD" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/tiles/department/chemistry/corner,
-/obj/effect/turf_decal/tiles/department/chemistry/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tiles/department/chemistry/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tiles/department/chemistry/corner{
-	dir = 1
-	},
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/storage/tools/auxiliary)
 "aOG" = (
 /turf/simulated/wall/r_wall,
 /area/station/turret_protected/ai_upload)
@@ -6076,12 +5963,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
-"aTQ" = (
-/obj/effect/map_effect/dynamic_airlock/door/exterior,
-/obj/machinery/door/airlock/external/glass,
-/obj/machinery/access_button/offset/southwest,
-/turf/simulated/floor/plasteel/dark/airless,
-/area/station/hallway/secondary/entry/west)
 "aTR" = (
 /obj/effect/turf_decal/trimline/misc/toxins/filled/shrink_ccw{
 	dir = 4
@@ -6135,18 +6016,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/engine_foyer)
-"aUi" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge Access"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge blast";
-	name = "Bridge Blast Doors"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/command/bridge)
 "aUp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6170,21 +6039,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/north)
-"aUs" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/glass,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Courtroom"
-	},
-/turf/simulated/floor/wood,
-/area/station/legal/courtroom/gallery)
 "aUw" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tiles/neutral/corner{
@@ -6354,24 +6208,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/engine_foyer)
-"aVi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/turf_decal/tiles/department/chemistry/corner{
-	dir = 4
-	},
-/obj/machinery/door/airlock/atmos/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/atmos/control)
 "aVk" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tiles/department/cargo/side,
@@ -6888,18 +6724,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/north)
-"aXS" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/security/checkpoint/secondary)
 "aXZ" = (
 /obj/machinery/light{
 	dir = 8
@@ -7129,38 +6953,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
-"aZP" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore/north)
-"aZQ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore/north)
-"aZR" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore/north)
 "aZS" = (
 /obj/structure/sign/directions/science{
 	pixel_x = 32;
@@ -7263,6 +7055,17 @@
 "bam" = (
 /turf/simulated/wall/r_wall,
 /area/station/command/office/ce)
+"bar" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/south)
 "bau" = (
 /obj/structure/table/wood,
 /obj/item/clothing/mask/cigarette/cigar,
@@ -7374,17 +7177,6 @@
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel/dark,
 /area/station/hallway/primary/central/se)
-"bbk" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/carpet,
-/area/station/service/library)
 "bbn" = (
 /obj/item/radio/intercom{
 	name = "north bump";
@@ -7456,25 +7248,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/tech_storage)
-"bby" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Crew Quarters Access"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/locker)
-"bbz" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Crew Quarters Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/locker)
 "bbB" = (
 /obj/machinery/economy/vending/snack,
 /turf/simulated/floor/plasteel/dark,
@@ -7843,23 +7616,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/station/command/office/ce)
-"bdD" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/door/airlock/command,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
-/turf/simulated/floor/plasteel,
 /area/station/command/office/ce)
 "bdE" = (
 /obj/machinery/computer/card/minor/ce,
@@ -8324,23 +8080,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/ce)
-"bfh" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "seclock";
-	name = "Checkpoint Lockdown"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/checkpoint/secondary)
 "bfl" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/machinery/requests_console/directional/north,
@@ -8991,7 +8730,7 @@
 /obj/machinery/computer/general_air_control{
 	dir = 8;
 	name = "Tank Monitor";
-	autolink_sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous Oxide","waste_sensor"="Gas Mix Tank")
+	autolink_sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous Oxide", "waste_sensor" = "Gas Mix Tank")
 	},
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 4
@@ -9618,31 +9357,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/ne)
-"blm" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/tech_storage)
-"blq" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/spawner/random/dirt/frequent,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fsmaint)
 "blr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /obj/effect/turf_decal/tiles/dark/corner{
@@ -9715,24 +9429,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore2)
-"blI" = (
-/obj/machinery/door/firedoor,
-/obj/structure/sign/directions/medical{
-	pixel_x = -32;
-	pixel_y = 8
-	},
-/obj/structure/sign/directions/science{
-	pixel_x = -32;
-	pixel_y = -8
-	},
-/obj/structure/sign/directions/evac{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/nw)
 "blJ" = (
 /obj/item/radio/intercom/custom{
 	pixel_y = 25
@@ -9850,20 +9546,6 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/command/bridge)
-"bmh" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/airlock/engineering/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/engine_foyer)
 "bmm" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -10583,25 +10265,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/ai)
-"bpr" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/reinforced/normal{
-	dir = 1;
-	name = "Head of Personnel's Desk"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/command/hop{
-	dir = 1
-	},
-/obj/machinery/door/window/classic/normal{
-	name = "Reception Window"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "hop";
-	name = "privacy shutters"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/command/office/hop)
 "bpt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -10619,6 +10282,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/supply/sorting)
+"bpF" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/iaa,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "IAA"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/legal/lawoffice)
 "bpG" = (
 /obj/machinery/door/airlock/external/glass{
 	id_tag = "admin_home";
@@ -10974,24 +10658,34 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/ai)
-"brG" = (
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock";
-	name = "Escape Pod Hatch"
-	},
-/obj/structure/fans/tiny,
-/obj/docking_port/mobile/pod{
-	id = "pod1";
-	name = "escape pod 1"
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/pod_1)
 "brI" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/ai)
+"brL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/turf_decal/tiles/department/chemistry/corner{
+	dir = 4
+	},
+/obj/machinery/door/airlock/atmos/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/atmos/control)
 "brM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -11099,18 +10793,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat)
-"bsj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/command,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/command/captain,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/station/command/office/captain/bedroom)
 "bsk" = (
 /obj/structure/closet/secure_closet/evidence,
 /obj/machinery/light/small{
@@ -11134,18 +10816,6 @@
 "bsp" = (
 /turf/simulated/wall,
 /area/station/service/bar)
-"bsq" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/tiles/department/medical/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/barber)
 "bsw" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/plasteel/dark,
@@ -11546,14 +11216,6 @@
 /obj/item/cane,
 /turf/simulated/floor/plating,
 /area/station/command/office/captain)
-"buj" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/command,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/command/eva,
-/turf/simulated/floor/plasteel,
-/area/station/ai_monitored/storage/eva)
 "bul" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -12303,11 +11965,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
-"bwS" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/security/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/east)
 "bwW" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -12386,16 +12043,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat)
-"bxp" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Command Hallway"
-	},
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/science/robotics/showroom)
 "bxq" = (
 /obj/structure/rack{
 	dir = 8;
@@ -12801,6 +12448,30 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/east)
+"byH" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner{
+	dir = 1
+	},
+/obj/structure/sign/directions/evac{
+	pixel_x = -32;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/engineering{
+	pixel_x = -32
+	},
+/obj/structure/sign/directions/medical{
+	pixel_x = -32;
+	pixel_y = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/west)
 "byJ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -13140,28 +12811,9 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
-"bAg" = (
-/obj/machinery/door/airlock/command{
-	name = "Command Desk"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/turf/simulated/floor/plasteel/dark,
-/area/station/command/bridge)
 "bAi" = (
 /obj/structure/bookcase,
 /turf/simulated/floor/wood,
-/area/station/command/bridge)
-"bAj" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/obj/effect/turf_decal/tiles/department/command/side{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
 "bAk" = (
 /obj/structure/cable{
@@ -13222,15 +12874,6 @@
 	},
 /turf/simulated/floor/plasteel/dark/full,
 /area/station/security/evidence)
-"bAt" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/directional/east,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/neutral/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/south)
 "bAv" = (
 /obj/structure/chair/stool{
 	dir = 4
@@ -13351,6 +12994,23 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/hardsuitstorage)
+"bAZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plating,
+/area/station/maintenance/medmaint)
 "bBc" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -13721,6 +13381,20 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/command/office/captain)
+"bCs" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/apmaint)
 "bCt" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/turf_decal/tiles/dark/corner,
@@ -13966,10 +13640,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
-"bDC" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/east)
 "bDE" = (
 /obj/machinery/economy/vending/snack,
 /obj/machinery/light,
@@ -14298,17 +13968,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
-"bFL" = (
-/obj/structure/extinguisher_cabinet{
-	name = "west bump";
-	pixel_x = -27
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/west)
 "bFM" = (
 /obj/structure/chair/comfy/teal{
 	dir = 4
@@ -14381,6 +14040,19 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/command/office/captain)
+"bFY" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/corner,
+/obj/structure/sign/directions/evac{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/north)
 "bGa" = (
 /obj/item/radio/intercom{
 	name = "west bump";
@@ -14391,15 +14063,6 @@
 /obj/effect/turf_decal/tiles/department/command/corner,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
-"bGb" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line,
-/obj/structure/sign/poster/official/random/directional/east,
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/supply/aft)
 "bGd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14491,6 +14154,27 @@
 	},
 /turf/simulated/floor/carpet/grimey,
 /area/station/telecomms/computer)
+"bHm" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/sign/directions/engineering{
+	dir = 4;
+	pixel_x = 32
+	},
+/obj/structure/sign/directions/bridge{
+	dir = 4;
+	pixel_x = 32;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/security{
+	dir = 4;
+	pixel_x = 32;
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/tiles/neutral/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/nw)
 "bHq" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/structure/sign/electricshock{
@@ -14543,20 +14227,6 @@
 	icon_state = "cult"
 	},
 /area/station/legal/magistrate)
-"bHy" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Power Monitoring"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/electrical/fore_port)
 "bHz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14642,15 +14312,6 @@
 /obj/effect/turf_decal/tiles/jobs/bar/checker,
 /turf/simulated/floor/plasteel,
 /area/station/service/bar)
-"bHK" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/maintcentral)
 "bHL" = (
 /obj/machinery/light{
 	dir = 8
@@ -14865,14 +14526,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
-/area/station/service/bar)
-"bIE" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/woodsiding,
-/obj/effect/turf_decal/tiles/jobs/bar/checker,
-/turf/simulated/floor/plasteel,
 /area/station/service/bar)
 "bIG" = (
 /obj/structure/disposalpipe/segment,
@@ -15401,6 +15054,26 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/command/office/captain/bedroom)
+"bKA" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/department/virology/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/service/hydroponics)
 "bKH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/roller,
@@ -15542,29 +15215,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/east)
-"bLA" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/classic/reversed,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "kitchen_counter";
-	name = "Kitchen Counter Shutters"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/all/service/kitchen,
-/obj/structure/window/reinforced{
+"bLC" = (
+/obj/machinery/door/airlock/maintenance{
 	dir = 4
 	},
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = -3
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = 3
-	},
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/kitchen)
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint2)
 "bLE" = (
 /obj/effect/turf_decal/tiles/department/security/corner,
 /obj/structure/sign/engineering{
@@ -15949,19 +15610,6 @@
 	icon_state = "solarpanel"
 	},
 /area/station/engineering/solar/aft_starboard)
-"bNM" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/command,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/command/eva,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/ai_monitored/storage/eva)
 "bNP" = (
 /obj/machinery/camera{
 	active_power_consumption = 0;
@@ -16006,9 +15654,20 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/telecomms/chamber)
-"bOe" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command,
+"bOf" = (
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/wood,
+/area/station/security/permabrig)
+"bOk" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -16018,13 +15677,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
 /turf/simulated/floor/plasteel,
 /area/station/command/teleporter)
-"bOf" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/wood,
-/area/station/security/permabrig)
 "bOo" = (
 /obj/structure/bookcase{
 	name = "bookcase (Non-Fiction)"
@@ -16063,22 +15715,23 @@
 "bOA" = (
 /turf/simulated/floor/greengrid,
 /area/station/turret_protected/ai_upload)
-"bOB" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/west)
 "bOG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/spacehut)
+"bOH" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/aft2)
 "bOI" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/simulated/floor/catwalk,
@@ -16503,23 +16156,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/office/ntrep)
-"bQF" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/east)
-"bQG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/west)
 "bQI" = (
 /turf/simulated/wall,
 /area/station/service/kitchen)
@@ -17091,19 +16727,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/blueshield)
-"bTm" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/security/checkpoint/secondary)
 "bTn" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/external/glass{
@@ -17279,13 +16902,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
-"bUM" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/west)
 "bUN" = (
 /obj/machinery/suit_storage_unit/mime/secure,
 /turf/simulated/floor/catwalk,
@@ -17378,13 +16994,6 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/station/command/office/blueshield)
-"bVi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
 "bVj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -17423,15 +17032,6 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
-"bVA" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Hydroponics Pasture"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel,
-/area/station/service/pasture)
 "bVC" = (
 /obj/structure/table,
 /obj/item/radio,
@@ -17681,16 +17281,6 @@
 "bWJ" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/wood,
-/area/station/science/robotics/showroom)
-"bWK" = (
-/obj/effect/spawner/window/reinforced/polarized/grilled{
-	id = "SHOW"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
 /area/station/science/robotics/showroom)
 "bWN" = (
 /turf/simulated/floor/wood,
@@ -18124,17 +17714,6 @@
 	icon_state = "chapel"
 	},
 /area/station/service/chapel)
-"bYN" = (
-/obj/machinery/economy/vending/wallmed/directional/west,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Command Hallway"
-	},
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/science/robotics/showroom)
 "bYQ" = (
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 4
@@ -18200,16 +17779,6 @@
 "bZv" = (
 /turf/simulated/wall,
 /area/station/service/hydroponics)
-"bZx" = (
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id_tag = "evashutter";
-	name = "E.V.A. Storage Shutter"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/ai_monitored/storage/eva)
 "bZy" = (
 /obj/structure/closet/emcloset,
 /obj/effect/spawner/random/maintenance,
@@ -18688,24 +18257,6 @@
 /obj/machinery/alarm/directional/west,
 /turf/simulated/floor/carpet/royalblack,
 /area/station/command/office/ntrep)
-"ccm" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/command{
-	id_tag = "ntrepofficedoor";
-	name = "NT Representative's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/ntrep,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/wood,
-/area/station/command/office/ntrep)
 "ccn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -18943,15 +18494,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/science/robotics)
-"cdq" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/medmaint)
 "cdw" = (
 /obj/item/beacon,
 /turf/simulated/floor/plasteel,
@@ -19016,18 +18558,6 @@
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
-"cdQ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/atmos,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/atmos/control)
 "cdT" = (
 /turf/simulated/wall,
 /area/station/maintenance/port)
@@ -19050,25 +18580,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/legal/magistrate)
-"cdW" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tiles/department/medical/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/south)
-"cdX" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
 "cdZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -19145,15 +18656,6 @@
 /obj/machinery/disposal,
 /turf/simulated/floor/plasteel/dark,
 /area/station/hallway/primary/central/se)
-"cek" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/starboard2)
 "cel" = (
 /obj/machinery/power/apc/directional/north,
 /obj/structure/cable{
@@ -19278,36 +18780,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
-"cfm" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical,
-/obj/machinery/holosign/surgery{
-	id = "surgery1"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
-/obj/effect/turf_decal/tiles/department/command,
-/turf/simulated/floor/plasteel/dark,
-/area/station/medical/surgery/primary)
-"cfp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/medical/medbay)
 "cfq" = (
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "Morgue"
@@ -19377,22 +18849,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
-"cfC" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/department/virology/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/service/hydroponics)
 "cfD" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -19507,18 +18963,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/north)
-"cgx" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/south)
 "cgy" = (
 /obj/effect/turf_decal/tiles/department/science/corner,
 /turf/simulated/floor/plasteel,
@@ -19707,6 +19151,23 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
+"cht" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/iaa,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Lockdown Blast Doors"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/legal/lawoffice)
 "chw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -19764,20 +19225,6 @@
 "chM" = (
 /turf/simulated/wall,
 /area/station/medical/paramedic)
-"chO" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Hydroponics Storage"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/department/virology,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/se)
 "chR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19791,25 +19238,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/wood,
 /area/station/maintenance/abandonedbar)
-"chU" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id_tag = "paramedic";
-	name = "Paramedic Garage"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/caution/stand_clear{
-	dir = 1
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/medical/paramedic)
 "chV" = (
 /obj/structure/table,
 /obj/item/folder/white{
@@ -20244,17 +19672,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/solar/aft_starboard)
-"cjY" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
 "cjZ" = (
 /obj/machinery/alarm/directional/south,
 /obj/effect/turf_decal/tiles/department/virology/side,
@@ -20617,6 +20034,24 @@
 "cmq" = (
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/reception)
+"cmr" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/machinery/door/airlock/atmos/glass{
+	autoclose = 0;
+	id_tag = "atmossm_door_ext";
+	name = "Atmospherics Access Chamber";
+	dir = 4
+	},
+/obj/machinery/access_button{
+	autolink_id = "atmossm_btn_ext";
+	name = "Atmospherics Access Button";
+	pixel_x = 24;
+	req_access = list(24)
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/engine/reactor)
 "cms" = (
 /obj/effect/mapping_helpers/turfs/burn,
 /turf/simulated/floor/plating,
@@ -20885,6 +20320,18 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/hallway/secondary/exit)
+"cnZ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/command{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/command/eva,
+/turf/simulated/floor/plasteel,
+/area/station/ai_monitored/storage/eva)
 "cob" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -21831,17 +21278,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/ai_upload)
-"csT" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/neutral/corner,
-/obj/structure/sign/directions/evac{
-	pixel_x = 32
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/north)
 "csV" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/plantbgone{
@@ -22238,17 +21674,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/rnd)
-"cux" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id_tag = "Secure Armory";
-	name = "Secure Armory Shutters"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/armory/secure)
 "cuy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -22277,23 +21702,6 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/station/science/xenobiology)
-"cuF" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical,
-/obj/machinery/holosign/surgery{
-	id = "surgery2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
-/obj/effect/turf_decal/tiles/department/command,
-/turf/simulated/floor/plasteel/dark,
-/area/station/medical/surgery/secondary)
 "cuH" = (
 /obj/item/seeds/tomato,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -22464,6 +21872,17 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/aft2)
+"cvC" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/starboard2)
 "cvE" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -22705,6 +22124,35 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/command/office/rd)
+"cwL" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/turf_decal/stripes/white/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner,
+/obj/structure/sign/directions/science{
+	pixel_x = 32;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/bridge{
+	pixel_x = 32
+	},
+/obj/structure/sign/directions/security{
+	pixel_x = 32;
+	pixel_y = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/east)
 "cwO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23342,18 +22790,6 @@
 /obj/structure/sign/biohazard,
 /turf/simulated/wall,
 /area/station/maintenance/xenobio_south)
-"cAf" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/maintenance/apmaint)
 "cAi" = (
 /obj/item/reagent_containers/syringe,
 /turf/simulated/floor/plating,
@@ -23678,14 +23114,6 @@
 /obj/effect/turf_decal/tiles/department/science/side,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/robotics)
-"cBP" = (
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/science/research)
 "cBQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23702,23 +23130,6 @@
 "cBR" = (
 /turf/simulated/wall/r_wall,
 /area/station/science/misc_lab)
-"cBS" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	name = "Server Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/rd,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/department/science,
-/turf/simulated/floor/plasteel/dark,
-/area/station/science/server)
 "cBX" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -23727,18 +23138,6 @@
 /obj/effect/spawner/random/blood/maybe,
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
-"cCa" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line,
-/turf/simulated/floor/plasteel/dark,
-/area/station/medical/medbay)
 "cCf" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -23913,6 +23312,17 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/lobby)
+"cCR" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "cCV" = (
 /obj/effect/turf_decal/tiles/department/science/side,
 /turf/simulated/floor/plasteel/white,
@@ -24023,6 +23433,23 @@
 /obj/item/pen,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
+"cDx" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock{
+	name = "Dormitories";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral/corner,
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "cDA" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -24287,25 +23714,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/command/office/cmo)
-"cEU" = (
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "medbayfoyerport";
-	name = "Medbay Entrance"
-	},
-/obj/effect/turf_decal/tiles/department/medical,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/reception)
 "cEX" = (
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tiles/neutral/corner{
@@ -24619,19 +24027,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/cryo)
-"cGn" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/turf/simulated/floor/plasteel/white,
-/area/station/maintenance/aft)
 "cGo" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/apmaint)
@@ -24988,25 +24383,6 @@
 /obj/effect/spawner/window,
 /turf/simulated/floor/plating,
 /area/station/science/lobby)
-"cHQ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	name = "Genetics Shutters";
-	id_tag = "geneticsprivacy"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/genetics,
-/obj/machinery/door/window/classic/normal,
-/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "genetics"
-	},
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/turf_decal/tiles/department/science,
-/turf/simulated/floor/plasteel/dark,
-/area/station/science/genetics)
 "cHR" = (
 /obj/machinery/crema_switch{
 	pixel_x = -26
@@ -25064,20 +24440,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/command/office/cmo)
-"cIf" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/white,
-/area/station/maintenance/asmaint)
 "cIh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -25390,19 +24752,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/permabrig)
-"cKb" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/turf_decal/tiles/department/medical,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/coldroom)
 "cKe" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -25582,25 +24931,6 @@
 /obj/effect/turf_decal/siding,
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/cryo)
-"cKR" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/spawner/window/reinforced/polarized/grilled{
-	id = "SHOW"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/science/robotics/showroom)
 "cKS" = (
 /obj/machinery/ai_slipper,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -26033,13 +25363,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"cNe" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
 "cNf" = (
 /obj/machinery/power/apc/reinforced/directional/north,
 /obj/structure/cable/extra_insulated{
@@ -26157,6 +25480,24 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
+"cNE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/highsecurity{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/science/rd,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/station_engineering,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/gravitygenerator)
 "cNF" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
@@ -26216,13 +25557,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/solar/aft_starboard)
-"cNS" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/south)
 "cNZ" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -26421,24 +25755,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
-"cPv" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/service/chapel_office,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
-"cPA" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
 "cPC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -26454,12 +25770,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
-"cPD" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/science/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/south)
 "cPF" = (
 /obj/effect/landmark/start/doctor,
 /obj/effect/turf_decal/tiles/department/medical/side{
@@ -26495,25 +25805,6 @@
 	},
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel/dark,
-/area/station/hallway/secondary/exit)
-"cPN" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Departure Lounge"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/exit)
-"cPO" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Departure Lounge"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "cPT" = (
 /obj/structure/cable{
@@ -27450,18 +26741,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/chapel/funeral)
-"cVP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/service/chapel_office,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/service/chapel/office)
 "cVT" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/chair/comfy/black{
@@ -27708,19 +26987,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/fitness)
-"cXr" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line,
-/turf/simulated/floor/plasteel/dark,
-/area/station/medical/medbay)
 "cXs" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall,
@@ -28264,6 +27530,25 @@
 /obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/plasteel,
 /area/station/science/robotics)
+"dbm" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Lockdown Blast Doors"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore2)
 "dbt" = (
 /obj/item/grenade/chem_grenade/cleaner{
 	pixel_y = 9;
@@ -28945,13 +28230,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison)
-"dgn" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/starboard2)
 "dgr" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/machinery/alarm/directional/east,
@@ -28987,11 +28265,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/surgery/primary)
-"dgI" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "dgO" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -29151,18 +28424,6 @@
 /obj/effect/landmark/spawner/xeno,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/tech_storage)
-"did" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/security/checkpoint/secondary)
 "dif" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
@@ -29197,6 +28458,21 @@
 /obj/effect/turf_decal/tiles/department/medical,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/exam_room)
+"diw" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/asmaint)
 "diL" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -29281,6 +28557,36 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/minisat,
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat)
+"dkF" = (
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	location = "Atmospherics"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "atmos";
+	name = "Atmospherics Blast Door"
+	},
+/obj/machinery/door/window/classic/reversed{
+	name = "Atmospherics Access";
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/atmos{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/purple,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos/control)
 "dkG" = (
 /obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
@@ -29363,30 +28669,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/arrival/station)
-"dmg" = (
-/obj/machinery/door/airlock/public/glass{
-	autoclose = 0;
-	heat_proof = 1;
-	id_tag = "turbine_door_ext";
-	locked = 1;
-	name = "Incinerator Interior Airlock"
-	},
-/obj/machinery/airlock_controller/access_controller{
-	name = "Turbine Access Console";
-	pixel_x = 40;
-	pixel_y = 8;
-	ext_door_link_id = "turbine_door_ext";
-	int_door_link_id = "turbine_door_int";
-	ext_button_link_id = "turbine_btn_ext";
-	int_button_link_id = "turbine_btn_int"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/engine,
-/area/station/maintenance/turbine)
 "dmi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -29549,21 +28831,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/mineral/tranquillite,
 /area/station/service/mime)
-"doE" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/classic/reversed,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "kitchen_counter";
-	name = "Kitchen Counter Shutters"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/all/service/kitchen,
-/obj/item/food/pie,
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/kitchen)
 "doS" = (
 /obj/machinery/conveyor/southeast/ccw{
 	id = "QMLoad2"
@@ -29604,19 +28871,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
-"dpM" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Power Monitoring"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/electrical/aft_starboard)
 "dpV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -29696,6 +28950,25 @@
 /mob/living/basic/cockroach,
 /turf/simulated/floor/plating,
 /area/station/maintenance/theatre)
+"drg" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator Foyer";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/delivery,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Engineering";
+	name = "Engineering Security Doors"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/engine_foyer)
 "drF" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
@@ -29731,19 +29004,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
-"dsw" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Power Monitoring"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/electrical/port)
 "dsz" = (
 /obj/effect/turf_decal/trimline/misc/toxins/corner{
 	dir = 8
@@ -29862,12 +29122,6 @@
 /obj/effect/turf_decal/tiles/department/medical,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/reception)
-"dwp" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/newscaster/directional/east,
-/obj/effect/turf_decal/tiles/department/security/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/east)
 "dwC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -29919,6 +29173,15 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/surgery/observation)
+"dxb" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/service/chapel_office,
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "dxh" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -30142,6 +29405,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"dBj" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/west)
 "dBS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/extinguisher_cabinet{
@@ -30310,16 +29589,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/north)
-"dFf" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/east)
 "dFA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -30524,17 +29793,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
-"dJw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison)
 "dJB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30646,6 +29904,22 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
+"dLD" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/atmos{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/atmos/control)
 "dLF" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -30727,6 +30001,18 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/station/public/vacant_office)
+"dNG" = (
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/reception)
 "dNN" = (
 /obj/effect/turf_decal/tiles/department/security/side,
 /obj/machinery/camera{
@@ -30735,6 +30021,18 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
+"dNR" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "dNU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30852,11 +30150,6 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_starboard)
-"dPX" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/neutral/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/west)
 "dQb" = (
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics)
@@ -30905,46 +30198,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel/dark,
 /area/station/hallway/secondary/entry/west)
-"dRU" = (
-/obj/effect/mapping_helpers/airlock/windoor/access/all/science/xenobio,
-/obj/machinery/door/window/classic/normal{
-	name = "Containment Pen #6"
-	},
-/obj/machinery/door/window/classic/normal{
-	name = "Containment Pen #6";
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "xenobio6";
-	name = "Xenobio Pen 6 Blast Door"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/windoor/access/all/science/xenobio{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/science/xenobiology)
-"dRX" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/rd,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tiles/department/science,
-/turf/simulated/floor/plasteel/white,
-/area/station/command/office/rd)
 "dRY" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -31134,16 +30387,6 @@
 /obj/item/clothing/mask/breath,
 /turf/simulated/floor/indestructible/titanium/blue,
 /area/shuttle/arrival/station)
-"dUv" = (
-/obj/machinery/door/airlock/engineering,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/solar_maintenance/aft_starboard)
 "dUG" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -31186,6 +30429,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
+"dVU" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/security/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/east)
 "dVX" = (
 /obj/machinery/light{
 	dir = 8
@@ -31222,6 +30472,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
+"dWB" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Power Monitoring";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/electrical/fore_port)
 "dWN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -31330,23 +30597,6 @@
 /obj/effect/spawner/random/blood/often,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
-"dYb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/sign/command/ai_upload{
-	pixel_x = 32
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/science/research)
 "dYc" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/poster/contraband/random/directional/north,
@@ -31480,6 +30730,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard2)
+"dZP" = (
+/obj/machinery/door/airlock/mining/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/supply/office)
 "dZQ" = (
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 1
@@ -31682,6 +30950,40 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/public/mrchangs)
+"edo" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/virology/glass{
+	name = "Containment Cells";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/virology)
+"edt" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/white/side,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/south)
 "edy" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable/green{
@@ -31707,16 +31009,6 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
-"edD" = (
-/obj/machinery/door/airlock/external/glass{
-	hackProof = 1;
-	name = "Escape Airlock";
-	id_tag = "emergency_home"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/turf_decal/tiles/department/security,
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/secondary/exit)
 "edM" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/effect/turf_decal/trimline/department/service/filled/warning{
@@ -31989,13 +31281,6 @@
 /obj/effect/turf_decal/tiles/department/medical,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage/secondary)
-"ejj" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Escape Pod 1 Airlock";
-	id_tag = "emergency_home"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/secondary/entry/west)
 "ejk" = (
 /obj/effect/spawner/window/reinforced/polarized/grilled{
 	id = "HoS"
@@ -32383,6 +31668,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
+"epz" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/department/virology/side{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/public/sleep)
 "epF" = (
 /obj/structure/closet/wardrobe/black,
 /obj/machinery/light{
@@ -32465,6 +31768,18 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
+"era" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/north)
 "ere" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -32565,19 +31880,6 @@
 "esA" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/range)
-"esC" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/classic/normal{
-	name = "Cargo Desk"
-	},
-/obj/item/desk_bell{
-	anchored = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/general,
-/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
-/turf/simulated/floor/plating,
-/area/station/supply/office)
 "etd" = (
 /obj/item/assembly/signaler{
 	code = 6;
@@ -32617,16 +31919,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/execution)
-"etn" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/north)
 "etp" = (
 /obj/machinery/light{
 	dir = 4
@@ -32713,16 +32005,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
-"euL" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/classic/normal{
-	name = "Cargo Desk"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/general,
-/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
-/turf/simulated/floor/plating,
-/area/station/supply/office)
 "euY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -32767,33 +32049,6 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/lobby)
-"evo" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/stripes/white/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner,
-/obj/structure/sign/directions/science{
-	pixel_x = 32;
-	pixel_y = -8
-	},
-/obj/structure/sign/directions/bridge{
-	pixel_x = 32
-	},
-/obj/structure/sign/directions/security{
-	pixel_x = 32;
-	pixel_y = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/east)
 "evr" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/xenobio_south)
@@ -32937,6 +32192,27 @@
 	},
 /turf/simulated/floor/carpet/purple,
 /area/station/service/library)
+"exl" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/command{
+	id_tag = "ntrepofficedoor";
+	name = "NT Representative's Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/ntrep,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/wood,
+/area/station/command/office/ntrep)
 "exI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -32948,26 +32224,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
-"exR" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "xenobio7";
-	name = "Xenobio Pen 7 Blast Door"
-	},
-/obj/machinery/door/window/classic/normal{
-	name = "Containment Pen #7";
-	dir = 1
-	},
-/obj/machinery/door/window/classic/normal{
-	name = "Containment Pen #7"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/windoor/access/all/science/xenobio,
-/obj/effect/mapping_helpers/airlock/windoor/access/all/science/xenobio{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/science/xenobiology)
 "exZ" = (
 /obj/machinery/atmospherics/binary/volume_pump/on{
 	name = "External to Filter"
@@ -33153,6 +32409,24 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/security/main)
+"eCl" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/airlock/engineering/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/engine_foyer)
 "eCn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -33252,17 +32526,6 @@
 /obj/effect/turf_decal/tiles/department/cargo/corner,
 /turf/simulated/floor/plasteel,
 /area/station/supply/lobby)
-"eEn" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fore2)
 "eEA" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -33315,15 +32578,6 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
-"eFw" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line,
-/turf/simulated/floor/plasteel/dark,
-/area/station/medical/medbay)
 "eFF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -33348,6 +32602,23 @@
 /obj/effect/turf_decal/tiles/department/chemistry/side,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
+"eFK" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "eFO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -33375,18 +32646,6 @@
 /obj/machinery/economy/vending/hatdispenser,
 /turf/simulated/floor/plasteel/dark,
 /area/station/public/locker)
-"eFY" = (
-/obj/machinery/door/airlock,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/janitor,
-/turf/simulated/floor/plasteel,
-/area/station/service/janitor)
 "eGd" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -33522,18 +32781,6 @@
 /obj/item/stamp/captain,
 /turf/simulated/floor/wood,
 /area/station/command/office/captain)
-"eIq" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
 "eIu" = (
 /obj/machinery/seed_extractor,
 /obj/machinery/alarm/directional/north,
@@ -33768,6 +33015,31 @@
 	},
 /turf/simulated/floor/carpet/royalblack,
 /area/station/supply/qm)
+"eNi" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/sign/directions/evac{
+	pixel_x = 32;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/engineering{
+	pixel_x = 32
+	},
+/obj/structure/sign/directions/medical{
+	pixel_x = 32;
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner,
+/turf/simulated/floor/plasteel,
+/area/station/security/checkpoint/secondary)
 "eNl" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/sop_engineering{
@@ -33803,21 +33075,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/chemistry)
-"eNT" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "kitchen_counter";
-	name = "Kitchen Counter Shutters"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/all/service/kitchen,
-/obj/machinery/door/window/classic/normal,
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/kitchen)
 "eNY" = (
 /obj/machinery/economy/atm/directional/west,
 /obj/effect/turf_decal/tiles/neutral/corner{
@@ -33904,6 +33161,20 @@
 /obj/effect/turf_decal/tiles/neutral/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
+"eOV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/command{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/command/captain,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/station/command/office/captain/bedroom)
 "eOZ" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -33946,18 +33217,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/robotics/showroom)
-"eQi" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Power Monitoring"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/electrical/aft_starboard)
 "eQm" = (
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 8
@@ -34212,23 +33471,6 @@
 "eTu" = (
 /turf/simulated/floor/plasteel/reactor_pool/wall/ladder,
 /area/station/engineering/engine/reactor)
-"eTy" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/machinery/door/airlock/atmos/glass{
-	autoclose = 0;
-	id_tag = "atmossm_door_ext";
-	name = "Atmospherics Access Chamber"
-	},
-/obj/machinery/access_button{
-	autolink_id = "atmossm_btn_ext";
-	name = "Atmospherics Access Button";
-	pixel_x = 24;
-	req_access = list(24)
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/engine/reactor)
 "eTU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -34264,6 +33506,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
+"eUe" = (
+/obj/machinery/economy/vending/wallmed/directional/west,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Command Hallway";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/science/robotics/showroom)
 "eUt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -34702,13 +33958,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
-"fbi" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/white,
-/area/station/maintenance/asmaint)
 "fbq" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/machinery/door/poddoor/preopen{
@@ -34951,6 +34200,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/captain/bedroom)
+"fez" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/engineering{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plating,
+/area/station/maintenance/solar_maintenance/aft_port)
 "feL" = (
 /obj/effect/turf_decal/tiles/department/virology/side{
 	dir = 10
@@ -35141,6 +34401,22 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/toxins/mixing)
+"fhA" = (
+/obj/machinery/door/airlock/engineering/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/equipmentstorage)
 "fhC" = (
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
@@ -35284,17 +34560,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/checkpoint/secondary)
-"fja" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
 "fjg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -35549,6 +34814,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
+"fnK" = (
+/obj/effect/mapping_helpers/airlock/access/all/science/tox,
+/obj/machinery/door/airlock/research{
+	name = "Toxins Loop Observation";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/asmaint)
 "fnQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -35684,31 +34960,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
-"fqX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "medbayfoyerport";
-	name = "Medbay Entrance"
-	},
-/obj/effect/turf_decal/tiles/department/medical,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/reception)
 "fre" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35815,6 +35066,27 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
+"fte" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical{
+	dir = 4
+	},
+/obj/machinery/holosign/surgery{
+	id = "surgery1"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/effect/turf_decal/tiles/department/command,
+/turf/simulated/floor/plasteel/dark,
+/area/station/medical/surgery/primary)
 "fth" = (
 /obj/structure/table/reinforced,
 /obj/machinery/kitchen_machine/microwave{
@@ -35924,20 +35196,26 @@
 	},
 /turf/simulated/floor/catwalk/black,
 /area/station/engineering/control)
-"fwO" = (
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
 "fwY" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
 /area/station/security/permabrig)
+"fxi" = (
+/obj/machinery/door/airlock/engineering{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/solar_maintenance/fore_starboard)
 "fxt" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -36203,18 +35481,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
-"fBK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/tox,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/research/glass,
-/obj/machinery/door/firedoor/heavy,
-/turf/simulated/floor/plasteel/dark,
-/area/station/science/toxins/launch)
 "fBQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -36300,10 +35566,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/asmaint)
-"fCQ" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/supply/lobby)
 "fCU" = (
 /obj/structure/marker_beacon/dock_marker/collision,
 /obj/structure/lattice/catwalk,
@@ -36356,15 +35618,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
-"fDC" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
 "fDE" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 1
@@ -36625,13 +35878,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/research)
-"fHM" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/carpet,
-/area/station/service/library)
 "fHQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -36696,22 +35942,15 @@
 /obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/noslip,
 /area/station/engineering/atmos/control)
-"fJd" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig"
+"fIX" = (
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tiles/department/engineering/corner{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison/cell_block/a)
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/north)
 "fJe" = (
 /obj/effect/turf_decal/tiles/department/security/side,
 /obj/machinery/economy/vending/sustenance,
@@ -36732,6 +35971,27 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/north)
+"fJG" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "seclock";
+	name = "Checkpoint Lockdown"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/checkpoint/secondary)
 "fJJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -36758,6 +36018,15 @@
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/simulated/floor/catwalk,
 /area/station/ai_monitored/storage/eva)
+"fKb" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "fLa" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -36955,6 +36224,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
+"fOA" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/service/hydroponics)
+"fOE" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "fOW" = (
 /obj/structure/disposalpipe/junction/reversed,
 /obj/effect/turf_decal/tiles/department/science/corner{
@@ -37114,6 +36401,16 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"fRQ" = (
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/research)
 "fRR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -37221,6 +36518,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/north)
+"fUq" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore2)
 "fUr" = (
 /obj/machinery/newscaster/directional/south,
 /obj/structure/disposalpipe/segment{
@@ -37530,6 +36837,27 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
+"fYz" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/window/reinforced/polarized/grilled{
+	id = "SHOW"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/science/robotics/showroom)
 "fYA" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -37594,6 +36922,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
+"fZo" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/starboard)
 "fZt" = (
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
@@ -37655,10 +36995,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/fitness)
-"gas" = (
-/obj/machinery/door/airlock/titanium/glass,
-/turf/simulated/floor/indestructible/titanium,
-/area/shuttle/arrival/station)
 "gaw" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light_construct{
@@ -37666,6 +37002,25 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
+"gaI" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison/cell_block/a)
 "gaM" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/plating/airless,
@@ -37697,6 +37052,23 @@
 	},
 /turf/simulated/floor/catwalk/black,
 /area/station/engineering/secure_storage)
+"gbu" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "gbx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -37952,21 +37324,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/lobby)
-"gfq" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/security,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/interrogation)
 "gft" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 8
@@ -37998,6 +37355,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"gfL" = (
+/obj/machinery/door/airlock/external/glass{
+	hackProof = 1;
+	name = "Escape Airlock";
+	id_tag = "emergency_home";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/turf_decal/tiles/department/security,
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/secondary/exit)
 "gfY" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 2
@@ -38093,6 +37461,21 @@
 /obj/structure/table/wood,
 /turf/simulated/floor/plasteel/dark,
 /area/station/procedure/trainer_office)
+"ghi" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "seclock";
+	name = "Checkpoint Lockdown"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/checkpoint/secondary)
 "ght" = (
 /obj/machinery/alarm/directional/north,
 /obj/structure/cable{
@@ -38260,17 +37643,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
-"glB" = (
-/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
-/obj/machinery/door/airlock/research,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/dark,
-/area/station/science/robotics/chargebay)
 "glQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -38383,20 +37755,6 @@
 	},
 /turf/space,
 /area/space)
-"gnP" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line,
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/supply)
 "gnQ" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -38663,11 +38021,35 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
+"grL" = (
+/obj/machinery/door/airlock/research/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/medical/genetics,
+/obj/effect/turf_decal/tiles/white/side,
+/turf/simulated/floor/plasteel,
+/area/station/science/genetics)
 "grP" = (
 /obj/structure/table,
 /obj/item/candle,
 /turf/simulated/floor/plasteel/dark,
 /area/station/hallway/secondary/exit)
+"grR" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/west)
 "gsb" = (
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 9
@@ -38685,18 +38067,6 @@
 /obj/effect/turf_decal/tiles/neutral/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/west)
-"gsQ" = (
-/obj/machinery/door/airlock/engineering/glass,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/equipmentstorage)
 "gsS" = (
 /obj/effect/turf_decal/tiles/department/security/corner{
 	dir = 1
@@ -38760,22 +38130,6 @@
 	},
 /turf/simulated/floor/plasteel/dark/full,
 /area/station/security/permabrig)
-"gtJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	name = "testing range blast door";
-	id_tag = "rdrnd"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/research,
-/obj/machinery/door/airlock/research{
-	name = "Research Test Range"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel,
-/area/station/science/testrange)
 "gtS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -38894,6 +38248,29 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/xenobio_south)
+"gxf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/door/airlock/multi_tile/glass,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
 "gxm" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -38947,6 +38324,32 @@
 	},
 /turf/simulated/floor/greengrid,
 /area/station/science/robotics/chargebay)
+"gyI" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "open";
+	id_tag = "AI Chamber Entrance Shutters";
+	name = "AI Chamber Entrance Shutters";
+	opacity = 0
+	},
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = -25
+	},
+/obj/machinery/door/airlock/highsecurity{
+	locked = 1;
+	name = "AI Chamber";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel/dark,
+/area/station/turret_protected/aisat/interior)
 "gyK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel/dark,
@@ -39007,16 +38410,15 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
-"gAj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
+"gzC" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
-/area/station/maintenance/fore2)
+/area/station/hallway/primary/central/west)
 "gAx" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39053,6 +38455,32 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
 /area/station/turret_protected/ai_upload)
+"gAS" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/science/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/south)
+"gAT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/service/chapel_office,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/service/chapel/office)
 "gAV" = (
 /obj/effect/spawner/random/fungus/frequent,
 /turf/simulated/wall,
@@ -39327,6 +38755,19 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/storage)
+"gFu" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
 "gFz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -39407,6 +38848,19 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/storage)
+"gGx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison)
 "gGN" = (
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 1
@@ -39729,6 +39183,18 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
+"gLe" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Power Monitoring";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/turf/simulated/floor/plating,
+/area/station/maintenance/electrical/port)
 "gLl" = (
 /obj/machinery/alarm/directional/east,
 /obj/effect/turf_decal/tiles/department/cargo/corner,
@@ -39881,6 +39347,29 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fpmaint)
+"gNu" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/airlock/atmos/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/tiles/department/engineering/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos/distribution)
 "gNM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -40119,27 +39608,6 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/supply/storage)
-"gRq" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/all/engineering/atmos,
-/obj/machinery/door/window/reinforced/normal,
-/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
-/obj/item/desk_bell{
-	pixel_x = 7;
-	pixel_y = 7;
-	anchored = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/turf/simulated/floor/plating,
-/area/station/engineering/atmos/control)
 "gRt" = (
 /obj/machinery/light/small,
 /obj/effect/turf_decal/tiles/department/virology/side,
@@ -40749,6 +40217,19 @@
 /obj/structure/sink/directional/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
+"haY" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Fore-Starboard Atmospherics Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/asmaint)
 "hbc" = (
 /obj/machinery/atmospherics/unary/tank/air,
 /turf/simulated/floor/plating,
@@ -40839,15 +40320,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/station/service/mime)
-"hds" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Maintenance"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "hdw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40943,28 +40415,6 @@
 /obj/machinery/alarm/directional/north,
 /turf/simulated/floor/carpet,
 /area/station/legal/magistrate)
-"heV" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner{
-	dir = 1
-	},
-/obj/structure/sign/directions/evac{
-	pixel_x = -32;
-	pixel_y = -8
-	},
-/obj/structure/sign/directions/engineering{
-	pixel_x = -32
-	},
-/obj/structure/sign/directions/medical{
-	pixel_x = -32;
-	pixel_y = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
 "hfb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/turf_decal/stripes/line{
@@ -41041,16 +40491,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
-"hgu" = (
-/obj/effect/spawner/window/reinforced/polarized/grilled{
-	id = "SHOW"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/science/robotics/showroom)
 "hgD" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -41414,6 +40854,13 @@
 /obj/machinery/alarm/directional/east,
 /turf/simulated/floor/plasteel,
 /area/station/security/storage)
+"hoE" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/south)
 "hoO" = (
 /obj/item/trash/spentcasing/shotgun,
 /obj/effect/turf_decal/stripes/line{
@@ -41429,6 +40876,17 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/medmaint)
+"hpb" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/port)
 "hph" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
@@ -41475,16 +40933,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos/control)
-"hqT" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/security/lobby)
 "hrf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc/directional/east,
@@ -41972,16 +41420,6 @@
 /obj/structure/sign/public/pods,
 /turf/simulated/wall/r_wall,
 /area/station/hallway/secondary/entry/west)
-"hyD" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/north)
 "hyN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tiles/department/science/side{
@@ -42148,6 +41586,19 @@
 	},
 /turf/simulated/floor/engine/co2,
 /area/station/engineering/atmos)
+"hBJ" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Fore-Starboard Atmospherics Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "hBM" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tiles/white/corner{
@@ -42357,6 +41808,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/lobby)
+"hEW" = (
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "medbayfoyerport";
+	name = "Medbay Entrance";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/reception)
 "hEX" = (
 /obj/machinery/economy/vending/coffee,
 /turf/simulated/floor/plasteel,
@@ -42368,6 +41841,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/science/testrange)
+"hFg" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/east)
 "hFs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -42474,6 +41959,21 @@
 /obj/machinery/newscaster/security_unit/directional/north,
 /turf/simulated/floor/carpet/red,
 /area/station/command/office/hos)
+"hGN" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Crew Quarters Access";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/locker)
 "hGS" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -42656,6 +42156,20 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison)
+"hKT" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/fsmaint2)
 "hLt" = (
 /obj/machinery/camera{
 	c_tag = "Chapel Office - Backroom";
@@ -42699,6 +42213,17 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
+"hLY" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/lobby)
 "hMb" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/secure_data/laptop,
@@ -42710,6 +42235,24 @@
 /obj/effect/spawner/random/dirt/maybe,
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics/chargebay)
+"hMu" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/poddoor/preopen{
+	name = "testing range blast door";
+	id_tag = "rdrnd"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/asmaint)
 "hMv" = (
 /obj/effect/landmark/spawner/rev,
 /obj/structure/morgue{
@@ -42717,6 +42260,16 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
+"hMF" = (
+/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+/obj/machinery/door/airlock/research{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/station/science/robotics)
 "hMI" = (
 /obj/effect/mapping_helpers/turfs/rust/probably,
 /turf/simulated/wall,
@@ -43031,6 +42584,24 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/main)
+"hSD" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/machinery/door/airlock/atmos/glass{
+	autoclose = 0;
+	id_tag = "atmossm_door_int";
+	name = "Atmospherics Access Chamber";
+	dir = 4
+	},
+/obj/machinery/access_button{
+	autolink_id = "atmossm_btn_int";
+	name = "Atmospherics Access Button";
+	pixel_x = -24;
+	req_access = list(24)
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/plating,
+/area/station/engineering/engine/reactor)
 "hSG" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -43229,17 +42800,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/virology)
-"hXd" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
-/obj/structure/cable/extra_insulated/pre_connect{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/xenobio_south)
 "hXW" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment,
@@ -43487,25 +43047,27 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/supply)
-"ibQ" = (
-/obj/machinery/door/firedoor,
-/obj/structure/sign/directions/engineering{
-	dir = 4;
-	pixel_x = 32
+"ibM" = (
+/obj/machinery/door/poddoor/preopen{
+	name = "Biohazard Shutter";
+	id_tag = "RnDChem"
 	},
-/obj/structure/sign/directions/bridge{
-	dir = 4;
-	pixel_x = 32;
-	pixel_y = -8
+/obj/machinery/door/airlock/research/glass{
+	name = "Test Chamber";
+	dir = 4
 	},
-/obj/structure/sign/directions/security{
-	dir = 4;
-	pixel_x = 32;
-	pixel_y = 8
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/effect/turf_decal/tiles/neutral/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/nw)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
+/obj/effect/mapping_helpers/airlock/access/any/science/tox_storage,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/test_chamber)
 "ibR" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -43607,6 +43169,17 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engimaint)
+"idm" = (
+/obj/machinery/door/airlock/security{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/evidence,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/evidence)
 "idr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -43715,20 +43288,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/asmaint)
-"ifJ" = (
-/obj/effect/mapping_helpers/airlock/access/any/supply/general,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mining,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/supply)
 "ifM" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -44071,6 +43630,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/service/hydroponics)
+"imY" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line,
+/turf/simulated/floor/plasteel/dark,
+/area/station/medical/medbay)
 "imZ" = (
 /obj/effect/turf_decal/tiles/department/medical/side,
 /turf/simulated/floor/plasteel/white,
@@ -44121,6 +43694,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
+"ioF" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/lobby)
 "ioR" = (
 /obj/structure/sign/security{
 	pixel_y = 32;
@@ -44149,16 +43728,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/cafeteria)
-"ipo" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/fsmaint2)
 "ipC" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -44188,6 +43757,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
+"iqk" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/structure/barricade/wooden/crude,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/abandonedservers)
 "iqm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9
@@ -44212,6 +43792,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"iqu" = (
+/obj/machinery/door/airlock/engineering{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/solar_maintenance/aft_starboard)
 "iqy" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -44497,16 +44091,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
 /area/station/procedure/trainer_office)
-"iwv" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"iwQ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/obj/machinery/door/airlock/command,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/station/science/robotics/showroom)
+/obj/effect/mapping_helpers/airlock/access/all/command/magistrate,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Magistrate"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Lockdown Blast Doors"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/legal/magistrate)
 "iwW" = (
 /obj/machinery/door/airlock/medical{
 	name = "Abandoned Storage"
@@ -44723,6 +44326,19 @@
 /obj/effect/turf_decal/tiles/dark/corner,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/transmission_laser)
+"izN" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "izT" = (
 /obj/effect/turf_decal/tiles/department/security/corner,
 /obj/effect/turf_decal/tiles/department/security/corner{
@@ -44767,18 +44383,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos/control)
-"iAx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "iAB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -45353,6 +44957,40 @@
 /obj/effect/landmark/spawner/nukedisc_respawn,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/main)
+"iGA" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	name = "testing range blast door";
+	id_tag = "rdrnd"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/machinery/door/airlock/research{
+	name = "Research Test Range";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/science/testrange)
+"iGD" = (
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Lockdown Blast Doors"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "iGR" = (
 /obj/structure/closet/crate{
 	name = "Silver Crate"
@@ -45396,29 +45034,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
-"iHo" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "open";
-	id_tag = "AI Chamber Entrance Shutters";
-	name = "AI Chamber Entrance Shutters";
-	opacity = 0
-	},
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = -25
-	},
-/obj/machinery/door/airlock/highsecurity{
-	locked = 1;
-	name = "AI Chamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/dark,
-/area/station/turret_protected/aisat/interior)
 "iHv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/fakestairs,
@@ -45466,6 +45081,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/north)
+"iHX" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Departure Lounge";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/exit)
 "iId" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -45488,23 +45113,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
-"iID" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
 "iIM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -46016,6 +45624,19 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
+"iQe" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Departure Lounge";
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/exit)
 "iQk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -46035,15 +45656,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/south)
-"iQp" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/external/glass,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
 "iQC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -46223,6 +45835,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
+"iTH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/medmaint)
 "iTN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -46482,6 +46104,34 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/robotics)
+"jab" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "medbayfoyerport";
+	name = "Medbay Entrance";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/reception)
 "jac" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -46793,6 +46443,21 @@
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"jeK" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore2)
 "jeS" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -46891,16 +46556,6 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
-"jhk" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
 "jhI" = (
 /obj/machinery/atmospherics/refill_station/plasma,
 /turf/simulated/floor/catwalk,
@@ -47113,6 +46768,13 @@
 /obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"jlN" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/west)
 "jlO" = (
 /obj/effect/spawner/random/trash,
 /obj/structure/cable/extra_insulated{
@@ -47303,6 +46965,16 @@
 /obj/effect/turf_decal/tiles/department/science/side,
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/xenobiology)
+"jqZ" = (
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "jrd" = (
 /obj/effect/turf_decal/tiles/department/virology/side{
 	dir = 5
@@ -47330,6 +47002,20 @@
 /mob/living/basic/mouse/white/brain,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
+"jse" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/effect/turf_decal/tiles/department/command/side{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/bridge)
 "jsh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -47572,6 +47258,14 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/execution)
+"jvv" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Escape Pod 3 Airlock";
+	id_tag = "emergency_home";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "jvK" = (
 /obj/effect/spawner/random/cobweb/right/rare,
 /obj/machinery/atmospherics/unary/tank/air{
@@ -47896,6 +47590,20 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/security/brig)
+"jCb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore2)
 "jCd" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -47909,6 +47617,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
+"jCr" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "bridge blast";
+	name = "Bridge Blast Doors"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/bridge)
 "jCz" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -47972,14 +47697,6 @@
 /obj/effect/turf_decal/tiles/department/cargo/side,
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
-"jDh" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/firealarm/directional/west,
-/obj/effect/turf_decal/tiles/department/medical/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/south)
 "jDj" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -47996,15 +47713,6 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
-"jDv" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/structure/barricade/wooden/crude,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/abandonedservers)
 "jDx" = (
 /obj/machinery/requests_console/directional/west,
 /obj/structure/table/glass,
@@ -48079,6 +47787,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"jEF" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore/north)
 "jEN" = (
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Aft-Port";
@@ -48224,16 +47946,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
-"jGm" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft2)
 "jGq" = (
 /obj/structure/closet/crate/engineering/electrical,
 /obj/effect/spawner/random/maintenance,
@@ -48384,16 +48096,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/cryo)
-"jIR" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/east)
 "jIT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -48847,6 +48549,20 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
+"jOj" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/south)
 "jOp" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6
@@ -48921,6 +48637,27 @@
 	icon_state = "showroomfloor"
 	},
 /area/station/service/kitchen/freezer)
+"jOT" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	name = "Genetics Shutters";
+	id_tag = "geneticsprivacy"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/genetics,
+/obj/machinery/door/window/classic/normal,
+/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "genetics"
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/tiles/department/science,
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/genetics)
 "jOX" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/iv_bag/salglu,
@@ -48959,18 +48696,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/blue,
 /area/station/command/office/blueshield)
-"jPu" = (
-/obj/machinery/door/airlock/engineering,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/public/construction)
 "jPv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -49034,20 +48759,6 @@
 "jQw" = (
 /turf/simulated/floor/plasteel,
 /area/station/security/range)
-"jQx" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/classic/normal,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "kitchen_counter";
-	name = "Kitchen Counter Shutters"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/all/service/kitchen,
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/kitchen)
 "jQA" = (
 /obj/item/kirbyplants/large,
 /obj/effect/turf_decal/tiles/white/corner{
@@ -49272,6 +48983,21 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics)
+"jSv" = (
+/obj/machinery/door/airlock/public/glass{
+	autoclose = 0;
+	heat_proof = 1;
+	id_tag = "turbine_door_int";
+	name = "Incinerator Exterior Airlock";
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/engine,
+/area/station/maintenance/turbine)
 "jSA" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -49291,6 +49017,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
+"jSL" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/legal/courtroom/gallery)
 "jSN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -49361,6 +49097,17 @@
 /obj/structure/disposalpipe/segment/corner,
 /turf/simulated/floor/wood,
 /area/station/supply/qm)
+"jTn" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/starboard2)
 "jTs" = (
 /obj/structure/lattice,
 /turf/space,
@@ -49372,27 +49119,26 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
-"jTD" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/machinery/door/airlock/atmos/glass{
-	autoclose = 0;
-	id_tag = "atmossm_door_int";
-	name = "Atmospherics Access Chamber"
-	},
-/obj/machinery/access_button{
-	autolink_id = "atmossm_btn_int";
-	name = "Atmospherics Access Button";
-	pixel_x = -24;
-	req_access = list(24)
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plating,
-/area/station/engineering/engine/reactor)
 "jTQ" = (
 /obj/machinery/alarm/directional/east,
 /turf/simulated/floor/engine,
 /area/station/science/xenobiology)
+"jTZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/turf_decal/tiles/department/medical/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/barber)
 "jUl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49600,6 +49346,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
+"jYg" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/carpet,
+/area/station/service/library)
 "jYj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
@@ -49638,39 +49399,19 @@
 /obj/effect/turf_decal/tiles/neutral/corner,
 /turf/simulated/floor/plasteel,
 /area/station/public/fitness)
-"jYT" = (
-/obj/structure/table/reinforced,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/armory{
-	dir = 1
+"jZi" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
 	},
-/obj/machinery/door/window/classic/normal{
-	name = "Reception Window"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
 	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Lockdown Blast Doors"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/item/desk_bell{
-	pixel_x = 7;
-	pixel_y = 7;
-	anchored = 1
-	},
-/obj/machinery/door/window/reinforced/normal{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/autoname/desk{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
-/turf/simulated/floor/plasteel,
-/area/station/security/lobby)
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "jZk" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -49688,6 +49429,19 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/hallway/secondary/entry/lounge)
+"jZO" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tiles/white/side,
+/turf/simulated/floor/plasteel,
+/area/station/medical/reception)
 "jZY" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -49838,6 +49592,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
+"kbI" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison/cell_block/a)
 "kbN" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/execution)
@@ -49883,6 +49650,18 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
+"kcF" = (
+/obj/effect/spawner/window/reinforced/polarized/grilled{
+	id = "SHOW"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/science/robotics/showroom)
 "kcG" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -49943,16 +49722,6 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/station/command/office/hos)
-"kdn" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Trainer's Office";
-	id_tag = "nct"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/procedure/trainer,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel/dark,
-/area/station/procedure/trainer_office)
 "kdq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49984,6 +49753,27 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
+"kdS" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical{
+	dir = 4
+	},
+/obj/machinery/holosign/surgery{
+	id = "surgery2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/effect/turf_decal/tiles/department/command,
+/turf/simulated/floor/plasteel/dark,
+/area/station/medical/surgery/secondary)
 "kdY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -50273,6 +50063,27 @@
 /obj/structure/table/glass,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
+"kih" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/window/reinforced/normal{
+	dir = 1;
+	name = "Head of Personnel's Desk"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/command/hop{
+	dir = 1
+	},
+/obj/machinery/door/window/classic/normal{
+	name = "Reception Window"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "hop";
+	name = "privacy shutters"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/command/office/hop)
 "kii" = (
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 4
@@ -50384,16 +50195,6 @@
 "kkk" = (
 /turf/simulated/floor/plasteel,
 /area/station/supply/break_room)
-"kkw" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Escape Pod Airlock"
-	},
-/obj/docking_port/mobile/pod{
-	id = "pod3";
-	name = "escape pod 3"
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/pod_3)
 "kkI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -50418,6 +50219,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonershuttle)
+"klm" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/atmos{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/turbine)
 "kln" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -50523,6 +50341,17 @@
 	icon_state = "showroomfloor"
 	},
 /area/station/medical/coldroom)
+"kmC" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Trainer's Office";
+	id_tag = "nct";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/procedure/trainer,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel/dark,
+/area/station/procedure/trainer_office)
 "kmO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
@@ -50588,6 +50417,17 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
 /area/station/security/checkpoint/secondary)
+"kog" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/medical/medbay)
 "koo" = (
 /obj/effect/spawner/airlock/e_to_w/long/square,
 /turf/simulated/wall/r_wall,
@@ -50652,6 +50492,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/service/hydroponics)
+"kpL" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Escape Pod 1 Airlock";
+	id_tag = "emergency_home";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/secondary/entry/west)
 "kpT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -50800,12 +50648,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/xenobio_south)
-"ktn" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/stairs{
-	dir = 1
-	},
-/area/station/security/brig)
 "kto" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -50821,6 +50663,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/engine/reactor)
+"kts" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/smith,
+/obj/machinery/door/airlock/mining/glass{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/smith_office)
 "ktw" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/simulated/floor/plasteel,
@@ -50997,20 +50855,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/service/library)
-"kxD" = (
-/obj/machinery/door/airlock/mining/glass,
-/obj/effect/mapping_helpers/airlock/access/any/supply/general,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/supply/office)
 "kxI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/spawner/window/reinforced/grilled,
@@ -51209,6 +51053,18 @@
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/wood,
 /area/station/command/office/blueshield)
+"kBw" = (
+/obj/machinery/door/airlock/research{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/tox,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/aft2)
 "kBy" = (
 /obj/structure/closet/jcloset,
 /obj/item/radio/intercom{
@@ -51333,6 +51189,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/engine_foyer)
+"kDS" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/airlock/atmos{
+	name = "Fore-Port Atmospherics Maintenance";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore2)
 "kDU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable{
@@ -51485,17 +51352,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison)
-"kGr" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/maintenance/external,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
 "kGv" = (
 /turf/simulated/floor/wood,
 /area/station/security/permabrig)
@@ -51506,13 +51362,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
-"kGF" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prisonlockers)
 "kGI" = (
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 8
@@ -51642,6 +51491,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
+"kIX" = (
+/obj/structure/extinguisher_cabinet{
+	name = "west bump";
+	pixel_x = -27
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/west)
 "kJn" = (
 /obj/machinery/light_switch{
 	dir = 1;
@@ -51699,6 +51561,23 @@
 	},
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/electrical/fore_port)
+"kKD" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/security/checkpoint/secondary)
 "kLn" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=1.5-Fore-Central";
@@ -51939,6 +51818,16 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/paramedic)
+"kNP" = (
+/obj/machinery/door/airlock/external/glass{
+	hackProof = 1;
+	name = "Escape Airlock";
+	id_tag = "emergency_home";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/secondary/exit)
 "kNU" = (
 /obj/structure/table/wood,
 /obj/item/megaphone,
@@ -52045,6 +51934,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
+"kPE" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/carpet,
+/area/station/service/library)
 "kPK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52579,6 +52479,14 @@
 	icon_state = "cult"
 	},
 /area/station/legal/magistrate)
+"kXY" = (
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Auxiliary Chamber";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/turf/simulated/floor/plating/airless,
+/area/station/engineering/atmos)
 "kYi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -52594,6 +52502,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/range)
+"kYk" = (
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "kYt" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -52606,20 +52530,6 @@
 	},
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/fsmaint2)
-"kYO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/highsecurity,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/science/rd,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/station_engineering,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/gravitygenerator)
 "kYQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -52654,16 +52564,15 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
-"kZt" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Fore-Starboard Atmospherics Maintenance"
+"kZQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/maintenance/fore)
 "lab" = (
 /obj/effect/turf_decal/tiles/department/medical/corner{
 	dir = 4
@@ -52721,6 +52630,17 @@
 /obj/structure/grille,
 /turf/space,
 /area/space/nearstation)
+"laO" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod Airlock";
+	dir = 4
+	},
+/obj/docking_port/mobile/pod{
+	id = "pod3";
+	name = "escape pod 3"
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/pod_3)
 "laR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/extinguisher,
@@ -52742,6 +52662,18 @@
 /obj/machinery/firealarm/directional/south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
+"lbj" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/station/security/lobby)
 "lbt" = (
 /obj/structure/bookcase/sop,
 /turf/simulated/floor/carpet,
@@ -52866,14 +52798,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/xenobiology)
-"lcT" = (
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
 "lcY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -52906,29 +52830,21 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"ldl" = (
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison)
 "ldn" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/effect/spawner/airlock/e_to_w,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_port)
-"ldw" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Lockdown Blast Doors"
-	},
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison/cell_block/a)
 "ldJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -52938,6 +52854,17 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"ldN" = (
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/main)
 "ldQ" = (
 /obj/machinery/light{
 	dir = 4
@@ -52955,20 +52882,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/xenobio_north)
-"lee" = (
-/obj/machinery/door/airlock/public/glass{
-	autoclose = 0;
-	heat_proof = 1;
-	id_tag = "turbine_door_int";
-	name = "Incinerator Exterior Airlock"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/engine,
-/area/station/maintenance/turbine)
 "leu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -53149,6 +53062,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/office/hos)
+"lgJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/public/vacant_office)
 "lgL" = (
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/riot{
@@ -53235,30 +53163,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
-"lhY" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/any/supply/mail_sorting,
-/obj/machinery/door/airlock/mining/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/station/supply/sorting)
-"lhZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
-/obj/structure/cable/extra_insulated/pre_connect{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/xenobio_north)
 "lio" = (
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/solar/aft_port)
@@ -53359,19 +53263,6 @@
 "lkE" = (
 /turf/simulated/floor/wood,
 /area/station/command/office/hos)
-"lkH" = (
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/medical/genetics,
-/obj/effect/turf_decal/tiles/white/side,
-/turf/simulated/floor/plasteel,
-/area/station/science/genetics)
 "lkK" = (
 /obj/item/radio/intercom{
 	name = "west bump";
@@ -53556,13 +53447,6 @@
 /obj/effect/turf_decal/tiles/department/medical,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/exam_room)
-"lnv" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/maintenance/aft2)
 "lnP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -53639,6 +53523,16 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/plating,
 /area/station/supply/warehouse)
+"loJ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line,
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/supply)
 "loM" = (
 /obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/carpet/purple,
@@ -53932,6 +53826,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/purple,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos/control)
+"lsl" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Courtroom"
+	},
+/turf/simulated/floor/wood,
+/area/station/legal/courtroom/gallery)
 "lsn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -54076,6 +53989,19 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/cafeteria)
+"lwe" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	name = "Bar Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/station/service/bar)
 "lwx" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -54104,6 +54030,19 @@
 /obj/effect/landmark/lightsout,
 /turf/simulated/floor/carpet,
 /area/station/service/library)
+"lxP" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/east)
 "lyc" = (
 /turf/simulated/floor/plating/airless,
 /area/station/hallway/secondary/exit)
@@ -54254,6 +54193,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
+"lAT" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/station/security/lobby)
 "lAW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -54336,20 +54285,6 @@
 /obj/effect/spawner/random/oil/maybe,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"lBQ" = (
-/obj/machinery/door/airlock,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/kitchen)
 "lCb" = (
 /obj/machinery/economy/vending/assist/free,
 /obj/effect/turf_decal/delivery/hollow,
@@ -54416,6 +54351,21 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"lDC" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Departure Lounge";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/exit)
 "lDD" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tiles/department/engineering/corner{
@@ -54508,24 +54458,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/hallway/secondary/exit)
-"lFO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/any/science/rd,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/station_engineering,
-/obj/machinery/door/airlock/command/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/gravitygenerator)
 "lFS" = (
 /obj/machinery/economy/vending/cola,
 /obj/machinery/light,
@@ -54657,6 +54589,19 @@
 /obj/item/stack/spacecash/c20,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint2)
+"lIB" = (
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock";
+	name = "Escape Pod Hatch";
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/obj/docking_port/mobile/pod{
+	id = "pod1";
+	name = "escape pod 1"
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/pod_1)
 "lIF" = (
 /obj/machinery/access_button{
 	autolink_id = "perma_btn_ext";
@@ -54972,16 +54917,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
-"lOd" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore2)
 "lOf" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -54992,6 +54927,18 @@
 "lOz" = (
 /turf/simulated/wall,
 /area/station/supply/smith_office)
+"lOF" = (
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "lOK" = (
 /obj/structure/chair{
 	dir = 1
@@ -55244,16 +55191,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/distribution)
-"lSO" = (
-/obj/machinery/door/airlock{
-	name = "Central Emergency Storage"
-	},
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/maintcentral)
 "lTi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -55412,18 +55349,6 @@
 /obj/effect/decal/cleanable/confetti,
 /turf/simulated/floor/wood,
 /area/station/maintenance/gambling_den)
-"lWi" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/command/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/obj/effect/turf_decal/tiles/department/command/side{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/command/bridge)
 "lWk" = (
 /obj/effect/spawner/random/barrier/obstruction,
 /turf/simulated/floor/plating,
@@ -55521,6 +55446,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison/cell_block/a)
+"lYK" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "seclock";
+	name = "Checkpoint Lockdown"
+	},
+/obj/structure/sign/public/arrivals{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/checkpoint/secondary)
 "lYR" = (
 /obj/structure/closet/secure_closet/cargotech,
 /obj/effect/turf_decal/tiles/department/cargo/side{
@@ -55727,6 +55670,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
+"mcb" = (
+/obj/machinery/door/airlock/titanium/glass{
+	dir = 4
+	},
+/turf/simulated/floor/indestructible/titanium,
+/area/shuttle/arrival/station)
 "mcj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -56078,28 +56027,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/public/toilet/lockerroom)
-"mic" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/genetics,
-/obj/machinery/door/window/classic/reversed,
-/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	name = "Genetics Shutters";
-	id_tag = "geneticsprivacy"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "genetics"
-	},
-/obj/item/desk_bell{
-	pixel_x = 7;
-	pixel_y = 7;
-	anchored = 1
-	},
-/obj/effect/turf_decal/tiles/department/science,
-/turf/simulated/floor/plasteel/dark,
-/area/station/science/genetics)
 "mig" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -56406,6 +56333,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/supply/lobby)
+"mnP" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Maintenance";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "mnV" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 4
@@ -56793,6 +56730,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/storage)
+"mvN" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/east,
+/obj/effect/turf_decal/tiles/department/security/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/east)
 "mvP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -57060,10 +57005,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/chapel/funeral)
-"mCc" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
 "mCu" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
@@ -57374,6 +57315,26 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/xenobiology)
+"mHT" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "Server Access";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/rd,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/department/science,
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/server)
 "mIh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -57551,6 +57512,22 @@
 /obj/machinery/light,
 /turf/simulated/floor/carpet,
 /area/station/security/detective)
+"mLm" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/classic/reversed,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/all/service/kitchen,
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/kitchen)
 "mLn" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -57572,14 +57549,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/south)
-"mLA" = (
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/airlock/security/glass,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
 "mLH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -57669,19 +57638,6 @@
 /obj/machinery/access_button/offset/southeast,
 /turf/simulated/floor/plasteel/dark,
 /area/station/hallway/secondary/entry/west)
-"mNp" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "mNu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57713,16 +57669,6 @@
 /obj/structure/sign/service/botany,
 /turf/simulated/wall,
 /area/station/service/hydroponics)
-"mOc" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/south)
 "mOs" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -57791,11 +57737,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
-"mPh" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/neutral/corner,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/south)
 "mPl" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -57976,6 +57917,13 @@
 /obj/item/clothing/glasses/hud/health,
 /turf/simulated/floor/carpet/blue,
 /area/station/command/office/cmo)
+"mTZ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/white/side,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/south)
 "mUd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -58030,15 +57978,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
-"mUv" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
 "mUI" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/noslip,
@@ -58117,20 +58056,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_starboard)
-"mVD" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/poddoor/preopen{
-	name = "testing range blast door";
-	id_tag = "rdrnd"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/research,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/asmaint)
 "mVG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -58141,17 +58066,6 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/east)
-"mWr" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
 "mWD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -58344,14 +58258,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/supply/qm)
-"mYX" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line,
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/supply/aft)
 "mYZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -58532,6 +58438,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"nbk" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/command{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/blueshield,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/wood,
+/area/station/command/office/blueshield)
 "nbl" = (
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 4
@@ -58636,6 +58562,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
+"ncT" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "ncU" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
@@ -58764,6 +58706,12 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
+"nem" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/east)
 "neW" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -59041,27 +58989,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
-"nhT" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/sign/directions/evac{
-	pixel_x = 32;
-	pixel_y = -8
-	},
-/obj/structure/sign/directions/engineering{
-	pixel_x = 32
-	},
-/obj/structure/sign/directions/medical{
-	pixel_x = 32;
-	pixel_y = 8
-	},
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner,
-/turf/simulated/floor/plasteel,
-/area/station/security/checkpoint/secondary)
 "nhU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -59095,6 +59022,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/station/public/vacant_office)
+"niA" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Abandoned Warehouse";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "niC" = (
 /obj/effect/turf_decal/tiles/department/medical/checker,
 /turf/simulated/floor/plasteel/white,
@@ -59334,6 +59270,25 @@
 /mob/living/basic/pig,
 /turf/simulated/floor/grass,
 /area/station/service/pasture)
+"nnk" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock{
+	name = "Recreation Area";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "nns" = (
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 4
@@ -59569,31 +59524,6 @@
 /obj/machinery/mineral/equipment_vendor,
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
-"nqR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
 "nrj" = (
 /obj/structure/chair/wood,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -59696,6 +59626,20 @@
 	},
 /turf/simulated/floor/catwalk/white,
 /area/station/medical/surgery/observation)
+"nur" = (
+/obj/machinery/door/airlock/vault{
+	locked = 1;
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/supply/vault,
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/vault)
 "nuz" = (
 /obj/effect/turf_decal/tiles/neutral/corner{
 	dir = 1
@@ -59753,33 +59697,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/bluegrid,
 /area/station/turret_protected/ai)
-"nvQ" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Power Monitoring"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical/port)
 "nwE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 4
 	},
 /turf/simulated/wall,
 /area/station/maintenance/asmaint)
-"nwQ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Bar Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/bar,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/station/service/bar)
 "nwU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -59850,16 +59773,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/cloning)
-"nyp" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Fore-Starboard Atmospherics Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/asmaint)
 "nyv" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-4"
@@ -59923,19 +59836,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/engine_foyer)
-"nzU" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "nAg" = (
 /obj/effect/turf_decal/trimline/department/security/corner{
 	dir = 1
@@ -60098,24 +59998,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/xenobiology)
-"nDj" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Staff Entrance"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "psychoffice"
-	},
-/turf/simulated/floor/wood,
-/area/station/medical/psych)
 "nDk" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -60586,6 +60468,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/toxins/mixing)
+"nLT" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/door/airlock/command{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
+/turf/simulated/floor/plasteel,
+/area/station/command/office/ce)
 "nMb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -60922,7 +60825,7 @@
 /obj/machinery/computer/general_air_control{
 	dir = 4;
 	name = "Bomb Mix Monitor";
-	autolink_sensors = list("burn_sensor"="Burn Mix")
+	autolink_sensors = list("burn_sensor" = "Burn Mix")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -61124,20 +61027,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/vault)
-"nUq" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line,
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/supply/aft)
 "nUt" = (
 /obj/effect/landmark/spawner/nukedisc_respawn,
 /turf/simulated/floor/plating,
@@ -61167,14 +61056,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
-"nUU" = (
-/obj/machinery/door/airlock/medical/glass,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/medical,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/reception)
 "nUW" = (
 /obj/item/radio/intercom{
 	name = "south bump";
@@ -61270,14 +61151,6 @@
 /obj/effect/spawner/random/oil/maybe,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"nWR" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/security/lobby)
 "nWZ" = (
 /obj/structure/closet/l3closet/scientist,
 /turf/simulated/floor/plating,
@@ -61434,6 +61307,18 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
+"nYO" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/classic/normal{
+	name = "Cargo Desk"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
+/turf/simulated/floor/plating,
+/area/station/supply/office)
 "nYP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -61556,6 +61441,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard)
+"obr" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Power Monitoring";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/electrical/port)
 "obt" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/item/reagent_containers/glass/bucket,
@@ -61587,6 +61486,21 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
+"oca" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/maintenance/external{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/port)
 "och" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -61749,6 +61663,31 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/east)
+"ofA" = (
+/obj/machinery/door/airlock/public/glass{
+	autoclose = 0;
+	heat_proof = 1;
+	id_tag = "turbine_door_ext";
+	locked = 1;
+	name = "Incinerator Interior Airlock";
+	dir = 4
+	},
+/obj/machinery/airlock_controller/access_controller{
+	name = "Turbine Access Console";
+	pixel_x = 40;
+	pixel_y = 8;
+	ext_door_link_id = "turbine_door_ext";
+	int_door_link_id = "turbine_door_int";
+	ext_button_link_id = "turbine_btn_ext";
+	int_button_link_id = "turbine_btn_int"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/engine,
+/area/station/maintenance/turbine)
 "ofC" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/item/gps/mining,
@@ -61793,15 +61732,6 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel,
 /area/station/medical/break_room)
-"oga" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Fore Atmospherics Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fore)
 "ogg" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -61817,6 +61747,33 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/supply/aft)
+"ogl" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/telecomms/computer)
+"ogn" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line,
+/turf/simulated/floor/plasteel/dark,
+/area/station/medical/medbay)
 "ogq" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -62010,20 +61967,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/visible/purple,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
-"ojh" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Lockdown Blast Doors"
-	},
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison/cell_block/a)
 "oji" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -62035,39 +61978,33 @@
 	icon_state = "solarpanel"
 	},
 /area/station/engineering/solar/aft_port)
-"ojt" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown";
-	opacity = 0
+"ojB" = (
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line,
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/supply/aft)
 "ojN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/expedition)
-"okh" = (
+"okj" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fore2)
+/turf/simulated/floor/plating,
+/area/station/maintenance/medmaint)
 "okB" = (
 /obj/machinery/newscaster/security_unit/directional/west,
 /obj/effect/turf_decal/tiles/department/security/side{
@@ -62165,13 +62102,6 @@
 /obj/structure/bookcase/random,
 /turf/simulated/floor/wood,
 /area/station/security/permabrig)
-"onD" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Escape Pod 2 Airlock";
-	id_tag = "emergency_home"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/secondary/entry/east)
 "onF" = (
 /obj/item/radio/intercom{
 	name = "north bump";
@@ -62217,6 +62147,22 @@
 /obj/item/seeds/eggplant,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard2)
+"oon" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
+/obj/effect/mapping_helpers/airlock/access/any/service/janitor,
+/obj/effect/mapping_helpers/airlock/access/any/service/library,
+/obj/effect/mapping_helpers/airlock/access/any/service/bar,
+/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
+/obj/effect/turf_decal/tiles/department/medical/checker,
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/service/break_room)
 "ooC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -62285,6 +62231,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
+"opE" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/port)
 "opT" = (
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 4
@@ -62336,25 +62297,6 @@
 "oqD" = (
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/fore2)
-"oqG" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/classic/normal{
-	name = "Cargo Desk"
-	},
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/general,
-/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
-/turf/simulated/floor/plating,
-/area/station/supply/office)
-"oqO" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/white/side,
-/turf/simulated/floor/plasteel,
-/area/station/medical/reception)
 "oqZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -62438,20 +62380,6 @@
 /obj/item/dissector,
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/xenobiology)
-"orV" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/classic/reversed,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "kitchen_counter";
-	name = "Kitchen Counter Shutters"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/all/service/kitchen,
-/obj/effect/turf_decal/tiles/dark/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/kitchen)
 "osq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -62549,18 +62477,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics)
-"ouE" = (
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/supply/smith,
-/obj/machinery/door/airlock/mining/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/supply/smith_office)
 "ova" = (
 /obj/machinery/door/window/classic/normal{
 	name = "Coffin Storage";
@@ -62572,6 +62488,24 @@
 /obj/structure/closet/coffin,
 /turf/simulated/floor/plating,
 /area/station/service/chapel/funeral)
+"ovn" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "ovo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -62719,19 +62653,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/xenobiology)
-"oxT" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/iaa,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Lockdown Blast Doors"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/station/legal/lawoffice)
 "oxY" = (
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Foyer";
@@ -62854,6 +62775,17 @@
 /obj/structure/sign/cargo,
 /turf/simulated/floor/plating,
 /area/station/supply/lobby)
+"oAk" = (
+/obj/machinery/door/airlock{
+	name = "Central Emergency Storage";
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/maintcentral)
 "oAm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/nosmoking/alt{
@@ -63024,17 +62956,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
-"oCU" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/white,
-/area/station/maintenance/asmaint)
 "oCX" = (
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/machinery/camera{
@@ -63400,6 +63321,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/break_room)
+"oIw" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Command Hallway";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/science/robotics/showroom)
 "oIE" = (
 /obj/machinery/light{
 	dir = 1
@@ -63717,24 +63651,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/xenobio_north)
-"oOu" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/command,
-/obj/effect/mapping_helpers/airlock/access/all/command/blueshield,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/wood,
-/area/station/command/office/blueshield)
 "oOv" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -63748,6 +63664,24 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
+"oOD" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore2)
 "oOE" = (
 /obj/effect/spawner/random/dirt/frequent,
 /obj/effect/turf_decal/tiles/neutral,
@@ -63803,25 +63737,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/public/construction)
-"oPE" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/virology/glass{
-	name = "Containment Cells"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/virology)
 "oPH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/turf_decal/tiles/department/security/side{
@@ -63836,6 +63751,30 @@
 "oPJ" = (
 /turf/simulated/floor/carpet/purple,
 /area/station/service/library)
+"oPN" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/rd,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tiles/department/science,
+/turf/simulated/floor/plasteel/white,
+/area/station/command/office/rd)
 "oPX" = (
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall,
@@ -63847,25 +63786,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
-"oQu" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/security/lobby)
 "oQx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -64314,6 +64234,27 @@
 "oWE" = (
 /turf/simulated/wall/r_wall,
 /area/station/public/fitness)
+"oWH" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Staff Entrance";
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "psychoffice"
+	},
+/turf/simulated/floor/wood,
+/area/station/medical/psych)
 "oWK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -64451,17 +64392,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
-"oZr" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance/external,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
 "oZv" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil,
@@ -64485,12 +64415,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
-"oZX" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/service/crematorium,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
 "pah" = (
 /obj/effect/turf_decal/woodsiding{
 	dir = 8
@@ -64514,6 +64438,19 @@
 	icon_state = "cult"
 	},
 /area/station/legal/magistrate)
+"paS" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison)
 "paZ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -64726,6 +64663,21 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"peO" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/aft)
 "pfa" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
@@ -64887,17 +64839,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/lobby)
-"piX" = (
-/obj/structure/cable/extra_insulated{
+"piA" = (
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/white,
-/area/station/maintenance/starboard2)
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/mining{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/supply)
 "pjb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -65507,14 +65466,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/lobby)
-"pvr" = (
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
-/obj/machinery/door/airlock{
-	name = "Abandoned Hydroponics Backroom"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/starboard2)
 "pvt" = (
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 10
@@ -65549,13 +65500,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/chemistry)
-"pwj" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/starboard2)
 "pwo" = (
 /obj/structure/target_stake,
 /turf/simulated/floor/engine,
@@ -65689,6 +65633,36 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/asmaint)
+"pyi" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore/north)
+"pyu" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/engineering{
+	name = "Power Transmission Laser";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/station_engineer,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint2)
 "pyv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -65732,14 +65706,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/asmaint)
-"pyZ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line,
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/supply)
 "pzw" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
@@ -65783,17 +65749,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/robotics)
-"pzE" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
 "pzK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -65816,20 +65771,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/north)
-"pzX" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock{
-	name = "Dormitories"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/neutral/corner,
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
 "pAx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -65839,6 +65780,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
+"pAB" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id_tag = "evashutter";
+	name = "E.V.A. Storage Shutter"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/ai_monitored/storage/eva)
 "pAO" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -65869,24 +65822,21 @@
 /obj/effect/turf_decal/tiles/department/medical/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/break_room)
-"pAU" = (
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
+"pAQ" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Power Monitoring";
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/science/research)
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/electrical/aft_starboard)
 "pBu" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -66114,6 +66064,25 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/lounge)
+"pEM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line,
+/turf/simulated/floor/plasteel/dark,
+/area/station/medical/medbay)
 "pEO" = (
 /obj/machinery/light/small,
 /obj/structure/chair{
@@ -66136,6 +66105,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/nw)
+"pEY" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/kitchen)
 "pFo" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/effect/turf_decal/stripes/line{
@@ -66214,18 +66201,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/security/permabrig)
-"pHc" = (
-/obj/machinery/door/airlock/mining,
-/obj/effect/mapping_helpers/airlock/access/any/supply/expedition,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/supply/expedition)
 "pHt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -66261,18 +66236,6 @@
 /obj/effect/turf_decal/tiles/neutral/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/east)
-"pHM" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/service/hydroponics)
-"pHY" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/white/side,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/south)
 "pIj" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/turf_decal/tiles/department/security/side{
@@ -66360,14 +66323,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/permabrig)
-"pJt" = (
-/obj/machinery/door/airlock,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/starboard)
 "pJv" = (
 /obj/effect/turf_decal/tiles/department/medical/corner{
 	dir = 8
@@ -66649,15 +66604,29 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/service/hydroponics)
-"pPn" = (
+"pPM" = (
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/south)
+/area/station/security/lobby)
 "pPP" = (
 /obj/machinery/light/small,
 /obj/effect/spawner/random/loot_crate,
@@ -66678,19 +66647,6 @@
 /obj/effect/spawner/random/trash,
 /turf/simulated/floor/plating,
 /area/station/maintenance/xenobio_south)
-"pQq" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Telecoms Server Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/telecomms/chamber)
 "pQv" = (
 /obj/machinery/power/apc/directional/north,
 /obj/structure/cable{
@@ -66723,21 +66679,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/hallway/secondary/entry/east)
-"pQS" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Hydroponics Pasture"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
-/obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/spawner/random/dirt/frequent,
-/obj/effect/turf_decal/tiles/department/medical/checker,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/pasture)
 "pQV" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -66767,13 +66708,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/south)
-"pRl" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Fabrication"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/engine/reactor)
 "pRp" = (
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 8
@@ -66918,15 +66852,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/asmaint)
-"pTs" = (
-/obj/machinery/door/airlock/external/glass{
-	hackProof = 1;
-	name = "Escape Airlock";
-	id_tag = "emergency_home"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/secondary/exit)
 "pTt" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/abandonedbar)
@@ -66937,24 +66862,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/evidence)
-"pTL" = (
-/obj/machinery/door/poddoor/preopen{
-	name = "Biohazard Shutter";
-	id_tag = "RnDChem"
-	},
-/obj/machinery/door/airlock/research/glass{
-	name = "Test Chamber"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
-/obj/effect/mapping_helpers/airlock/access/any/science/tox_storage,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/test_chamber)
 "pTR" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -67041,22 +66948,6 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
-"pUx" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
 "pUA" = (
 /turf/simulated/floor/indestructible/titanium,
 /area/shuttle/arrival/station)
@@ -67160,6 +67051,20 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/east)
+"pWb" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/south)
 "pWw" = (
 /obj/item/circuitboard/aiupload_broken,
 /obj/item/toy/ai,
@@ -67190,6 +67095,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/west)
+"pXb" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/south)
 "pXe" = (
 /obj/item/reagent_containers/drinks/cans/badminbrew,
 /turf/simulated/floor/plating,
@@ -67350,6 +67264,23 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
+"pZK" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/all/service/kitchen,
+/obj/machinery/door/window/classic/normal,
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/kitchen)
 "qac" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
@@ -67379,6 +67310,18 @@
 /obj/structure/closet/wardrobe/xenos,
 /turf/simulated/floor/indestructible/titanium/blue,
 /area/shuttle/arrival/station)
+"qaA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/west)
 "qaF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tiles/department/cargo/side,
@@ -67664,14 +67607,6 @@
 /obj/item/pen,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft2)
-"qfd" = (
-/obj/effect/mapping_helpers/airlock/access/all/science/tox,
-/obj/machinery/door/airlock/research{
-	name = "Toxins Loop Observation"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/asmaint)
 "qfl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -67718,6 +67653,18 @@
 /obj/effect/spawner/random/trash/spread_tiles,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"qft" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/machinery/door/airlock/atmos{
+	name = "Fore-Port Atmospherics Maintenance";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore2)
 "qfB" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -67736,15 +67683,6 @@
 /obj/machinery/porta_turret/ai_turret,
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/ai)
-"qfX" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/obj/machinery/door/airlock/atmos{
-	name = "Fore-Port Atmospherics Maintenance"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore2)
 "qgk" = (
 /turf/simulated/wall/r_wall,
 /area/station/command/office/captain)
@@ -67763,6 +67701,18 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/hallway/secondary/exit)
+"qgs" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/east)
 "qgM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/spawner/random/dirt/frequent,
@@ -67793,14 +67743,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"qhk" = (
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison)
 "qht" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -67834,26 +67776,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/break_room)
-"qhC" = (
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Lockdown Blast Doors"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/airlock/security/glass,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
-"qid" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Escape Pod 3 Airlock";
-	id_tag = "emergency_home"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
 "qif" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -68003,6 +67925,19 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos/control)
+"qlv" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/starboard2)
 "qlx" = (
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/genetics)
@@ -68147,14 +68082,6 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
-"qoO" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/security/lobby)
 "qpk" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -68512,6 +68439,23 @@
 /obj/machinery/status_display/supply_display,
 /turf/simulated/wall,
 /area/station/supply/office)
+"quQ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/command{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/command/eva,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/ai_monitored/storage/eva)
 "quY" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -68643,6 +68587,19 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/station/security/range)
+"qwR" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/east)
 "qwW" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -68764,35 +68721,6 @@
 /obj/effect/spawner/random/barrier/grille_often,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
-"qyW" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/science/research)
-"qzd" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Lockdown Blast Doors"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fore2)
 "qzP" = (
 /obj/structure/rack,
 /turf/simulated/floor/plasteel,
@@ -68909,6 +68837,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/supply/aft)
+"qBn" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Fabrication";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/engine/reactor)
 "qBy" = (
 /obj/machinery/newscaster/directional/east,
 /obj/effect/landmark/start/quartermaster,
@@ -68939,6 +68875,17 @@
 /obj/effect/landmark/lightsout,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
+"qBZ" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/asmaint)
 "qCm" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/sink/directional/east,
@@ -68949,14 +68896,6 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
-"qCL" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/door/airlock/atmos{
-	name = "Fore-Port Atmospherics Maintenance"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore2)
 "qDd" = (
 /obj/structure/table/glass,
 /obj/item/roller{
@@ -69041,6 +68980,18 @@
 /obj/effect/turf_decal/tiles/department/cargo/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/supply)
+"qFk" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/turf/simulated/floor/engine,
+/area/station/engineering/engine/reactor)
 "qFs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -69253,6 +69204,22 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/research)
+"qJX" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/tech_storage)
 "qKg" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -69270,6 +69237,22 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"qKi" = (
+/obj/machinery/door/airlock/mining{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/expedition,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/expedition)
 "qKA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/cable/extra_insulated{
@@ -69312,16 +69295,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/greengrid,
 /area/station/science/robotics/chargebay)
-"qLb" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/supply/cargo_bay,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/supply/warehouse)
 "qLd" = (
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 8
@@ -69398,6 +69371,13 @@
 /obj/structure/sign/poster/official/cleanliness/directional/south,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/research)
+"qLB" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/medical,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/cryo)
 "qLK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -69467,6 +69447,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
+"qMO" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/supply)
 "qMU" = (
 /obj/machinery/computer/cryopod{
 	pixel_y = -30;
@@ -69525,6 +69516,16 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
+"qOa" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/tiles/department/medical/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/south)
 "qPe" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -69735,6 +69736,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
+"qRy" = (
+/obj/effect/mapping_helpers/turfs/damage,
+/obj/structure/mineral_door/wood,
+/obj/structure/barricade/wooden/crude,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/maintenance/asmaint)
 "qRA" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -69822,6 +69832,25 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/reception)
+"qSA" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/command/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/department/command/side{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/bridge)
 "qSB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -70019,6 +70048,20 @@
 /obj/machinery/alarm/directional/south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
+"qVv" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/machinery/door/airlock/command{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/science/robotics/showroom)
 "qVA" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth"
@@ -70161,6 +70204,14 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/chemistry)
+"qYl" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Escape Pod 2 Airlock";
+	id_tag = "emergency_home";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/secondary/entry/east)
 "qYA" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/door/window/classic/reversed{
@@ -70218,19 +70269,6 @@
 "rab" = (
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
-"rag" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/engineering{
-	name = "Power Transmission Laser"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/station_engineer,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fsmaint2)
 "rak" = (
 /obj/effect/landmark/start/chemist,
 /obj/structure/chair/office,
@@ -70440,6 +70478,31 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonershuttle)
+"rdU" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/classic/reversed,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/all/service/kitchen,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/kitchen)
 "rdY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tiles/department/science/side{
@@ -70485,17 +70548,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
-"rfC" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "rfD" = (
 /obj/effect/turf_decal/tiles/department/science/corner{
 	dir = 4
@@ -70524,6 +70576,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint2)
+"rgc" = (
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id_tag = "paramedic";
+	name = "Paramedic Garage"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/medical/paramedic)
 "rgh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -70793,6 +70866,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/catwalk/grey,
 /area/station/maintenance/starboard)
+"rkh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/north)
 "rkU" = (
 /obj/structure/sink/directional/east,
 /obj/machinery/light/small,
@@ -71197,6 +71282,21 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard)
+"rrm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/cable/extra_insulated/pre_connect{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/xenobio_north)
 "rrq" = (
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 1
@@ -71575,6 +71675,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore2)
+"rxb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/sign/command/ai_upload{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/research)
 "rxc" = (
 /turf/simulated/wall,
 /area/station/maintenance/abandonedservers)
@@ -71886,23 +72005,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/ai_transit_tube)
-"rCs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+"rCP" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
-/obj/machinery/door/airlock/medical/glass{
-	name = null
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "psychoffice"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/wood,
-/area/station/medical/psych)
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/starboard2)
 "rDd" = (
 /obj/effect/turf_decal/woodsiding{
 	dir = 8
@@ -72232,6 +72351,22 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/gravitygenerator)
+"rIn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/tox,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/research/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/heavy{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/toxins/launch)
 "rIq" = (
 /obj/machinery/atmospherics/unary/tank/air,
 /turf/simulated/floor/plating,
@@ -72307,16 +72442,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/hallway/secondary/entry/lounge)
-"rJs" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fpmaint)
 "rJR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 5
@@ -72326,21 +72451,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos/control)
-"rKa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/medical{
-	name = "Paramedic's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/paramedic,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/tiles/department/medical,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/paramedic)
 "rKb" = (
 /obj/effect/spawner/random/dirt/frequent,
 /obj/effect/mapping_helpers/turfs/damage,
@@ -72405,13 +72515,6 @@
 /obj/effect/turf_decal/tiles/neutral/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/bridge)
-"rKV" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/west)
 "rLw" = (
 /obj/machinery/atmospherics/air_sensor{
 	autolink_id = "waste_sensor";
@@ -72790,17 +72893,6 @@
 	},
 /turf/simulated/floor/catwalk,
 /area/station/science/testrange)
-"rRg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/station/public/vacant_office)
 "rRk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -72929,6 +73021,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
+"rSU" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/command/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/effect/turf_decal/tiles/department/command/side{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/bridge)
 "rSV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -72936,23 +73044,6 @@
 /obj/machinery/newscaster/directional/south,
 /turf/simulated/floor/carpet,
 /area/station/security/detective)
-"rTe" = (
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external/glass{
-	name = "Labor Camp Airlock";
-	id_tag = "laborcamp_home"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Lockdown Blast Doors"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/security/prisonershuttle)
 "rTD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -73042,6 +73133,28 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/service/chapel)
+"rUN" = (
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/warden)
 "rUT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -73110,23 +73223,6 @@
 /obj/effect/turf_decal/tiles/neutral/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/west)
-"rXj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line,
-/turf/simulated/floor/plasteel/dark,
-/area/station/medical/medbay)
 "rXk" = (
 /obj/machinery/light_switch{
 	dir = 1;
@@ -73384,6 +73480,18 @@
 "saZ" = (
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonershuttle)
+"sbf" = (
+/obj/effect/spawner/window/reinforced/polarized/grilled{
+	id = "SHOW"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/science/robotics/showroom)
 "sbg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/white,
@@ -73402,6 +73510,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
+"sbu" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/port)
 "sbv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -73597,6 +73721,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard2)
+"sfe" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "sfi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -73606,6 +73741,17 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
+"sfn" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/department/medical,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/surgery/observation)
 "sft" = (
 /obj/machinery/economy/atm/directional/north,
 /obj/structure/cable/extra_insulated{
@@ -73655,13 +73801,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/fsmaint2)
-"sfS" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/department/engineering/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft/north)
 "sfW" = (
 /obj/effect/turf_decal/tiles/department/science/corner{
 	dir = 4
@@ -73679,6 +73818,30 @@
 /obj/effect/landmark/start/chef,
 /turf/simulated/floor/plasteel/white/grid,
 /area/station/service/kitchen/freezer)
+"sgq" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/genetics,
+/obj/machinery/door/window/classic/reversed,
+/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	name = "Genetics Shutters";
+	id_tag = "geneticsprivacy"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "genetics"
+	},
+/obj/item/desk_bell{
+	pixel_x = 7;
+	pixel_y = 7;
+	anchored = 1
+	},
+/obj/effect/turf_decal/tiles/department/science,
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/genetics)
 "sgx" = (
 /obj/vehicle/janicart,
 /obj/effect/turf_decal/delivery/hollow,
@@ -73692,6 +73855,15 @@
 /obj/structure/sink/directional/west,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
+"sgR" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/north)
 "sgZ" = (
 /obj/effect/turf_decal/tiles/white/corner{
 	dir = 8
@@ -73705,13 +73877,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/west)
-"shb" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint2)
 "shj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -73884,11 +74049,30 @@
 "skv" = (
 /turf/simulated/floor/plasteel,
 /area/station/engineering/engine/reactor)
+"skC" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/maintcentral)
 "skD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/portable/canister/air,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"skG" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "skN" = (
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 8
@@ -73941,14 +74125,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/public/construction)
-"smj" = (
-/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
-/obj/machinery/door/airlock/research,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/station/science/robotics)
 "smq" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -74025,19 +74201,6 @@
 "soK" = (
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/asmaint)
-"soO" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/research,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/rnd)
 "soQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 8
@@ -74075,18 +74238,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
-"spm" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "spt" = (
 /obj/machinery/atmospherics/unary/thermomachine/freezer/on/server{
 	dir = 8
@@ -74238,19 +74389,48 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel/dark/full,
 /area/station/security/prison/cell_block/a)
+"srk" = (
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
+"srq" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/cargo_bay,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/supply/warehouse)
 "srE" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/rack,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
-"srJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Abandoned Warehouse"
+"srN" = (
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id_tag = "Secure Armory";
+	name = "Secure Armory Shutters"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/armory/secure)
 "srS" = (
 /obj/machinery/light{
 	dir = 4
@@ -74389,6 +74569,26 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
+"svG" = (
+/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "transittube";
+	name = "Transit Tube Blast Door"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/ai_transit_tube)
 "svH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -74505,6 +74705,24 @@
 /obj/effect/turf_decal/tiles/department/science/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/south)
+"sxz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/medical{
+	name = "Paramedic's Office";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/paramedic,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/department/medical,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/paramedic)
 "sxF" = (
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 4
@@ -74699,6 +74917,19 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison)
+"sBp" = (
+/obj/machinery/door/airlock{
+	name = "Dormitories";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "sBw" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-4"
@@ -74753,20 +74984,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_port)
-"sCr" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
-	name = "Research Division Server Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/rd,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/department/science,
-/turf/simulated/floor/plasteel/dark,
-/area/station/science/server)
 "sCE" = (
 /turf/simulated/floor/plasteel,
 /area/station/science/robotics)
@@ -74797,17 +75014,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/testrange)
-"sDf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "seclock";
-	name = "Checkpoint Lockdown"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/checkpoint/secondary)
 "sDg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -75009,6 +75215,21 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/xenobiology)
+"sFW" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "sGe" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
@@ -75016,6 +75237,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
+"sGo" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/command{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/command/captain,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/office/captain)
 "sGp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/space_heater,
@@ -75093,6 +75330,56 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/solar/aft_port)
+"sHH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore/north)
+"sHJ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Lockdown Blast Doors"
+	},
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison/cell_block/a)
+"sHM" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/research)
 "sIf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/portable/canister/sleeping_agent,
@@ -75124,6 +75411,32 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
+"sIx" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/turf_decal/tiles/department/chemistry/corner,
+/obj/effect/turf_decal/tiles/department/chemistry/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/chemistry/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tiles/department/chemistry/corner{
+	dir = 1
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/storage/tools/auxiliary)
 "sIC" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel,
@@ -75201,6 +75514,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/security/permabrig)
+"sKC" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore2)
 "sKD" = (
 /obj/structure/table,
 /obj/item/food/chips,
@@ -75229,6 +75553,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"sKT" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "xenobio3";
+	name = "Xenobio Pen 3 Blast Door"
+	},
+/obj/machinery/door/window/classic/normal{
+	name = "Containment Pen #3"
+	},
+/obj/machinery/door/window/classic/normal{
+	name = "Containment Pen #3";
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/all/science/xenobio{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/all/science/xenobio,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/xenobiology)
 "sLd" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -75390,6 +75736,26 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
+"sNq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/any/science/rd,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/station_engineering,
+/obj/machinery/door/airlock/command/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/gravitygenerator)
 "sNA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -75415,6 +75781,20 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"sNT" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft2)
 "sOi" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/indestructible/titanium,
@@ -75606,21 +75986,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"sSE" = (
+"sSC" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/supply/mail_sorting,
+/obj/machinery/door/airlock/mining/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plating,
-/area/station/maintenance/medmaint)
+/turf/simulated/floor/plasteel,
+/area/station/supply/sorting)
 "sSH" = (
 /obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/plating,
@@ -75749,16 +76131,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
-"sVB" = (
-/obj/machinery/door/airlock/engineering,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/solar_maintenance/fore_starboard)
 "sVE" = (
 /obj/effect/turf_decal/tiles/neutral/corner{
 	dir = 8
@@ -75810,6 +76182,19 @@
 /obj/effect/turf_decal/tiles/neutral/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/north)
+"sWF" = (
+/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+/obj/machinery/door/airlock/research{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/robotics/chargebay)
 "sWL" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
@@ -75893,6 +76278,23 @@
 /obj/item/food/monkeycube,
 /turf/simulated/floor/grass/no_creep,
 /area/station/maintenance/medmaint)
+"sXX" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/spawner/random/dirt/frequent,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "sXZ" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -75954,6 +76356,41 @@
 "sYX" = (
 /turf/simulated/wall,
 /area/station/hallway/supply)
+"sZh" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "atmos";
+	name = "Atmospherics Blast Door"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/all/engineering/atmos,
+/obj/machinery/door/window/reinforced/normal,
+/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
+/obj/item/desk_bell{
+	pixel_x = 7;
+	pixel_y = 7;
+	anchored = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/control)
+"sZq" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Fore Atmospherics Maintenance";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
 "sZv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -76087,6 +76524,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/bridge)
+"tbm" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Crew Quarters Access";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/locker)
 "tbr" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
@@ -76153,6 +76600,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/xenobiology)
+"tci" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/tiles/white/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/security/checkpoint/secondary)
 "tcx" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -76338,14 +76801,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
-"tfD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/medmaint)
 "tfH" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -76385,6 +76840,17 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel,
 /area/station/medical/break_room)
+"tgB" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/theatre)
 "tgE" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -76474,19 +76940,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/carpet/blue,
 /area/station/command/office/blueshield)
-"tiN" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/starboard2)
 "tjq" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -76604,6 +77057,23 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
+"tlQ" = (
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Lockdown Blast Doors"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "tlV" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -76709,6 +77179,22 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
+"tnm" = (
+/obj/machinery/door/airlock/engineering{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/construction)
 "tnr" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -76785,9 +77271,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/research)
-"tnO" = (
-/turf/simulated/wall/indestructible/titanium,
-/area/shuttle/arrival/station)
 "tnP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -76884,6 +77367,19 @@
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/wood,
 /area/station/legal/courtroom)
+"toS" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
 "tph" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -77272,6 +77768,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/east)
+"twk" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/woodsiding,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/jobs/bar/checker,
+/turf/simulated/floor/plasteel,
+/area/station/service/bar)
 "twu" = (
 /obj/effect/spawner/window/reinforced/polarized/grilled{
 	id = "Detective"
@@ -77486,6 +77998,22 @@
 /obj/effect/turf_decal/tiles/department/engineering/side,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
+"tzb" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/janitor,
+/turf/simulated/floor/plasteel,
+/area/station/service/janitor)
 "tzj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -77541,6 +78069,22 @@
 /obj/item/stack/cable_coil,
 /turf/simulated/floor/catwalk/grey,
 /area/station/maintenance/electrical/aft_starboard)
+"tAh" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/security/checkpoint/secondary)
 "tAr" = (
 /obj/structure/table,
 /obj/item/reagent_containers/drinks/coffee{
@@ -77688,16 +78232,6 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/lounge)
-"tDr" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tiles/white/side,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/south)
 "tDs" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -78053,31 +78587,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
-"tKV" = (
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
-/obj/effect/mapping_helpers/airlock/access/any/service/janitor,
-/obj/effect/mapping_helpers/airlock/access/any/service/library,
-/obj/effect/mapping_helpers/airlock/access/any/service/bar,
-/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
-/obj/effect/turf_decal/tiles/department/medical/checker,
-/obj/machinery/door/airlock,
-/turf/simulated/floor/plasteel/white,
-/area/station/service/break_room)
 "tKX" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/engine,
 /area/station/maintenance/asmaint)
-"tLR" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint)
 "tLT" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -78392,6 +78905,18 @@
 /obj/structure/sink/kitchen/old/directional/west,
 /turf/simulated/floor/plasteel/white,
 /area/station/security/permabrig)
+"tRM" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "tRN" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable,
@@ -78490,21 +79015,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/service/library)
-"tUH" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/command/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/department/command/side{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/command/bridge)
 "tUP" = (
 /obj/machinery/light{
 	dir = 4
@@ -78616,6 +79126,17 @@
 /obj/machinery/light,
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/surgery/primary)
+"tWQ" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/directional/east,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/corner,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/south)
 "tWV" = (
 /obj/effect/spawner/random/barrier/grille_often,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -78885,6 +79406,28 @@
 "uaU" = (
 /turf/simulated/floor/carpet,
 /area/station/legal/magistrate)
+"uaV" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "xenobio7";
+	name = "Xenobio Pen 7 Blast Door"
+	},
+/obj/machinery/door/window/classic/normal{
+	name = "Containment Pen #7";
+	dir = 1
+	},
+/obj/machinery/door/window/classic/normal{
+	name = "Containment Pen #7"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/all/science/xenobio,
+/obj/effect/mapping_helpers/airlock/windoor/access/all/science/xenobio{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/xenobiology)
 "ubf" = (
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 1
@@ -79103,6 +79646,25 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/station/service/bar)
+"uem" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
 "ueu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -79229,6 +79791,17 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/surgery/observation)
+"ufH" = (
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prisonlockers)
 "ufI" = (
 /turf/simulated/wall,
 /area/station/supply/warehouse)
@@ -79299,6 +79872,14 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/station/command/office/hos)
+"uhE" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/stairs{
+	dir = 1
+	},
+/area/station/security/brig)
 "uhI" = (
 /obj/effect/spawner/random/barrier/grille_maybe,
 /turf/simulated/floor/plasteel,
@@ -79427,6 +80008,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"ujd" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/security{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/interrogation)
 "ujg" = (
 /obj/machinery/door/airlock/security/glass,
 /obj/effect/mapping_helpers/airlock/access/all/security/doors,
@@ -79570,25 +80170,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/procedure/trainer_office)
-"ulq" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/door/airlock/atmos/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
-	},
-/obj/effect/turf_decal/tiles/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/tiles/department/engineering/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/distribution)
 "uls" = (
 /obj/machinery/atmospherics/portable/canister/air,
 /obj/effect/turf_decal/tiles/department/engineering/side{
@@ -79596,6 +80177,19 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos/control)
+"ulM" = (
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock";
+	name = "Escape Pod Hatch";
+	dir = 4
+	},
+/obj/docking_port/mobile/pod{
+	id = "pod2";
+	name = "escape pod 2"
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/pod_2)
 "umh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -79653,6 +80247,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/west)
+"unp" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/classic/normal{
+	name = "Cargo Desk"
+	},
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
+/turf/simulated/floor/plating,
+/area/station/supply/office)
 "unq" = (
 /obj/structure/morgue{
 	dir = 8
@@ -79790,16 +80400,14 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
 /area/station/service/hydroponics)
-"upn" = (
-/obj/machinery/door/airlock{
-	name = "Bathroom"
+"upw" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/service/crematorium,
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "upE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -79807,6 +80415,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
+"upT" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line,
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/supply/aft)
 "uqr" = (
 /obj/structure/closet/radiation,
 /obj/item/tank/internals/oxygen,
@@ -79934,6 +80558,28 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/public/toilet/lockerroom)
+"utv" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "xenobio2";
+	name = "Xenobio Pen 2 Blast Door"
+	},
+/obj/machinery/door/window/classic/normal{
+	name = "Containment Pen #2";
+	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/window/classic/normal{
+	name = "Containment Pen #2"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/all/science/xenobio{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/all/science/xenobio,
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/xenobiology)
 "utw" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -79972,18 +80618,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/security/permabrig)
-"uuE" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/command,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/command/captain,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/command/office/captain)
 "uuG" = (
 /obj/structure/table,
 /turf/simulated/floor/plating,
@@ -80008,15 +80642,6 @@
 /obj/structure/sign/poster/official/obey/directional/south,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"uvM" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/nw)
 "uwk" = (
 /obj/effect/spawner/random/trash,
 /obj/machinery/light/small{
@@ -80227,6 +80852,28 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
+"uAs" = (
+/obj/effect/mapping_helpers/airlock/windoor/access/all/science/xenobio,
+/obj/machinery/door/window/classic/normal{
+	name = "Containment Pen #6"
+	},
+/obj/machinery/door/window/classic/normal{
+	name = "Containment Pen #6";
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "xenobio6";
+	name = "Xenobio Pen 6 Blast Door"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/all/science/xenobio{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/xenobiology)
 "uAA" = (
 /obj/effect/map_effect/dynamic_airlock,
 /turf/simulated/floor/plating,
@@ -80354,6 +81001,21 @@
 /obj/effect/turf_decal/loading_area,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
+"uDb" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "bridge blast";
+	name = "Bridge Blast Doors"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/bridge)
 "uDi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
@@ -80534,6 +81196,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"uGI" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/classic/normal{
+	name = "Cargo Desk"
+	},
+/obj/item/desk_bell{
+	anchored = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
+/turf/simulated/floor/plating,
+/area/station/supply/office)
 "uHj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -80852,18 +81529,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engimaint)
-"uKy" = (
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock";
-	name = "Escape Pod Hatch"
-	},
-/obj/docking_port/mobile/pod{
-	id = "pod2";
-	name = "escape pod 2"
-	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/pod_2)
 "uKz" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -80956,16 +81621,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/hallway/secondary/entry/west)
-"uMi" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Departure Lounge"
-	},
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/exit)
 "uMj" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -81004,6 +81659,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"uMM" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/north)
 "uMR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tiles/department/security/corner,
@@ -81255,6 +81919,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
+"uRb" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Power Monitoring";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/electrical/aft_starboard)
 "uRe" = (
 /turf/simulated/floor/plasteel,
 /area/station/hallway/supply)
@@ -81270,35 +81950,40 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
-"uRM" = (
+"uRP" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Secure Gate";
 	name = "Security Lockdown Blast Doors"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/airlock/security/glass,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
-"uRN" = (
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/legal/courtroom)
+"uRR" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "transittube";
-	name = "Transit Tube Blast Door"
-	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/hatch,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/ai_transit_tube)
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/turf/simulated/floor/engine,
+/area/station/engineering/engine/reactor)
 "uRT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -81444,18 +82129,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
-"uUr" = (
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/brig)
 "uUx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -81481,18 +82154,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
-"uUI" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/woodsiding,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/jobs/bar/checker,
-/turf/simulated/floor/plasteel,
-/area/station/service/bar)
 "uUX" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -81613,6 +82274,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
+"uWJ" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/woodsiding,
+/obj/effect/turf_decal/tiles/jobs/bar/checker,
+/turf/simulated/floor/plasteel,
+/area/station/service/bar)
 "uWQ" = (
 /obj/machinery/door/window/classic/normal{
 	name = "Court Cell"
@@ -81628,26 +82301,6 @@
 	},
 /turf/simulated/floor/catwalk/white,
 /area/station/maintenance/aft2)
-"uXf" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "xenobio2";
-	name = "Xenobio Pen 2 Blast Door"
-	},
-/obj/machinery/door/window/classic/normal{
-	name = "Containment Pen #2";
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/classic/normal{
-	name = "Containment Pen #2"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/all/science/xenobio{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/all/science/xenobio,
-/turf/simulated/floor/plasteel/dark,
-/area/station/science/xenobiology)
 "uXA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -81810,20 +82463,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/asmaint)
-"vaE" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/tiles/white/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/firealarm/directional/east,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
 "vaG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -82046,16 +82685,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
-"vdx" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison/cell_block/a)
 "vdB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -82100,6 +82729,23 @@
 /obj/machinery/atmospherics/portable/canister/air,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
+"vdV" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Hydroponics Storage";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/department/virology,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/se)
 "vdW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -82201,6 +82847,21 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/storage/secondary)
+"vfA" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/starboard2)
 "vfC" = (
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 8
@@ -82210,6 +82871,36 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel/dark,
+/area/station/security/armory/secure)
+"vfM" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/nw)
+"vfY" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/reinforced/normal,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/general,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/armory{
+	dir = 1
+	},
+/obj/machinery/door/window/reinforced/reversed{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/autoname/desk{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark/full,
 /area/station/security/armory/secure)
 "vge" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -82620,13 +83311,6 @@
 "vob" = (
 /turf/simulated/wall,
 /area/station/medical/storage)
-"voe" = (
-/obj/effect/mapping_helpers/turfs/damage,
-/obj/structure/mineral_door/wood,
-/obj/structure/barricade/wooden/crude,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/station/maintenance/asmaint)
 "voi" = (
 /obj/machinery/economy/vending/hydronutrients,
 /obj/effect/turf_decal/tiles/department/virology/side{
@@ -82822,14 +83506,6 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/simulated/floor/carpet/arcade,
 /area/station/maintenance/fore)
-"vrF" = (
-/obj/effect/turf_decal/tiles/department/security/side{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison)
 "vrH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -82890,6 +83566,31 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/command/teleporter)
+"vso" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prisonershuttle)
 "vsw" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/directional/south,
@@ -82910,6 +83611,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"vsL" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	name = "Recreation Area";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "vsZ" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tiles/department/medical/side,
@@ -83092,26 +83806,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
-"vvr" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "xenobio3";
-	name = "Xenobio Pen 3 Blast Door"
-	},
-/obj/machinery/door/window/classic/normal{
-	name = "Containment Pen #3"
-	},
-/obj/machinery/door/window/classic/normal{
-	name = "Containment Pen #3";
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/all/science/xenobio{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/all/science/xenobio,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/science/xenobiology)
 "vvx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/turf_decal/tiles/white/corner{
@@ -83356,17 +84050,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
-"vyL" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tiles/white/side,
-/turf/simulated/floor/plasteel,
-/area/station/medical/reception)
 "vyT" = (
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 1
@@ -83504,6 +84187,15 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/security/brig)
+"vAk" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/east)
 "vAK" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
@@ -83591,6 +84283,33 @@
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"vCJ" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore2)
+"vCL" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "vCS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -83688,13 +84407,6 @@
 	},
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/fsmaint2)
-"vDG" = (
-/obj/machinery/door/airlock/security,
-/obj/effect/mapping_helpers/airlock/access/all/security/evidence,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/evidence)
 "vDP" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -83806,27 +84518,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard)
-"vFv" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prisonershuttle)
 "vFw" = (
 /obj/effect/spawner/random/trash,
 /turf/simulated/floor/plating,
@@ -83838,6 +84529,17 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
+"vFG" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "vFT" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -83901,28 +84603,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/xenobio_north)
-"vHq" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Detective"
-	},
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/access/all/security/forensics,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/security/detective)
 "vHA" = (
 /obj/machinery/light{
 	dir = 4
@@ -84247,15 +84927,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
-"vOw" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/supply/lobby)
 "vOE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -84440,6 +85111,21 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
+"vSn" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "vSM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -84457,23 +85143,6 @@
 /obj/effect/landmark/spawner/xeno,
 /turf/simulated/floor/carpet/arcade,
 /area/station/maintenance/fore)
-"vSZ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/reinforced/normal,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/general,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/armory{
-	dir = 1
-	},
-/obj/machinery/door/window/reinforced/reversed{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/autoname/desk{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/dark/full,
-/area/station/security/armory/secure)
 "vTk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office,
@@ -84526,6 +85195,13 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/station/turret_protected/ai)
+"vUa" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/white/side,
+/turf/simulated/floor/plasteel,
+/area/station/medical/reception)
 "vUb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -84727,6 +85403,19 @@
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel,
 /area/station/command/office/rd)
+"vXK" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Command Hallway";
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/science/robotics/showroom)
 "vXM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -84766,6 +85455,19 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"vYA" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tiles/department/medical/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/south)
 "vZh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
@@ -84843,6 +85545,19 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/permabrig)
+"vZL" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fpmaint)
 "vZU" = (
 /obj/machinery/atmospherics/unary/thermomachine/freezer{
 	dir = 1
@@ -85228,6 +85943,22 @@
 /obj/effect/turf_decal/tiles/department/science/side,
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/toxins/mixing)
+"wgH" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/classic/normal,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/all/service/kitchen,
+/obj/effect/turf_decal/tiles/dark/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/kitchen)
 "wgO" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -85257,6 +85988,16 @@
 /obj/effect/spawner/random/cobweb/right/rare,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"whq" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/station/security/lobby)
 "whu" = (
 /obj/effect/turf_decal/tiles/department/medical/checker,
 /turf/simulated/floor/plasteel/white,
@@ -85455,20 +86196,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
-"wky" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/turf/simulated/floor/engine,
-/area/station/engineering/engine/reactor)
 "wkz" = (
 /obj/machinery/light{
 	dir = 1
@@ -85923,44 +86650,11 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/command/bridge)
-"wsz" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/warden)
-"wsM" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/engineering,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plating,
-/area/station/maintenance/solar_maintenance/aft_port)
 "wsN" = (
 /obj/effect/landmark/start/research_director,
 /obj/effect/turf_decal/tiles/dark/checker,
 /turf/simulated/floor/plasteel,
 /area/station/command/office/rd)
-"wsS" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fore2)
 "wsY" = (
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall,
@@ -86322,14 +87016,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/lobby)
-"wxV" = (
-/obj/machinery/door/airlock/research,
-/obj/effect/mapping_helpers/airlock/access/all/science/tox,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/white,
-/area/station/maintenance/aft2)
 "wxY" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -86723,6 +87409,14 @@
 /obj/effect/turf_decal/tiles/department/chemistry/side,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/chemistry)
+"wDO" = (
+/obj/effect/map_effect/dynamic_airlock/door/exterior,
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
+	},
+/obj/machinery/access_button/offset/southwest,
+/turf/simulated/floor/plasteel/dark/airless,
+/area/station/hallway/secondary/entry/west)
 "wDR" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
@@ -86951,20 +87645,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/supply)
-"wHz" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge Access"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge blast";
-	name = "Bridge Blast Doors"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/command/bridge)
 "wHB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -87037,20 +87717,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/procedure/trainer_office)
-"wIR" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "seclock";
-	name = "Checkpoint Lockdown"
-	},
-/obj/structure/sign/public/arrivals{
-	pixel_x = 32
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/checkpoint/secondary)
 "wIX" = (
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 4
@@ -87079,6 +87745,18 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/research)
+"wJk" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/west)
 "wJA" = (
 /obj/effect/spawner/window/reinforced/tinted,
 /turf/simulated/floor/plating,
@@ -87199,6 +87877,32 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/west)
+"wLC" = (
+/obj/machinery/door/airlock/command{
+	name = "Command Desk";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/bridge)
+"wLG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "wLX" = (
 /obj/structure/sign/poster/contraband/random/directional/south,
 /turf/simulated/floor/plating,
@@ -87271,16 +87975,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/xenobiology)
-"wMQ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Command Hallway"
-	},
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/science/robotics/showroom)
 "wMX" = (
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 5
@@ -87344,6 +88038,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
+"wNM" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/asmaint)
 "wNO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -87508,6 +88220,24 @@
 /obj/effect/turf_decal/tiles/department/medical/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/break_room)
+"wQl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
+/obj/machinery/door/airlock/medical/glass{
+	name = null;
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "psychoffice"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/wood,
+/area/station/medical/psych)
 "wQo" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/meter,
@@ -87639,6 +88369,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/smith_office)
+"wTm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/medical/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/department/chemistry,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/chemistry)
 "wTu" = (
 /obj/effect/turf_decal/tiles/department/cargo/corner{
 	dir = 4
@@ -87682,23 +88430,6 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
-"wUE" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge Access"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge blast";
-	name = "Bridge Blast Doors"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/command/bridge)
 "wUG" = (
 /obj/structure/plasticflaps/mining,
 /obj/machinery/conveyor/east{
@@ -87746,6 +88477,21 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/reception)
+"wVs" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/starboard)
 "wVD" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -87763,17 +88509,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
-"wVL" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tiles/neutral/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/east)
 "wVO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -87796,6 +88531,26 @@
 /obj/effect/turf_decal/tiles/neutral/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/west)
+"wWn" = (
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/science/research)
 "wWp" = (
 /obj/machinery/mineral/stacking_unit_console{
 	pixel_y = 32
@@ -87816,6 +88571,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft2)
+"wWA" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/cable/extra_insulated/pre_connect{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/xenobio_south)
 "wWG" = (
 /obj/machinery/light{
 	dir = 1
@@ -88101,6 +88871,16 @@
 /obj/effect/spawner/random/dirt/maybe,
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics/chargebay)
+"xbg" = (
+/obj/effect/turf_decal/tiles/department/security/side{
+	dir = 8
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison)
 "xbh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 10
@@ -88162,6 +88942,21 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
+"xbN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/medical/medbay)
 "xbO" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -88243,6 +89038,18 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/bluegrid/telecomms/server,
 /area/station/science/server/coldroom)
+"xcy" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Hydroponics Pasture";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/service/pasture)
 "xcF" = (
 /obj/effect/turf_decal/tiles/department/virology/side{
 	dir = 8
@@ -88302,15 +89109,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"xef" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fsmaint)
 "xek" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -88377,6 +89175,19 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
+"xeJ" = (
+/obj/machinery/door/airlock{
+	name = "Bathroom";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/brig)
 "xeM" = (
 /obj/machinery/computer/supplycomp/public{
 	dir = 8
@@ -88706,15 +89517,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat)
-"xiM" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/dark,
-/area/station/hallway/supply)
 "xiU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -88816,13 +89618,6 @@
 /obj/effect/turf_decal/tiles/department/science/side,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/robotics)
-"xkR" = (
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Auxiliary Chamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/turf/simulated/floor/plating/airless,
-/area/station/engineering/atmos)
 "xkY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -88837,6 +89632,23 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"xlf" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/turf_decal/tiles/department/medical,
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/coldroom)
 "xlj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -88990,6 +89802,21 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/cryo)
+"xnV" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/asmaint)
 "xoa" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -89109,17 +89936,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
-"xpP" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/asmaint)
 "xpU" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/machinery/door/poddoor/preopen{
@@ -89194,19 +90010,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/tools)
-"xrl" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/atmos,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/turbine)
 "xrx" = (
 /obj/effect/turf_decal/stripes/end,
 /obj/machinery/power/apc/directional/north,
@@ -89273,17 +90076,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/engine,
 /area/station/science/xenobiology)
-"xsl" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/prison)
 "xsF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -89612,7 +90404,7 @@
 	dir = 8;
 	level = 3;
 	name = "Distribution and Waste Monitor";
-	autolink_sensors = list("mair_in_meter"="Mixed Air In","air_sensor"="Mixed Air Supply Tank","mair_out_meter"="Mixed Air Out","dloop_atm_meter"="Distribution Loop","wloop_atm_meter"="Waste Loop")
+	autolink_sensors = list("mair_in_meter" = "Mixed Air In", "air_sensor" = "Mixed Air Supply Tank", "mair_out_meter" = "Mixed Air Out", "dloop_atm_meter" = "Distribution Loop", "wloop_atm_meter" = "Waste Loop")
 	},
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 4
@@ -89681,15 +90473,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/station/hallway/supply)
-"xzl" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/medical/medbay)
 "xzC" = (
 /obj/structure/table/reinforced,
 /obj/item/taperecorder{
@@ -89797,6 +90580,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/office/hop)
+"xCn" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/research,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/rnd)
 "xCv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -89914,6 +90714,14 @@
 /obj/structure/sign/command,
 /turf/simulated/wall/r_wall,
 /area/station/command/bridge)
+"xDP" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "xEh" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -89934,6 +90742,31 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
+"xEt" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fpmaint)
+"xEF" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line,
+/obj/structure/sign/poster/official/random/directional/east,
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/supply/aft)
 "xEJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/extra_insulated{
@@ -90080,22 +90913,6 @@
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /turf/simulated/floor/plasteel/white,
 /area/station/security/permabrig)
-"xHw" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/public/glass,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore/east)
 "xHy" = (
 /obj/structure/bed,
 /obj/machinery/flasher{
@@ -90257,6 +91074,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/main)
+"xJK" = (
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external/glass{
+	name = "Labor Camp Airlock";
+	id_tag = "laborcamp_home";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Lockdown Blast Doors"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/security/prisonershuttle)
 "xJQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -90324,6 +91159,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/service/chapel)
+"xKM" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line,
+/turf/simulated/floor/plasteel/dark,
+/area/station/hallway/supply)
 "xKZ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -90380,20 +91231,6 @@
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/station/service/hydroponics)
-"xLH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/medical/glass,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/department/chemistry,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/chemistry)
 "xLO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -90442,6 +91279,32 @@
 /obj/effect/spawner/random/food_or_drink,
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
+"xMN" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Detective"
+	},
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/forensics,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/security/detective)
 "xNo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 6
@@ -90747,6 +91610,12 @@
 "xSh" = (
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
+"xSk" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/west)
 "xSv" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plating,
@@ -90963,6 +91832,29 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/west)
+"xXn" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/security/storage)
 "xXt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -91116,6 +92008,48 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass/no_creep,
 /area/station/science/research)
+"xYX" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Lockdown Blast Doors"
+	},
+/obj/machinery/door/airlock/security/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/prison/cell_block/a)
+"xYZ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/public/glass{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore/east)
 "xZa" = (
 /obj/structure/plasticflaps{
 	opacity = 1
@@ -91132,6 +92066,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"xZH" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Hydroponics Pasture";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
+/obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/spawner/random/dirt/frequent,
+/obj/effect/turf_decal/tiles/department/medical/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/pasture)
 "xZM" = (
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 8
@@ -91380,6 +92332,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"ycN" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line,
+/turf/simulated/floor/plasteel/dark,
+/area/station/medical/medbay)
 "ycT" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/carpet/purple,
@@ -91725,6 +92692,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
+"yjs" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance/external{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
 "yjC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -101417,7 +102399,7 @@ abq
 abq
 ayy
 qcE
-aTQ
+wDO
 aef
 aef
 oxF
@@ -102186,7 +103168,7 @@ ogs
 naz
 uni
 nfG
-heV
+byH
 ekm
 sgZ
 uni
@@ -102426,9 +103408,9 @@ aaa
 aSr
 bxR
 aUW
-brG
+lIB
 aqA
-ejj
+kpL
 aCn
 aCn
 mye
@@ -102443,12 +103425,12 @@ dLz
 gXl
 aCn
 aCn
-mCc
+xSk
 aCn
 aCn
 aCn
 jQJ
-jPu
+tnm
 iXo
 oPA
 oPA
@@ -102700,7 +103682,7 @@ bvE
 nFk
 uIu
 uIu
-vaE
+dBj
 dFM
 vDv
 xXi
@@ -103714,27 +104696,27 @@ aaa
 aaa
 aaa
 bin
-tnO
-tnO
+bin
+bin
 bXH
-tnO
+bin
 biq
 biq
 biq
 biq
-tnO
+bin
 bXH
-tnO
-tnO
-tnO
-tnO
+bin
+bin
+bin
+bin
 aaa
 hSu
 rFj
 vzM
 kOX
 yem
-rRg
+lgJ
 bHg
 jba
 niq
@@ -103759,11 +104741,11 @@ efl
 vxn
 pDJ
 dha
-kGr
+oca
 faO
 vrf
 tab
-iQp
+hpb
 rNF
 oxa
 rNF
@@ -103771,7 +104753,7 @@ rNF
 rNF
 oxa
 rNF
-iQp
+hpb
 gla
 eDl
 aqB
@@ -103970,7 +104952,7 @@ aaa
 aaa
 aaa
 bin
-tnO
+bin
 aHn
 rUr
 pUA
@@ -104225,8 +105207,8 @@ aaa
 aaa
 aaa
 bin
-tnO
-tnO
+bin
+bin
 sOi
 qav
 bkb
@@ -104484,7 +105466,7 @@ aaa
 biq
 eVt
 wuL
-tnO
+bin
 cnM
 bkb
 pUA
@@ -104505,7 +105487,7 @@ oNg
 bmv
 jzG
 jbH
-rJs
+xEt
 lqU
 jlO
 aci
@@ -104741,7 +105723,7 @@ aaa
 biq
 pUA
 pUA
-gas
+mcb
 pUA
 vhk
 ivC
@@ -104754,8 +105736,8 @@ uKz
 ivC
 wKi
 bcw
-tnO
-tnO
+bin
+bin
 aaa
 qrA
 oNg
@@ -104998,7 +105980,7 @@ aaa
 biq
 jaQ
 eLs
-tnO
+bin
 xxq
 bkb
 pUA
@@ -105037,7 +106019,7 @@ jCQ
 kQO
 iDj
 aWW
-pHc
+qKi
 xiU
 tzj
 qVo
@@ -105253,8 +106235,8 @@ aaa
 aaa
 aaa
 bin
-tnO
-tnO
+bin
+bin
 qTT
 arJ
 bkb
@@ -105313,7 +106295,7 @@ abq
 gsm
 qwW
 cAv
-nvQ
+gLe
 nUL
 clT
 wHB
@@ -105321,7 +106303,7 @@ iRe
 gFT
 joM
 hXW
-oZr
+yjs
 nZw
 hhu
 tZO
@@ -105512,7 +106494,7 @@ aaa
 aaa
 aaa
 bin
-tnO
+bin
 otf
 aoS
 pUA
@@ -105570,7 +106552,7 @@ abq
 gsm
 sDg
 mrw
-dsw
+obr
 eyH
 eyH
 uWH
@@ -105770,20 +106752,20 @@ aaa
 aaa
 aaa
 bin
-tnO
-tnO
+bin
+bin
 bXH
-tnO
+bin
 biq
 biq
 biq
 biq
-tnO
+bin
 bXH
-tnO
-tnO
-tnO
-tnO
+bin
+bin
+bin
+bin
 aaa
 hSu
 kDq
@@ -105796,7 +106778,7 @@ biu
 buD
 gOe
 bRB
-bTm
+kKD
 dma
 iCa
 aOB
@@ -106065,7 +107047,7 @@ csZ
 jTb
 nPz
 ehY
-ouE
+kts
 bsL
 jGY
 sRO
@@ -106313,7 +107295,7 @@ rwj
 bgX
 qQD
 wSU
-tLR
+vZL
 kUX
 adY
 lOz
@@ -106349,7 +107331,7 @@ cAN
 ocA
 iJf
 eKP
-cjY
+opE
 lUP
 lGt
 auC
@@ -106638,7 +107620,7 @@ xbA
 hCM
 fFX
 htr
-oPE
+edo
 pps
 dRY
 nsm
@@ -106812,7 +107794,7 @@ rOL
 qST
 qST
 qST
-ape
+lxP
 btp
 bvB
 wDL
@@ -107052,9 +108034,9 @@ aaa
 hfX
 tMb
 gEK
-uKy
+ulM
 pQM
-onD
+qYl
 qFK
 qFK
 bzs
@@ -107069,19 +108051,19 @@ fHi
 qFK
 qFK
 qFK
-bDC
+nem
 btp
 sBw
 jZG
 oHZ
 bvB
 btp
-aXS
+tci
 bWm
 nza
 avQ
 hBM
-sDf
+ghi
 bce
 nVo
 kdr
@@ -107141,7 +108123,7 @@ ilz
 cAw
 cSG
 bYa
-hds
+mnP
 cmG
 crG
 bZP
@@ -107326,19 +108308,19 @@ oQx
 eQV
 uKl
 uKl
-evo
+cwL
 vMo
 naY
 jjF
 uBf
 iMw
 nRK
-did
+tAh
 bpc
 bpc
 bpc
 sRK
-bfh
+fJG
 yjC
 nhE
 dma
@@ -107590,12 +108572,12 @@ bvD
 btp
 rTD
 btp
-nhT
+eNi
 oln
 kob
 tQk
 suO
-wIR
+lYK
 rBp
 xqq
 rXi
@@ -107898,7 +108880,7 @@ mAw
 oXm
 oXm
 tJB
-eIq
+sbu
 cCM
 mER
 hso
@@ -108620,7 +109602,7 @@ wIQ
 xXM
 szJ
 tyE
-kdn
+kmC
 iwi
 fsB
 uJR
@@ -108673,7 +109655,7 @@ bZP
 bZP
 cYF
 jsL
-srJ
+niA
 lgi
 apb
 apb
@@ -109403,7 +110385,7 @@ hsb
 nYn
 xJy
 oWs
-wBc
+sKC
 bUs
 rbK
 fmR
@@ -109413,7 +110395,7 @@ rho
 lFY
 kwj
 wbb
-lhY
+sSC
 pLg
 yev
 pHC
@@ -109973,11 +110955,11 @@ crG
 crG
 crG
 kYX
-cAf
+bCs
 nup
 jFX
 cYX
-cGn
+peO
 cKD
 tPF
 wMw
@@ -109987,7 +110969,7 @@ cXY
 iRP
 mao
 deH
-cPA
+jZi
 jWJ
 xPl
 lSh
@@ -110162,7 +111144,7 @@ fuV
 tdq
 vXo
 pzz
-anB
+tgB
 jQZ
 svZ
 lIM
@@ -110188,7 +111170,7 @@ kGf
 ncU
 iSJ
 xJQ
-gnP
+xKM
 kMa
 joG
 qBm
@@ -110196,7 +111178,7 @@ hNt
 qBm
 qBm
 ndj
-nUq
+upT
 oHF
 xfe
 cEt
@@ -110247,7 +111229,7 @@ rkU
 bZU
 cLk
 cLg
-wsM
+fez
 cLe
 awe
 bTj
@@ -110435,7 +111417,7 @@ aWV
 fIE
 oDE
 qPI
-ifJ
+piA
 vGW
 taM
 xZP
@@ -110445,7 +111427,7 @@ uFm
 wBr
 gtS
 uRe
-pyZ
+loJ
 jee
 cyW
 cyW
@@ -110453,7 +111435,7 @@ dfl
 cyW
 sJG
 ovo
-mYX
+ojB
 ndg
 cyW
 iuw
@@ -110462,7 +111444,7 @@ cyW
 aIC
 gJs
 gJs
-qLb
+srq
 mLQ
 bzG
 loD
@@ -110702,7 +111684,7 @@ wJG
 gJM
 gzu
 ovF
-xiM
+qMO
 lNM
 fAY
 sec
@@ -110710,7 +111692,7 @@ jhT
 pJR
 pJR
 gLl
-bGb
+xEF
 snJ
 sJG
 iuw
@@ -111200,9 +112182,9 @@ aCz
 aDG
 dtM
 aGp
-aHB
+nur
 nYm
-xHw
+xYZ
 fGb
 aLK
 fEB
@@ -111410,7 +112392,7 @@ udK
 udK
 smq
 kzQ
-nqR
+gxf
 lLb
 udK
 udK
@@ -111515,7 +112497,7 @@ vob
 kmz
 mhm
 kzy
-cKb
+xlf
 cKW
 jRt
 cNL
@@ -111750,7 +112732,7 @@ bZP
 uzS
 gPc
 fYB
-spm
+ncT
 tty
 oYn
 eak
@@ -111776,7 +112758,7 @@ ctP
 rjA
 hkr
 cNK
-cfm
+fte
 sBQ
 coD
 cHZ
@@ -111791,7 +112773,7 @@ aAh
 chy
 chn
 wOt
-oZX
+upw
 deM
 cHj
 hLt
@@ -111915,7 +112897,7 @@ adi
 adi
 wVg
 gjy
-fja
+gFu
 fCF
 adi
 adi
@@ -111977,12 +112959,12 @@ iCh
 fIE
 sTC
 iJH
-fCQ
+ioF
 uZZ
 hrF
 hDK
 uzN
-oqG
+unp
 dOt
 iGi
 eJP
@@ -112172,7 +113154,7 @@ xJa
 gYi
 pEb
 nHq
-iID
+uem
 nHq
 nHq
 nHq
@@ -112234,12 +113216,12 @@ cnN
 gXL
 sTC
 iJH
-fCQ
+ioF
 hDK
 yeE
 mGS
 uzN
-euL
+nYO
 puo
 iKo
 edb
@@ -112429,7 +113411,7 @@ adi
 iGr
 adi
 umL
-pzE
+toS
 rRO
 adi
 adi
@@ -112472,7 +113454,7 @@ tyR
 lIM
 pgb
 kSM
-qfX
+qft
 oXE
 oNa
 xvd
@@ -112491,12 +113473,12 @@ lIM
 wbr
 aMM
 jzz
-vOw
+hLY
 njd
 qTp
 qyd
 uzN
-esC
+uGI
 jAA
 iGi
 edb
@@ -112715,7 +113697,7 @@ msL
 bqv
 vwH
 aln
-bHy
+dWB
 eni
 rGo
 mtd
@@ -112726,7 +113708,7 @@ inQ
 tnd
 mtd
 pRR
-qCL
+kDS
 giu
 uLF
 lIM
@@ -112748,7 +113730,7 @@ lIM
 ggK
 sTC
 iJH
-fCQ
+ioF
 hDK
 npF
 tfW
@@ -112794,17 +113776,17 @@ cxu
 cue
 cpb
 imZ
-bNx
+qLB
 cik
 mnr
 cFh
 kwD
 cJa
-cIB
+sfn
 wtz
 uwB
 cNK
-cuF
+kdS
 wXy
 vuE
 cQC
@@ -112819,7 +113801,7 @@ bZU
 chy
 sKI
 xiA
-cPv
+dxb
 ocC
 cxQ
 cFz
@@ -113023,14 +114005,14 @@ ofC
 cGo
 jMW
 crG
-dgI
+fOE
 qvC
 eNZ
 cpM
 cpM
 cpM
 uMz
-rfC
+vSn
 mOJ
 fNT
 xqG
@@ -113042,7 +114024,7 @@ sES
 bTe
 rqt
 fYE
-rKa
+sxz
 vtc
 nGt
 hci
@@ -113051,13 +114033,13 @@ jNa
 cue
 cpb
 imZ
-bNx
+qLB
 cDO
 fqe
 cFg
 cHg
 cIZ
-cIB
+sfn
 cuy
 jNq
 wEZ
@@ -113072,7 +114054,7 @@ cZq
 deg
 lDG
 dby
-ojt
+sFW
 cTx
 muo
 vCt
@@ -113082,7 +114064,7 @@ oyM
 bNb
 tOS
 wvo
-cVP
+gAT
 cow
 bXR
 uBX
@@ -113215,7 +114197,7 @@ tfK
 wXi
 adi
 adi
-wsS
+fUq
 mtd
 mtd
 gYO
@@ -113267,7 +114249,7 @@ wxM
 pdH
 tqE
 mnJ
-kxD
+dZP
 egn
 egn
 qnb
@@ -113487,7 +114469,7 @@ xGT
 mtd
 qDi
 rTX
-gAj
+jCb
 xbk
 mtd
 mtd
@@ -113751,7 +114733,7 @@ mtd
 mtd
 mtd
 hBx
-okh
+oOD
 wmL
 wvG
 wvG
@@ -113761,7 +114743,7 @@ wmL
 vZp
 rlF
 vtU
-eEn
+jeK
 wwE
 ozx
 wAp
@@ -113772,7 +114754,7 @@ mkW
 gPX
 nMQ
 ssS
-lOd
+vCJ
 xLd
 fcQ
 vBI
@@ -113806,7 +114788,7 @@ caA
 cbx
 rFD
 bVf
-chU
+rgc
 ceS
 chZ
 chV
@@ -114033,7 +115015,7 @@ lIM
 bMC
 iHW
 wkn
-blI
+aqj
 xKF
 vcK
 sVE
@@ -114045,7 +115027,7 @@ bhc
 sVE
 sVE
 pET
-bFL
+kIX
 jfN
 oMj
 jfN
@@ -114055,7 +115037,7 @@ dKB
 jfN
 jfN
 jfN
-rKV
+grR
 bfV
 bsV
 bZh
@@ -114290,7 +115272,7 @@ lIM
 rEF
 bei
 fUo
-uvM
+vfM
 dJB
 mIo
 dJB
@@ -114302,7 +115284,7 @@ nnt
 jPQ
 eCF
 qtp
-bOB
+wJk
 hCu
 fBQ
 bJc
@@ -114312,7 +115294,7 @@ tJc
 hCu
 pxk
 hCu
-bQG
+qaA
 kLW
 fPd
 cyB
@@ -114335,7 +115317,7 @@ gLu
 cxp
 fLa
 eOZ
-cXr
+ycN
 dLU
 atf
 luR
@@ -114349,7 +115331,7 @@ rKC
 rtb
 mFQ
 pIt
-rXj
+pEM
 ujh
 hDL
 blu
@@ -114547,7 +115529,7 @@ bzK
 bvK
 kuP
 jmL
-ibQ
+bHm
 xKg
 rvX
 cfI
@@ -114559,7 +115541,7 @@ vNb
 biK
 bzR
 sWV
-dPX
+jlN
 wWh
 brN
 bJd
@@ -114569,7 +115551,7 @@ iYA
 sUc
 bRO
 bTC
-bUM
+gzC
 bMR
 bXT
 bNk
@@ -114583,7 +115565,7 @@ hIO
 eYp
 viO
 cxt
-rCs
+wQl
 lsz
 rot
 oQc
@@ -114592,7 +115574,7 @@ sLT
 rot
 iEk
 aen
-eFw
+ogn
 aVZ
 rot
 rot
@@ -114606,7 +115588,7 @@ rot
 qSD
 rot
 oQc
-cfp
+xbN
 rot
 aVZ
 pdE
@@ -114614,7 +115596,7 @@ hZT
 oOv
 apl
 cxK
-pUx
+ovn
 nfU
 aBc
 tDk
@@ -114834,7 +115816,7 @@ bMR
 bek
 cca
 bnl
-nDj
+oWH
 wmj
 wmj
 dXu
@@ -114849,7 +115831,7 @@ cfF
 cwq
 cdZ
 cov
-xzl
+kog
 lcd
 lzO
 nBF
@@ -114863,7 +115845,7 @@ nBF
 cRM
 cRL
 daP
-cCa
+imY
 daP
 mnA
 cPj
@@ -114876,7 +115858,7 @@ nNX
 rgh
 oxb
 wOt
-diT
+skG
 cUX
 wKI
 deP
@@ -115293,7 +116275,7 @@ hRV
 oRK
 dNU
 jSc
-gfq
+ujd
 fom
 hvR
 qke
@@ -115335,7 +116317,7 @@ bFH
 bMV
 bCi
 bMX
-bNM
+quQ
 bRS
 bRu
 bRX
@@ -115343,7 +116325,7 @@ bOR
 bOR
 bOR
 bOR
-bZx
+pAB
 caM
 bcK
 lKK
@@ -115543,7 +116525,7 @@ pFS
 dTV
 bod
 cnv
-vDG
+idm
 pnB
 sPh
 lGL
@@ -115592,7 +116574,7 @@ bHq
 qyb
 bJs
 bKT
-buj
+cnZ
 fla
 vkO
 bXV
@@ -115604,7 +116586,7 @@ bMS
 dDT
 jdP
 bcX
-oqO
+vUa
 ciB
 dAq
 nht
@@ -115789,7 +116771,7 @@ wih
 tOc
 ucH
 kGh
-qzd
+dbm
 qZo
 vrK
 lIM
@@ -115857,11 +116839,11 @@ bOR
 bOR
 bOR
 bOR
-bZx
+pAB
 rUT
 jdP
 bcX
-oqO
+vUa
 mwo
 fGE
 skP
@@ -116118,7 +117100,7 @@ bMS
 caD
 jdP
 bcX
-oqO
+vUa
 asn
 xFH
 bVF
@@ -116282,12 +117264,12 @@ aaa
 aaa
 aaa
 aPj
-rTe
+xJK
 lKy
 gXI
 rdE
 hAr
-vFv
+vso
 iZa
 wcb
 jOD
@@ -116303,7 +117285,7 @@ xcv
 wyE
 mxD
 kHZ
-qhk
+xbg
 qLd
 qLd
 qLd
@@ -116314,7 +117296,7 @@ wyE
 qLd
 dgg
 lcu
-qhk
+xbg
 cIG
 hgp
 eEO
@@ -116414,7 +117396,7 @@ epQ
 eod
 xJV
 tQO
-cdX
+dNR
 ubV
 ngU
 jfY
@@ -116560,7 +117542,7 @@ mAM
 eQO
 duz
 axO
-xsl
+paS
 lQh
 bbF
 skX
@@ -116571,7 +117553,7 @@ nnS
 fJm
 hKP
 sGI
-dJw
+gGx
 iuW
 obP
 tNL
@@ -116603,7 +117585,7 @@ osw
 bvK
 bep
 ccP
-lSO
+oAk
 clO
 nTz
 dIc
@@ -116615,7 +117597,7 @@ bye
 bym
 xnp
 bCa
-bpr
+kih
 biL
 bFR
 vBv
@@ -116632,11 +117614,11 @@ tAr
 tZp
 jdP
 bcX
-oqO
+vUa
 qSu
 eVn
 xxa
-fqX
+jab
 mJe
 gBG
 vdn
@@ -116817,7 +117799,7 @@ sQA
 mbM
 mbM
 mbM
-vrF
+ldl
 mbM
 lVE
 sxF
@@ -116828,7 +117810,7 @@ mxD
 mbM
 mbM
 gKa
-vrF
+ldl
 dWV
 ckF
 tNL
@@ -116856,7 +117838,7 @@ bBQ
 bKZ
 bBQ
 iig
-fHM
+kPE
 eHb
 hdX
 sWe
@@ -116889,22 +117871,22 @@ nXD
 tZp
 jdP
 bcX
-oqO
+vUa
 oNo
 iFi
 cNP
-cEU
+hEW
 cUa
 daP
 atq
 lQc
 qvg
 wql
-xLH
+wTm
 rtq
 pUh
 lqv
-sSE
+bAZ
 idr
 tOF
 cLd
@@ -117062,7 +118044,7 @@ tKg
 jaM
 rYN
 mxD
-kGF
+ufH
 hph
 eYN
 xIo
@@ -117113,7 +118095,7 @@ uNW
 gDH
 kxl
 vNB
-bbk
+jYg
 gBB
 beq
 jmL
@@ -117134,7 +118116,7 @@ bFI
 bFI
 jQo
 bMX
-bOe
+bOk
 bPo
 bRY
 bXZ
@@ -117146,11 +118128,11 @@ ebs
 tZp
 dfv
 car
-vyL
+jZO
 ogq
 oHy
 mwo
-cEU
+hEW
 opu
 cwq
 cwY
@@ -117200,10 +118182,10 @@ lab
 kUp
 hdB
 rEQ
-pTs
+kNP
 xGf
 xGf
-pTs
+kNP
 aaa
 aaa
 aaa
@@ -117310,7 +118292,7 @@ aaa
 aaa
 aaa
 aaa
-rTe
+xJK
 jHc
 mnI
 saZ
@@ -117346,17 +118328,17 @@ aSm
 eRv
 oRt
 iuW
-fJd
+gaI
 mmK
 lmC
 xlJ
 hfZ
 pLD
-ldw
+xYX
 qlY
 gAx
 huV
-vHq
+xMN
 aev
 bPX
 sUU
@@ -117383,12 +118365,12 @@ bub
 bur
 bwg
 crh
-lWi
+rSU
 tdv
 xnn
 bGa
 enU
-wHz
+jCr
 vge
 tbd
 bMW
@@ -117603,13 +118585,13 @@ lZU
 wiM
 oNr
 eEO
-vdx
+kbI
 wyP
 axY
 dhZ
 ioy
 tmZ
-ojh
+sHJ
 orw
 uwW
 lAG
@@ -117640,12 +118622,12 @@ btY
 boE
 boE
 btQ
-bAj
+jse
 vdP
 bDr
 oRh
 bHD
-aUi
+uDb
 bJj
 bKX
 bMW
@@ -117714,10 +118696,10 @@ kMK
 kUp
 hdB
 rEQ
-pTs
+kNP
 xGf
 xGf
-pTs
+kNP
 aaa
 aaa
 aaa
@@ -117847,7 +118829,7 @@ dOh
 iyd
 gyR
 hCh
-wsz
+rUN
 mcs
 tQD
 pwY
@@ -118113,7 +119095,7 @@ lDa
 hSz
 hFN
 arP
-bBR
+ldN
 eEO
 oNr
 tNL
@@ -118162,7 +119144,7 @@ bFK
 bkW
 bLl
 bNd
-bYN
+eUe
 bUX
 bUX
 bUX
@@ -118179,7 +119161,7 @@ eFO
 hxd
 bNj
 mYj
-nUU
+dNG
 mYj
 uZP
 pri
@@ -118192,12 +119174,12 @@ oCZ
 cLd
 chw
 dWX
-tfD
+iTH
 nfW
 hpa
 pVQ
 uRI
-cdq
+okj
 pst
 hSf
 cWE
@@ -118419,7 +119401,7 @@ bwi
 bkW
 bac
 bNd
-wMQ
+oIw
 nFV
 ejG
 ejG
@@ -118462,7 +119444,7 @@ chy
 gfY
 cvE
 uzO
-mUv
+cCR
 mOZ
 cvE
 cvE
@@ -118902,7 +119884,7 @@ qpr
 aRp
 rNv
 rNv
-qoO
+whq
 okB
 aQp
 aRC
@@ -118911,7 +119893,7 @@ pRQ
 aXR
 skN
 tZs
-aZP
+jEF
 ioR
 pzV
 ber
@@ -118939,13 +119921,13 @@ ilU
 bWJ
 bWN
 bSd
-bWK
+sbf
 bYg
 bYg
 bNp
 ccn
 pcN
-cdW
+vYA
 bAK
 bAK
 bAK
@@ -118956,13 +119938,13 @@ coz
 bcH
 ctQ
 lTT
-sfS
+fIX
 sZI
 sZI
 rmE
 cYL
 qLo
-jDh
+qOa
 xDC
 qBb
 qBb
@@ -118975,7 +119957,7 @@ iQm
 cns
 cns
 lyp
-cNS
+pXb
 cns
 mBr
 eNY
@@ -118984,7 +119966,7 @@ cEX
 tVJ
 qqM
 kzm
-cPN
+iHX
 cRt
 sfB
 kUp
@@ -119127,7 +120109,7 @@ hfK
 vgs
 qXR
 rXz
-cux
+srN
 vYn
 aWu
 aWu
@@ -119141,7 +120123,7 @@ lDa
 hSz
 hFN
 arP
-bBR
+ldN
 eEO
 jvk
 tNL
@@ -119159,7 +120141,7 @@ pir
 fDP
 tuB
 cMl
-hqT
+lbj
 aMi
 ebf
 wXE
@@ -119168,7 +120150,7 @@ aUp
 aMi
 aKG
 aMi
-aZQ
+sHH
 gBB
 bcZ
 bes
@@ -119183,7 +120165,7 @@ bwe
 btV
 bwj
 byt
-bAg
+wLC
 vBA
 bDZ
 bFO
@@ -119191,18 +120173,18 @@ vXg
 bJq
 bay
 nxu
-iwv
+qVv
 dhm
 cwr
 bVc
 uPy
-cKR
+fYz
 nmc
 lOK
 bSZ
 cbE
 qBP
-mOc
+jOj
 jcg
 jcg
 uIA
@@ -119213,13 +120195,13 @@ niU
 aet
 xvi
 rtk
-hyD
+rkh
 tPc
 noA
 pRh
 tPc
 rQg
-pPn
+bar
 tve
 tve
 bIS
@@ -119232,7 +120214,7 @@ tve
 tve
 tve
 tEL
-cgx
+pWb
 tve
 sbG
 jPe
@@ -119241,7 +120223,7 @@ cOO
 lVz
 cvI
 tve
-cPO
+lDC
 kzH
 cRA
 cTC
@@ -119256,10 +120238,10 @@ eWU
 kUp
 hdB
 rEQ
-pTs
+kNP
 xGf
 xGf
-pTs
+kNP
 cZp
 aaa
 aaa
@@ -119384,12 +120366,12 @@ fWJ
 yiU
 wZs
 ybj
-vSZ
+vfY
 mvz
 awY
 rpQ
 rhg
-aFe
+xXn
 fes
 gqv
 uhf
@@ -119402,13 +120384,13 @@ okZ
 fht
 wYA
 pAx
-oQu
+pPM
 apP
 cCN
 ekH
 rSk
 oRx
-jYT
+aqc
 lft
 gQi
 orw
@@ -119416,7 +120398,7 @@ orw
 orw
 aqz
 kii
-nWR
+lAT
 raL
 soY
 hSc
@@ -119425,7 +120407,7 @@ aUq
 aNt
 wST
 aNt
-aZR
+pyi
 bbs
 dEM
 tyF
@@ -119453,13 +120435,13 @@ bQr
 bSd
 bSd
 bWJ
-hgu
+kcF
 bYg
 bYg
 tZp
 cco
 bcX
-cPD
+gAS
 cgy
 cgy
 cgy
@@ -119470,13 +120452,13 @@ jqB
 jma
 cPI
 crI
-csT
+bFY
 deF
 cyM
 cuc
 cyM
 rfD
-mPh
+hoE
 bIH
 cIt
 sxv
@@ -119489,7 +120471,7 @@ cIt
 bIH
 lHZ
 khl
-bAt
+tWQ
 mGK
 mLx
 vwU
@@ -119498,7 +120480,7 @@ cxl
 oSr
 xkB
 pya
-uMi
+iQe
 gLx
 fyO
 cTV
@@ -119773,7 +120755,7 @@ jYM
 auX
 lFN
 lHR
-edD
+gfL
 aaa
 aaa
 aaa
@@ -119961,7 +120943,7 @@ wsw
 bkW
 bJs
 bNd
-bxp
+vXK
 bQp
 bUX
 adP
@@ -120176,10 +121158,10 @@ fRm
 cIG
 pRp
 eEO
-mLA
+lOF
 eEO
 xVR
-uRM
+tlQ
 orw
 cZB
 orw
@@ -120218,7 +121200,7 @@ bFS
 bkW
 bJt
 bNd
-wMQ
+oIw
 ejG
 lna
 eQf
@@ -120236,7 +121218,7 @@ wyJ
 axy
 gkF
 wyJ
-cHQ
+jOT
 xkf
 pXO
 bGS
@@ -120426,17 +121408,17 @@ eEO
 cIG
 efx
 pRp
-lcT
+srk
 hYR
 jQP
 eEO
 eEO
 daH
 hLu
-uUr
+kYk
 hLu
 gRU
-qhC
+iGD
 dbJ
 mjh
 qAR
@@ -120493,13 +121475,13 @@ wyJ
 iFm
 gkF
 ckZ
-mic
+sgq
 cnw
 osq
 kEz
 iNe
 und
-lkH
+grL
 bAk
 oNl
 cic
@@ -120507,7 +121489,7 @@ cJp
 ndR
 kbk
 uxR
-smj
+hMF
 gVS
 ihd
 eBu
@@ -120670,7 +121652,7 @@ abq
 amx
 tnJ
 gYT
-upn
+xeJ
 tsO
 gam
 xVV
@@ -120683,7 +121665,7 @@ rXw
 rXw
 iKM
 rPD
-mWr
+izN
 rXw
 eSS
 ejR
@@ -120724,12 +121706,12 @@ bum
 boE
 boE
 sLs
-bAj
+jse
 bCA
 bEf
 byQ
 bFT
-aUi
+uDb
 bJv
 bLh
 bZl
@@ -120744,7 +121726,7 @@ aZJ
 caR
 fSz
 cee
-pHY
+mTZ
 wyJ
 wyJ
 iFm
@@ -120774,7 +121756,7 @@ fqi
 uEX
 cWF
 cWF
-glB
+sWF
 qFO
 pVr
 ogI
@@ -120940,14 +121922,14 @@ kRP
 kRP
 spF
 eZe
-fwO
+jqZ
 kRP
 kRP
 kRP
 dWV
 mJf
 wVS
-asa
+iwQ
 lgU
 uCW
 jcU
@@ -120963,7 +121945,7 @@ aOO
 bfr
 aSy
 qnu
-aUs
+lsl
 aAM
 aXd
 cAB
@@ -120981,12 +121963,12 @@ buE
 bvr
 cbY
 bWy
-tUH
+qSA
 rOG
 bEg
 rOG
 iIA
-wUE
+ajV
 hDx
 bLg
 bZl
@@ -121001,7 +121983,7 @@ wxb
 bcX
 cbG
 ceh
-tDr
+edt
 cfv
 mHn
 bUR
@@ -121038,7 +122020,7 @@ oAs
 oAs
 cOB
 cOB
-lnv
+bOH
 lTS
 dmi
 dLC
@@ -121482,7 +122464,7 @@ aVE
 xxA
 aZV
 aZV
-aXb
+jSL
 rEF
 beu
 rZk
@@ -121503,7 +122485,7 @@ bFV
 qgk
 bJw
 pUr
-oOu
+nbk
 bQe
 bRw
 bQn
@@ -121556,7 +122538,7 @@ cOp
 jXi
 jKP
 vbe
-jGm
+sNT
 bsM
 cSY
 lYB
@@ -121757,7 +122739,7 @@ bAm
 bHz
 bEj
 bHz
-uuE
+sGo
 rNN
 bLg
 cSJ
@@ -121798,7 +122780,7 @@ jKZ
 gDE
 jKZ
 jFa
-qyW
+sHM
 kfx
 jKZ
 jKZ
@@ -121985,7 +122967,7 @@ abZ
 abZ
 lcn
 lAE
-aMm
+uRP
 aNC
 aOS
 aOQ
@@ -122048,14 +123030,14 @@ cwR
 cwR
 cwR
 cxO
-cBP
+fRQ
 fWN
 cwR
 cwR
 cwR
 cwR
 cxO
-cBP
+fRQ
 clb
 cwR
 cwR
@@ -122239,7 +123221,7 @@ cIG
 cIG
 efx
 wdq
-ktn
+uhE
 lAE
 baL
 aMk
@@ -122305,14 +123287,14 @@ cwR
 cwR
 cwR
 cxO
-cBP
+fRQ
 fWN
 cwR
 cwR
 cwR
 cwR
 nli
-cBP
+fRQ
 clb
 cwR
 cwR
@@ -122496,10 +123478,10 @@ azr
 kcN
 sYU
 cna
-ktn
+uhE
 lAE
 lAE
-oxT
+cht
 etj
 kyo
 adA
@@ -122520,7 +123502,7 @@ rtY
 blc
 bsH
 bqq
-bsj
+eOV
 bug
 bwu
 eIj
@@ -122532,7 +123514,7 @@ qgk
 bMG
 bOY
 bOY
-ccm
+exl
 ihN
 bRP
 bTE
@@ -122562,14 +123544,14 @@ gBS
 cOZ
 cOZ
 dUd
-pAU
+wWn
 nkU
 gTS
 oic
 bef
 iKk
 uSJ
-dYb
+rxb
 lEw
 iNO
 mai
@@ -122767,7 +123749,7 @@ aQC
 ilf
 aTo
 aTo
-bby
+tbm
 rEF
 aMK
 bjD
@@ -122812,7 +123794,7 @@ jDj
 fNQ
 uHp
 cut
-soO
+xCn
 nry
 cwR
 cxP
@@ -123019,12 +124001,12 @@ khI
 aNG
 aVK
 ncG
-avd
+bpF
 aVJ
 rnv
 aRX
 aRX
-bbz
+hGN
 fEr
 trF
 bfW
@@ -123299,7 +124281,7 @@ cIj
 xFf
 cdO
 cPt
-bHK
+skC
 bJC
 bLg
 pmN
@@ -123571,7 +124553,7 @@ bZn
 xki
 jAV
 bqR
-cek
+qlv
 bHE
 bwP
 bHE
@@ -123758,7 +124740,7 @@ cLM
 vun
 bxN
 whf
-oga
+sZq
 mxw
 wzx
 alW
@@ -123800,13 +124782,13 @@ rEF
 pCy
 wkn
 bwl
-uSx
+sgR
 eNa
 wBR
 gCA
 aUM
 bvs
-wVL
+qwR
 mdE
 byF
 ofu
@@ -123817,7 +124799,7 @@ bHL
 bcN
 byg
 cfr
-bQF
+vAk
 hYs
 bSW
 bTW
@@ -123862,7 +124844,7 @@ tug
 cOp
 fEZ
 twE
-wxV
+kBw
 hns
 vir
 fNw
@@ -124043,7 +125025,7 @@ aCr
 qyI
 nbg
 aCr
-bVi
+kZQ
 uex
 aOU
 aTm
@@ -124057,13 +125039,13 @@ bdi
 bex
 qvE
 beo
-etn
+era
 dnj
 bnb
 qRA
 bqu
 qif
-dFf
+hFg
 hlD
 xpC
 wFq
@@ -124074,7 +125056,7 @@ bHM
 bJF
 bLt
 bOV
-jIR
+qgs
 bfI
 hBq
 bfI
@@ -124285,7 +125267,7 @@ kVN
 aAf
 wVD
 nYs
-cNe
+fKb
 gHm
 yeY
 opB
@@ -124314,13 +125296,13 @@ rEF
 bey
 bgd
 oWL
-qmI
+uMM
 kaK
 blg
 blk
 jyq
 deD
-dwp
+mvN
 wgh
 nVp
 pUF
@@ -124331,7 +125313,7 @@ wgh
 wgh
 wgh
 wgh
-bwS
+dVU
 bpI
 lsQ
 kwt
@@ -124342,7 +125324,7 @@ caF
 sQh
 cbK
 ccW
-chO
+vdV
 cfA
 dCx
 ggQ
@@ -124382,7 +125364,7 @@ dGk
 lJP
 dag
 qBO
-eQi
+pAQ
 xGo
 mxp
 geC
@@ -124639,7 +125621,7 @@ fVL
 fVL
 ejr
 ekF
-dpM
+uRb
 vNL
 fxt
 yab
@@ -124843,7 +125825,7 @@ bID
 bID
 xpF
 tmt
-jQx
+wgH
 hLX
 bQC
 tEq
@@ -124879,17 +125861,17 @@ mDX
 dnN
 cwR
 dAy
-gtJ
+iGA
 wkq
 lmq
 wuJ
 efs
 cxd
-mVD
+hMu
 pyh
 gVk
 fqz
-cIf
+wNM
 bjo
 cvw
 uJQ
@@ -125079,7 +126061,7 @@ aUy
 jJc
 aRX
 tEw
-bsq
+jTZ
 bfp
 dqw
 bsm
@@ -125100,7 +126082,7 @@ bEv
 bAv
 udl
 bHO
-orV
+mLm
 nic
 nic
 nic
@@ -125114,7 +126096,7 @@ cbD
 vAb
 ccZ
 kpx
-cfC
+bKA
 hvL
 cbL
 kCk
@@ -125322,7 +126304,7 @@ ajg
 awM
 dHU
 fpy
-aFy
+xDP
 aAJ
 aAJ
 oEt
@@ -125343,7 +126325,7 @@ bsm
 bgg
 bhC
 bjr
-aOD
+sIx
 vEp
 qeW
 bqA
@@ -125357,7 +126339,7 @@ bEv
 sTF
 mBe
 bHO
-jQx
+wgH
 nic
 oXP
 dnI
@@ -125389,7 +126371,7 @@ aZr
 nlS
 kLJ
 gTL
-dRX
+oPN
 hKb
 cwR
 xdT
@@ -125614,7 +126596,7 @@ bEv
 omK
 udl
 bHO
-doE
+aov
 nic
 bQJ
 aRy
@@ -125842,7 +126824,7 @@ tay
 tay
 tay
 gpT
-aJA
+epz
 aQI
 aBO
 aTt
@@ -125861,7 +126843,7 @@ hDH
 bnh
 iTo
 uMR
-bIE
+uWJ
 bGi
 bEv
 byK
@@ -125871,7 +126853,7 @@ qFs
 qFs
 bGd
 bHO
-eNT
+pZK
 nic
 edB
 vpw
@@ -125893,7 +126875,7 @@ csg
 nqo
 vlF
 uhJ
-pwj
+jTn
 sBZ
 hty
 cmB
@@ -125937,7 +126919,7 @@ mJt
 dPk
 oWK
 eSA
-fBK
+rIn
 voE
 chY
 jwh
@@ -126118,7 +127100,7 @@ bbH
 bni
 dnS
 wwo
-uUI
+twk
 sqp
 kWp
 bwC
@@ -126128,7 +127110,7 @@ uel
 bEv
 udl
 bHO
-bLA
+rdU
 nic
 pWX
 gXg
@@ -126385,7 +127367,7 @@ bvz
 bEv
 xLw
 uhV
-lBQ
+pEY
 fjy
 wxY
 uOM
@@ -126628,7 +127610,7 @@ con
 udr
 rrz
 bjB
-blm
+qJX
 oLw
 igE
 bqA
@@ -126843,7 +127825,7 @@ ofK
 fzj
 kFo
 lJM
-eFY
+tzb
 ttU
 mFB
 nDu
@@ -126869,7 +127851,7 @@ aIk
 llW
 aLd
 aMt
-aGM
+sBp
 aQC
 aQJ
 aQC
@@ -127169,7 +128151,7 @@ bYA
 cbt
 bYA
 ixf
-dgn
+cvC
 cwG
 ipj
 cwG
@@ -127185,10 +128167,10 @@ dct
 cmB
 cbf
 cyS
-cBS
+mHT
 gBa
 mdH
-sCr
+apS
 kDU
 cwR
 opd
@@ -127383,7 +128365,7 @@ aIp
 lnP
 mLn
 aQW
-pzX
+cDx
 viz
 nkh
 aRY
@@ -127392,7 +128374,7 @@ aUC
 aTo
 aYK
 aYK
-aVc
+vFG
 eYs
 bbH
 bjx
@@ -127463,7 +128445,7 @@ lTB
 uhc
 emj
 bME
-qfd
+fnK
 qEh
 wAf
 bdN
@@ -127717,7 +128699,7 @@ gxn
 pyU
 jun
 jFz
-xpP
+diw
 nSc
 coB
 cPc
@@ -127883,7 +128865,7 @@ apW
 arm
 skq
 vUY
-aBy
+nnk
 aJB
 awR
 azZ
@@ -127949,7 +128931,7 @@ cte
 cte
 cAP
 hMS
-tiN
+rCP
 uKc
 ipj
 lPm
@@ -127963,7 +128945,7 @@ cte
 pwP
 cFc
 eMh
-oCU
+xnV
 lLx
 qEh
 emj
@@ -128123,13 +129105,13 @@ aaa
 agk
 bCD
 lkK
-kkw
+laO
 rpy
-qid
+jvv
 sYw
 lPp
 lPp
-fDC
+sfe
 uNZ
 cXD
 ald
@@ -128216,7 +129198,7 @@ cwd
 yih
 cwd
 dhG
-piX
+vfA
 aOx
 cup
 qJN
@@ -128397,7 +129379,7 @@ apW
 aro
 mKy
 atT
-aCe
+vsL
 oQz
 aRt
 lqY
@@ -128493,7 +129475,7 @@ qaW
 iKT
 bME
 emj
-voe
+qRy
 gaZ
 jzw
 pSZ
@@ -128692,7 +129674,7 @@ bsp
 hvW
 azy
 aLC
-nwQ
+lwe
 toH
 gry
 skr
@@ -128925,7 +129907,7 @@ aBZ
 fAs
 aLi
 dAH
-aVc
+vFG
 aKZ
 wCm
 aSc
@@ -128961,7 +129943,7 @@ oqf
 vPk
 wnc
 pZd
-bVA
+xcy
 ces
 wgT
 ces
@@ -129223,7 +130205,7 @@ ces
 nac
 yhT
 nAq
-pHM
+fOA
 xQm
 lJt
 aoG
@@ -129248,7 +130230,7 @@ mUl
 wOZ
 tGP
 cPf
-pTL
+ibM
 nTp
 sXs
 bnB
@@ -129258,7 +130240,7 @@ bdN
 lEN
 oUf
 ifq
-nyp
+haY
 vQo
 dSx
 cQW
@@ -129702,7 +130684,7 @@ wAw
 swh
 kMd
 xNo
-mNp
+eFK
 mYe
 tKB
 hjU
@@ -129723,7 +130705,7 @@ iGZ
 xbW
 eMC
 pAP
-pQS
+xZH
 czK
 czK
 czK
@@ -129747,7 +130729,7 @@ gYF
 aoG
 bXC
 cFB
-pvr
+axC
 cwG
 ePK
 vGR
@@ -129775,7 +130757,7 @@ wnx
 usE
 cln
 csn
-dUv
+iqu
 cZA
 ddD
 bWl
@@ -129953,7 +130935,7 @@ tKB
 sSY
 eRa
 vIj
-nzU
+gbu
 xti
 vtt
 tbL
@@ -129969,11 +130951,11 @@ beG
 rlx
 qfs
 rlx
-blq
+sXX
 iHk
 xfn
 igm
-tKV
+oon
 gpX
 gpX
 tGS
@@ -130200,7 +131182,7 @@ iAS
 cxr
 skd
 ugX
-xef
+vCL
 kOE
 oia
 gWT
@@ -130747,7 +131729,7 @@ bqx
 aoG
 aMh
 pVi
-pJt
+fZo
 cOJ
 seF
 fDI
@@ -130796,7 +131778,7 @@ cNz
 qNS
 yar
 cNz
-fbi
+qBZ
 qEh
 emj
 kIH
@@ -131465,7 +132447,7 @@ nIj
 eQS
 dZx
 gPk
-jDv
+iqk
 lJT
 jdl
 gNO
@@ -131539,7 +132521,7 @@ aoG
 xxP
 fxC
 rkc
-xrl
+klm
 rRk
 sJr
 jDS
@@ -131729,12 +132711,12 @@ pqe
 xER
 fzK
 spJ
-jhk
+tRM
 alk
 bvL
 lPI
 aoF
-iAx
+wLG
 qIT
 nbD
 dAH
@@ -131778,7 +132760,7 @@ cmR
 chi
 hTD
 flH
-gRq
+sZh
 rJa
 fLx
 fUl
@@ -131803,9 +132785,9 @@ cjB
 rQt
 qlS
 cmM
-dmg
+ofA
 cqP
-lee
+jSv
 cuQ
 cwB
 bYh
@@ -132019,7 +133001,7 @@ nzO
 aXy
 aYY
 baU
-bdD
+nLT
 bhf
 beN
 bjG
@@ -132035,7 +133017,7 @@ jdK
 pig
 pig
 vbB
-aCo
+dkF
 uTa
 lsk
 uIq
@@ -132049,7 +133031,7 @@ avC
 nXk
 aub
 mlq
-agR
+wVs
 odL
 hvE
 cLr
@@ -132767,7 +133749,7 @@ aou
 qLX
 kzO
 fwl
-kZt
+hBJ
 oTw
 pfI
 cxr
@@ -132790,12 +133772,12 @@ eTX
 tdz
 baw
 aPp
-bmh
+eCl
 aPp
 bik
 bkw
 aPp
-bmh
+eCl
 bof
 kVO
 dOA
@@ -133064,7 +134046,7 @@ rGJ
 ejC
 mnX
 scF
-cdQ
+dLD
 chR
 bSQ
 uxi
@@ -133794,11 +134776,11 @@ edy
 eTp
 xfw
 uTV
-kYO
+cNE
 iWa
 ixV
 qvv
-aDb
+drg
 aGC
 ajO
 aGC
@@ -133823,7 +134805,7 @@ jvf
 xCb
 lCQ
 xCv
-gsQ
+fhA
 kEv
 kEv
 mDR
@@ -134304,7 +135286,7 @@ ank
 ank
 aqh
 ccM
-lFO
+sNq
 avV
 asQ
 kpT
@@ -134353,7 +135335,7 @@ bHb
 bHb
 bGK
 rao
-aVi
+brL
 kYQ
 fmi
 oje
@@ -134848,7 +135830,7 @@ fkk
 egm
 cFo
 hFO
-eTy
+cmr
 hfb
 nmh
 tpi
@@ -135102,7 +136084,7 @@ dyX
 imD
 tvk
 ccu
-jTD
+hSD
 iEX
 bza
 egm
@@ -135124,7 +136106,7 @@ aXJ
 fQQ
 fQQ
 pCg
-ulq
+gNu
 ofm
 fWW
 hkC
@@ -135413,7 +136395,7 @@ quL
 nyv
 vHf
 oxc
-lhZ
+rrm
 buu
 lKz
 qmm
@@ -135427,7 +136409,7 @@ pOV
 nNh
 myf
 kba
-hXd
+wWA
 wnY
 mjv
 aQE
@@ -135598,11 +136580,11 @@ fuX
 ois
 iPE
 iPE
-ipo
+hKT
 aDi
 gHz
 ntU
-wky
+uRR
 rfp
 mNw
 riC
@@ -135626,7 +136608,7 @@ nHB
 bpn
 mWL
 wiX
-uRN
+svG
 bsI
 klz
 bly
@@ -135850,7 +136832,7 @@ arC
 atV
 auk
 pCQ
-sVB
+fxi
 gxm
 rit
 cQr
@@ -136130,7 +137112,7 @@ bBF
 dzY
 rab
 rab
-pRl
+qBn
 skv
 jUF
 fnu
@@ -136186,7 +137168,7 @@ eUC
 eqj
 ivR
 mdi
-uXf
+utv
 cEd
 cXU
 qyo
@@ -136196,7 +137178,7 @@ bxi
 erC
 iUe
 ukL
-exR
+uaV
 mdi
 ivR
 jOA
@@ -136630,7 +137612,7 @@ enp
 bJW
 fmP
 aFY
-aOa
+qFk
 knc
 dXb
 muJ
@@ -137136,7 +138118,7 @@ qFA
 lIo
 pLF
 mhE
-shb
+bLC
 vDE
 nlt
 enp
@@ -137214,7 +138196,7 @@ eUC
 eqj
 ivR
 mdi
-vvr
+sKT
 fin
 czM
 czM
@@ -137224,7 +138206,7 @@ gTt
 vQz
 vQz
 iOU
-dRU
+uAs
 mdi
 ivR
 jOA
@@ -138228,7 +139210,7 @@ qbf
 qbf
 qbf
 qbf
-xkR
+kXY
 cqU
 cqU
 cqU
@@ -138420,7 +139402,7 @@ iLV
 uJG
 nOH
 uoX
-rag
+pyu
 qfm
 uZx
 nlt
@@ -146675,16 +147657,16 @@ bdI
 boH
 bqZ
 brI
-iHo
+gyI
 pUc
 bva
 bze
 bDa
-aIP
+ogl
 bDe
 bKn
 bDe
-pQq
+ave
 bRs
 fZV
 hxv

--- a/_maps/map_files/stations/submaps/boxstation.dmm
+++ b/_maps/map_files/stations/submaps/boxstation.dmm
@@ -124,6 +124,22 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"db" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/obj/machinery/door/airlock/engineering/glass{
+	autoclose = 0;
+	id_tag = "engsm_door_int";
+	locked = 1;
+	name = "Supermatter Interior Access";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/control)
 "de" = (
 /obj/effect/turf_decal/trimline/misc/toxins/filled/shrink_cw{
 	dir = 4
@@ -135,14 +151,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
-"dh" = (
-/obj/machinery/door/airlock/engineering/glass{
-	heat_proof = 1;
-	name = "Supermatter Chamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/turf/simulated/floor/engine,
-/area/station/engineering/engine/supermatter)
 "du" = (
 /obj/machinery/light{
 	dir = 8
@@ -168,21 +176,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/station/engineering/control)
-"dI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
-/obj/machinery/door/airlock/engineering/glass{
-	autoclose = 0;
-	id_tag = "engsm_door_int";
-	locked = 1;
-	name = "Supermatter Interior Access"
-	},
-/turf/simulated/floor/plasteel/dark,
 /area/station/engineering/control)
 "dJ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -220,17 +213,18 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
-"eT" = (
+"fa" = (
+/obj/machinery/door/airlock/engineering/glass{
+	heat_proof = 1;
+	name = "Supermatter Chamber";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Laser Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/engine,
-/area/station/engineering/control)
+/area/station/engineering/engine/supermatter)
 "fb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -473,6 +467,20 @@
 	network = list("SS13","Engineering")
 	},
 /turf/simulated/floor/engine,
+/area/station/engineering/control)
+"hQ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	autoclose = 0;
+	id_tag = "engsm_door_int";
+	locked = 1;
+	name = "Supermatter Interior Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/turf/simulated/floor/plasteel/dark,
 /area/station/engineering/control)
 "hV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -953,6 +961,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
+"or" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Laser Room";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/engine,
+/area/station/engineering/control)
 "ox" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1020,6 +1040,17 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"oS" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/obj/machinery/door/airlock/engineering/glass{
+	autoclose = 0;
+	id_tag = "engsm_door_ext";
+	locked = 1;
+	name = "Supermatter Exterior Access";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/control)
 "pi" = (
 /obj/structure/rack{
 	dir = 1
@@ -1051,16 +1082,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
-"pJ" = (
-/obj/machinery/door/airlock/engineering/glass{
-	autoclose = 0;
-	id_tag = "engsm_door_int";
-	locked = 1;
-	name = "Reactor Interior Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/control)
 "pK" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/delivery/hollow,
@@ -1070,6 +1091,17 @@
 /obj/effect/spawner/window/reinforced/plasma/grilled,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine/reactor)
+"pS" = (
+/obj/machinery/door/airlock/engineering/glass{
+	autoclose = 0;
+	id_tag = "engsm_door_int";
+	locked = 1;
+	name = "Reactor Interior Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/control)
 "qe" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -1084,21 +1116,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
-"qq" = (
-/obj/machinery/door/airlock/engineering/glass{
-	autoclose = 0;
-	id_tag = "engsm_door_ext";
-	locked = 1;
-	name = "Reactor Exterior Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/control)
 "qu" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/line{
@@ -1169,16 +1186,6 @@
 /obj/structure/closet/crate/can,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/engine/reactor)
-"rB" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Fabrication"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/control)
 "rE" = (
 /obj/machinery/atmospherics/unary/reactor_gas_node{
 	dir = 1
@@ -1319,16 +1326,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
-"tF" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
-/obj/machinery/door/airlock/engineering/glass{
-	autoclose = 0;
-	id_tag = "engsm_door_ext";
-	locked = 1;
-	name = "Reactor Exterior Access"
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/control)
 "tI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -1348,19 +1345,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
-"tP" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/engineering/glass{
-	autoclose = 0;
-	id_tag = "engsm_door_int";
-	locked = 1;
-	name = "Supermatter Interior Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/control)
 "tR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1377,6 +1361,17 @@
 	filter_type = 2
 	},
 /turf/simulated/floor/engine,
+/area/station/engineering/control)
+"uf" = (
+/obj/machinery/door/airlock/engineering/glass{
+	autoclose = 0;
+	id_tag = "engsm_door_int";
+	locked = 1;
+	name = "Supermatter Interior Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/turf/simulated/floor/plasteel/dark,
 /area/station/engineering/control)
 "up" = (
 /obj/structure/table/reinforced,
@@ -1467,21 +1462,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/station/engineering/control)
-"vJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
-/obj/machinery/door/airlock/engineering/glass{
-	autoclose = 0;
-	id_tag = "engsm_door_int";
-	locked = 1;
-	name = "Reactor Interior Access"
-	},
-/turf/simulated/floor/plasteel/dark,
 /area/station/engineering/control)
 "vL" = (
 /obj/machinery/access_button{
@@ -1579,27 +1559,6 @@
 /obj/structure/reflector/single{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/control)
-"xr" = (
-/obj/machinery/door/airlock/engineering/glass{
-	heat_proof = 1;
-	name = "Supermatter Chamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/engine/supermatter)
-"xy" = (
-/obj/machinery/door/airlock/engineering/glass{
-	autoclose = 0;
-	id_tag = "engsm_door_int";
-	locked = 1;
-	name = "Supermatter Interior Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/control)
 "xE" = (
@@ -2039,6 +1998,18 @@
 /obj/machinery/light,
 /turf/simulated/floor/plasteel/reactor_pool,
 /area/station/engineering/engine/reactor)
+"Ce" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Laser Room";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/engine,
+/area/station/engineering/control)
 "CA" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/caution{
@@ -2148,16 +2119,6 @@
 /obj/machinery/alarm/directional/west,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
-"EK" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
-/obj/machinery/door/airlock/engineering/glass{
-	autoclose = 0;
-	id_tag = "engsm_door_ext";
-	locked = 1;
-	name = "Supermatter Exterior Access"
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/control)
 "EM" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/delivery/hollow,
@@ -2272,21 +2233,6 @@
 /obj/machinery/alarm/engine/directional/east,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/supermatter)
-"GH" = (
-/obj/machinery/door/airlock/engineering/glass{
-	autoclose = 0;
-	id_tag = "engsm_door_ext";
-	locked = 1;
-	name = "Supermatter Exterior Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/control)
 "GM" = (
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
@@ -2504,6 +2450,17 @@
 /obj/machinery/atmospherics/supermatter_crystal,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/supermatter)
+"KP" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Fabrication";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/control)
 "Lc" = (
 /obj/structure/girder,
 /turf/simulated/floor/plasteel/dark,
@@ -2651,17 +2608,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
-"Ns" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Laser Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/engine,
-/area/station/engineering/control)
 "NM" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
@@ -2799,6 +2745,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"OL" = (
+/obj/machinery/door/airlock/engineering/glass{
+	autoclose = 0;
+	id_tag = "engsm_door_ext";
+	locked = 1;
+	name = "Reactor Exterior Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/control)
 "OV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -3211,6 +3173,17 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/control)
+"UM" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/obj/machinery/door/airlock/engineering/glass{
+	autoclose = 0;
+	id_tag = "engsm_door_ext";
+	locked = 1;
+	name = "Reactor Exterior Access";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/control)
 "UO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 5
@@ -3254,6 +3227,15 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
+"Vr" = (
+/obj/machinery/door/airlock/engineering/glass{
+	heat_proof = 1;
+	name = "Supermatter Chamber";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/turf/simulated/floor/engine,
+/area/station/engineering/engine/supermatter)
 "Vv" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -3339,6 +3321,22 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine,
+/area/station/engineering/control)
+"WF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/obj/machinery/door/airlock/engineering/glass{
+	autoclose = 0;
+	id_tag = "engsm_door_int";
+	locked = 1;
+	name = "Reactor Interior Access";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
 /area/station/engineering/control)
 "WG" = (
 /obj/effect/turf_decal/trimline/misc/toxins/line{
@@ -3503,6 +3501,22 @@
 	dir = 5
 	},
 /turf/simulated/floor/engine,
+/area/station/engineering/control)
+"Yr" = (
+/obj/machinery/door/airlock/engineering/glass{
+	autoclose = 0;
+	id_tag = "engsm_door_ext";
+	locked = 1;
+	name = "Supermatter Exterior Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
 /area/station/engineering/control)
 "Yu" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
@@ -3848,7 +3862,7 @@ SJ
 ld
 bH
 aN
-rB
+KP
 Tk
 MY
 VN
@@ -4208,10 +4222,10 @@ TJ
 TJ
 TJ
 TJ
-tF
+UM
 Ti
 CA
-pJ
+pS
 fq
 lU
 tk
@@ -4312,10 +4326,10 @@ TJ
 TJ
 TJ
 TJ
-qq
+OL
 vA
 fs
-vJ
+WF
 kn
 CY
 zf
@@ -5043,7 +5057,7 @@ TJ
 SJ
 TQ
 oz
-tP
+hQ
 Xu
 Oe
 iI
@@ -5109,7 +5123,7 @@ YG
 ju
 Qb
 mQ
-eT
+Ce
 cs
 NW
 QI
@@ -5307,9 +5321,9 @@ Qv
 Tp
 mg
 Px
-xr
+fa
 Zn
-dh
+Vr
 BS
 KO
 BS
@@ -5404,10 +5418,10 @@ TJ
 TJ
 TJ
 TJ
-EK
+oS
 Ti
 oo
-xy
+uf
 ft
 zZ
 IP
@@ -5508,10 +5522,10 @@ TJ
 TJ
 TJ
 TJ
-GH
+Yr
 vA
 SL
-dI
+db
 zB
 RL
 Dc
@@ -5525,7 +5539,7 @@ YG
 Wq
 Rr
 FO
-Ns
+or
 yX
 Mt
 hC

--- a/_maps/map_files/stations/submaps/cerestation.dmm
+++ b/_maps/map_files/stations/submaps/cerestation.dmm
@@ -50,6 +50,14 @@
 /obj/machinery/chem_master,
 /turf/simulated/floor/plasteel/freezer,
 /area/station/hallway/spacebridge/scidock)
+"dY" = (
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/maintcentral)
 "fh" = (
 /turf/simulated/mineral/ancient,
 /area/station/hallway/spacebridge/scidock)
@@ -64,15 +72,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
+"gw" = (
+/obj/machinery/door/airlock/research{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/tracks/mapped,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plasteel/freezer,
+/area/station/hallway/spacebridge/scidock)
 "ho" = (
 /turf/simulated/floor/plasteel/white,
-/area/station/hallway/spacebridge/scidock)
-"hA" = (
-/obj/machinery/door/airlock/glass,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
 /area/station/hallway/spacebridge/scidock)
 "ie" = (
 /obj/structure/falsewall,
@@ -81,23 +90,10 @@
 "iv" = (
 /turf/simulated/floor/plasteel/freezer,
 /area/station/hallway/spacebridge/scidock)
-"kV" = (
-/obj/machinery/door/airlock/glass,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/maintcentral)
 "ld" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
-"ly" = (
-/obj/machinery/door/airlock/glass,
-/obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/station/hallway/spacebridge/scidock)
 "mL" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/glass/beaker/drugs,
@@ -137,6 +133,16 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
+"ol" = (
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/station/hallway/spacebridge/scidock)
 "pk" = (
 /obj/machinery/floodlight{
 	light_power = 1
@@ -150,6 +156,13 @@
 /area/mine/unexplored/cere/engineering)
 "rd" = (
 /turf/simulated/wall,
+/area/station/hallway/spacebridge/scidock)
+"sa" = (
+/obj/machinery/door/airlock/research{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plasteel/white,
 /area/station/hallway/spacebridge/scidock)
 "tZ" = (
 /obj/machinery/chem_heater,
@@ -182,12 +195,29 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/hallway/spacebridge/scidock)
+"vN" = (
+/obj/machinery/door/airlock/research{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plasteel/freezer,
+/area/station/hallway/spacebridge/scidock)
 "vW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tiles/department/science/corner{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel/white,
+/area/station/hallway/spacebridge/scidock)
+"wh" = (
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
 /area/station/hallway/spacebridge/scidock)
 "wy" = (
 /turf/simulated/wall,
@@ -207,18 +237,13 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plasteel/white,
 /area/station/hallway/spacebridge/scidock)
-"zC" = (
-/obj/machinery/door/airlock/glass,
-/obj/structure/fans/tiny,
+"BJ" = (
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
-"Af" = (
-/obj/machinery/door/airlock/research,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plasteel/freezer,
-/area/station/hallway/spacebridge/scidock)
 "BP" = (
 /obj/structure/machine_frame,
 /turf/simulated/floor/plating{
@@ -303,11 +328,6 @@
 "KO" = (
 /obj/structure/machine_frame,
 /turf/simulated/floor/plasteel/freezer,
-/area/station/hallway/spacebridge/scidock)
-"Ms" = (
-/obj/machinery/door/airlock/research,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plasteel/white,
 /area/station/hallway/spacebridge/scidock)
 "Pe" = (
 /obj/structure/table/reinforced,
@@ -440,12 +460,6 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel/freezer,
-/area/station/hallway/spacebridge/scidock)
-"VM" = (
-/obj/machinery/door/airlock/research,
-/obj/effect/decal/cleanable/blood/tracks/mapped,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/simulated/floor/plasteel/freezer,
 /area/station/hallway/spacebridge/scidock)
 "WL" = (
@@ -736,17 +750,17 @@ ET
 ET
 ET
 ET
-zC
+dY
 fQ
 Xf
 ld
-kV
+BJ
 Vo
 Vb
-hA
+wh
 Id
 YQ
-ly
+ol
 Id
 Kf
 Id
@@ -1224,7 +1238,7 @@ Tg
 dO
 mL
 VG
-VM
+gw
 ET
 ET
 ET
@@ -1360,21 +1374,21 @@ ET
 ET
 ET
 ET
-zC
+dY
 fQ
 Xf
 ld
 ie
 dL
 Fg
-Ms
+sa
 cM
 vx
 dA
 ho
 yu
 nC
-Af
+vN
 iv
 Fb
 Pe

--- a/_maps/map_files/templates/biodome_beach.dmm
+++ b/_maps/map_files/templates/biodome_beach.dmm
@@ -134,13 +134,6 @@
 /obj/machinery/disco/immobile,
 /turf/simulated/floor/light,
 /area/ruin/powered/beach)
-"ay" = (
-/obj/machinery/door/airlock/sandstone{
-	name = "Restroom"
-	},
-/obj/effect/turf_decal/sand,
-/turf/simulated/floor/plating,
-/area/ruin/powered/beach)
 "az" = (
 /obj/item/clothing/neck/necklace/dope,
 /obj/item/reagent_containers/spray/spraytan,
@@ -205,13 +198,6 @@
 "aQ" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/wood,
-/area/ruin/powered/beach)
-"aR" = (
-/obj/machinery/door/airlock/sandstone{
-	name = "Bar"
-	},
-/obj/effect/turf_decal/sand,
-/turf/simulated/floor/plating,
 /area/ruin/powered/beach)
 "aU" = (
 /obj/effect/overlay/palmtree_l,
@@ -407,6 +393,14 @@
 /obj/item/clothing/mask/gas,
 /turf/simulated/floor/pod,
 /area/ruin/powered/beach)
+"fO" = (
+/obj/machinery/door/airlock/sandstone{
+	name = "Restroom";
+	dir = 4
+	},
+/obj/effect/turf_decal/sand,
+/turf/simulated/floor/plating,
+/area/ruin/powered/beach)
 "gg" = (
 /obj/effect/turf_decal/sand,
 /turf/simulated/floor/pod/dark,
@@ -509,6 +503,14 @@
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/wood,
+/area/ruin/powered/beach)
+"Kv" = (
+/obj/machinery/door/airlock/sandstone{
+	name = "Bar";
+	dir = 4
+	},
+/obj/effect/turf_decal/sand,
+/turf/simulated/floor/plating,
 /area/ruin/powered/beach)
 "Pl" = (
 /obj/effect/turf_decal/sand/plating,
@@ -911,7 +913,7 @@ aC
 aC
 aC
 aC
-aR
+Kv
 aK
 Pl
 bE
@@ -1007,7 +1009,7 @@ aC
 aC
 aC
 aC
-aR
+Kv
 aK
 bE
 bE
@@ -1196,7 +1198,7 @@ aa
 bW
 ao
 ar
-ay
+fO
 bE
 bE
 bE

--- a/_maps/map_files/templates/shelter_1.dmm
+++ b/_maps/map_files/templates/shelter_1.dmm
@@ -60,14 +60,16 @@
 /obj/structure/sign/mining/survival,
 /turf/simulated/wall/mineral/titanium/survival,
 /area/survivalpod)
-"n" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/survival_pod/glass,
-/turf/simulated/floor/pod,
-/area/survivalpod)
 "o" = (
 /obj/structure/sign/mining,
 /turf/simulated/wall/mineral/titanium/survival,
+/area/survivalpod)
+"L" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/survival_pod/glass{
+	dir = 4
+	},
+/turf/simulated/floor/pod,
 /area/survivalpod)
 
 (1,1,1) = {"
@@ -89,7 +91,7 @@ b
 d
 h
 h
-n
+L
 "}
 (4,1,1) = {"
 a

--- a/_maps/map_files/templates/shelter_2.dmm
+++ b/_maps/map_files/templates/shelter_2.dmm
@@ -106,11 +106,6 @@
 	dir = 1
 	},
 /area/survivalpod/luxurypod)
-"aw" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/survival_pod/glass,
-/turf/simulated/floor/pod,
-/area/survivalpod/luxurypod)
 "ax" = (
 /obj/structure/sign/mining/survival{
 	dir = 4
@@ -168,6 +163,13 @@
 /obj/structure/sink/kitchen/directional/west,
 /turf/simulated/floor/carpet/black,
 /area/survivalpod/luxurypod)
+"fL" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/survival_pod/glass{
+	dir = 4
+	},
+/turf/simulated/floor/pod,
+/area/survivalpod/luxurypod)
 "hp" = (
 /obj/structure/toilet/directional/north,
 /turf/simulated/floor/pod,
@@ -212,7 +214,7 @@ at
 au
 av
 ar
-aw
+fL
 "}
 (5,1,1) = {"
 aa

--- a/tools/mapping/fix_directional_airlocks.py
+++ b/tools/mapping/fix_directional_airlocks.py
@@ -1,0 +1,111 @@
+from pathlib import Path
+
+from avulto import DMM
+
+MULTI_TILE_AIRLOCK_PATH = "/obj/machinery/door/airlock/multi_tile"
+AIRLOCK_PATH = "/obj/machinery/door/airlock"
+FIREDOOR_PATH = "/obj/machinery/door/firedoor"
+
+
+def has_joiner(dmm: DMM, coord: tuple[int, int, int]):
+    tile = dmm.tiledef(*coord)
+    if tile.find("/turf/simulated/wall"):
+        return True
+    if tile.find("/turf/simulated/mineral"):
+        return True
+    if tile.find("/obj/structure/falsewall"):
+        return True
+
+    if tile.find(AIRLOCK_PATH):
+        return True
+    if tile.find(FIREDOOR_PATH):
+        return True
+
+    if tile.find("/obj/effect/spawner/window"):
+        return True
+
+    return False
+
+
+def get_single_tile_airlock_direction(dmm: DMM, coord: tuple[int, int, int]):
+    x, y, z = coord
+
+    if y + 1 <= dmm.size.y and y - 1 >= 1:
+        north = (x, y + 1, z)
+        south = (x, y - 1, z)
+
+        if has_joiner(dmm, north) and has_joiner(dmm, south):
+            return 2
+
+    if x + 1 <= dmm.size.x and x - 1 >= 1:
+        east = (x + 1, y, z)
+        west = (x - 1, y, z)
+
+        if has_joiner(dmm, east) and has_joiner(dmm, west):
+            return 4
+
+    return 2
+
+
+def get_multi_tile_airlock_direction(dmm: DMM, coord: tuple[int, int, int]):
+    x, y, z = coord
+
+    if y - 1 >= 1:
+        south = (x, y - 1, z)
+
+        if has_joiner(dmm, south):
+            return 2
+
+    if x - 1 >= 1:
+        west = (x - 1, y, z)
+
+        if has_joiner(dmm, west):
+            return 4
+
+    return 2
+
+
+def fix_map(dmm: DMM):
+    modified = False
+    for coord in dmm.coords():
+        tile = dmm.tiledef(*coord)
+
+        for pth in (AIRLOCK_PATH, FIREDOOR_PATH):
+            if tile.only(pth) is not None:
+                idx = tile.only(pth)
+                curdir = tile.get_prefab_var(idx, "dir", 2)
+                newdir = get_single_tile_airlock_direction(dmm, coord)
+                if curdir != newdir:
+                    modified = True
+                    tile.make_unique()
+                    if newdir == 2:
+                        tile.del_prefab_var(idx, "dir")
+                    else:
+                        tile.set_prefab_var(idx, "dir", newdir)
+
+        if tile.only(MULTI_TILE_AIRLOCK_PATH) is not None:
+            idx = tile.only(MULTI_TILE_AIRLOCK_PATH)
+            curdir = tile.get_prefab_var(idx, "dir", 2)
+            newdir = get_multi_tile_airlock_direction(dmm, coord)
+            if curdir != newdir:
+                modified = True
+                tile.make_unique()
+                if newdir == 2:
+                    tile.del_prefab_var(idx, "dir")
+                else:
+                    tile.set_prefab_var(idx, "dir", newdir)
+
+    if modified:
+        dmm.save_to(dmm.filepath)
+
+
+def fix_all_maps():
+    root = Path("_maps/map_files")
+    for dmm_file in root.glob("**/*.dmm"):
+        print(dmm_file)
+        dmm = DMM.from_file(dmm_file)
+        fix_map(dmm)
+
+
+if __name__ == "__main__":
+    fix_all_maps()


### PR DESCRIPTION
## What Does This PR Do
This PR sets the directions for airlocks and fire doors so that they are oriented correctly on the map proper. This is handled in-game as well, but this makes the maps easier to read and enforces good practice. The script used to do this has been added to a new directory, tools/mapping, in case it's needed in the future.
## Why It's Good For The Game
Good for mappers, consistency, etc.
## Images of changes
See MDB but also
<img width="1265" height="1177" alt="2026_04_23__11_53_35__paradise dme  boxstation dmm  - StrongDMM" src="https://github.com/user-attachments/assets/e22f48d3-ea76-444d-a466-1dcdeaa9e7bd" />
<img width="754" height="740" alt="2026_04_23__11_53_49__paradise dme  centcomm dmm  - StrongDMM" src="https://github.com/user-attachments/assets/edeab1c3-0d1c-4bb9-9a06-c2f0a8f4a4b7" />

## Testing
Spot checked boxstation and centcom.
<!-- How did you test the PR, if at all? -->

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
NPFC