### PR TITLE
Fixes spaceacillin not having a icon in the medical borgs hypospray radial menu

### DIFF
--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -27,7 +27,7 @@
 	var/list/reagent_ids_emagged = list("tirizene")
 	var/static/list/reagent_icons = list("salglu_solution" = image(icon = 'icons/goonstation/objects/iv.dmi', icon_state = "ivbag"),
 							"epinephrine" = image(icon = 'icons/obj/hypo.dmi', icon_state = "autoinjector"),
-							"spaceacillin" = image(icon = 'icons/obj/decals.dmi', icon_state = "bio"),
+							"spaceacillin" = image(icon = 'icons/obj/decals.dmi', icon_state = "biohazard"),
 							"charcoal" = image(icon = 'icons/obj/chemical.dmi', icon_state = "pill17"),
 							"hydrocodone" = image(icon = 'icons/obj/chemical.dmi', icon_state = "bottle19"),
 							"styptic_powder" = image(icon = 'icons/obj/chemical.dmi', icon_state = "bandaid2"),


### PR DESCRIPTION
## What Does This PR Do
Title

## Why It's Good For The Game
Was bugged, couldn't see what the option was


## Testing
<img width="300" height="309" alt="image" src="https://github.com/user-attachments/assets/c33e9677-0e5a-40fd-9819-3d2d08071d77" />

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
fix: Fixed spaceacillin not having a icon in the medical borgs hypospray radial menu
/:cl:

