### PR TITLE
Fix recycler ignoring items in containers.

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -136,6 +136,7 @@
 	if(isitem(AM0))
 		to_eat += AM0.GetAllContents()
 	var/items_recycled = 0
+	var/list/atom/movable/atoms_to_qdel = list()
 
 	for(var/i in to_eat)
 		var/atom/movable/AM = i
@@ -150,6 +151,7 @@
 				emergency_stop(AM)
 		else if(isitem(AM))
 			recycle_item(AM)
+			atoms_to_qdel += AM
 			items_recycled++
 		else
 			playsound(loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
@@ -158,6 +160,10 @@
 	if(items_recycled && sound && (last_consumption_sound + SOUND_COOLDOWN) < world.time)
 		playsound(loc, item_recycle_sound, 100, 0)
 		last_consumption_sound = world.time
+		for(var/atom/movable/AM in atoms_to_qdel)
+			if(QDELETED(AM))
+				continue
+			qdel(AM)
 
 /obj/machinery/recycler/proc/recycle_item(obj/item/I)
 	I.forceMove(loc)
@@ -165,10 +171,8 @@
 	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
 	var/material_amount = materials.get_item_material_amount(I)
 	if(!material_amount)
-		qdel(I)
 		return
 	materials.insert_item(I, multiplier = (amount_produced / 100))
-	qdel(I)
 	materials.retrieve_all()
 
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Moves qdeleting recycled items to the end of the recycling process instead of doing it as-we-go.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Fixes a bug where the recycler would recycle a container, qdelete the container, and then ignore everything inside because the contents were qdeleted along with the container.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted, recycled many storage items with contents: backpacks holding glass and metal sheets, utility belts, etc.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed recyclers ignoring items in containers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
