### PR TITLE
Farragus: Fixes another cable

### DIFF
--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -68553,7 +68553,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/dark,


### PR DESCRIPTION
## What Does This PR Do
Fixes the engineering yellow to maint cable transition so it can actualy transmit power. Green maint wire connected to a yellow wire that then connected to an orange maint wire, causing no power to flow.
## Why It's Good For The Game
Power should flow from engi.
## Testing
Visual inspection.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Farragus, fixes no power leaving the SM.
/:cl: