### PR TITLE
Removes hardstun from vortex anomalies

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -540,8 +540,6 @@
 				step_towards(O, src)
 		for(var/mob/living/M in T.contents)
 			step_towards(M, src)
-			if(drops_core || canister_spawned)
-				M.Weaken(3.5 SECONDS) //You ran into a black hole, you ride the pain train.
 			M.KnockDown(7 SECONDS)
 
 	//Damaging the turf

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -540,6 +540,9 @@
 				step_towards(O, src)
 		for(var/mob/living/M in T.contents)
 			step_towards(M, src)
+			if(HAS_TRAIT(M, TRAIT_MAGPULSE))
+				return
+			to_chat(M, SPAN_WARNING("You lose your footing and fall!"))
 			M.KnockDown(7 SECONDS)
 
 	//Damaging the turf

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -542,7 +542,7 @@
 			step_towards(M, src)
 			if(HAS_TRAIT(M, TRAIT_MAGPULSE))
 				return
-			to_chat(M, SPAN_WARNING("You lose your footing and fall!"))
+			to_chat(M, SPAN_WARNING("The vortex pulls you to the floor!"))
 			M.KnockDown(7 SECONDS)
 
 	//Damaging the turf

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -542,7 +542,7 @@
 			step_towards(M, src)
 			if(HAS_TRAIT(M, TRAIT_MAGPULSE))
 				return
-			to_chat(M, SPAN_WARNING("The vortex pulls you to the floor!"))
+			to_chat(M, SPAN_WARNING("[src]'s attractive pull causes you to lose your footing and fall!"))
 			M.KnockDown(7 SECONDS)
 
 	//Damaging the turf


### PR DESCRIPTION
## What Does This PR Do
Removes the hardstun from vortex anomalies, in favor of a magboots check. Having magboots enabled (TRAIT_MAGPULSE) will now prevent the knockdown from vortex anomalies affecting the user.
## Why It's Good For The Game
While anomalies can be properly countered through the atmospherics MODsuit or other equipment, the hardstun of vortex anomalies does not have a true counter outside of simply not being nearby; this is the only anomaly that is capable of stunning crew while tearing holes in the station. Anomalies should not actively punish you for being near them. 
## Testing
Spawned a vortex anomaly. Was knocked down repeatedly while magboots were inactive.
Spawned a vortex anomaly. Was not knocked down while magboots were active.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: Vortex anomalies are no longer capable of hardstunning, and instead can have their knockdown countered by wearing magboots.
/:cl: