### PR TITLE
Put disabled welders in open closets.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -358,7 +358,7 @@
 	if(!opened && user.loc == src)
 		to_chat(user, SPAN_WARNING("You can't weld [src] from inside!"))
 		return
-	if(!I.tool_enabled && opened) // if the welder isn't on, just put it in the open closet
+	if(!I.tool_enabled && opened) // If the welder isn't on, just put it in the open closet.
 		return FALSE
 	if(!I.tool_use_check(user, 0))
 		return

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -358,6 +358,8 @@
 	if(!opened && user.loc == src)
 		to_chat(user, SPAN_WARNING("You can't weld [src] from inside!"))
 		return
+	if(!I.tool_enabled && opened) // if the welder isn't on, just put it in the open closet
+		return FALSE
 	if(!I.tool_use_check(user, 0))
 		return
 	if(opened)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -130,7 +130,7 @@
 	if(!opened && user.loc == src)
 		to_chat(user, SPAN_WARNING("You can't weld [src] from inside!"))
 		return
-	if(!I.tool_enabled && opened) // if the welder isn't on, just put it in the open closet
+	if(!I.tool_enabled && opened) // If the welder isn't on, just put it in the open closet.
 		return FALSE
 	if(!I.tool_use_check(user, 0) || !opened)
 		return

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -130,6 +130,8 @@
 	if(!opened && user.loc == src)
 		to_chat(user, SPAN_WARNING("You can't weld [src] from inside!"))
 		return
+	if(!I.tool_enabled && opened) // if the welder isn't on, just put it in the open closet
+		return FALSE
 	if(!I.tool_use_check(user, 0) || !opened)
 		return
 	WELDER_ATTEMPT_SLICING_MESSAGE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

If the welder you are holding is currently off, and the closet you're clicking on is open, put the welder in the closet instead of putting out a message about it needing to be on to complete "this task".

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

I just think it's better gameplay for welders to be freely puttable in closets and crates when they're off, instead of throwing up an error message. Putting objects in open closets and crates is expected behavior when clicking on them.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted. Put deactivated welders in open closets and crates. Received error messages from deactivated welders on closed closets and crates. Used active welders to seal closed closets. Used active welders to deconstruct open closets and crates.  

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Allow clicking on open closets and crates with a disabled welder to put the welder in the closet or crate.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
