### PR TITLE
Makes Blind Canes Craftable

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -2,6 +2,7 @@ GLOBAL_LIST_INIT(rod_recipes, list (
 	new /datum/stack_recipe("grille", /obj/structure/grille, 2, time = 1 SECONDS, one_per_turf = TRUE, on_floor_or_lattice = TRUE),
 	new /datum/stack_recipe("table frame", /obj/structure/table_frame, 2, time = 1 SECONDS, one_per_turf = TRUE, on_floor = TRUE),
 	new /datum/stack_recipe("curtain rod", /obj/item/mounted/curtain/curtain_fixture, 2, 1, 20),
+	new /datum/stack_recipe("white cane", /obj/item/blindcane, 1, 1),
 	null,
 	new /datum/stack_recipe_list("railings...", list(
 		new /datum/stack_recipe("railing", /obj/structure/railing, 3, time = 1 SECONDS, one_per_turf = TRUE, on_floor = TRUE),

--- a/code/game/objects/items/weapons/misc_items.dm
+++ b/code/game/objects/items/weapons/misc_items.dm
@@ -31,7 +31,7 @@
 	flags = CONDUCT
 	force = 5.0
 	throwforce = 7.0
-	materials = list(MAT_METAL=50)
+	materials = list(MAT_METAL = 2000)
 	attack_verb = list("bludgeoned", "whacked", "disciplined", "thrashed", "Vaudevilled")
 
 /obj/item/cane/get_crutch_efficiency()
@@ -48,7 +48,7 @@
 	force = 5
 	throwforce = 7
 	w_class = WEIGHT_CLASS_SMALL // Canes can fold up to fit in bags or pockets
-	materials = list(MAT_METAL = 50)
+	materials = list(MAT_METAL = 1000)
 	attack_verb = list("smacked", "whacked", "bumped", "struck")
 	new_attack_chain = TRUE
 


### PR DESCRIPTION
## What Does This PR Do
* Allows blind canes to be crafted out of a metal rod.
* Increases metal content of blind canes to 1000 cm^3 to match the content of a metal rod.
* Makes the regular cane contain 2000 cm^3 as it is an equivilent item but with more material to be more sturdy (in exchange for not being collapsable).
## Why It's Good For The Game
* There is no way to get blind canes except by spawning with one.
* I feel this is a better implimentation of #31902, which adds blind canes to a cargo crate, for 200 Cr per cane.
## Testing
Got metal rod.
Made into blind cane.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
add: White Canes can now be crafted from 1 metal rod.
tweak: Increased metal content of White Cane to 1000 cm^3.
tweak: Increased metal content of Cane to 2000 cm^3.
/:cl: