### PR TITLE
Wallening Mapping QoL

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
@@ -163,10 +163,8 @@
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 1
 	},
-/obj/machinery/door/airlock/survival_pod/glass{
-	dir = 4
-	},
 /obj/structure/fans/tiny,
+/obj/machinery/door/airlock/survival_pod/glass/manual_rotation,
 /turf/simulated/floor/pod/dark,
 /area/ruin/powered)
 "Q" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/alien_cache_site.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/alien_cache_site.dmm
@@ -112,7 +112,7 @@
 /area/ruin/space/powered/alien_cache_site/cache_room)
 "IP" = (
 /obj/structure/fans/tiny/invisible,
-/obj/machinery/door/airlock/abductor/secure{
+/obj/machinery/door/airlock/abductor/secure/manual_rotation{
 	dir = 4
 	},
 /turf/simulated/floor/plating/abductor,
@@ -128,10 +128,10 @@
 	},
 /area/ruin/space/powered/alien_cache_site)
 "PB" = (
-/obj/machinery/door/airlock/abductor{
+/obj/structure/fans/tiny/invisible,
+/obj/machinery/door/airlock/abductor/manual_rotation{
 	dir = 4
 	},
-/obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/plating/abductor,
 /area/ruin/space/powered/alien_cache_site)
 "TW" = (

--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -16452,9 +16452,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "bjp" = (
-/obj/machinery/door/morgue{
-	name = "Confession Booth (Chaplain)";
-	req_access = list(22)
+/obj/machinery/door/morgue/manual_rotation{
+	name = "Confession Booth (Chaplain)"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/chapel)
@@ -17270,7 +17269,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/east)
 "bmg" = (
-/obj/machinery/door/morgue{
+/obj/machinery/door/morgue/manual_rotation{
 	name = "Confession Booth"
 	},
 /turf/simulated/floor/plasteel/dark,
@@ -18074,7 +18073,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/sorting)
 "boy" = (
-/obj/machinery/door/morgue{
+/obj/machinery/door/morgue/manual_rotation{
 	name = "Private Study";
 	req_access = list(37)
 	},

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -23758,11 +23758,11 @@
 /area/station/supply/storage)
 "dSn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/morgue{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/morgue/manual_rotation{
 	name = "Private Study";
 	req_access = list(37)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/library)
 "dSo" = (

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -26858,7 +26858,9 @@
 /turf/simulated/wall,
 /area/station/service/library)
 "cdC" = (
-/obj/machinery/door/morgue,
+/obj/machinery/door/morgue/manual_rotation{
+	name = "Study #2"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/library)
 "cdD" = (
@@ -30886,12 +30888,12 @@
 /turf/simulated/wall,
 /area/station/service/library)
 "csI" = (
-/obj/machinery/door/morgue{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/morgue/manual_rotation{
 	name = "Private Study";
 	req_access = list(37)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/library)
 "csJ" = (
@@ -46918,8 +46920,8 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
 "dQh" = (
-/obj/machinery/door/morgue{
-	name = "Confession Booth"
+/obj/machinery/door/morgue/manual_rotation{
+	name = "Confession Booth (Chaplain)"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/chapel/office)
@@ -47232,7 +47234,7 @@
 /turf/simulated/floor/carpet/black,
 /area/station/service/chapel/office)
 "dRN" = (
-/obj/machinery/door/morgue{
+/obj/machinery/door/morgue/manual_rotation{
 	name = "Confession Booth"
 	},
 /turf/simulated/floor/plasteel/dark,
@@ -93023,6 +93025,12 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/reception)
+"vIt" = (
+/obj/machinery/door/morgue/manual_rotation{
+	name = "Study #1"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/service/library)
 "vIR" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	autolink_id = "o2_in";
@@ -133626,7 +133634,7 @@ exy
 bYj
 jRu
 cbO
-cdC
+vIt
 ckj
 crn
 ciz

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -62017,7 +62017,7 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
 "mxo" = (
-/obj/machinery/door/morgue{
+/obj/machinery/door/morgue/manual_rotation{
 	name = "Confession Booth"
 	},
 /turf/simulated/floor/plating,
@@ -67471,9 +67471,8 @@
 /turf/simulated/floor/grass/no_creep,
 /area/station/science/genetics)
 "nAB" = (
-/obj/machinery/door/morgue{
-	name = "Confession Booth (Chaplain)";
-	req_access = list(22)
+/obj/machinery/door/morgue/manual_rotation{
+	name = "Confession Booth (Chaplain)"
 	},
 /turf/simulated/floor/plating,
 /area/station/service/chapel)
@@ -72612,7 +72611,7 @@
 /turf/simulated/floor/engine,
 /area/station/science/test_chamber)
 "oyD" = (
-/obj/machinery/door/morgue{
+/obj/machinery/door/morgue/manual_rotation{
 	name = "Study #2"
 	},
 /turf/simulated/floor/wood,
@@ -78851,10 +78850,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
 "pHY" = (
-/obj/machinery/door/morgue{
-	name = "Private Study";
-	req_access = list(37)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -78862,6 +78857,10 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/morgue/manual_rotation{
+	name = "Private Study";
+	req_access = list(37)
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
 	},
@@ -118470,7 +118469,7 @@
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/apmaint)
 "xDO" = (
-/obj/machinery/door/morgue{
+/obj/machinery/door/morgue/manual_rotation{
 	name = "Study #1"
 	},
 /turf/simulated/floor/wood,

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -20022,9 +20022,8 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/storage/secondary)
 "cmn" = (
-/obj/machinery/door/morgue{
-	name = "Confession Booth (Chaplain)";
-	req_access = list(22)
+/obj/machinery/door/morgue/manual_rotation{
+	name = "Confession Booth (Chaplain)"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/chapel/office)
@@ -20963,7 +20962,7 @@
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/atmos)
 "cqY" = (
-/obj/machinery/door/morgue{
+/obj/machinery/door/morgue/manual_rotation{
 	name = "Study #1"
 	},
 /turf/simulated/floor/wood,
@@ -21690,7 +21689,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/surgery/observation)
 "cuz" = (
-/obj/machinery/door/morgue{
+/obj/machinery/door/morgue/manual_rotation{
 	name = "Study #2"
 	},
 /turf/simulated/floor/wood,
@@ -70063,7 +70062,7 @@
 /turf/simulated/floor/wood,
 /area/station/science/robotics/showroom)
 "qVA" = (
-/obj/machinery/door/morgue{
+/obj/machinery/door/morgue/manual_rotation{
 	name = "Confession Booth"
 	},
 /turf/simulated/floor/plasteel/dark,

--- a/_maps/map_files/templates/shelter_1.dmm
+++ b/_maps/map_files/templates/shelter_1.dmm
@@ -66,9 +66,7 @@
 /area/survivalpod)
 "L" = (
 /obj/structure/fans/tiny,
-/obj/machinery/door/airlock/survival_pod/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/survival_pod/glass/manual_rotation,
 /turf/simulated/floor/pod,
 /area/survivalpod)
 

--- a/_maps/map_files/templates/shelter_2.dmm
+++ b/_maps/map_files/templates/shelter_2.dmm
@@ -165,9 +165,7 @@
 /area/survivalpod/luxurypod)
 "fL" = (
 /obj/structure/fans/tiny,
-/obj/machinery/door/airlock/survival_pod/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/survival_pod/glass/manual_rotation,
 /turf/simulated/floor/pod,
 /area/survivalpod/luxurypod)
 "hp" = (

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -121,6 +121,22 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 /obj/machinery/door/airlock/welded
 	welded = TRUE
 
+/// Special case so spawners with doors autorotate, otherwise identicle
+/obj/machinery/door/airlock/spawner
+
+/obj/machinery/door/airlock/spawner/Initialize(mapload)
+	. = ..()
+	return INITIALIZE_HINT_LATELOAD
+
+/// Lateint required to actually rotate
+/obj/machinery/door/airlock/spawner/LateInitialize()
+	. = ..()
+	var/direction = get_current_direction()
+	dir = direction
+
+/obj/machinery/door/airlock/spawner/welded
+	welded = TRUE
+
 /*
  * reimp, imitate an access denied event.
  */

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -7,18 +7,30 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_com
 	normal_integrity = 450
 
+/obj/machinery/door/airlock/command/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/security
 	icon = 'icons/obj/doors/airlocks/station/security.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_sec
 	normal_integrity = 450
 
+/obj/machinery/door/airlock/security/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/engineering
 	icon = 'icons/obj/doors/airlocks/station/engineering.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_eng
 
+/obj/machinery/door/airlock/engineering/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/medical
 	icon = 'icons/obj/doors/airlocks/station/medical.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_med
+
+/obj/machinery/door/airlock/medical/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/maintenance
 	name = "maintenance access"
@@ -26,37 +38,61 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_mai
 	normal_integrity = 250
 
+/obj/machinery/door/airlock/maintenance/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/maintenance/external
 	name = "external airlock access"
 	icon = 'icons/obj/doors/airlocks/station/maintenanceexternal.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_extmai
+
+/obj/machinery/door/airlock/maintenance/external/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/mining
 	name = "mining airlock"
 	icon = 'icons/obj/doors/airlocks/station/mining.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_min
 
+/obj/machinery/door/airlock/mining/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/atmos
 	name = "atmospherics airlock"
 	icon = 'icons/obj/doors/airlocks/station/atmos.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_atmo
 
+/obj/machinery/door/airlock/atmos/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/research
 	icon = 'icons/obj/doors/airlocks/station/research.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_research
+
+/obj/machinery/door/airlock/research/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/freezer
 	name = "freezer airlock"
 	icon = 'icons/obj/doors/airlocks/station/freezer.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_fre
 
+/obj/machinery/door/airlock/freezer/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/science
 	icon = 'icons/obj/doors/airlocks/station/science.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_science
 
+/obj/machinery/door/airlock/science/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/virology
 	icon = 'icons/obj/doors/airlocks/station/virology.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_viro
+
+/obj/machinery/door/airlock/virology/manual_rotation
+	manual_dir = TRUE
 
 //////////////////////////////////
 /*
@@ -67,52 +103,88 @@
 	opacity = FALSE
 	glass = TRUE
 
+/obj/machinery/door/airlock/glass/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/command/glass
 	opacity = FALSE
 	glass = TRUE
 	normal_integrity = 400
 
+/obj/machinery/door/airlock/command/glass/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/engineering/glass
 	opacity = FALSE
 	glass = TRUE
+
+/obj/machinery/door/airlock/engineering/glass/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/security/glass
 	opacity = FALSE
 	glass = TRUE
 	normal_integrity = 400
 
+/obj/machinery/door/airlock/security/glass/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/medical/glass
 	opacity = FALSE
 	glass = TRUE
+
+/obj/machinery/door/airlock/medical/glass/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/virology/glass
 	opacity = FALSE
 	glass = TRUE
 
+/obj/machinery/door/airlock/virology/glass/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/research/glass
 	opacity = FALSE
 	glass = TRUE
+
+/obj/machinery/door/airlock/research/glass/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/mining/glass
 	opacity = FALSE
 	glass = TRUE
 
+/obj/machinery/door/airlock/mining/glass/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/atmos/glass
 	opacity = FALSE
 	glass = TRUE
+
+/obj/machinery/door/airlock/atmos/glass/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/science/glass
 	opacity = FALSE
 	glass = TRUE
 
+/obj/machinery/door/airlock/science/glass/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/maintenance/glass
 	opacity = FALSE
 	glass = TRUE
+
+/obj/machinery/door/airlock/maintenance/glass/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/maintenance/external/glass
 	opacity = FALSE
 	glass = TRUE
 	normal_integrity = 200
+
+/obj/machinery/door/airlock/maintenance/external/glass/manual_rotation
+	manual_dir = TRUE
 
 //////////////////////////////////
 /*
@@ -125,9 +197,15 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_gold
 	paintable = FALSE
 
+/obj/machinery/door/airlock/gold/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/gold/glass
 	opacity = FALSE
 	glass = TRUE
+
+/obj/machinery/door/airlock/gold/glass/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/silver
 	name = "silver airlock"
@@ -135,9 +213,15 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_silver
 	paintable = FALSE
 
+/obj/machinery/door/airlock/silver/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/silver/glass
 	opacity = FALSE
 	glass = TRUE
+
+/obj/machinery/door/airlock/silver/glass/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/diamond
 	name = "diamond airlock"
@@ -147,10 +231,16 @@
 	explosion_block = 2
 	paintable = FALSE
 
+/obj/machinery/door/airlock/diamond/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/diamond/glass
 	normal_integrity = 950
 	opacity = FALSE
 	glass = TRUE
+
+/obj/machinery/door/airlock/diamond/glass/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/uranium
 	name = "uranium airlock"
@@ -159,6 +249,9 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_uranium
 	paintable = FALSE
 	var/last_event = 0
+
+/obj/machinery/door/airlock/uranium/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/uranium/Initialize(mapload)
 	. = ..()
@@ -173,12 +266,18 @@
 	opacity = FALSE
 	glass = TRUE
 
+/obj/machinery/door/airlock/uranium/glass/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/plasma
 	name = "plasma airlock"
 	desc = "No way this can end badly."
 	icon = 'icons/obj/doors/airlocks/station/plasma.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_plasma
 	paintable = FALSE
+
+/obj/machinery/door/airlock/plasma/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/plasma/temperature_expose(exposed_temperature, exposed_volume)
 	..()
@@ -212,6 +311,9 @@
 	opacity = FALSE
 	glass = TRUE
 
+/obj/machinery/door/airlock/plasma/glass/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/bananium
 	name = "bananium airlock"
 	desc = "Honkhonkhonk!"
@@ -221,9 +323,15 @@
 	doorClose = 'sound/items/bikehorn.ogg'
 	paintable = FALSE
 
+/obj/machinery/door/airlock/bananium/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/bananium/glass
 	opacity = FALSE
 	glass = TRUE
+
+/obj/machinery/door/airlock/bananium/glass/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/tranquillite
 	name = "tranquillite airlock"
@@ -236,15 +344,24 @@
 	boltDown = null
 	paintable = FALSE
 
+/obj/machinery/door/airlock/tranquillite/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/sandstone
 	name = "sandstone airlock"
 	icon = 'icons/obj/doors/airlocks/station/sandstone.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_sandstone
 	paintable = FALSE
 
+/obj/machinery/door/airlock/sandstone/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/sandstone/glass
 	opacity = FALSE
 	glass = TRUE
+
+/obj/machinery/door/airlock/sandstone/glass/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/wood
 	name = "wooden airlock"
@@ -252,9 +369,15 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_wood
 	paintable = FALSE
 
+/obj/machinery/door/airlock/wood/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/wood/glass
 	opacity = FALSE
 	glass = TRUE
+
+/obj/machinery/door/airlock/wood/glass/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/titanium
 	name = "shuttle airlock"
@@ -264,10 +387,16 @@
 	normal_integrity = 400
 	paintable = FALSE
 
+/obj/machinery/door/airlock/titanium/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/titanium/glass
 	normal_integrity = 350
 	opacity = FALSE
 	glass = TRUE
+
+/obj/machinery/door/airlock/titanium/glass/manual_rotation
+	manual_dir = TRUE
 
 //////////////////////////////////
 /*
@@ -279,9 +408,15 @@
 	overlays_file = 'icons/obj/doors/airlocks/station2/overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_public
 
+/obj/machinery/door/airlock/public/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/public/glass
 	opacity = FALSE
 	glass = TRUE
+
+/obj/machinery/door/airlock/public/glass/manual_rotation
+	manual_dir = TRUE
 
 //////////////////////////////////
 /*
@@ -304,9 +439,15 @@
 
 	return ..()
 
+/obj/machinery/door/airlock/external/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/external/glass
 	opacity = FALSE
 	glass = TRUE
+
+/obj/machinery/door/airlock/external/glass/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/external_no_weld
 	name = "external airlock"
@@ -319,6 +460,9 @@
 
 /obj/machinery/door/airlock/external_no_weld/welder_act(mob/user, obj/item/I)
 	return
+
+/obj/machinery/door/airlock/external_no_weld/manual_rotation
+	manual_dir = TRUE
 
 //////////////////////////////////
 /*
@@ -333,9 +477,15 @@
 	normal_integrity = 1000
 	security_level = 6
 
+/obj/machinery/door/airlock/centcom/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/centcom/glass
 	glass = TRUE
 	opacity = FALSE
+
+/obj/machinery/door/airlock/centcom/glass/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/centcom/glass/Initialize(mapload)
 	. = ..()
@@ -356,6 +506,9 @@
 	security_level = 6
 	paintable = FALSE
 
+/obj/machinery/door/airlock/vault/manual_rotation
+	manual_dir = TRUE
+
 //////////////////////////////////
 /*
 	MARK: Hatch Airlocks
@@ -369,9 +522,15 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_hatch
 	paintable = FALSE
 
+/obj/machinery/door/airlock/hatch/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/hatch/syndicate
 	name = "syndicate hatch"
 	req_access = list(ACCESS_SYNDICATE)
+
+/obj/machinery/door/airlock/hatch/syndicate/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/hatch/syndicate/command
 	name = "Command Center"
@@ -379,6 +538,9 @@
 	explosion_block = 2
 	normal_integrity = 1000
 	security_level = 6
+
+/obj/machinery/door/airlock/hatch/syndicate/command/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/hatch/syndicate/command/emag_act(mob/user)
 	to_chat(user, SPAN_NOTICE("The electronic systems in this door are far too advanced for your primitive hacking peripherals."))
@@ -391,6 +553,9 @@
 	aiControlDisabled = AICONTROLDISABLED_ON
 	safe = FALSE
 	normal_integrity = 100 // going to get boosted by security level anyway
+
+/obj/machinery/door/airlock/hatch/syndicate/command/trapped/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/hatch/syndicate/command/trapped/process()
 	if(locate(/mob/living) in get_turf(src))
@@ -410,6 +575,9 @@
 	hackProof = TRUE
 	aiControlDisabled = AICONTROLDISABLED_ON
 
+/obj/machinery/door/airlock/hatch/syndicate/vault/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/maintenance_hatch
 	name = "maintenance hatch"
 	icon = 'icons/obj/doors/airlocks/hatch/maintenance.dmi'
@@ -417,6 +585,9 @@
 	note_overlay_file = 'icons/obj/doors/airlocks/hatch/overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_mhatch
 	paintable = FALSE
+
+/obj/machinery/door/airlock/maintenance_hatch/manual_rotation
+	manual_dir = TRUE
 
 //////////////////////////////////
 /*
@@ -434,10 +605,16 @@
 	damage_deflection = 30
 	paintable = FALSE
 
+/obj/machinery/door/airlock/highsecurity/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/highsecurity/red
 	name = "secure armory airlock"
 	hackProof = TRUE
 	aiControlDisabled = AICONTROLDISABLED_ON
+
+/obj/machinery/door/airlock/highsecurity/red/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/highsecurity/red/Initialize(mapload)
 	. = ..()
@@ -493,6 +670,9 @@
 	security_level = 1
 	paintable = FALSE
 
+/obj/machinery/door/airlock/abductor/manual_rotation
+	manual_dir = TRUE
+
 // MARK: Clockwork Airlocks
 
 /obj/machinery/door/airlock/clockwork
@@ -502,6 +682,9 @@
 	overlays_file = 'icons/obj/doors/airlocks/clockwork/clockwork-overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_clockwork
 	paintable = FALSE
+
+/obj/machinery/door/airlock/clockwork/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/clockwork/Initialize(mapload)
 	. = ..()
@@ -515,6 +698,9 @@
 /obj/machinery/door/airlock/clockwork/glass
 	glass = TRUE
 	opacity = FALSE
+
+/obj/machinery/door/airlock/clockwork/glass/manual_rotation
+	manual_dir = TRUE
 
 //////////////////////////////////
 /*
@@ -546,6 +732,9 @@
 	var/stealth_opacity = TRUE
 	/// Inner airlock material (Glass, plasteel)
 	var/stealth_airlock_material = null
+
+/obj/machinery/door/airlock/cult/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/cult/Initialize(mapload)
 	. = ..()
@@ -608,9 +797,15 @@
 /obj/machinery/door/airlock/cult/friendly
 	friendly = TRUE
 
+/obj/machinery/door/airlock/cult/friendly/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/cult/glass
 	glass = TRUE
 	opacity = FALSE
+
+/obj/machinery/door/airlock/cult/glass/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/cult/glass/Initialize(mapload)
 	. = ..()
@@ -619,11 +814,17 @@
 /obj/machinery/door/airlock/cult/glass/friendly
 	friendly = TRUE
 
+/obj/machinery/door/airlock/cult/glass/friendly/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/cult/unruned
 	icon = 'icons/obj/doors/airlocks/cult/unruned/cult.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/cult/unruned/cult-overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_cult/unruned
 	openingoverlaytype = /obj/effect/temp_visual/cult/door/unruned
+
+/obj/machinery/door/airlock/cult/unruned/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/cult/unruned/Initialize(mapload)
 	. = ..()
@@ -634,9 +835,15 @@
 /obj/machinery/door/airlock/cult/unruned/friendly
 	friendly = TRUE
 
+/obj/machinery/door/airlock/cult/unruned/friendly/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/cult/unruned/glass
 	glass = TRUE
 	opacity = FALSE
+
+/obj/machinery/door/airlock/cult/unruned/glass/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/airlock/cult/unruned/glass/Initialize(mapload)
 	. = ..()
@@ -645,12 +852,18 @@
 /obj/machinery/door/airlock/cult/unruned/glass/friendly
 	friendly = TRUE
 
+/obj/machinery/door/airlock/cult/unruned/glass/friendly/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/cult/weak
 	name = "brittle cult airlock"
 	desc = "An airlock hastily corrupted by blood magic, it is unusually brittle in this state."
 	normal_integrity = 150
 	damage_deflection = 5
 	armor = null
+
+/obj/machinery/door/airlock/cult/weak/manual_rotation
+	manual_dir = TRUE
 
 //////////////////////////////////
 /*
@@ -667,6 +880,9 @@
 	assemblytype = /obj/structure/door_assembly/multi_tile
 	paintable = FALSE
 
+/obj/machinery/door/airlock/multi_tile/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/multi_tile/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change)
 	. = ..()
 	update_bounds()
@@ -677,6 +893,9 @@
 /obj/machinery/door/airlock/multi_tile/glass
 	opacity = FALSE
 	glass = TRUE
+
+/obj/machinery/door/airlock/multi_tile/glass/manual_rotation
+	manual_dir = TRUE
 
 /// Player view blocking fillers for multi-tile doors
 /obj/airlock_filler_object

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -51,6 +51,8 @@
 	/// How many levels of foam do we have on us? Capped at 5
 	var/foam_level = 0
 
+	/// Is this door prevented from autorotating?
+	var/manual_dir = FALSE
 	/// Is this door barricaded?
 	var/barricaded = FALSE
 	/// How much this door reduces superconductivity to when closed.
@@ -77,10 +79,11 @@
 	real_explosion_block = explosion_block
 	explosion_block = EXPLOSION_BLOCK_PROC
 
-	for(var/d in GLOB.cardinal)
-		var/turf/T = get_step(src, d)
-		if(iswallturf(T) || locate(/obj/structure/window/full) in T)
-			QUEUE_SMOOTH(T)
+	if(manual_dir == FALSE)
+		for(var/d in GLOB.cardinal)
+			var/turf/T = get_step(src, d)
+			if(iswallturf(T) || locate(/obj/structure/window/full) in T)
+				QUEUE_SMOOTH(T)
 	update_icon()
 	recalculate_atmos_connectivity()
 
@@ -442,7 +445,7 @@
 	SEND_SIGNAL(src, COMSIG_DOOR_OPEN)
 	operating = DOOR_OPENING
 	var/direction = get_current_direction()
-	dir = direction ? direction : NORTH
+	dir = direction
 	update_icon()
 	recalculate_atmos_connectivity()
 	do_animate("opening")
@@ -495,7 +498,7 @@
 			set_fillers_opacity(TRUE)
 	operating = NONE
 	var/direction = get_current_direction()
-	dir = direction ? direction : NORTH
+	dir = direction
 	update_icon()
 	recalculate_atmos_connectivity()
 	update_freelook_sight()
@@ -507,6 +510,8 @@
 
 /obj/machinery/door/proc/get_current_direction()
 	// Prioritize walls to avoid adjacent airlock shenanigans
+	if(manual_dir == TRUE)
+		return
 	for(var/direction in GLOB.cardinal)
 		if(iswallturf(get_step(src, direction)))
 			return direction
@@ -590,6 +595,10 @@
 /obj/machinery/door/morgue
 	icon = 'icons/obj/doors/doormorgue.dmi'
 	icon_state = "door1"
+
+
+/obj/machinery/door/morgue/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/proc/lock()
 	return

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -80,10 +80,16 @@
 		crush()
 	return TRUE
 
+/obj/machinery/door/poddoor//manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/poddoor/preopen
 	icon_state = "open"
 	density = FALSE
 	opacity = FALSE
+
+/obj/machinery/door/poddoor/preopen/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/poddoor/impassable
 	name = "reinforced blast door"
@@ -91,8 +97,14 @@
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	move_resist = INFINITY
 
+/obj/machinery/door/poddoor/impassable/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/poddoor/impassable/gamma
 	name = "gamma armory hatch"
+
+/obj/machinery/door/poddoor/impassable/gamma/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/poddoor/impassable/hostile_lockdown()
 	return
@@ -158,18 +170,30 @@
 	layer = CLOSED_BLASTDOOR_LAYER
 	width = 2
 
+/obj/machinery/door/poddoor/multi_tile/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/poddoor/multi_tile/triple
 	icon = 'icons/obj/doors/blastdoor_1x3.dmi'
 	width = 3
+
+/obj/machinery/door/poddoor/multi_tile/triple/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/poddoor/multi_tile/quad
 	icon = 'icons/obj/doors/blastdoor_1x4.dmi'
 	width = 4
 
+/obj/machinery/door/poddoor/multi_tile/quad/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/poddoor/multi_tile/impassable
 	desc = "A heavy duty blast door that opens mechanically. Looks even tougher than usual."
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	move_resist = INFINITY
+
+/obj/machinery/door/poddoor/multi_tile/impassable/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/poddoor/multi_tile/impassable/hostile_lockdown()
 	return
@@ -185,6 +209,12 @@
 	icon = 'icons/obj/doors/blastdoor_1x3.dmi'
 	width = 3
 
+/obj/machinery/door/poddoor/multi_tile/impassable/triple/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/poddoor/multi_tile/impassable/quad
 	icon = 'icons/obj/doors/blastdoor_1x4.dmi'
 	width = 4
+
+/obj/machinery/door/poddoor/multi_tile/impassable/quad/manual_rotation
+	manual_dir = TRUE

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -80,7 +80,7 @@
 		crush()
 	return TRUE
 
-/obj/machinery/door/poddoor//manual_rotation
+/obj/machinery/door/poddoor/manual_rotation
 	manual_dir = TRUE
 
 /obj/machinery/door/poddoor/preopen

--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -8,10 +8,16 @@
 	damage_deflection = 20
 	dir = EAST
 
+/obj/machinery/door/poddoor/shutters/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/poddoor/shutters/preopen
 	icon_state = "open"
 	density = FALSE
 	opacity = FALSE
+
+/obj/machinery/door/poddoor/shutters/preopen/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/poddoor/shutters/radiation
 	name = "radiation shutters"
@@ -20,12 +26,18 @@
 	rad_insulation_beta = RAD_BETA_BLOCKER
 	rad_insulation_gamma = RAD_VERY_EXTREME_INSULATION
 
+/obj/machinery/door/poddoor/shutters/radiation/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/poddoor/shutters/radiation/preopen
 	icon_state = "open"
 	density = FALSE
 	opacity = FALSE
 	rad_insulation_beta = RAD_NO_INSULATION
 	rad_insulation_gamma = RAD_NO_INSULATION
+
+/obj/machinery/door/poddoor/shutters/radiation/preopen/manual_rotation
+	manual_dir = TRUE
 
 /obj/machinery/door/poddoor/shutters/radiation/open()
 	. = ..()

--- a/code/game/objects/effects/spawners/random_barrier.dm
+++ b/code/game/objects/effects/spawners/random_barrier.dm
@@ -3,8 +3,8 @@
 	icon_state = "barrier"
 	loot = list(
 		/obj/effect/spawner/window/reinforced,
-		/obj/machinery/door/airlock,
-		/obj/machinery/door/airlock/welded,
+		/obj/machinery/door/airlock/spawner,
+		/obj/machinery/door/airlock/spawner/welded,
 		/obj/structure/barricade/wooden,
 		/obj/structure/falsewall,
 		/turf/simulated/wall,
@@ -32,7 +32,7 @@
 /obj/effect/spawner/random/barrier/obstruction
 	name = "obstruction"
 	loot = list(
-		/obj/machinery/door/airlock/welded,
+		/obj/machinery/door/airlock/spawner/welded,
 		/obj/structure/barricade/wooden,
 		/obj/structure/falsewall,
 		/turf/simulated/wall,
@@ -43,8 +43,8 @@
 	name = "possibly welded airlock"
 	icon_state = "airlock"
 	loot = list(
-		/obj/machinery/door/airlock = 3,
-		/obj/machinery/door/airlock/welded = 1,
+		/obj/machinery/door/airlock/spawner = 3,
+		/obj/machinery/door/airlock/spawner/welded = 1,
 	)
 
 /obj/effect/spawner/random/barrier/grille_often

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -154,9 +154,15 @@
 	overlays_file = 'icons/obj/doors/airlocks/survival/survival_overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_pod
 
+/obj/machinery/door/airlock/survival_pod/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/survival_pod/glass
 	opacity = FALSE
 	glass = TRUE
+
+/obj/machinery/door/airlock/survival_pod/glass/manual_rotation
+	manual_dir = TRUE
 
 /obj/structure/door_assembly/door_assembly_pod
 	name = "pod airlock assembly"

--- a/code/modules/ruins/objects_and_mobs/secure_alien_airlock.dm
+++ b/code/modules/ruins/objects_and_mobs/secure_alien_airlock.dm
@@ -5,6 +5,9 @@
 	locked = TRUE
 	req_access = list()
 
+/obj/machinery/door/airlock/abductor/secure/manual_rotation
+	manual_dir = TRUE
+
 /obj/machinery/door/airlock/abductor/secure/Initialize(mapload)
 	. = ..()
 	// Randomize the wires so they aren't the same as the station


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #31954 
Fixes various issues raised by mappers regarding wallening using the power of a migraine, two hours, and at least one odd fix.
- Airlock spawners not auto rotating
- Airlocks being forced to auto rotate no matter what
  - airlocks now have a `manual_dir` var, which skips attempts to automatically rotate, every door type and their subtypes has been given a "manual_rotation" subtype, direction must be var edited
  - no, this cannot be a mapping helper, trust me i tried, doesnt work with how they load.
- Replaces mapped in confession doors (library included) with their manual rotation subtype
- Replaces doors on certain ruins and prefabs (lavaland shelters) with their manual rotation subtype
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Post-wallening mapping QoL

Hayden will probably kill me if I dont

More manual control on door direction/placement
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
- Made sure manual_rotation doors didnt rotate automatically and kept their manually set direction
- Made sure replaced library private study door had proper access
- Made sure doors spawned using spawners rotated correctly
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Doors now have a manual rotation subtype for mapping purposes
fix: Doors spawned by spawners now rotate automatically
tweak: Changes confession, library study and lavaland shelter to manual rotation doors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
