### PR TITLE
Fix for Phlogiston Chem Reaction

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -213,8 +213,8 @@
 	name = "Phlogiston"
 	id = "phlogiston"
 	result = "phlogiston"
-	required_reagents = list("phosphorus" = 1, "plasma" = 1, "sacid" = 1, "stabilizing_agent" = 1)
-	result_amount = 4
+	required_reagents = list("phosacid" = 1, "plasma" = 1, "stabilizing_agent" = 1)
+	result_amount = 3
 	mix_message = "The substance becomes sticky and extremely warm."
 
 /datum/chemical_reaction/phlogiston_dust
@@ -230,7 +230,7 @@
 	name = "Phlogiston Fire"
 	id = "phlogiston_fire"
 	result = "phlogiston"
-	required_reagents = list("phosphorus" = 1, "plasma" = 1, "sacid" = 1)
+	required_reagents = list("phosacid" = 1, "plasma" = 1)
 	mix_message = "The substance erupts into wild flames."
 
 /datum/chemical_reaction/phlogiston_fire/on_reaction(datum/reagents/holder, created_volume)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This is a fix for the Phlogiston chem recipe, which was broken by the recipe for Phosphoric Acid.

The process now involves making the Phosphoric Acid first, and then adding plasma.  Optionally, stabilizer.

This also updates the Phlog fire reaction accordingly.

Resulting amounts have been modified.  It ends up requiring a bit more stabilizer per the ratio, but it's quite close and the chem amount maths math.


Note that this relates to this issue, but there's no activity on the issue, and it's a very fast fix:

https://github.com/ParadiseSS13/Paradise/issues/31858

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Phlog is fun.  It's currently not possible to make, and this restores it.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Made some phlog with the new recipe, and it worked.  Resulting amount is intuitive.

It should be noted that I looked for other recipes involving 'phosacid' and found none, so I don't believe this will lead to complications.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed Phlog reaction recipe and Phlog Fire reaction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
