### PR TITLE
Allow simply putting soap/mop/rag in storage if clean.

### DIFF
--- a/code/game/objects/cleaning.dm
+++ b/code/game/objects/cleaning.dm
@@ -15,6 +15,20 @@
 
 // skip_do_after - When TRUE, do after and visible messages are disabled
 
+/atom/proc/is_dirty()
+	if(HAS_TRAIT(src, TRAIT_CMAGGED)) //So we don't need a cleaning_act for every cmaggable object
+		return TRUE
+	if(ismob(src))
+		// Mobs always get cleaned directly, because humans have clothing that needs cleaning, and because it'd just feel weird to automatically clean under them.
+		return TRUE
+	if(blood_DNA)
+		return TRUE
+	for(var/obj/effect/decal/cleanable/C in src)
+		return TRUE
+	for(var/obj/effect/heretic_rune/H in src)
+		return TRUE
+	return FALSE
+
 /atom/proc/cleaning_act(mob/user, atom/cleaner, cleanspeed = 5 SECONDS, text_verb = "clean", text_description = " with [cleaner].", text_targetname = name, skip_do_after = FALSE)
 	var/is_cmagged = FALSE
 
@@ -22,24 +36,12 @@
 		to_chat(user, SPAN_NOTICE("You need to take that [text_targetname] off before cleaning it."))
 		return FALSE
 
-	var/is_dirty = FALSE
+	var/is_dirty = is_dirty()
+
 	if(HAS_TRAIT(src, TRAIT_CMAGGED)) //So we don't need a cleaning_act for every cmaggable object
 		is_cmagged = TRUE
 		text_verb = "clean the ooze off"
 		cleanspeed = CMAG_CLEANTIME
-		is_dirty = TRUE
-	else if(ismob(src))
-		// Mobs always get cleaned directly, because humans have clothing that needs cleaning, and because it'd just feel weird to automatically clean under them.
-		is_dirty = TRUE
-	else if(blood_DNA)
-		is_dirty = TRUE
-	else
-		for(var/obj/effect/decal/cleanable/C in src)
-			is_dirty = TRUE
-			break
-		for(var/obj/effect/heretic_rune/H in src)
-			is_dirty = TRUE
-			break
 
 	if(!is_dirty && !isturf(src))
 		// We don't need cleaning, so let's spare the janitor a pixel hunt and let the floor under us get cleaned instead.

--- a/code/game/objects/cleaning.dm
+++ b/code/game/objects/cleaning.dm
@@ -16,7 +16,7 @@
 // skip_do_after - When TRUE, do after and visible messages are disabled
 
 /atom/proc/is_dirty()
-	if(HAS_TRAIT(src, TRAIT_CMAGGED)) //So we don't need a cleaning_act for every cmaggable object
+	if(HAS_TRAIT(src, TRAIT_CMAGGED)) // So we don't need a cleaning_act for every cmaggable object
 		return TRUE
 	if(ismob(src))
 		// Mobs always get cleaned directly, because humans have clothing that needs cleaning, and because it'd just feel weird to automatically clean under them.

--- a/code/game/objects/items/soap.dm
+++ b/code/game/objects/items/soap.dm
@@ -24,6 +24,9 @@
 
 /obj/item/soap/interact_with_atom(atom/target, mob/living/user, list/modifiers)
 	if(!ismob(target))
+		// if it's a storage item and it isn't dirty, just put the soap in the storage
+		if(isstorage(target) && !target.is_dirty())
+			return ..()
 		target.cleaning_act(user, src, cleanspeed)
 		return ITEM_INTERACT_COMPLETE
 

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -62,6 +62,10 @@
 	if(istype(target, /obj/structure/janitorialcart/) || istype(target, /obj/structure/mopbucket))
 		return ITEM_INTERACT_COMPLETE
 
+	// if it's a storage item and it isn't dirty, just put the mop in the storage
+	if(isstorage(target) && !target.is_dirty())
+		return ..()
+
 	if(reagents.total_volume < 1)
 		to_chat(user, SPAN_WARNING("Your mop is dry!"))
 		return ITEM_INTERACT_COMPLETE

--- a/code/modules/detective_work/footprints_and_rag.dm
+++ b/code/modules/detective_work/footprints_and_rag.dm
@@ -22,6 +22,9 @@
 		return ..()
 
 /obj/item/reagent_containers/glass/rag/normal_act(atom/target, mob/living/user)
+	// if it's a storage item and it isn't dirty, just put the rag in the storage
+	if(isstorage(target) && !target.is_dirty())
+		return ..()
 	target.cleaning_act(user, src, wipespeed)
 	return TRUE
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Re-enables click-to-store functionality on soap, mops, and rags if the clicked storage doesn't need cleaning.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

I'm just getting annoyed trying to juggle my inhand items as a janitor.
Oh, and it partially addresses #30390.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted. Placed soap, mop, and rag in clean worn backpack. Dirtied backpack. Got appropriate interactions of either cleaning it or message about removing the backpack before cleaning. Attempted and failed to put cyborg soap and mop abilities in backpack.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Added the ability to put soap, a mop, or a rag in a container with simple left click if the container is already clean. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
