### PR TITLE
Re-adds the old shop to Cyberiad, Kerberos and Diagoras

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -20361,10 +20361,8 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/hydroponics)
 "bwu" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 6
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "bwv" = (
@@ -44529,7 +44527,8 @@
 /area/station/supply/sorting)
 "dHN" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/space_heater,
+/obj/structure/closet/firecloset,
+/obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
 "dHT" = (
@@ -46287,6 +46286,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "eqE" = (
@@ -90258,6 +90258,8 @@
 "xWJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
+/obj/structure/closet/emcloset,
+/obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
 "xWL" = (
@@ -111775,7 +111777,7 @@ blQ
 blQ
 blQ
 bsc
-bwy
+bnK
 dHN
 mBl
 blQ

--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -6996,24 +6996,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonershuttle)
-"aBG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/port/east)
 "aBI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -13571,6 +13553,7 @@
 	dir = 4
 	},
 /obj/item/storage/toolbox/mechanical,
+/obj/item/storage/box/lights/mixed,
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/tools)
 "aZs" = (
@@ -14547,9 +14530,9 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "bcX" = (
-/obj/item/radio/intercom{
-	name = "south bump";
-	pixel_y = -28
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /obj/effect/turf_decal/tiles/department/cargo/side,
 /turf/simulated/floor/plasteel,
@@ -16214,6 +16197,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/east)
 "biH" = (
@@ -16652,13 +16638,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/service/hydroponics)
-"bkf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/alarm/directional/south,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/port/east)
 "bkg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16675,17 +16654,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/west)
-"bkk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/port/east)
 "bkn" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -17225,8 +17193,17 @@
 /turf/simulated/wall,
 /area/station/maintenance/port)
 "blR" = (
-/turf/simulated/wall,
-/area/station/public/storage/emergency/port)
+/obj/machinery/door/airlock/mining{
+	name = "Expedition Headquarters";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/expedition,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/expedition)
 "blW" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel,
@@ -17751,15 +17728,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "bnz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/turf_decal/tiles/department/cargo/side{
 	dir = 5
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/alarm/directional/north,
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
 	},
-/turf/simulated/floor/plating,
-/area/station/public/storage/emergency/port)
+/turf/simulated/floor/plasteel,
+/area/station/supply/expedition)
 "bnA" = (
 /obj/machinery/light_switch{
 	name = "north bump";
@@ -17868,18 +17846,6 @@
 "bnS" = (
 /turf/simulated/wall,
 /area/station/public/storage/tools/auxiliary)
-"bnT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/mining{
-	name = "Expedition Headquarters"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/supply/expedition,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plasteel,
-/area/station/supply/expedition)
 "bnW" = (
 /obj/machinery/computer/station_alert,
 /obj/effect/turf_decal/tiles/department/engineering/side,
@@ -18229,26 +18195,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
 "bpb" = (
-/obj/machinery/alarm/directional/west,
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+/obj/effect/turf_decal/tiles/department/cargo/side{
+	dir = 10
 	},
-/obj/item/flashlight/flare/glowstick/emergency,
-/obj/item/flashlight/flare/glowstick/emergency,
-/obj/item/flashlight/flare/glowstick/emergency,
-/obj/item/flashlight/flare/glowstick/emergency,
-/obj/item/flashlight/flare/glowstick/emergency,
-/obj/item/flashlight/flare/glowstick/emergency,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	name = "south bump";
-	pixel_y = -28
-	},
-/turf/simulated/floor/plating,
-/area/station/public/storage/emergency/port)
+/obj/machinery/mineral/equipment_vendor/explorer,
+/turf/simulated/floor/plasteel,
+/area/station/supply/expedition)
 "bpc" = (
 /obj/machinery/firealarm/directional/south,
 /turf/simulated/floor/plasteel,
@@ -18286,15 +18238,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/west)
-"bpi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/public/storage/emergency/port)
 "bpj" = (
 /obj/structure/disposalpipe/junction/y{
 	dir = 1
@@ -18302,13 +18245,18 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/east)
 "bpl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/suit_storage_unit/expedition,
-/obj/effect/turf_decal/tiles/department/cargo/side{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel,
-/area/station/supply/expedition)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/blood/often,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/catwalk/grey,
+/area/station/public/storefront)
 "bpm" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=QM";
@@ -18642,9 +18590,22 @@
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "bql" = (
-/obj/machinery/economy/atm/directional/east,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	name = "Storefront Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/barricade/wooden/crude,
 /turf/simulated/floor/plasteel,
-/area/station/hallway/primary/port/east)
+/area/station/public/storefront)
 "bqm" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -18722,15 +18683,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
-"bqA" = (
-/obj/effect/spawner/random/cobweb/left/rare,
-/obj/structure/closet/secure_closet/explorer,
-/obj/machinery/requests_console/directional/west,
-/obj/effect/turf_decal/tiles/department/cargo/side{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel,
-/area/station/supply/expedition)
 "bqB" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -18741,9 +18693,13 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
 "bqC" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/station/public/storage/emergency/port)
+/obj/effect/spawner/random/cobweb/left/rare,
+/obj/effect/turf_decal/tiles/department/cargo/side{
+	dir = 9
+	},
+/obj/machinery/economy/vending/exploredrobe,
+/turf/simulated/floor/plasteel,
+/area/station/supply/expedition)
 "bqF" = (
 /obj/structure/bookcase/sop,
 /turf/simulated/floor/wood,
@@ -18769,9 +18725,9 @@
 /turf/simulated/floor/plasteel,
 /area/station/service/hydroponics)
 "bqJ" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/supply/expedition)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/public/storefront)
 "bqK" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal{
@@ -19013,14 +18969,12 @@
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "brz" = (
-/obj/structure/closet/walllocker/emerglocker/directional/north,
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+/obj/effect/turf_decal/tiles/department/cargo/side{
+	dir = 1
 	},
-/obj/item/extinguisher,
-/turf/simulated/floor/plating,
-/area/station/public/storage/emergency/port)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/station/supply/expedition)
 "brA" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/librarian,
@@ -19042,16 +18996,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/hallway/secondary/exit)
-"brE" = (
-/obj/effect/turf_decal/tiles/department/cargo/side{
-	dir = 5
-	},
-/obj/machinery/alarm/directional/north,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
-/turf/simulated/floor/plasteel,
-/area/station/supply/expedition)
 "brF" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -19232,25 +19176,15 @@
 /area/station/public/locker)
 "bsm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/explorer,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel,
-/area/station/supply/expedition)
-"bsn" = (
-/obj/structure/closet/secure_closet/explorer,
-/obj/machinery/camera{
-	c_tag = "AI Satellite Atmospherics";
-	dir = 4;
-	network = list("SS13","MiniSat")
-	},
 /obj/effect/turf_decal/tiles/department/cargo/side{
-	dir = 8
+	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/directional/east,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/supply/expedition)
 "bso" = (
@@ -19310,16 +19244,10 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
 "bsD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/public/storage/emergency/port)
-"bsI" = (
-/obj/structure/closet/secure_closet/explorer,
-/obj/effect/turf_decal/tiles/department/cargo/side{
+/obj/effect/turf_decal/tiles/department/cargo/corner{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/supply/expedition)
 "bsJ" = (
@@ -19343,13 +19271,6 @@
 "bsL" = (
 /turf/simulated/wall/r_wall,
 /area/station/hallway/primary/central/ne)
-"bsM" = (
-/obj/machinery/power/apc/directional/east,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/public/storage/emergency/port)
 "bsN" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -19856,15 +19777,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
 "bui" = (
-/obj/structure/table,
-/obj/item/storage/box/lights/mixed,
-/obj/item/storage/toolbox/emergency,
-/obj/structure/extinguisher_cabinet{
-	name = "south bump";
-	pixel_y = -30
+/obj/effect/turf_decal/tiles/department/cargo/side{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/station/public/storage/emergency/port)
+/obj/machinery/requests_console/directional/west,
+/turf/simulated/floor/plasteel,
+/area/station/supply/expedition)
 "buk" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
@@ -19878,7 +19796,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/junction,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/nw)
 "bun" = (
@@ -19886,9 +19804,6 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tiles/department/cargo/corner{
 	dir = 8
 	},
@@ -20213,10 +20128,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/ne)
 "bvF" = (
-/obj/machinery/light/small,
-/obj/item/stack/rods,
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
+/obj/effect/turf_decal/tiles/department/cargo/side,
+/obj/structure/closet/secure_closet/explorer,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/station/supply/expedition)
 "bvI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -20474,20 +20390,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "bwz" = (
-/obj/machinery/mineral/equipment_vendor/explorer,
-/obj/effect/turf_decal/tiles/department/cargo/side{
-	dir = 6
-	},
+/obj/structure/shelf,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/station/supply/expedition)
+/area/station/public/storefront)
 "bwA" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/effect/turf_decal/tiles/department/cargo/side,
+/obj/structure/shelf,
 /turf/simulated/floor/plasteel,
-/area/station/supply/expedition)
+/area/station/public/storefront)
 "bwB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -21541,12 +21451,15 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/public/locker)
 "bBU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/effect/turf_decal/tiles/department/cargo/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tiles/department/cargo/side,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment/corner,
 /turf/simulated/floor/plasteel,
 /area/station/supply/expedition)
 "bBZ" = (
@@ -21581,10 +21494,10 @@
 /turf/space,
 /area/space)
 "bCj" = (
-/obj/structure/closet/emcloset,
-/obj/effect/spawner/random/maintenance,
+/obj/structure/closet/secure_closet/explorer,
+/obj/effect/turf_decal/tiles/department/cargo/side,
 /turf/simulated/floor/plasteel,
-/area/station/maintenance/port)
+/area/station/supply/expedition)
 "bCk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21928,6 +21841,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/supply/sorting)
 "bDP" = (
@@ -30546,14 +30460,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
 "con" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tiles/department/cargo/side{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/station/supply/expedition)
+/area/station/public/storefront)
 "cop" = (
 /obj/machinery/alarm/directional/east,
 /obj/structure/table/wood,
@@ -31057,14 +30969,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/surgery/primary)
-"cqQ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/port)
 "cqS" = (
 /obj/structure/sign/poster/contraband/random/directional/east,
 /turf/simulated/floor/plasteel,
@@ -34495,11 +34399,6 @@
 "cEH" = (
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
-"cEJ" = (
-/obj/effect/turf_decal/delivery/white/hollow,
-/obj/machinery/atmospherics/portable/canister/air,
-/turf/simulated/floor/plating,
-/area/station/public/storage/emergency/port)
 "cEK" = (
 /obj/machinery/light{
 	dir = 4
@@ -45475,6 +45374,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
+"dZU" = (
+/obj/machinery/door_control{
+	id = "store2";
+	name = "Storefront Shutters Control";
+	pixel_x = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/station/public/storefront)
 "eac" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -45679,6 +45587,21 @@
 /obj/effect/turf_decal/tiles/department/medical/side,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
+"edg" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/port/east)
 "edp" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -45847,9 +45770,6 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
-	},
-/obj/structure/sign/public/tools{
-	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/east)
@@ -46293,6 +46213,7 @@
 	dir = 8;
 	sort_type_txt = "1"
 	},
+/obj/machinery/alarm/directional/south,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/east)
 "epQ" = (
@@ -46361,6 +46282,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
+"eqy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/port)
 "eqE" = (
 /obj/machinery/door/airlock/command{
 	id_tag = "cmoofficedoor";
@@ -48781,24 +48709,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
-"fvs" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/port/east)
 "fvB" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -49284,12 +49194,6 @@
 /obj/structure/sign/poster/official/safety_internals/directional/east,
 /turf/simulated/floor/engine,
 /area/station/science/test_chamber)
-"fEL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/firecloset,
-/obj/effect/spawner/random/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
 "fEO" = (
 /obj/structure/chair/stool/bar{
 	dir = 8
@@ -51108,6 +51012,9 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/west)
+"gvY" = (
+/turf/simulated/wall,
+/area/station/public/storefront)
 "gwb" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /obj/effect/decal/cleanable/blood,
@@ -51234,11 +51141,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/public/toilet/unisex)
-"gyA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/explorer,
-/turf/simulated/floor/plasteel,
-/area/station/supply/expedition)
 "gyG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -53182,6 +53084,13 @@
 /obj/effect/turf_decal/caution,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"hqT" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/station/public/storefront)
 "hqU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/sofa/bench/left{
@@ -54258,6 +54167,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
+"hQo" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/public/storefront)
 "hQW" = (
 /obj/machinery/computer/fission_monitor{
 	dir = 1
@@ -54434,6 +54349,15 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/smes)
+"hVI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/suit_storage_unit/expedition,
+/obj/effect/turf_decal/tiles/department/cargo/side{
+	dir = 1
+	},
+/obj/machinery/newscaster/directional/north,
+/turf/simulated/floor/plasteel,
+/area/station/supply/expedition)
 "hVP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -55022,11 +54946,17 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/east)
 "ile" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
+/obj/machinery/power/apc/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/turf/simulated/floor/plasteel,
-/area/station/supply/expedition)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/catwalk/grey,
+/area/station/public/storefront)
 "ilf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55645,6 +55575,14 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/north)
+"ixn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/power/apc/directional/south,
+/obj/structure/cable,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/port/east)
 "ixP" = (
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/simulated/floor/plasteel/reactor_pool,
@@ -55973,15 +55911,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
-"iFm" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/public/storage/emergency/port)
 "iFu" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -55999,6 +55928,17 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/north)
+"iFC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/port/east)
 "iFR" = (
 /obj/machinery/computer/med_data{
 	dir = 1
@@ -56906,24 +56846,6 @@
 /obj/structure/table,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
-"iYO" = (
-/obj/machinery/light_switch{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/turf/simulated/floor/plating,
-/area/station/public/storage/emergency/port)
 "iZj" = (
 /obj/structure/chair/stool{
 	dir = 4
@@ -57344,6 +57266,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
+"jiW" = (
+/obj/effect/turf_decal/tiles/department/cargo/side{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/station/supply/expedition)
 "jje" = (
 /turf/simulated/wall,
 /area/station/hallway/secondary/entry/south)
@@ -58456,14 +58385,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hardsuitstorage)
-"jJs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/directional/south,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/port/east)
 "jJE" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -59207,9 +59128,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/disposal)
 "jZQ" = (
-/obj/structure/closet/secure_closet/explorer,
-/obj/machinery/newscaster/directional/west,
-/obj/effect/turf_decal/tiles/department/cargo/side{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/explorer,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
@@ -63531,6 +63455,16 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/hallway/secondary/exit)
+"lVW" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/cobweb/left/rare,
+/turf/simulated/floor/plasteel,
+/area/station/public/storefront)
 "lWg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tiles/department/security/side{
@@ -63614,6 +63548,15 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/rnd)
+"lXP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/expedition)
 "lYc" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/plating,
@@ -65563,12 +65506,6 @@
 /obj/effect/turf_decal/tiles/department/medical,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay2)
-"mQd" = (
-/obj/effect/turf_decal/tiles/department/cargo/side{
-	dir = 10
-	},
-/turf/simulated/floor/plasteel,
-/area/station/supply/expedition)
 "mQt" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -65691,6 +65628,27 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/rnd)
+"mTH" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/alarm/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/cobweb/right/frequent,
+/turf/simulated/floor/plating,
+/area/station/public/storefront)
+"mTX" = (
+/obj/machinery/camera{
+	c_tag = "AI Satellite Atmospherics";
+	dir = 4;
+	network = list("SS13","MiniSat")
+	},
+/obj/effect/turf_decal/tiles/department/cargo/side{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/expedition)
 "mUi" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -67770,6 +67728,17 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/toxins/mixing)
+"nRT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/suit_storage_unit/expedition,
+/obj/effect/turf_decal/tiles/department/cargo/side{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/expedition)
 "nSc" = (
 /obj/machinery/door/window/reinforced/normal{
 	dir = 8;
@@ -69070,18 +69039,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
-"ovl" = (
-/obj/machinery/door/airlock{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/public/storage/emergency/port)
 "ovL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -70457,6 +70414,14 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/aft2)
+"pag" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Bay Warehouse Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/cargo_bay,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/maintenance/port)
 "pak" = (
 /obj/structure/rack,
 /obj/item/circuitboard/chem_heater{
@@ -72529,6 +72494,10 @@
 /obj/effect/turf_decal/tiles/department/medical/checker,
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/aft)
+"pXc" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/station/public/storefront)
 "pXs" = (
 /obj/item/clothing/under/misc/swimsuit/black,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -73015,6 +72984,14 @@
 /obj/structure/sign/command,
 /turf/simulated/wall/r_wall,
 /area/station/command/bridge)
+"qkj" = (
+/obj/effect/turf_decal/tiles/department/cargo/side{
+	dir = 10
+	},
+/obj/structure/closet/secure_closet/explorer,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/station/supply/expedition)
 "qkk" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -73496,6 +73473,11 @@
 /obj/structure/sign/medical/examroom,
 /turf/simulated/floor/plating,
 /area/station/medical/patients_rooms1)
+"qrZ" = (
+/obj/machinery/economy/atm/directional/east,
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/port/east)
 "qsa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -74712,6 +74694,14 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/security/permabrig)
+"qRf" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	name = "Storefront Shutters";
+	id_tag = "store2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/storefront)
 "qRr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -77777,13 +77767,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
-"snM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
 "soh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10
@@ -78561,6 +78544,9 @@
 	c_tag = "Port Hallway";
 	dir = 1
 	},
+/obj/structure/sign/cargo/salvage{
+	pixel_y = -32
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/east)
 "sHq" = (
@@ -79293,11 +79279,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "sZe" = (
+/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/economy/vending/exploredrobe,
-/obj/effect/turf_decal/tiles/department/cargo/side,
-/turf/simulated/floor/plasteel,
-/area/station/supply/expedition)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/public/storefront)
 "sZg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
@@ -79719,6 +79705,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard)
+"tji" = (
+/obj/effect/turf_decal/tiles/department/cargo/corner,
+/turf/simulated/floor/plasteel,
+/area/station/supply/expedition)
 "tjl" = (
 /obj/structure/dresser,
 /obj/effect/turf_decal/tiles/department/medical/checker,
@@ -80091,16 +80081,6 @@
 /obj/structure/weightmachine/stacklifter,
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
-"tvf" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tiles/department/cargo/corner{
-	dir = 8
-	},
-/obj/structure/sign/cargo/salvage{
-	pixel_x = -32
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central/nw)
 "tvi" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -81068,6 +81048,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/supply/sorting)
 "tPD" = (
@@ -81263,6 +81244,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/supply/sorting)
 "tSR" = (
@@ -82135,6 +82117,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"uoa" = (
+/obj/effect/landmark/start/explorer,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/expedition)
 "uod" = (
 /obj/structure/rack{
 	dir = 1
@@ -82665,7 +82657,15 @@
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
 "uAa" = (
-/obj/effect/landmark/start/explorer,
+/obj/effect/turf_decal/tiles/department/cargo/side{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/expedition)
 "uAd" = (
@@ -85332,16 +85332,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
 "vRD" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Warehouse Maintenance";
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/cargo_bay,
-/obj/machinery/door/firedoor{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
+/obj/effect/spawner/random/fungus/maybe,
+/turf/simulated/wall,
+/area/station/supply/warehouse)
 "vRG" = (
 /obj/structure/sign/poster/contraband/revolver/directional/north,
 /turf/simulated/floor/wood,
@@ -85522,11 +85515,16 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/lounge)
 "vVK" = (
-/obj/machinery/power/apc/directional/south,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tiles/department/cargo/side,
+/obj/item/radio/intercom{
+	name = "south bump";
+	pixel_y = -28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/table,
 /turf/simulated/floor/plasteel,
 /area/station/supply/expedition)
 "vVQ" = (
@@ -85694,12 +85692,9 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "vZu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tiles/department/cargo/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/supply/expedition)
+/obj/effect/spawner/random/blood/maybe,
+/turf/simulated/floor/plating,
+/area/station/public/storefront)
 "vZD" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 4
@@ -86048,6 +86043,17 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/genetics)
+"wfv" = (
+/obj/effect/landmark/start/explorer,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/station/supply/expedition)
 "wfQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/turf_decal/tiles/dark/corner,
@@ -87037,6 +87043,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/asmaint)
+"wAp" = (
+/obj/structure/closet/secure_closet/explorer,
+/obj/effect/turf_decal/tiles/department/cargo/side{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/expedition)
 "wAG" = (
 /obj/machinery/chem_master,
 /obj/structure/sign/poster/contraband/random/directional/south,
@@ -87615,6 +87628,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prisonlockers)
+"wMA" = (
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/sorting)
 "wNh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
@@ -87911,15 +87930,16 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/expedition,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/supply/expedition)
 "wTp" = (
@@ -89755,12 +89775,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint2)
 "xMk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table/flipped,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/station/supply/expedition)
+/area/station/public/storefront)
 "xMn" = (
 /obj/item/radio/intercom{
 	name = "east bump";
@@ -111498,8 +111522,8 @@ bwu
 myP
 rVV
 fkr
-cqQ
-rVV
+myP
+eqy
 jnc
 blQ
 fea
@@ -111755,7 +111779,7 @@ bwy
 dHN
 mBl
 blQ
-blQ
+pag
 blQ
 blQ
 blQ
@@ -112003,14 +112027,14 @@ xYM
 biD
 bms
 sHf
-blR
+wrU
 bqC
 bpb
+wrU
 blQ
-mBl
-bwy
-fEL
+jtD
 blQ
+qsc
 bDI
 bzC
 bBk
@@ -112259,14 +112283,14 @@ xZC
 jrN
 bgA
 blO
-sba
+bkg
 blR
 brz
 bsD
 bui
-blQ
-mSb
-bnK
+mTX
+jiW
+qkj
 vRD
 cCh
 bEB
@@ -112515,16 +112539,16 @@ aUE
 aaa
 gdZ
 bgA
-aBG
-bkk
-ovl
+bmf
+sba
+wrU
 bnz
-bpi
-iYO
-blQ
-bwy
+bsQ
+bKs
+qQc
+bKs
 bvF
-blQ
+qsc
 byv
 bEB
 cCh
@@ -112774,14 +112798,14 @@ gdZ
 bgA
 qrk
 egd
-blR
-iFm
-bsM
-cEJ
-blQ
-snM
+wrU
+wrU
+aCX
+bKs
+qVd
+bKs
 bCj
-blQ
+qsc
 cCh
 bEC
 bBj
@@ -113030,15 +113054,15 @@ aaa
 tKX
 bgA
 biJ
-bkf
+bkg
+blW
 wrU
-wrU
-wrU
-wrU
-blQ
-jtD
-blQ
-blQ
+nRT
+uoa
+wfv
+tji
+wAp
+qsc
 bzB
 bBj
 bCu
@@ -113286,15 +113310,15 @@ aSu
 aSu
 aSu
 bgE
-fvs
-jJs
+bmf
+bkg
+blX
 wrU
-bqA
-bsI
+kBW
 jZQ
-bsn
-mQd
-flB
+rsA
+bDJ
+wrU
 qsc
 qsc
 qsc
@@ -113545,11 +113569,11 @@ fVJ
 ikL
 bmx
 bpj
+qrZ
 wrU
-brE
-bsQ
+hVI
+lXP
 bKs
-qQc
 bcX
 wrU
 bxe
@@ -113803,10 +113827,10 @@ bgJ
 rVo
 epu
 wrU
-wrU
-aCX
+flB
+bsW
+lXP
 bKs
-qVd
 vVK
 wrU
 bxd
@@ -114058,10 +114082,10 @@ cYH
 dim
 gIc
 biG
-bkg
-blW
+ixn
 wrU
-bpl
+iam
+bpn
 uAa
 bsm
 bBU
@@ -114069,7 +114093,7 @@ wTj
 tSN
 bDN
 tPw
-lje
+wMA
 bIG
 bJE
 bKI
@@ -114316,12 +114340,12 @@ mfx
 biF
 dmv
 bkg
-blX
 wrU
-kBW
-gyA
-rsA
-bDJ
+wrU
+wrU
+wrU
+wrU
+wrU
 wrU
 kCk
 byl
@@ -114571,15 +114595,15 @@ cGS
 cYK
 dim
 gIc
-dmx
-bkg
+edg
+iFC
 bql
-wrU
+lVW
 bpl
 ile
 bqJ
 bwA
-wrU
+gvY
 bxf
 wKl
 bzI
@@ -114830,13 +114854,13 @@ gHr
 rWK
 dmx
 bkg
-wrU
-flB
-bsW
+gvY
+pXc
+hQo
 xMk
-bKs
+hqT
 sZe
-wrU
+gvY
 lnv
 wKl
 bzH
@@ -115087,13 +115111,13 @@ gHr
 djO
 bmC
 bks
-wrU
-iam
-bpn
+gvY
+mTH
+dZU
 con
 vZu
 bwz
-wrU
+gvY
 bxg
 sfJ
 bzK
@@ -115344,13 +115368,13 @@ gHr
 qZp
 yhp
 bkq
-wrU
-wrU
-wrU
-bnT
-wrU
-wrU
-wrU
+gvY
+gvY
+gvY
+qRf
+qRf
+gvY
+gvY
 bfx
 bfx
 bfx
@@ -115605,7 +115629,7 @@ dnN
 beu
 pGm
 bun
-tvf
+bnO
 bnO
 bnO
 kun

--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -20390,6 +20390,7 @@
 "bwz" = (
 /obj/structure/shelf,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/south,
 /turf/simulated/floor/plasteel,
 /area/station/public/storefront)
 "bwA" = (
@@ -74700,6 +74701,7 @@
 	name = "Storefront Shutters";
 	id_tag = "store2"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/station/public/storefront)
 "qRr" = (

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -33089,9 +33089,9 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
 "czG" = (
-/obj/machinery/space_heater,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/station/maintenance/port)
+/area/station/public/storefront)
 "czH" = (
 /obj/machinery/light{
 	dir = 8
@@ -33537,19 +33537,25 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/port2)
 "cBb" = (
-/obj/effect/landmark/spawner/nukedisc_respawn,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/port)
-"cBd" = (
 /obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
+/obj/machinery/power/apc/directional/west,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/storefront)
+"cBd" = (
 /obj/effect/turf_decal/tiles/neutral/side{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
-/area/station/maintenance/port)
+/area/station/public/storefront)
 "cBe" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/glass/fifty{
@@ -34274,23 +34280,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "cDX" = (
-/obj/effect/turf_decal/tiles/neutral,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/port)
+/turf/simulated/wall,
+/area/station/public/storefront)
 "cDZ" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 2
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/port)
-"cEa" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tiles/neutral/side{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
 "cEh" = (
 /obj/machinery/camera{
@@ -50934,6 +50930,9 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
 "eTZ" = (
@@ -60154,15 +60153,14 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
 "iEX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
@@ -61211,6 +61209,13 @@
 /obj/effect/turf_decal/tiles/department/virology/side,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
+"iZV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tiles/neutral,
+/obj/structure/closet,
+/obj/effect/spawner/random/maintenance,
+/turf/simulated/floor/plasteel,
+/area/station/public/storefront)
 "jac" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -64698,6 +64703,11 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
+"kAu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/spawner/nukedisc_respawn,
+/turf/simulated/floor/plating,
+/area/station/maintenance/port)
 "kAw" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -66717,6 +66727,15 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/research)
+"lrt" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/station/public/storefront)
 "lrF" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -74384,6 +74403,15 @@
 "ovL" = (
 /turf/simulated/wall,
 /area/station/hallway/secondary/entry/north)
+"owq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/station/maintenance/port)
 "owJ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/service/chapel{
@@ -78721,6 +78749,19 @@
 /obj/structure/sign/electricshock,
 /turf/simulated/wall/r_wall,
 /area/station/science/robotics/showroom)
+"qil" = (
+/obj/machinery/door_control{
+	id = "store2";
+	name = "Storefront Shutters Control";
+	pixel_x = 24
+	},
+/obj/machinery/alarm/directional/south,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/table_frame,
+/turf/simulated/floor/plating,
+/area/station/public/storefront)
 "qiP" = (
 /obj/effect/turf_decal/tiles/department/virology/side{
 	dir = 4
@@ -82112,6 +82153,9 @@
 /obj/effect/turf_decal/tiles/neutral/corner{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
 "ryd" = (
@@ -82379,6 +82423,17 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/north)
+"rDk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/catwalk/grey,
+/area/station/public/storefront)
 "rDv" = (
 /obj/structure/table/reinforced,
 /obj/item/rpd,
@@ -84537,6 +84592,15 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
+"ssA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	name = "Storefront Shutters";
+	id_tag = "store2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/storefront)
 "ssO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -84719,6 +84783,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/execution)
+"sxE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tiles/neutral/side{
+	dir = 1
+	},
+/obj/effect/spawner/random/maintenance,
+/obj/structure/shelf,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/storefront)
 "sxI" = (
 /obj/machinery/light{
 	dir = 8
@@ -89409,6 +89485,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/south)
+"uiR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tiles/neutral,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/public/storefront)
 "uiU" = (
 /obj/structure/closet/emcloset,
 /obj/structure/window/reinforced{
@@ -91964,6 +92049,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
+"vkr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance{
+	name = "Storefront Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/station/public/storefront)
 "vku" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -94512,6 +94614,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
+"wmf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/port)
 "wmz" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
@@ -97330,6 +97448,14 @@
 /obj/effect/turf_decal/tiles/neutral/side,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
+"xoT" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	name = "Storefront Shutters";
+	id_tag = "store2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/storefront)
 "xpf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -132616,7 +132742,7 @@ bYj
 bYj
 uCq
 cHA
-dhG
+kAu
 drn
 cGi
 dmq
@@ -133127,9 +133253,9 @@ ctN
 cvp
 cwN
 bYj
-cWn
-dhG
-dhG
+cDX
+cDX
+cDX
 cDX
 dhG
 cGs
@@ -133384,10 +133510,10 @@ bwT
 cvq
 cwO
 bYj
-czF
+sxE
 cBb
-cHr
-dlM
+iZV
+cDX
 drn
 eAq
 drn
@@ -133641,11 +133767,11 @@ ctH
 bzx
 cwP
 bYj
-drn
-cHr
-drn
-drn
-dhG
+lrt
+uiR
+rDk
+vkr
+owq
 iEX
 rFW
 rFW
@@ -133900,10 +134026,10 @@ cbK
 bYj
 czG
 cBd
-dlM
-cEa
+qil
+cDX
 cNh
-eAq
+wmf
 jOV
 cIS
 vyZ
@@ -134155,10 +134281,10 @@ bYj
 bYj
 bYj
 bYj
-cHA
-cHA
-cHA
-cHA
+ssA
+xoT
+cDX
+cDX
 cHA
 eTB
 cHA

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -61214,6 +61214,7 @@
 /obj/effect/turf_decal/tiles/neutral,
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
+/obj/machinery/firealarm/directional/south,
 /turf/simulated/floor/plasteel,
 /area/station/public/storefront)
 "jac" = (
@@ -84599,6 +84600,7 @@
 	name = "Storefront Shutters";
 	id_tag = "store2"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/station/public/storefront)
 "ssO" = (
@@ -97454,6 +97456,7 @@
 	name = "Storefront Shutters";
 	id_tag = "store2"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/station/public/storefront)
 "xpf" = (

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -5737,6 +5737,7 @@
 "bjf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/shelf,
+/obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/plasteel,
 /area/station/public/storefront)
 "bjm" = (
@@ -69603,6 +69604,9 @@
 	name = "Storefront Shutters";
 	id_tag = "store1";
 	dir = 2
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/storefront)

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -239,7 +239,7 @@
 /obj/effect/spawner/random/fungus/maybe,
 /obj/effect/mapping_helpers/turfs/rust/maybe,
 /turf/simulated/wall,
-/area/station/maintenance/dorms/starboard)
+/area/station/public/storefront)
 "aeB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
@@ -5734,6 +5734,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/medical/storage)
+"bjf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/shelf,
+/turf/simulated/floor/plasteel,
+/area/station/public/storefront)
 "bjm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6182,11 +6187,15 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/hos)
 "bob" = (
-/obj/structure/rack,
-/obj/item/poster/random_contraband,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/dorms/starboard)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/storefront)
 "bog" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -6765,6 +6774,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/junction{
 	dir = 1
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dorms/starboard)
@@ -16003,6 +16015,14 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/station/science/misc_lab)
+"diR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/reinforced/directional/west,
+/obj/structure/cable/extra_insulated{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/storefront)
 "diW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -22969,15 +22989,22 @@
 /turf/simulated/floor/carpet/blue,
 /area/station/command/office/blueshield)
 "eEs" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/glowstick,
-/obj/effect/spawner/random/glowstick,
-/obj/effect/spawner/random/glowstick,
-/obj/effect/spawner/random/glowstick,
-/obj/effect/spawner/random/glowstick,
-/obj/effect/spawner/random/glowstick,
+/obj/machinery/door/airlock/maintenance{
+	name = "Storefront Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/station/maintenance/dorms/starboard)
+/area/station/public/storefront)
 "eEt" = (
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/effect/turf_decal/tiles/department/science/corner,
@@ -23961,10 +23988,8 @@
 /area/station/maintenance/apmaint)
 "eON" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/plasteel,
-/area/station/maintenance/dorms/starboard)
+/area/station/public/storefront)
 "eOP" = (
 /obj/structure/railing{
 	dir = 8
@@ -30851,11 +30876,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
 "geX" = (
-/obj/structure/closet,
 /obj/effect/spawner/random/cobweb/right/frequent,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/dorms/starboard)
+/turf/simulated/floor/plasteel,
+/area/station/public/storefront)
 "gff" = (
 /obj/machinery/economy/vending/engidrobe,
 /turf/simulated/floor/plasteel,
@@ -42881,6 +42907,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/toxins/mixing)
+"iAZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/dorms/starboard)
 "iBa" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -53452,6 +53488,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
+"kHU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/glowstick,
+/obj/effect/spawner/random/glowstick,
+/obj/effect/spawner/random/glowstick,
+/obj/effect/spawner/random/glowstick,
+/obj/effect/spawner/random/glowstick,
+/obj/effect/spawner/random/glowstick,
+/turf/simulated/floor/plating,
+/area/station/maintenance/dorms/starboard)
 "kHY" = (
 /obj/structure/rack,
 /obj/item/screwdriver,
@@ -56194,6 +56241,9 @@
 /obj/effect/spawner/random/barrier/grille_maybe,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dorms/port)
+"llP" = (
+/turf/simulated/wall,
+/area/station/public/storefront)
 "llQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -61057,6 +61107,11 @@
 /obj/effect/turf_decal/tiles/department/medical,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/sleeper)
+"mnz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair,
+/turf/simulated/floor/plating,
+/area/station/public/storefront)
 "mnB" = (
 /obj/effect/turf_decal/tiles/department/security/corner{
 	dir = 4
@@ -61434,6 +61489,17 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dorms/port)
+"mrm" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/door_control{
+	id = "store1";
+	name = "Storefront Shutters Control";
+	pixel_x = 24
+	},
+/turf/simulated/floor/plating,
+/area/station/public/storefront)
 "mrn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -63369,6 +63435,17 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/procedure/trainer_office)
+"mNo" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/rack,
+/turf/simulated/floor/plasteel,
+/area/station/public/storefront)
 "mNs" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -66144,6 +66221,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hardsuitstorage)
+"nnK" = (
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/dorms/starboard)
 "nnO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -69512,6 +69596,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
+"nTP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	name = "Storefront Shutters";
+	id_tag = "store1";
+	dir = 2
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/storefront)
 "nTT" = (
 /obj/effect/spawner/window/reinforced/polarized/grilled{
 	id = "HoS"
@@ -72324,9 +72418,10 @@
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
 "otY" = (
-/obj/item/stack/rods,
+/obj/machinery/alarm/directional/west,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
-/area/station/maintenance/dorms/starboard)
+/area/station/public/storefront)
 "ouc" = (
 /turf/simulated/floor/engine,
 /area/station/hallway/spacebridge/security/west)
@@ -73295,6 +73390,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dorms/starboard)
 "oFG" = (
@@ -90682,6 +90780,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/interrogation)
+"rYR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/station/maintenance/dorms/starboard)
 "rYU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -96467,6 +96574,11 @@
 	icon_state = "medium"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/dorms/starboard)
 "thz" = (
@@ -99250,16 +99362,18 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/range)
 "tKe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dorms/starboard)
 "tKg" = (
@@ -103036,6 +103150,9 @@
 	dir = 2
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/extra_insulated{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dorms/starboard)
 "uxl" = (
@@ -110815,11 +110932,6 @@
 /obj/machinery/alarm/directional/west,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"vZe" = (
-/obj/effect/spawner/random/trash,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/dorms/starboard)
 "vZj" = (
 /obj/machinery/teleport/hub,
 /turf/simulated/floor/plasteel,
@@ -113730,6 +113842,14 @@
 /obj/effect/turf_decal/tiles/department/security/checker,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/storage)
+"wFt" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/station/public/storefront)
 "wFz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -120710,6 +120830,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
+"ydv" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/station/maintenance/dorms/starboard)
 "ydw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -156421,7 +156549,7 @@ vAZ
 vAZ
 vAZ
 qIf
-smY
+nnK
 oHA
 xmm
 cCH
@@ -157188,13 +157316,13 @@ xsJ
 rcW
 dxH
 vAZ
+kHU
 fRA
-fRA
-vZe
-jOP
-nCL
-kcb
-xmm
+llP
+llP
+llP
+llP
+llP
 rxd
 pjq
 jYc
@@ -157448,10 +157576,10 @@ vAZ
 tVF
 voE
 aeo
-bsr
-qIf
+diR
+mNo
 otY
-xmm
+llP
 akP
 fXo
 qMg
@@ -157696,19 +157824,19 @@ cqq
 iIw
 pIl
 uxe
-ssZ
+iAZ
 btt
 oFC
-ssZ
+iAZ
 tKe
 thq
-fRA
-fRA
+rYR
+ydv
 eEs
-tUY
+wFt
 bob
 eON
-xmm
+nTP
 rxd
 iSc
 rxd
@@ -157960,12 +158088,12 @@ egS
 gsU
 fRA
 oPi
-pIl
-xmi
-cPy
-kcb
-rHN
-xmm
+kTt
+llP
+bjf
+mrm
+mnz
+nTP
 rxd
 iSc
 qSf
@@ -158222,7 +158350,7 @@ oBS
 oBS
 oBS
 geX
-xmm
+llP
 wxg
 iSc
 shL


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Title

Shifts the Cyberiad explorer room over a bit to make room, the office itself is on the corner of arrivals and cargo hall.

Kerberos Office is slotted in below library

Emerald Office is slotted in above Changs and Jani closet.

All of these locations are on the more frequently travelled areas for more interaction if used.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Old shop was a nice spot for RP without having to spend a big part of the round actually making the shop, which was unfortunately removed at some points.  

The stations listed didn't all have the shop, but no reason not to add them especially with how little space it takes up.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Cyberiad Shop
<img width="707" height="720" alt="image" src="https://github.com/user-attachments/assets/ea734c0e-7c7b-41d7-926a-780636498b47" />
Kerberos Shop
<img width="857" height="740" alt="image" src="https://github.com/user-attachments/assets/ccab0343-ccbe-4274-a0f3-bd487825bcbd" />
Diagoras Shop
<img width="693" height="677" alt="image" src="https://github.com/user-attachments/assets/fe51986d-fd51-4491-86fb-4e2db7b8ca63" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
- Made sure box explorer room looked/functioned correctly
- Made sure shutters, apcs and air alarms on all shops worked
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Added Old shops to Cyberiad, Kerberos and Diagoras.
tweak: Moved Cyberiad explorer room over a bit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
