### PR TITLE
Cyberiad tweaks: light replacer, filing cabinet, desk bells.

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -34027,6 +34027,10 @@
 	pixel_x = 3;
 	pixel_y = -7
 	},
+/obj/item/lightreplacer{
+	pixel_y = 6;
+	pixel_x = -2
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
 "cDc" = (
@@ -52872,7 +52876,6 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
 "hjH" = (
-/obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -60377,6 +60380,9 @@
 /obj/effect/mapping_helpers/airlock/windoor/access/any/command/hop{
 	dir = 8
 	},
+/obj/item/desk_bell{
+	anchored = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/station/command/office/hop)
 "kBr" = (
@@ -64144,6 +64150,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"mjr" = (
+/obj/structure/filingcabinet/chestdrawer,
+/turf/simulated/floor/wood,
+/area/station/public/vacant_office)
 "mjE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/watertank,
@@ -66144,6 +66154,25 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/indestructible/titanium,
 /area/shuttle/arrival/station)
+"ngy" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/window/classic/reversed{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/autoname/desk{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/hydroponics{
+	dir = 1
+	},
+/obj/item/desk_bell{
+	anchored = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/service/hydroponics)
 "ngD" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 2
@@ -66742,6 +66771,11 @@
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/airlock/windoor/access/all/engineering/general{
 	dir = 4
+	},
+/obj/item/desk_bell{
+	pixel_x = -5;
+	pixel_y = 4;
+	anchored = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
@@ -105068,7 +105102,7 @@ bmo
 brl
 bss
 bqr
-brU
+mjr
 brU
 wbo
 bBH
@@ -131286,7 +131320,7 @@ brr
 brr
 brr
 bxL
-gLf
+ngy
 bAr
 boi
 wBF


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Adds a light replacer to the Cyberiad's engineering department. Moves a filing cabinet that would block people in the unused office. Adds more desk bells.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

You don't like desk bells? Ding! ? ):

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<img width="418" height="393" alt="engineering light replacer" src="https://github.com/user-attachments/assets/62991ef6-ba2b-47e4-9a14-340071c28ac2" />
<img width="528" height="432" alt="moved cabinet" src="https://github.com/user-attachments/assets/54619ef1-9bd3-43d1-803d-fa840c597a2b" />
<img width="346" height="422" alt="engineering desk bell" src="https://github.com/user-attachments/assets/105b04b0-fea6-4084-a416-86a234c77054" />
<img width="328" height="297" alt="HOP desk bell" src="https://github.com/user-attachments/assets/9a17045c-8e6c-44ca-bee4-6a3eccd63ba8" />
<img width="366" height="311" alt="botany desk bell" src="https://github.com/user-attachments/assets/50061938-3adc-4ff5-b9d2-29a7a4965e5c" />


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

Compiled, hosted. Strolled around the station ringing bells.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Added a light replacer to Cyberiad's engineering department.
add: Added more desk bells to the Cyberiad.
tweak: Moved a Cyberiad filing cabinet to no longer block people from exiting their office.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
