### PR TITLE
Add tgui dev server suppot for Linux

### DIFF
--- a/tgui/packages/tgui-dev-server/dreamseeker.js
+++ b/tgui/packages/tgui-dev-server/dreamseeker.js
@@ -148,7 +148,7 @@ async function getLinuxEntries(pidsToResolve) {
 
   for (const [linuxPid, addrs] of wineServers) {
     try {
-      const env = await fs.readFile(`/proc/${linuxPid}/environ`);
+      const env = await fs.readFile(`/proc/${linuxPid}/environ`, 'utf8');
       const prefix = env.split('\0').find(l => l.startsWith("WINEPREFIX"))?.split('=')[1];
       if(!prefix) continue;
 
@@ -167,8 +167,8 @@ async function getLinuxEntries(pidsToResolve) {
           }
         }
       }
-    } catch (e) {
-      logger.log(`something broke but nobody knows what`);
+    } catch (err) {
+      logger.log(err);
       continue;
     }
   }

--- a/tgui/packages/tgui-dev-server/dreamseeker.js
+++ b/tgui/packages/tgui-dev-server/dreamseeker.js
@@ -6,6 +6,8 @@
 
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
+import fs from "fs/promises";
+import os from 'node:os';
 
 import axios, { isAxiosError } from 'axios';
 
@@ -74,32 +76,10 @@ export class DreamSeeker {
       return instances;
     }
 
-    const command = 'netstat -ano | findstr TCP | findstr 0.0.0.0:0';
-
     try {
-      const { stdout } = await promisify(exec)(command, {
-        // Max buffer of 1MB (default is 200KB)
-        maxBuffer: 1024 * 1024,
-      });
-
-      // Line format:
-      // proto addr mask mode pid
-      const entries = [];
-      const lines = stdout.split('\r\n');
-
-      for (let line of lines) {
-        const words = line.match(/\S+/g);
-        if (!words || words.length === 0) {
-          continue;
-        }
-        const entry = {
-          addr: words[1],
-          pid: parseInt(words[4], 10),
-        };
-        if (pidsToResolve.includes(entry.pid)) {
-          entries.push(entry);
-        }
-      }
+      const entries = os.platform() === 'win32'
+        ? await getWindowsEntries(pidsToResolve)
+        : await getLinuxEntries(pidsToResolve);
 
       const len = entries.length;
       logger.log('found', len, plural('instance', len));
@@ -119,6 +99,87 @@ export class DreamSeeker {
     }
     return instances;
   }
+}
+
+async function getWindowsEntries(pidsToResolve) {
+  const { stdout } = await run('netstat -ano | findstr TCP | findstr 0.0.0.0:0')
+
+  // Line format:
+  // proto addr mask mode pid
+  const entries = [];
+  const lines = stdout.split('\r\n');
+
+  for (let line of lines) {
+    const words = line.match(/\S+/g);
+    if (!words || words.length === 0) {
+      continue;
+    }
+    const entry = {
+      addr: words[1],
+      pid: parseInt(words[4], 10),
+    };
+    if (pidsToResolve.includes(entry.pid)) {
+      entries.push(entry);
+    }
+  }
+  return entries;
+}
+
+async function getLinuxEntries(pidsToResolve) {
+  const { stdout } = await run('ss -tlnp');
+  
+  const wineServers = new Map();
+
+  for (const line of stdout.split('\n')) {
+    if (!line.includes('wineserver') || !line.includes('127.0.0.1')) continue;
+
+    const parts = line.trim().split(/\s+/);
+    const addr = parts[3]
+
+    const pidMatch = line.match(/pid=(\d+)/);
+    if (!pidMatch) continue;
+
+    const linuxPid = pidMatch[1];
+    if (!wineServers.has(linuxPid)) wineServers.set(linuxPid, [])
+    wineServers.get(linuxPid).push(addr);
+  }
+
+  const entries = [];
+
+  for (const [linuxPid, addrs] of wineServers) {
+    try {
+      const env = await fs.readFile(`/proc/${linuxPid}/environ`);
+      const prefix = env.split('\0').find(l => l.startsWith("WINEPREFIX"))?.split('=')[1];
+      if(!prefix) continue;
+
+      const { stdout: winedbgOut } = await run(`WINEPREFIX=${prefix} winedbg --command "info proc"`);
+      const winPids = winedbgOut.split('\n');
+
+      for (const line of winPids) {
+        if(!line.includes('dreamseeker.exe')) continue;
+
+        const parts = line.trim().split(/\s+/);
+        const winPid = parseInt(parts[0], 16)
+
+        if(pidsToResolve.includes(winPid)) {
+          for (const addr of addrs) {
+            entries.push({addr, pid: winPid})
+          }
+        }
+      }
+    } catch (e) {
+      logger.log(`something broke but nobody knows what`);
+      continue;
+    }
+  }
+
+  return entries
+}
+
+async function run(command) {
+  return promisify(exec)(command, {
+    maxBuffer: 1024 * 1024,
+  });
 }
 
 function plural(word, n) {

--- a/tgui/packages/tgui-dev-server/dreamseeker.js
+++ b/tgui/packages/tgui-dev-server/dreamseeker.js
@@ -9,7 +9,6 @@ import os from 'node:os';
 import { promisify } from 'node:util';
 
 import axios, { isAxiosError } from 'axios';
-import fs from 'fs/promises';
 
 import { createLogger } from './logging.js';
 
@@ -127,7 +126,7 @@ async function getWindowsEntries(pidsToResolve) {
 async function getLinuxEntries(pidsToResolve) {
   const { stdout } = await run('ss -tlnp');
 
-  const wineServers = new Map();
+  const addrs = [];
 
   for (const line of stdout.split('\n')) {
     if (!line.includes('wineserver') || !line.includes('127.0.0.1')) continue;
@@ -135,45 +134,21 @@ async function getLinuxEntries(pidsToResolve) {
     const parts = line.trim().split(/\s+/);
     const addr = parts[3];
 
-    const pidMatch = line.match(/pid=(\d+)/);
-    if (!pidMatch) continue;
-
-    const linuxPid = pidMatch[1];
-    if (!wineServers.has(linuxPid)) wineServers.set(linuxPid, []);
-    wineServers.get(linuxPid).push(addr);
+    addrs.push(addr);
   }
 
-  const entries = [];
+  const entries = (await Promise.all(
+    addrs.map(async (addr) => {
+      try {
+        const result = await axios.get(`http://${addr}/pid.htm`, { timeout: 300 });
 
-  for (const [linuxPid, addrs] of wineServers) {
-    try {
-      const env = await fs.readFile(`/proc/${linuxPid}/environ`, 'utf8');
-      const prefix = env
-        .split('\0')
-        .find((l) => l.startsWith('WINEPREFIX'))
-        ?.split('=')[1];
-      if (!prefix) continue;
-
-      const { stdout: winedbgOut } = await run(`WINEPREFIX=${prefix} winedbg --command "info proc"`);
-      const winPids = winedbgOut.split('\n');
-
-      for (const line of winPids) {
-        if (!line.includes('dreamseeker.exe')) continue;
-
-        const parts = line.trim().split(/\s+/);
-        const winPid = parseInt(parts[0], 16);
-
-        if (pidsToResolve.includes(winPid)) {
-          for (const addr of addrs) {
-            entries.push({ addr, pid: winPid });
-          }
-        }
+        const pid = parseInt(result.data, 10);
+        return Number.isNaN(pid) ? null : { pid, addr };
+      } catch {
+        return null;
       }
-    } catch (err) {
-      logger.log(err);
-      continue;
-    }
-  }
+    })
+  )).filter(Boolean);
 
   return entries;
 }

--- a/tgui/packages/tgui-dev-server/dreamseeker.js
+++ b/tgui/packages/tgui-dev-server/dreamseeker.js
@@ -5,11 +5,11 @@
  */
 
 import { exec } from 'node:child_process';
-import { promisify } from 'node:util';
-import fs from "fs/promises";
 import os from 'node:os';
+import { promisify } from 'node:util';
 
 import axios, { isAxiosError } from 'axios';
+import fs from 'fs/promises';
 
 import { createLogger } from './logging.js';
 
@@ -77,9 +77,8 @@ export class DreamSeeker {
     }
 
     try {
-      const entries = os.platform() === 'win32'
-        ? await getWindowsEntries(pidsToResolve)
-        : await getLinuxEntries(pidsToResolve);
+      const entries =
+        os.platform() === 'win32' ? await getWindowsEntries(pidsToResolve) : await getLinuxEntries(pidsToResolve);
 
       const len = entries.length;
       logger.log('found', len, plural('instance', len));
@@ -102,7 +101,7 @@ export class DreamSeeker {
 }
 
 async function getWindowsEntries(pidsToResolve) {
-  const { stdout } = await run('netstat -ano | findstr TCP | findstr 0.0.0.0:0')
+  const { stdout } = await run('netstat -ano | findstr TCP | findstr 0.0.0.0:0');
 
   // Line format:
   // proto addr mask mode pid
@@ -127,20 +126,20 @@ async function getWindowsEntries(pidsToResolve) {
 
 async function getLinuxEntries(pidsToResolve) {
   const { stdout } = await run('ss -tlnp');
-  
+
   const wineServers = new Map();
 
   for (const line of stdout.split('\n')) {
     if (!line.includes('wineserver') || !line.includes('127.0.0.1')) continue;
 
     const parts = line.trim().split(/\s+/);
-    const addr = parts[3]
+    const addr = parts[3];
 
     const pidMatch = line.match(/pid=(\d+)/);
     if (!pidMatch) continue;
 
     const linuxPid = pidMatch[1];
-    if (!wineServers.has(linuxPid)) wineServers.set(linuxPid, [])
+    if (!wineServers.has(linuxPid)) wineServers.set(linuxPid, []);
     wineServers.get(linuxPid).push(addr);
   }
 
@@ -149,21 +148,24 @@ async function getLinuxEntries(pidsToResolve) {
   for (const [linuxPid, addrs] of wineServers) {
     try {
       const env = await fs.readFile(`/proc/${linuxPid}/environ`, 'utf8');
-      const prefix = env.split('\0').find(l => l.startsWith("WINEPREFIX"))?.split('=')[1];
-      if(!prefix) continue;
+      const prefix = env
+        .split('\0')
+        .find((l) => l.startsWith('WINEPREFIX'))
+        ?.split('=')[1];
+      if (!prefix) continue;
 
       const { stdout: winedbgOut } = await run(`WINEPREFIX=${prefix} winedbg --command "info proc"`);
       const winPids = winedbgOut.split('\n');
 
       for (const line of winPids) {
-        if(!line.includes('dreamseeker.exe')) continue;
+        if (!line.includes('dreamseeker.exe')) continue;
 
         const parts = line.trim().split(/\s+/);
-        const winPid = parseInt(parts[0], 16)
+        const winPid = parseInt(parts[0], 16);
 
-        if(pidsToResolve.includes(winPid)) {
+        if (pidsToResolve.includes(winPid)) {
           for (const addr of addrs) {
-            entries.push({addr, pid: winPid})
+            entries.push({ addr, pid: winPid });
           }
         }
       }
@@ -173,7 +175,7 @@ async function getLinuxEntries(pidsToResolve) {
     }
   }
 
-  return entries
+  return entries;
 }
 
 async function run(command) {

--- a/tgui/packages/tgui-dev-server/dreamseeker.js
+++ b/tgui/packages/tgui-dev-server/dreamseeker.js
@@ -137,18 +137,20 @@ async function getLinuxEntries(pidsToResolve) {
     addrs.push(addr);
   }
 
-  const entries = (await Promise.all(
-    addrs.map(async (addr) => {
-      try {
-        const result = await axios.get(`http://${addr}/pid.htm`, { timeout: 300 });
+  const entries = (
+    await Promise.all(
+      addrs.map(async (addr) => {
+        try {
+          const result = await axios.get(`http://${addr}/pid.htm`, { timeout: 300 });
 
-        const pid = parseInt(result.data, 10);
-        return Number.isNaN(pid) ? null : { pid, addr };
-      } catch {
-        return null;
-      }
-    })
-  )).filter(Boolean);
+          const pid = parseInt(result.data, 10);
+          return Number.isNaN(pid) ? null : { pid, addr };
+        } catch {
+          return null;
+        }
+      })
+    )
+  ).filter(Boolean);
 
   return entries;
 }

--- a/tgui/packages/tgui-dev-server/reloader.js
+++ b/tgui/packages/tgui-dev-server/reloader.js
@@ -79,9 +79,17 @@ export async function reloadByondCache(bundleDir) {
     return;
   }
 
-  const pids = cacheDirs.map((cacheDir) => {
-    return parseInt(cacheDir.split('tmp')[1], 10);
-  });
+  const pids = [];
+
+  for (const cacheDir of cacheDirs) {
+    const pid = parseInt(cacheDir.split('tmp')[1], 10);
+    pids.push(pid);
+
+    const pidFile = cacheDir + '/pid.htm';
+    if(!fs.existsSync(pidFile)) {
+      fs.writeFileSync(pidFile, String(pid), 'utf8');
+    }
+  }
 
   const dssPromise = DreamSeeker.getInstancesByPids(pids);
   // Copy assets

--- a/tgui/packages/tgui-dev-server/reloader.js
+++ b/tgui/packages/tgui-dev-server/reloader.js
@@ -80,7 +80,7 @@ export async function reloadByondCache(bundleDir) {
   }
 
   const pids = cacheDirs.map((cacheDir) => {
-    return parseInt(cacheDir.split('\\cache\\tmp')[1], 10);
+    return parseInt(cacheDir.split('tmp')[1], 10);
   });
 
   const dssPromise = DreamSeeker.getInstancesByPids(pids);

--- a/tgui/packages/tgui-dev-server/reloader.js
+++ b/tgui/packages/tgui-dev-server/reloader.js
@@ -86,7 +86,7 @@ export async function reloadByondCache(bundleDir) {
     pids.push(pid);
 
     const pidFile = cacheDir + '/pid.htm';
-    if(!fs.existsSync(pidFile)) {
+    if (!fs.existsSync(pidFile)) {
       fs.writeFileSync(pidFile, String(pid), 'utf8');
     }
   }


### PR DESCRIPTION
## What Does This PR Do
Modifies the TGUI dev server, to make it work on Linux without funky workarounds. The dev server will now create a small .htm within the tmp directory of each instance, containing the respective PID derived from the tmp dir. (So it creates a pid.htm file with content 1234 inside of /cache/tmp1234). When discovering Dreamseeker instances, Linux will probe a bunch of addresses collected by `ss -tlnp` and it'll only keep the ones that respond with pid.htm. This lets it associate address <-> pid without relying on fragile wine tools.
## Why It's Good For The Game
Tuxkind gets TGUI dev server
## Testing
I cannot test Windows, as I don't have windows, but it should in theory be completely unaltered.

I hot reloaded UIs on a local dev server. I also ran 2 dreamseeker instances with the dev server and it connected to both.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC