### PR TITLE
Farragus: Fixes incorrect cable under transformer

### DIFF
--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -98131,10 +98131,10 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/checkpoint/secondary)
 "tZa" = (
-/obj/structure/cable/extra_insulated{
+/obj/machinery/power/smes/transformer,
+/obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/smes/transformer,
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/maintenance/electrical/fore_port)
 "tZf" = (


### PR DESCRIPTION
## What Does This PR Do
Replaces a HV cable under the sec transformer with a normal one.
## Why It's Good For The Game
No power to sec.
## Testing
Visual inspection.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Fixed farragus sec transformer room having wrong cable type.
/:cl:
