### PR TITLE
Adds missing firelocks to Delta, Meta, and Emerald medchem

### DIFF
--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -67664,6 +67664,7 @@
 /area/station/medical/surgery/primary)
 "lEa" = (
 /obj/machinery/smartfridge/secure/medbay,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/chemistry)
 "lEc" = (

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -25431,6 +25431,9 @@
 	name = "Chemistry Privacy Shutter"
 	},
 /obj/effect/mapping_helpers/airlock/windoor/access/any/medical/chemistry,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/medical/chemistry)
 "fcP" = (
@@ -57529,6 +57532,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/windoor/access/any/medical/chemistry,
 /obj/effect/mapping_helpers/airlock/windoor/autoname/desk,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/medical/chemistry)
 "lyH" = (

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -58896,6 +58896,7 @@
 /obj/machinery/door/window/classic/reversed{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/medical/chemistry)
 "ndU" = (
@@ -67210,6 +67211,7 @@
 /obj/effect/mapping_helpers/airlock/windoor/autoname/desk{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/medical/chemistry)
 "pUh" = (


### PR DESCRIPTION
## What Does This PR Do
Adds missing desk firelocks to Meta, Delta, and Emerald.
## Why It's Good For The Game
Fridges and desks are not atmos proof.
## Images of changes
<img width="192" height="96" alt="image" src="https://github.com/user-attachments/assets/e903c337-4bc8-4057-b6d8-ab46b5e96195" />
<img width="128" height="96" alt="image" src="https://github.com/user-attachments/assets/cc8c56d3-c98b-47a7-b415-1fb094615deb" />
<img width="96" height="128" alt="image" src="https://github.com/user-attachments/assets/34352b82-8abe-4e16-bd06-9d551eb5f454" />

## Testing
Visual inspection.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
add: Added firelocks to the medchem desks of Delta, Meta, and Emerald.
/:cl: