### PR TITLE
Fixes Silicons being unable to examine turfs.

### DIFF
--- a/code/_onclick/ai_onclick.dm
+++ b/code/_onclick/ai_onclick.dm
@@ -59,10 +59,11 @@
 	if(modifiers["shift"])
 		if(isturf(A))
 			var/turf/clicked_turf = A
-			for(var/obj/machinery/door/AL in clicked_turf.contents)
+			var/obj/machinery/door/AL = locate() in clicked_turf.contents
+			if(AL)
 				AL.try_to_activate_door(src)
-		else
-			ShiftClickOn(A)
+				return
+		ShiftClickOn(A)
 		return
 	if(modifiers["alt"]) // alt and alt-gr (rightalt)
 		AltClickOn(A)

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -39,10 +39,11 @@
 	if(modifiers["shift"])
 		if(isturf(A))
 			var/turf/clicked_turf = A
-			for(var/obj/machinery/door/AL in clicked_turf.contents)
+			var/obj/machinery/door/AL = locate() in clicked_turf.contents
+			if(AL)
 				AL.try_to_activate_door(src)
-		else
-			ShiftClickOn(A)
+				return
+		ShiftClickOn(A)
 		return
 	if(modifiers["alt"]) // alt and alt-gr (rightalt)
 		AltClickOn(A)


### PR DESCRIPTION
## What Does This PR Do
Changes silicon click code so that if an airlock is not found on a turf, it will proc shiftclick() instead of just early-returning.
## Why It's Good For The Game
Allows silicons to once again see wall and floor lore. Very important for disassembling reinforced walls.
## Testing
Became silicon. Shift-clicked a wall, shift-clicked a floor. Saw wall and floor lore.
Shift-clicked a floor with an airlock on it, the airlock operated without also giving me lore at the same time.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Fixed silicons being unable to examine turfs.
/:cl: