### PR TITLE
Tweaks Cyberiad Port Engi Maint

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -36531,9 +36531,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
 "cNE" = (
@@ -37837,13 +37834,7 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/extra_insulated{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/reinforced/directional/south,
-/obj/effect/turf_decal/stripes/end{
-	dir = 1
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
 "cSF" = (
@@ -45418,6 +45409,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm/directional/south,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
 "eak" = (
@@ -46594,6 +46588,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint2)
+"eyR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
@@ -50400,7 +50401,11 @@
 /turf/simulated/floor/carpet/royalblack,
 /area/station/maintenance/apmaint)
 "ghs" = (
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/power/apc/reinforced/directional/north,
+/obj/effect/turf_decal/stripes/end,
+/obj/structure/cable/extra_insulated{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
 "ghv" = (
@@ -55885,6 +55890,9 @@
 /area/station/medical/patients_rooms1)
 "iCq" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
 "iCY" = (
@@ -55959,10 +55967,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
-"iFh" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint2)
 "iFu" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -58757,6 +58761,13 @@
 /obj/effect/spawner/random/cobweb/right/frequent,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
+"jQS" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint2)
 "jQX" = (
 /obj/machinery/light/small,
 /obj/item/soap,
@@ -112234,7 +112245,7 @@ cZw
 rFc
 cLi
 cLi
-dkp
+cNB
 pgV
 qod
 pGN
@@ -112749,7 +112760,7 @@ kjM
 hsO
 uMl
 cLi
-cUh
+eyR
 qod
 icI
 dOs
@@ -114032,7 +114043,7 @@ cgQ
 cZw
 ogh
 rYt
-lVs
+jQS
 gSd
 tmS
 qod
@@ -115060,7 +115071,7 @@ gYs
 sWO
 cNB
 gSd
-iFh
+lVs
 eyE
 cZw
 cNB

--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -16699,16 +16699,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/nw)
-"bkr" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint2)
 "bks" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -23812,9 +23802,6 @@
 "bLV" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/spacecash/c50,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/apmaint2)
 "bMb" = (
@@ -36073,8 +36060,6 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
-/obj/structure/grille/broken,
-/obj/item/stack/rods,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -39494,6 +39479,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/catwalk,
 /area/station/engineering/secure_storage)
+"cZI" = (
+/obj/machinery/power/grounding_rod,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint2)
 "cZL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -44469,7 +44458,7 @@
 /obj/structure/cable/extra_insulated/pre_connect{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/apmaint2)
 "dHj" = (
 /obj/machinery/door/firedoor{
@@ -44919,6 +44908,11 @@
 /obj/effect/turf_decal/delivery/white/hollow,
 /turf/simulated/floor/plasteel,
 /area/station/medical/storage)
+"dOs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/cigbutt,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint2)
 "dOR" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 4
@@ -46437,7 +46431,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/engine/reactor)
 "euD" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
@@ -46447,7 +46440,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/apmaint2)
 "euQ" = (
 /obj/effect/spawner/random/maintenance,
@@ -50407,7 +50400,6 @@
 /turf/simulated/floor/carpet/royalblack,
 /area/station/maintenance/apmaint)
 "ghs" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
@@ -53428,6 +53420,13 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/doors,
 /turf/simulated/floor/wood,
 /area/station/legal/courtroom/gallery)
+"hyc" = (
+/obj/structure/shelf/engineering,
+/obj/effect/spawner/random/engineering/materials,
+/obj/effect/spawner/random/engineering/materials,
+/obj/effect/spawner/random/engineering/toolbox,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint2)
 "hyj" = (
 /obj/structure/rack{
 	dir = 1
@@ -54639,6 +54638,16 @@
 /obj/structure/closet/l3closet/scientist,
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
+"icI" = (
+/obj/structure/table/flipped{
+	dir = 1
+	},
+/obj/effect/turf_decal/tiles/department/engineering/side{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint2)
 "ido" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -54868,8 +54877,8 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
 "iir" = (
-/obj/structure/closet/crate,
-/obj/item/vending_refill/cargodrobe,
+/obj/structure/closet/crate/engineering,
+/obj/item/vending_refill/engidrobe,
 /obj/item/vending_refill/boozeomat,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
@@ -54982,7 +54991,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/apmaint2)
 "ikL" = (
 /obj/structure/disposalpipe/segment,
@@ -55049,7 +55058,6 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
 "ilS" = (
@@ -56209,17 +56217,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft2)
-"iKY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/largecrate,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/sign/engineering/power{
-	pixel_x = -32
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint2)
 "iLY" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
@@ -57120,6 +57117,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"jer" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Aft Port Solar Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/solar_maintenance/aft_port)
 "jet" = (
 /obj/machinery/light{
 	dir = 1
@@ -59636,9 +59647,6 @@
 /area/station/maintenance/apmaint2)
 "kjM" = (
 /obj/item/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/apmaint2)
 "kjU" = (
@@ -60812,17 +60820,6 @@
 /obj/effect/turf_decal/tiles/department/command,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/cmo)
-"kLd" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint2)
 "kLe" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -61936,7 +61933,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-4"
 	},
@@ -61944,7 +61940,7 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/apmaint2)
 "lmU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
@@ -61956,7 +61952,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
 "lnh" = (
 /obj/structure/chair/stool,
@@ -63248,19 +63244,14 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/reception)
 "lQm" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Aft Port Solar Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/extra_insulated{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/solar_maintenance/aft_port)
+/area/station/maintenance/apmaint2)
 "lQz" = (
 /obj/structure/safe/floor{
 	known_by = list("captain")
@@ -65338,7 +65329,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/rd,
-/turf/simulated/floor/plasteel/dark,
+/turf/simulated/floor/plasteel,
 /area/station/engineering/gravitygenerator)
 "mLo" = (
 /obj/effect/spawner/window/reinforced/plasma/grilled,
@@ -66614,7 +66605,7 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/apmaint2)
 "nsZ" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -67573,7 +67564,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/apmaint2)
 "nMU" = (
 /obj/structure/disposalpipe/segment{
@@ -68332,6 +68323,13 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/science/robotics)
+"ods" = (
+/obj/structure/chair/sofa/right{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint2)
 "odD" = (
 /obj/structure/bookcase,
 /turf/simulated/floor/wood,
@@ -71838,6 +71836,16 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/asmaint)
+"pGN" = (
+/obj/effect/turf_decal/tiles/department/engineering/side{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/flipped{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint2)
 "pHs" = (
 /obj/machinery/newscaster/directional/north,
 /obj/effect/turf_decal/tiles/department/medical/checker,
@@ -72500,7 +72508,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/apmaint2)
 "pVb" = (
 /obj/structure/chair/comfy/brown{
@@ -73505,7 +73513,6 @@
 /obj/machinery/door/poddoor/shutters{
 	id_tag = "maint_house"
 	},
-/obj/structure/barricade/wooden,
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
@@ -74120,6 +74127,27 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/abandonedservers)
+"qEc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/reagent_containers/drinks/bottle/beer{
+	pixel_x = -10;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/drinks/bottle/beer{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_uplift{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/drinks/bottle/beer{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint2)
 "qEg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -75546,6 +75574,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"rjt" = (
+/obj/machinery/power/tesla_coil,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint2)
 "rjD" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -77626,6 +77658,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"shl" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/spawner/random/engineering/tools,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint2)
 "sht" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/cable/extra_insulated{
@@ -78477,19 +78517,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"sEh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/extra_insulated{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint2)
 "sEj" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -78570,6 +78597,13 @@
 /obj/item/storage/bag/plants/seed_sorting_tray,
 /turf/simulated/floor/grass,
 /area/station/security/permabrig)
+"sFW" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint2)
 "sGj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -79991,6 +80025,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/station/command/office/hop)
+"toI" = (
+/obj/effect/turf_decal/tiles/department/engineering/side{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint2)
 "toQ" = (
 /obj/structure/chair{
 	dir = 1
@@ -81970,13 +82011,6 @@
 /obj/structure/disaster_counter/toxins,
 /turf/simulated/wall/r_wall,
 /area/station/science/toxins/launch)
-"uiB" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/space,
-/area/station/engineering/solar/aft_port)
 "ujt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -82658,19 +82692,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/gravitygenerator)
-"uyl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/extra_insulated{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/apmaint2)
 "uyu" = (
 /obj/effect/turf_decal/trimline/misc/toxins/filled/shrink_cw,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -83257,6 +83278,16 @@
 "uQE" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/solar_maintenance/fore_port)
+"uQL" = (
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint2)
 "uQX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/landmark/spawner/rev,
@@ -83514,7 +83545,6 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
 "uVX" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -84045,14 +84075,13 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
 "vjx" = (
-/obj/structure/girder,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/apmaint2)
 "vjQ" = (
 /obj/machinery/door/firedoor{
@@ -84199,6 +84228,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/incinerator)
+"vnk" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/spawner/random/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint2)
 "vnr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/disposalpipe/segment{
@@ -85329,6 +85366,13 @@
 /obj/structure/closet/crate/can,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/engine/reactor)
+"vOd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tiles/department/engineering/side{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint2)
 "vOj" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -86088,6 +86132,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
 "wer" = (
@@ -86561,6 +86606,16 @@
 /obj/effect/spawner/random/cobweb/right/frequent,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
+"wnR" = (
+/obj/structure/sign/engineering/power{
+	pixel_x = -32
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/largecrate,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint2)
 "woA" = (
 /obj/machinery/shower/directional/east,
 /obj/effect/turf_decal/delivery,
@@ -86706,7 +86761,6 @@
 /obj/machinery/door/poddoor/shutters{
 	id_tag = "maint_house"
 	},
-/obj/structure/barricade/wooden,
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
@@ -87922,7 +87976,6 @@
 /area/station/aisat/service)
 "wQI" = (
 /obj/structure/closet/crate/internals,
-/obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
 "wQK" = (
@@ -88142,7 +88195,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage)
 "wXb" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -88150,7 +88202,7 @@
 /area/station/maintenance/apmaint2)
 "wXg" = (
 /obj/effect/spawner/random/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -111418,10 +111470,10 @@ cLi
 rEZ
 cLi
 rEZ
-aaa
-uiB
-aaa
-aaa
+cRA
+otx
+xSF
+aab
 aaa
 aaa
 aaa
@@ -111671,13 +111723,13 @@ rYt
 rHY
 gSd
 qsa
-cLi
-aab
-aab
-aaa
+toI
+wXb
+cUh
+hyc
+cRA
+jCt
 swl
-otx
-xSF
 aab
 aab
 aaa
@@ -111928,14 +111980,14 @@ ieW
 vYD
 ilt
 sXR
-pOC
-aaa
-aab
-aab
+vOd
+cUh
+shl
+cRA
+cRA
+ntD
 swl
-jCt
 swl
-aab
 aab
 aab
 aab
@@ -112184,15 +112236,15 @@ cLi
 cLi
 dkp
 pgV
-cKe
-pOC
-aaa
-aaa
-swl
-swl
-ntD
-swl
-swl
+qod
+pGN
+cUh
+vnk
+cRA
+cSR
+gOm
+cVl
+sdw
 aab
 aab
 aaa
@@ -112440,16 +112492,16 @@ bLV
 oWV
 cLi
 cLi
-cNB
+csC
 cLF
-cLi
-aaa
-aab
+icI
+cNB
+qEc
 cRA
-cSR
-gOm
-cVl
-sdw
+cTa
+cUe
+cVd
+cRA
 aaa
 aaa
 aaa
@@ -112698,14 +112750,14 @@ hsO
 uMl
 cLi
 cUh
-cKe
-rEZ
-aaa
-aaa
-cRA
-cTa
-cUe
-cVd
+qod
+icI
+dOs
+cUh
+sdw
+cST
+cUd
+cVm
 cRA
 mnN
 mnN
@@ -112955,14 +113007,14 @@ jQI
 kjG
 cLi
 cNB
-cKe
-pOC
-aaa
-aab
-sdw
-cST
-cUd
-cVm
+qod
+cLi
+ods
+uQL
+cRA
+cRA
+jer
+cRA
 sdw
 sTc
 jEc
@@ -113213,14 +113265,14 @@ sJC
 rMq
 gSd
 eAw
-pOC
-aab
-aab
-cRA
-cRA
+cLi
+cLi
+cLi
+cQy
+wnR
 lQm
-cRA
-sdw
+cNB
+cQy
 onZ
 kgK
 tdO
@@ -113469,15 +113521,15 @@ lnh
 kym
 cLi
 cUh
-kLd
-rEZ
-aaa
-aaa
+qod
+cLi
+rjt
+rjt
 oyi
-iKY
+cNB
 hgj
 eNV
-cLi
+cQy
 fzl
 lIl
 xEw
@@ -113727,10 +113779,10 @@ cLi
 cLi
 cNB
 qod
-rEZ
-aaa
-aaa
-cQy
+cLi
+dkp
+cNB
+sFW
 cNB
 wjN
 ikK
@@ -113983,10 +114035,10 @@ rYt
 lVs
 gSd
 tmS
-cKe
-pOC
-aaa
-aaa
+qod
+cLi
+cZI
+cZI
 oyi
 cNB
 cNB
@@ -114239,15 +114291,15 @@ lqg
 cZw
 sJQ
 csC
-cZw
+cNB
 eAw
 wcG
 oyi
-pOC
+cQy
 cQy
 cLi
-cZw
-uyl
+cNB
+nME
 iir
 bFC
 bFC
@@ -114500,11 +114552,11 @@ cNB
 weq
 cLi
 jUM
-cZw
+cNB
 wXb
 rMq
 wQI
-sEh
+nME
 mAq
 bFC
 jtw
@@ -115018,7 +115070,7 @@ cZw
 cKe
 cLi
 cLi
-uyl
+nME
 mAq
 kyo
 rne
@@ -115275,7 +115327,7 @@ gSd
 qWJ
 cNB
 rMq
-uyl
+nME
 cNB
 bFC
 sOz
@@ -115789,7 +115841,7 @@ cZw
 qWJ
 tmS
 gSd
-uyl
+nME
 cNB
 xsP
 mLi
@@ -116302,7 +116354,7 @@ cLi
 uZa
 gST
 vLT
-bkr
+vLT
 pUZ
 nsU
 vjx


### PR DESCRIPTION
## What Does This PR Do
* Adds a catwalk covering the power cable leading to the PTL (as can be found on other stations).
* Adds a small maint closet with 2 rods and 2 tesla coils (as can be found on other stations).
* Replaces a space void with a small hangout area.

## Why It's Good For The Game
Catwalk looks cool and needs to appear more often, this is a good usecase.
Parity of stuff found in stations.
Cool hangout area.
## Images of changes
<img width="832" height="608" alt="image" src="https://github.com/user-attachments/assets/d830e01d-8d50-4bd1-a5ed-e76aea8283d7" />
<img width="1167" height="1208" alt="image" src="https://github.com/user-attachments/assets/079d0b34-9cde-4f5f-9649-a0d9af88d4d0" />

## Testing
Visual inspection.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
tweak: Slightly remapped cyberiad port engimaints.
/:cl: