### PR TITLE
Mining machines can now read skeleton access

### DIFF
--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -188,7 +188,7 @@
 		if(scan_id)
 			var/accepted
 			for(var/req in req_access_claim)
-				if(req in ID.access)
+				if(req in ID.GetAccess())
 					accepted = TRUE
 					break
 			if(!accepted)

--- a/code/modules/mining/salvage_redemption.dm
+++ b/code/modules/mining/salvage_redemption.dm
@@ -72,7 +72,7 @@
 			return ITEM_INTERACT_COMPLETE
 		var/claimed = FALSE
 		for(var/access in req_access_claim)
-			if(anyone_claim || (access in ID.access))
+			if(anyone_claim || (access in ID.GetAccess()))
 				ID.mining_points += points
 				ID.total_mining_points += points
 				to_chat(user, SPAN_NOTICE("<b>[points] Salvage Points</b> claimed. You have earned a total of <b>[ID.total_mining_points] Salvage Points</b> this Shift!"))

--- a/code/modules/smithing/machinery/smart_hopper.dm
+++ b/code/modules/smithing/machinery/smart_hopper.dm
@@ -103,7 +103,7 @@
 			return ITEM_INTERACT_COMPLETE
 		var/claimed = FALSE
 		for(var/access in req_access_claim)
-			if(anyone_claim || (access in ID.access))
+			if(anyone_claim || (access in ID.GetAccess()))
 				ID.mining_points += points
 				ID.total_mining_points += points
 				to_chat(user, SPAN_NOTICE("<b>[points] Mining Points</b> claimed. You have earned a total of <b>[ID.total_mining_points] Mining Points</b> this Shift!"))


### PR DESCRIPTION
## What Does This PR Do

Updates the ore redemption machine, salvage redemption machine, and smart hopper to check ID access through GetAccess() instead of reading ID.access directly.

This ports the fix from ss220club/Paradise-SS220#2268

## Why It's Good For The Game

ID.access doesn't account for skeleton access. Low population scenario will allow crew to use mining machinery.

## Testing
- Tested in TM for a weak on downstream, no problems found. Functionality confirmed.

## Declaration

- [x] I confirm that I either do not require pre-approval for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
fix: ore redemption, salvage redemption, and smart hopper now can be used with skeleton access
/:cl: