### PR TITLE
Fixes non-functional electrochromic windows and shutters in cyberiad mech bay

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -44770,7 +44770,7 @@
 	id = "robo"
 	},
 /turf/simulated/floor/plating,
-/area/station/science/robotics/chargebay)
+/area/station/science/robotics)
 "dLN" = (
 /obj/effect/decal/cleanable/molten_object/large,
 /turf/simulated/floor/plating,
@@ -47989,6 +47989,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
+"fgi" = (
+/turf/simulated/wall/r_wall,
+/area/station/science/robotics)
 "fgk" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom/command,
@@ -136045,7 +136048,7 @@ bau
 pua
 bHI
 cfy
-bGr
+fgi
 bWj
 dpB
 bWj


### PR DESCRIPTION
## What Does This PR Do
Changes the area of some tiles with windows and shutters in the mech bay to be robotics to allow the buttons controlling them to function.

## Why It's Good For The Game
These shutters and windows have been around for years but the buttons don't work because they're not in the correct area. This corrects that.

## Images of changes
The windows in question.
<img width="128" height="128" alt="image" src="https://github.com/user-attachments/assets/50be5677-b17e-46ac-b01f-7b01b97ef642" />

## Testing
Pressed the buttons.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
fix: Fixed the box mech bay window shutters and electrochromic windows not being functional.
/:cl: