### PR TITLE
Fixes non-antags being able to exfiltrate

### DIFF
--- a/code/modules/antagonists/_common/antag_exfiltration.dm
+++ b/code/modules/antagonists/_common/antag_exfiltration.dm
@@ -110,7 +110,7 @@
 
 /obj/item/wormhole_jaunter/extraction/activate(mob/user)
 	if(!isAntag(user))
-		to_chat(user, SPAN_WARNING("The flare refuses to ignite."))
+		to_chat(user, SPAN_WARNING("No matter how much you try, you can't get [src] to ignite!"))
 		return
 
 	if(!turf_check(user))

--- a/code/modules/antagonists/_common/antag_exfiltration.dm
+++ b/code/modules/antagonists/_common/antag_exfiltration.dm
@@ -109,6 +109,10 @@
 			. += SPAN_WARNING(" - [A.name]")
 
 /obj/item/wormhole_jaunter/extraction/activate(mob/user)
+	if(!isAntag(user))
+		to_chat(user, SPAN_WARNING("The flare refuses to ignite."))
+		return
+
 	if(!turf_check(user))
 		return
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes an oversight that allowed non-antagonists to light and go through antag exfiltration portals.

## Why It's Good For The Game

Crew who are not antagonists should not be antagging.

## Testing

Tried to light the flare as crew. Failed.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed non-antagonists lighting and going through exfiltration portals
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
