### PR TITLE
Adds a power cell charger to Cyberiad Cargo

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -25563,7 +25563,8 @@
 	c_tag = "Cargo Office";
 	dir = 4
 	},
-/obj/item/multitool,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
 "bTG" = (
@@ -26282,7 +26283,10 @@
 "bWW" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
-/obj/item/screwdriver/cargo,
+/obj/item/multitool{
+	pixel_x = 7;
+	pixel_y = 12
+	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
 "bXd" = (
@@ -26684,6 +26688,9 @@
 	pixel_y = -5
 	},
 /obj/machinery/newscaster/directional/south,
+/obj/item/screwdriver/cargo{
+	pixel_y = 10
+	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
 "bYH" = (
@@ -43154,12 +43161,15 @@
 /area/station/aisat/service)
 "dpB" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/science/robotics,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard";
 	name = "Biohazard Shutter"
+	},
+/obj/machinery/door/airlock/research/glass,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "robo"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics/chargebay)
@@ -67743,7 +67753,6 @@
 /area/station/public/toilet/unisex)
 "nQD" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/science/robotics,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -67758,6 +67767,10 @@
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard";
 	name = "Biohazard Shutter"
+	},
+/obj/machinery/door/airlock/research/glass,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "robo"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics/chargebay)


### PR DESCRIPTION
## What Does This PR Do
Adds a power cell charger (plus power cell) to the cyberiad cargo office.

## Why It's Good For The Game
Other stations in rotation have a power cell charger somewhere in cargo. The number of times that I've gone to cargo and asked for a power cell only to find there's nowhere to charge it up is painful, this ends now.

## Images of changes
<img width="96" height="192" alt="image" src="https://github.com/user-attachments/assets/53a7c691-355f-4673-aa12-f519eacce344" />

## Testing
Visual inspection.
<!-- How did you test the PR, if at all? -->

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
add: Added a power cell charger (and power cell) to cyberiad cargo office.
/:cl: