### PR TITLE
Maybe fixes nanomap rendering

### DIFF
--- a/tools/github-actions/nanomap-renderer-invoker.sh
+++ b/tools/github-actions/nanomap-renderer-invoker.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -e
+# Get dependencies
+sudo apt install libc6
 # Generate maps
 tools/github-actions/dmm-tools-para minimap --enable nanomaps --width 2040 --height 2040 "./_maps/map_files/stations/boxstation.dmm"
 tools/github-actions/dmm-tools-para minimap --enable nanomaps --width 2040 --height 2040 "./_maps/map_files/stations/deltastation.dmm"

--- a/tools/github-actions/nanomap-renderer-invoker.sh
+++ b/tools/github-actions/nanomap-renderer-invoker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 # Get dependencies
-sudo apt install libc6
+apt install libc6
 # Generate maps
 tools/github-actions/dmm-tools-para minimap --enable nanomaps --width 2040 --height 2040 "./_maps/map_files/stations/boxstation.dmm"
 tools/github-actions/dmm-tools-para minimap --enable nanomaps --width 2040 --height 2040 "./_maps/map_files/stations/deltastation.dmm"


### PR DESCRIPTION
## What Does This PR Do
Maybe fixes nanomap rendering - no good way to test, but I have reason to believe this might work.

```
aa07@AA07-S-UBUNTU:~/code/Paradise/tools/github-actions# ldd dmm-tools-para
./dmm-tools-para: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by ./dmm-tools-para)
        linux-vdso.so.1 (0x00007ffd397bf000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f33a813b000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f33a8054000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f33a7e2b000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f33a83ff000)
aa07@AA07-S-UBUNTU:~/code/Paradise/tools/github-actions# lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 22.04.5 LTS
Release:        22.04
Codename:       jammy
aa07@AA07-S-UBUNTU:~/code/Paradise/tools/github-actions#
```

Given that the current error is `tools/github-actions/dmm-tools-para: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by tools/github-actions/dmm-tools-para)`, and it works fine on my server which is also ubuntu 22.04.5 LTS, I have reason to believe we are just missing a dependency.

If this works, woot woot. If this doesn't work, I will proceed to fix it by screaming 300 times in a corner.

## Why It's Good For The Game
Nanomaps should work

## Images of changes
N/A

## Testing
N/A

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
N/A