### PR TITLE
Adds Electrochromic Glass Doors to Cyberiad Robotics

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -43154,12 +43154,15 @@
 /area/station/aisat/service)
 "dpB" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/science/robotics,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard";
 	name = "Biohazard Shutter"
+	},
+/obj/machinery/door/airlock/research/glass,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "robo"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics/chargebay)
@@ -67743,7 +67746,6 @@
 /area/station/public/toilet/unisex)
 "nQD" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/science/robotics,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -67758,6 +67760,10 @@
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard";
 	name = "Biohazard Shutter"
+	},
+/obj/machinery/door/airlock/research/glass,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "robo"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics/chargebay)


### PR DESCRIPTION
## What Does This PR Do
Adds electrochomic glass airlocks to Cyberiad's robotics doors leading to the mech bay.

## Why It's Good For The Game
Allows the public to see if there's anyone inside when they enter from the centre of the station and head directly to the mech bay, and allows the roboticists to see if there's anyone waiting outside or if a dead IPC or borg has been left lying in the mech bay.

Electrochomic panels allow the current status quo of privacy to be restored with the push of a button.

## Images of changes
<img width="96" height="288" alt="image" src="https://github.com/user-attachments/assets/70198e24-be28-4607-8aa5-445221e6534d" />

## Testing
Pushed the button.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog

:cl:
tweak: Cyberiad Robotics Mech Bay doors now have electrochromic glass.
/:cl:
