### PR TITLE
Add the ability to install headsets in desk bells.

### DIFF
--- a/code/game/objects/items/devices/radio/radio_objects.dm
+++ b/code/game/objects/items/devices/radio/radio_objects.dm
@@ -272,7 +272,7 @@ GLOBAL_LIST_EMPTY(deadsay_radio_systems)
 /obj/item/radio/proc/ToggleReception()
 	listening = !listening && !(wires.is_cut(WIRE_RADIO_RECEIVER) || wires.is_cut(WIRE_RADIO_SIGNAL))
 
-/obj/item/radio/proc/autosay(message, from, channel, follow_target_override) //BS12 EDIT
+/obj/item/radio/proc/autosay(message, from, channel, follow_target_override, is_emote = FALSE, sender_job = null, vname = null) //BS12 EDIT
 	var/datum/radio_frequency/connection = null
 	if(channel && channels && length(channels) > 0)
 		if(channel == "department")
@@ -297,7 +297,11 @@ GLOBAL_LIST_EMPTY(deadsay_radio_systems)
 			break
 	if(jammed)
 		message = Gibberish(message, 100)
-	var/list/message_pieces = message_to_multilingual(message)
+	var/list/message_pieces
+	if(is_emote)
+		message_pieces = list(new /datum/multilingual_say_piece(GLOB.all_languages["Noise"], message))
+	else
+		message_pieces = message_to_multilingual(message)
 
 		// Make us a message datum!
 	var/datum/tcomms_message/tcm = new
@@ -306,8 +310,8 @@ GLOBAL_LIST_EMPTY(deadsay_radio_systems)
 	tcm.radio = src
 	tcm.sender_name = from
 	tcm.message_pieces = message_pieces
-	tcm.sender_job = "Automated Announcement"
-	tcm.vname = "synthesized voice"
+	tcm.sender_job = sender_job || "Automated Announcement"
+	tcm.vname = vname || "synthesized voice"
 	tcm.signal_type = SIGNALTYPE_AINOTRACK
 	// Datum radios dont have a location (obviously)
 	if(loc && loc.z)

--- a/code/modules/paperwork/desk_bell.dm
+++ b/code/modules/paperwork/desk_bell.dm
@@ -18,6 +18,8 @@
 	var/ring_sound = 'sound/machines/bell.ogg'
 	/// The remote signaller that we're gonna activate to this bell
 	var/obj/item/assembly/signaler/attached_signaler
+	var/obj/item/radio/headset/attached_headset
+	var/radio_channel
 	new_attack_chain = TRUE
 
 /obj/item/desk_bell/examine(mob/user)
@@ -26,6 +28,8 @@
 		. += SPAN_NOTICE("It's anchored in place.")
 	if(!isnull(attached_signaler))
 		. += SPAN_NOTICE("There seems to be an antenna sticking out of the base.")
+	if(!isnull(attached_headset))
+		. += SPAN_NOTICE("There's a little microphone poking out of it. You can probably use a multitool to change the channel.")
 	if(broken_ringer)
 		. += SPAN_NOTICE("The clapper looks off. You can probably screw it back in place.")
 
@@ -41,16 +45,24 @@
 	return ..()
 
 /obj/item/desk_bell/item_interaction(mob/living/user, obj/item/used, list/modifiers)
-	if(!istype(used, /obj/item/assembly/signaler))
-		return ..()
-	// can only attach its on your person
+	if(istype(used, /obj/item/assembly/signaler))
+		try_attach_signaler(user, used)
+		return ITEM_INTERACT_COMPLETE
+	if(istype(used, /obj/item/radio/headset))
+		try_attach_headset(user, used)
+		return ITEM_INTERACT_COMPLETE
+	return ..()
+
+/obj/item/desk_bell/proc/try_attach_signaler(mob/living/user, obj/item/assembly/signaler/signal)
+	if(!istype(signal))
+		return FALSE
+	// can only attach if it's on your person
 	if(!in_inventory)
-		to_chat(user, SPAN_WARNING("[src] needs to be in your inventory if you want to attach [used] to it!"))
-		return ITEM_INTERACT_COMPLETE
-	if(!isnull(attached_signaler))
-		to_chat(user, SPAN_NOTICE("There's already a signaler attached!"))
-		return ITEM_INTERACT_COMPLETE
-	var/obj/item/assembly/signaler/signal = used
+		to_chat(user, SPAN_WARNING("[src] needs to be in your inventory if you want to attach [signal] to it!"))
+		return FALSE
+	if(!isnull(attached_signaler) || !isnull(attached_headset))
+		to_chat(user, SPAN_NOTICE("There's already something attached!"))
+		return FALSE
 	user.transfer_item_to(signal, src)
 	attached_signaler = signal
 	if(signal.receiving)
@@ -60,7 +72,32 @@
 		SPAN_NOTICE("You attach [signal] to [src].")
 	)
 	add_fingerprint(user)
-	return ITEM_INTERACT_COMPLETE
+	return TRUE
+
+/obj/item/desk_bell/proc/try_attach_headset(mob/living/user, obj/item/radio/headset/radio)
+	if(!istype(radio))
+		return FALSE
+	// can only attach if it's on your person
+	if(!in_inventory)
+		to_chat(user, SPAN_WARNING("[src] needs to be in your inventory if you want to attach [radio] to it!"))
+		return FALSE
+	if(!isnull(attached_signaler) || !isnull(attached_headset))
+		to_chat(user, SPAN_NOTICE("There's already something attached!"))
+		return FALSE
+
+	var/new_channel = tgui_input_list(user, "Select Radio Channel", "Desk Bell Headset", radio.channels - "Common")
+	if(!(new_channel && (new_channel in radio.channels)))
+		return FALSE
+
+	radio_channel = new_channel
+	user.transfer_item_to(radio, src)
+	attached_headset = radio
+	user.visible_message(
+		SPAN_NOTICE("[user] attaches [radio] to [src]."),
+		SPAN_NOTICE("You attach [radio] to [src].")
+	)
+	add_fingerprint(user)
+	return TRUE
 
 /obj/item/desk_bell/proc/on_signal()
 	SIGNAL_HANDLER  // COMSIG_ASSEMBLY_PULSED
@@ -97,6 +134,18 @@
 		anchored = FALSE
 
 	add_fingerprint(M)
+
+// Change radio channel
+/obj/item/desk_bell/multitool_act(mob/living/user, /obj/item/tool)
+	if(isnull(attached_headset))
+		to_chat(user, SPAN_WARNING("[src] has no headset in it to adjust!"))
+		return FALSE
+	var/new_channel = tgui_input_list(user, "Select Radio Channel", "Desk Bell Headset", attached_headset.channels - "Common")
+	if(new_channel && (new_channel in attached_headset.channels))
+		radio_channel = new_channel
+		add_fingerprint(user)
+		return TRUE
+	return FALSE
 
 // Fix the clapper
 /obj/item/desk_bell/screwdriver_act(mob/living/user, obj/item/tool)
@@ -143,6 +192,12 @@
 		user.put_in_hands(attached_signaler)
 		UnregisterSignal(attached_signaler, COMSIG_ASSEMBLY_PULSED)
 		attached_signaler = null
+	if(attached_headset)
+		if(!tool.use_tool(src, user, 0.5 SECONDS, volume = tool.tool_volume))
+			return TRUE
+		to_chat(user, SPAN_NOTICE("You remove [attached_headset]."))
+		user.put_in_hands(attached_headset)
+		attached_headset = null
 
 /// Check if the clapper breaks, and if it does, break it
 /obj/item/desk_bell/proc/check_clapper(mob/living/user)
@@ -162,6 +217,21 @@
 	flick("desk_bell_ring", src)
 	if(attached_signaler && !from_signaler)
 		attached_signaler.signal()
+	if(attached_headset)
+		var/datum/tcomms_message/tcm = new
+		tcm.connection = attached_headset.secure_radio_connections[radio_channel]
+		tcm.sender = attached_headset
+		tcm.radio = attached_headset
+		tcm.sender_name = "[name] in [get_location_name(src)]"
+		tcm.message_pieces = list(new /datum/multilingual_say_piece(GLOB.all_languages["Noise"], "dings!"))
+		tcm.sender_job = "Desk Bell"
+		tcm.vname = "clear bell"
+		tcm.signal_type = SIGNALTYPE_AINOTRACK
+		tcm.source_level = loc.z
+		tcm.freq = tcm.connection.frequency
+		for(var/obj/machinery/tcomms/core/C in GLOB.tcomms_machines)
+			C.handle_message(tcm)
+		qdel(tcm)
 	times_rang++
 	return TRUE
 

--- a/code/modules/paperwork/desk_bell.dm
+++ b/code/modules/paperwork/desk_bell.dm
@@ -218,20 +218,7 @@
 	if(attached_signaler && !from_signaler)
 		attached_signaler.signal()
 	if(attached_headset)
-		var/datum/tcomms_message/tcm = new
-		tcm.connection = attached_headset.secure_radio_connections[radio_channel]
-		tcm.sender = attached_headset
-		tcm.radio = attached_headset
-		tcm.sender_name = "[name] in [get_location_name(src)]"
-		tcm.message_pieces = list(new /datum/multilingual_say_piece(GLOB.all_languages["Noise"], "dings!"))
-		tcm.sender_job = "Desk Bell"
-		tcm.vname = "clear bell"
-		tcm.signal_type = SIGNALTYPE_AINOTRACK
-		tcm.source_level = loc.z
-		tcm.freq = tcm.connection.frequency
-		for(var/obj/machinery/tcomms/core/C in GLOB.tcomms_machines)
-			C.handle_message(tcm)
-		qdel(tcm)
+		attached_headset.autosay("dings!", "[name] in [get_location_name(src)]", radio_channel, is_emote = TRUE, sender_job = "Desk Bell", vname = "clear bell")
 	times_rang++
 	return TRUE
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Adds the ability to install headsets into desk bells. When someone rings the bell, it will also ring over the chosen radio channel.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Away from your desk often? Want an easy way for people to call you there? Want a convenient doorbell ditch button? Just plug your department's headset into the desk bell. But probably make sure you're still wearing a different one, or else you won't hear it.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<img width="371" height="157" alt="desk bell and headset" src="https://github.com/user-attachments/assets/bcffbc97-4980-4232-8abf-2707d553351a" />
<img width="332" height="363" alt="radio channel menu" src="https://github.com/user-attachments/assets/00947fb6-c6fe-4dbd-b58a-b48c71938159" />
<img width="435" height="41" alt="ding" src="https://github.com/user-attachments/assets/1757b12c-688b-4993-bd7c-2af977a2cde9" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

Compiled, hosted. Installed headset in desk bell, chose channel. Anchored and rang desk bell. Used multitool to change radio channel inhand and on desk. Removed headset from desk bell. Installed remote signaler in desk bell. Rang desk bell and heard beeps. Uninstalled remote signaler from desk bell.

Requires more extensive testing now that it alters the autosay proc. I would appreciate a test merge as well.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Added the ability to install headsets in desk bells.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
