### PR TITLE
removes logging of basic mobs eating

### DIFF
--- a/code/datums/elements/basic_eating.dm
+++ b/code/datums/elements/basic_eating.dm
@@ -109,8 +109,6 @@
 		var/obj/item/stack/food_stack = target
 		final_target = food_stack.split(eater, 1)
 
-	add_attack_logs(eater, target, "eaten, [add_to_contents ? "consuming it" : "destroying it"]")
-
 	if(add_to_contents)
 		var/atom/movable/movable_target = final_target
 		movable_target.forceMove(eater)


### PR DESCRIPTION
## What Does This PR Do

removes the attack logging of basic mobs eating stuff like goldgrubs eating ore

## Why It's Good For The Game

<img width="646" height="629" alt="Screenshot 2026-05-07 003343" src="https://github.com/user-attachments/assets/4037d204-63f0-416e-a442-b81996eb8cf2" />
(attack log spam over for something that's never going to be needed to be looked back at is annoying to wade through)

## Testing

tested the before and after of removing the line in some mobs. no logs showed up after

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<img width="635" height="67" alt="image" src="https://github.com/user-attachments/assets/b540e426-1e89-4c74-b308-410320ffbca8" />

## Changelog

NPFC
