### PR TITLE
Nerfs heretic effects on sacrifice

### DIFF
--- a/code/modules/antagonists/heretic/status_effects/heretic_debuffs.dm
+++ b/code/modules/antagonists/heretic/status_effects/heretic_debuffs.dm
@@ -217,7 +217,7 @@
 // MARK: Necropolis curse
 /datum/status_effect/necropolis_curse
 	id = "necrocurse"
-	duration = 10 MINUTES //you're cursed for 10 minutes have fun
+	duration = 3 MINUTES // Lasts for the same time as Unholy Determination
 	tick_interval = 5 SECONDS
 	alert_type = null
 	var/curse_flags = NONE

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -490,7 +490,10 @@
 	metabolization_rate = 0.5
 	/// How much toxin damage do we do each tick?
 	var/toxin_damage = 0.25
-	//Keeps track of the hand timer so we can cleanup on removal
+	/// Interval between hand throws
+	var/throw_interval = 4 SECONDS
+	/// Keeps track of when the last hand was thrown
+	var/next_throw_time
 
 //Warns you about the impenting hands
 /datum/reagent/helgrasp/on_mob_add(mob/living/affected_mob, amount)
@@ -502,7 +505,9 @@
 /datum/reagent/helgrasp/on_mob_life(mob/living/carbon/affected_mob)
 	var/update_flags = STATUS_UPDATE_NONE
 	update_flags |= affected_mob.adjustToxLoss(toxin_damage, FALSE)
-	spawn_hands(affected_mob)
+	if(next_throw_time < world.time + throw_interval)
+		spawn_hands(affected_mob)
+		next_throw_time = world.time + throw_interval
 	return ..() | update_flags
 
 /datum/reagent/helgrasp/proc/spawn_hands(mob/living/carbon/affected_mob)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Reduces the duration of Necropolis's Curse to 3 minutes from 10, and increases time between hands when affected by mansusgrasp or helgrasp from 2 seconds to 4.

## Why It's Good For The Game

The heretic sacrifice has a unique mechanic that allows you to play a minigame to dodge hands to survive. This was not well balanced around Paradise's combat, making it nearly impossible to achieve. By changing the intervals between hands, and reducing the duration of the curse so that if you fail you're not punished for excessive time frames, it better accounts for Paradise's slower move speed (and the fact you're likely injured when sacrificed)

## Testing

Injested mansusgrasp. Dodged hands. Verified time was reduced.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<img width="1822" height="305" alt="image" src="https://github.com/user-attachments/assets/f8e2b032-3105-49c1-9901-f758b3499820" />

## Changelog

:cl:
tweak: Reduced duration of Necropolis's Curse
tweak: Increased time between cursed hands caused by helgrasp and mansusgrasp reagents.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
