### PR TITLE
Adds Floor Lore

### DIFF
--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -1,5 +1,6 @@
 /turf/simulated/floor/mech_bay_recharge_floor
 	name = "mech bay recharge station"
+	desc = "A spot to recharge a mecha's power cell."
 	icon = 'icons/mecha/mech_bay.dmi'
 	icon_state = "recharge_floor"
 

--- a/code/game/objects/items/stacks/tiles/tile_mineral.dm
+++ b/code/game/objects/items/stacks/tiles/tile_mineral.dm
@@ -1,7 +1,7 @@
 /obj/item/stack/tile/mineral/plasma
 	name = "plasma tile"
 	singular_name = "plasma floor tile"
-	desc = "A tile made out of highly flammable plasma. This can only end well."
+	desc = "Flooring constructed from pure plasma crystal. There is absolutely nothing that can go wrong."
 	icon_state = "tile_plasma"
 	origin_tech = "plasmatech=1"
 	turf_type = /turf/simulated/floor/mineral/plasma
@@ -21,7 +21,7 @@
 /obj/item/stack/tile/mineral/uranium
 	name = "uranium tile"
 	singular_name = "uranium floor tile"
-	desc = "A tile made out of uranium. You feel a bit woozy."
+	desc = "Flooring made from uranium. It's radioactive, IT'S RADIOACTIVE!"
 	icon_state = "tile_uranium"
 	turf_type = /turf/simulated/floor/mineral/uranium
 	mineralType = "uranium"
@@ -34,7 +34,7 @@ GLOBAL_LIST_INIT(gold_tile_recipes, list ( \
 /obj/item/stack/tile/mineral/gold
 	name = "gold tile"
 	singular_name = "gold floor tile"
-	desc = "A tile made out of gold, the swag seems strong here."
+	desc = "Flooring made of solid gold. It's only a matter of time before someone tries to steal it."
 	icon_state = "tile_gold"
 	turf_type = /turf/simulated/floor/mineral/gold
 	mineralType = "gold"
@@ -63,7 +63,7 @@ GLOBAL_LIST_INIT(silver_tile_recipes, list ( \
 /obj/item/stack/tile/mineral/silver
 	name = "silver tile"
 	singular_name = "silver floor tile"
-	desc = "A tile made out of silver, the light shining from it is blinding."
+	desc = "Flooring made of solid silver. Not quite as valuable as gold, but still very snobby to use."
 	icon_state = "tile_silver"
 	turf_type = /turf/simulated/floor/mineral/silver
 	mineralType = "silver"
@@ -88,7 +88,7 @@ GLOBAL_LIST_INIT(silverfancy_tile_recipes, list ( \
 /obj/item/stack/tile/mineral/diamond
 	name = "diamond tile"
 	singular_name = "diamond floor tile"
-	desc = "A tile made out of diamond. Wow, just, wow."
+	desc = "Flooring made out of pure diamond. Considering the large variety of industrial and scientific uses for diamond, this seems extremely wasteful."
 	icon_state = "tile_diamond"
 	origin_tech = "materials=2"
 	turf_type = /turf/simulated/floor/mineral/diamond
@@ -98,7 +98,7 @@ GLOBAL_LIST_INIT(silverfancy_tile_recipes, list ( \
 /obj/item/stack/tile/mineral/bananium
 	name = "bananium tile"
 	singular_name = "bananium floor tile"
-	desc = "A tile made out of bananium, HOOOOOOOOONK!"
+	desc = "Flooring constructed from pure bananium crystal. It squeaks with every step taken on it. Pressing into it causes it to HONK!"
 	icon_state = "tile_bananium"
 	turf_type = /turf/simulated/floor/mineral/bananium
 	mineralType = "bananium"
@@ -107,7 +107,7 @@ GLOBAL_LIST_INIT(silverfancy_tile_recipes, list ( \
 /obj/item/stack/tile/mineral/tranquillite
 	name = "silent tile"
 	singular_name = "silent floor tile"
-	desc = "A tile made out of tranquillite, SHHHHHHHHH!"
+	desc = "Flooring constructed from pure tranquilite crystal. No matter how hard it is stamped on, no sound is produced."
 	icon_state = "tile_tranquillite"
 	turf_type = /turf/simulated/floor/mineral/tranquillite
 	mineralType = "tranquillite"
@@ -115,8 +115,8 @@ GLOBAL_LIST_INIT(silverfancy_tile_recipes, list ( \
 
 /obj/item/stack/tile/mineral/abductor
 	name = "alien floor tile"
+	desc = "Did we learn the secrets of building floors from an advanced alien civilization like this one?"
 	singular_name = "alien floor tile"
-	desc = "A tile made out of alien alloy."
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "tile_abductor"
 	origin_tech = "materials=6;abductor=1"
@@ -126,7 +126,7 @@ GLOBAL_LIST_INIT(silverfancy_tile_recipes, list ( \
 /obj/item/stack/tile/mineral/titanium
 	name = "titanium tile"
 	singular_name = "titanium floor tile"
-	desc = "A tile made of titanium, used for shuttles."
+	desc = "Lightweight flooring made out of titanium, often used in spacecraft construction."
 	icon_state = "tile_shuttle"
 	turf_type = /turf/simulated/floor/mineral/titanium
 	mineralType = "titanium"
@@ -137,9 +137,9 @@ GLOBAL_LIST_INIT(silverfancy_tile_recipes, list ( \
 	icon_state = "tile_plasma"
 
 /obj/item/stack/tile/mineral/plastitanium
-	name = "plas-titanium tile"
-	singular_name = "plas-titanium floor tile"
-	desc = "A tile made of plas-titanium, used for very evil shuttles."
+	name = "plastitanium tile"
+	singular_name = "plastitanium floor tile"
+	desc = "Evil-looking flooring made out of plastitanium. Often used for constructing military-grade spacecraft."
 	icon_state = "tile_darkshuttle"
 	turf_type = /turf/simulated/floor/mineral/plastitanium
 	mineralType = "plastitanium"

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -116,7 +116,7 @@
 /obj/item/stack/tile/carpet
 	name = "carpet"
 	singular_name = "carpet"
-	desc = "A piece of carpet. It is the same size as a floor tile."
+	desc = "Textile flooring often used to try and add more class to a room."
 	icon_state = "tile-carpet"
 	turf_type = /turf/simulated/floor/carpet
 	resistance_flags = FLAMMABLE
@@ -127,6 +127,7 @@
 
 /obj/item/stack/tile/carpet/black
 	name = "black carpet"
+	desc = "Elegant black textile flooring with a gold trim around the edges."
 	icon_state = "tile-carpet-black"
 	turf_type = /turf/simulated/floor/carpet/black
 	table_type = /obj/structure/table/wood/fancy/black
@@ -136,6 +137,7 @@
 
 /obj/item/stack/tile/carpet/blue
 	name = "blue carpet"
+	desc = "Blue textile flooring with a repeating white diamond pattern, and a thick white border around the edges."
 	icon_state = "tile-carpet-blue"
 	turf_type = /turf/simulated/floor/carpet/blue
 	table_type = /obj/structure/table/wood/fancy/blue
@@ -145,6 +147,7 @@
 
 /obj/item/stack/tile/carpet/cyan
 	name = "cyan carpet"
+	desc = "Cyan textile flooring with a thick white border and inwards-facing tassels around the edges."
 	icon_state = "tile-carpet-cyan"
 	turf_type = /turf/simulated/floor/carpet/cyan
 	table_type = /obj/structure/table/wood/fancy/cyan
@@ -154,6 +157,7 @@
 
 /obj/item/stack/tile/carpet/green
 	name = "green carpet"
+	desc = "Dark green textile flooring with intricate repeating patterns and edges woven with gold colored thread."
 	icon_state = "tile-carpet-green"
 	turf_type = /turf/simulated/floor/carpet/green
 	table_type = /obj/structure/table/wood/fancy/green
@@ -163,6 +167,7 @@
 
 /obj/item/stack/tile/carpet/orange
 	name = "orange carpet"
+	desc = "Orange textile flooring with a repeating gold diamond pattern, and a thick gold border around the edges."
 	icon_state = "tile-carpet-orange"
 	turf_type = /turf/simulated/floor/carpet/orange
 	table_type = /obj/structure/table/wood/fancy/orange
@@ -172,6 +177,7 @@
 
 /obj/item/stack/tile/carpet/purple
 	name = "purple carpet"
+	desc = "Regal purple textile flooring with a repeating white diamond pattern, and a thick white border around the edges."
 	icon_state = "tile-carpet-purple"
 	turf_type = /turf/simulated/floor/carpet/purple
 	table_type = /obj/structure/table/wood/fancy/purple
@@ -181,6 +187,7 @@
 
 /obj/item/stack/tile/carpet/red
 	name = "red carpet"
+	desc = "Crimson textile flooring with a repeating white diamond pattern, and a thick white border around the edges."
 	icon_state = "tile-carpet-red"
 	turf_type = /turf/simulated/floor/carpet/red
 	table_type = /obj/structure/table/wood/fancy/red
@@ -190,6 +197,7 @@
 
 /obj/item/stack/tile/carpet/royalblack
 	name = "royal black carpet"
+	desc = "Jet-black textile flooring with a repeating gold diamond pattern, and a thick gold border around the edges."
 	icon_state = "tile-carpet-royalblack"
 	turf_type = /turf/simulated/floor/carpet/royalblack
 	table_type = /obj/structure/table/wood/fancy/royalblack
@@ -201,6 +209,7 @@
 
 /obj/item/stack/tile/carpet/royalblue
 	name = "royal blue carpet"
+	desc = "Royal blue textile flooring with a repeating gold diamond pattern, and a thick gold border around the edges."
 	icon_state = "tile-carpet-royalblue"
 	turf_type = /turf/simulated/floor/carpet/royalblue
 	table_type = /obj/structure/table/wood/fancy/royalblue
@@ -213,6 +222,7 @@
 
 /obj/item/stack/tile/carpet/grimey
 	name = "cheap carpet"
+	desc = "Cheap nasty textile flooring. Close inspection shows that this carpet is full of dirt, grease, and who knows what else. Not something you want to lie down on."
 	icon_state = "tile-carpet-grimey"
 	turf_type = /turf/simulated/floor/carpet/grimey
 /obj/item/stack/tile/carpet/grimey/ten
@@ -223,10 +233,10 @@
 
 //Plasteel
 /obj/item/stack/tile/plasteel
-	name = "floor tiles"
+	name = "steel floor tiles"
 	gender = PLURAL
 	singular_name = "floor tile"
-	desc = "Those could work as a pretty decent throwing weapon."
+	desc = "Mass-produced steel flooring. Cheap, robust, easy to clean, and it can be found all across the Orion arm in one form or another."
 	force = 6
 	materials = list(MAT_METAL=500)
 	throwforce = 10
@@ -238,6 +248,11 @@
 	resistance_flags = FIRE_PROOF
 	merge_type = /obj/item/stack/tile/plasteel
 
+/obj/item/stack/tile/plasteel/examine(mob/user)
+	. = ..()
+	if(!is_cyborg)
+		. += SPAN_NOTICE("These could work as a pretty decent throwing weapon.")
+
 /obj/item/stack/tile/plasteel/cyborg
 	energy_type = /datum/robot_storage/energy/metal_tile
 	is_cyborg = TRUE
@@ -247,7 +262,7 @@
 	name = "light tiles"
 	gender = PLURAL
 	singular_name = "light floor tile"
-	desc = "A floor tile made of glass, with an integrated light. Use a multitool on it to change its color."
+	desc = "Highly advanced technology that combines the functions of walking surface and area lighting. What will science think of next?"
 	icon_state = "tile_white"
 	force = 3
 	throwforce = 5
@@ -326,6 +341,7 @@
 
 /obj/item/stack/tile/catwalk
 	name = "catwalk tiles"
+	desc = "Flooring made of a metal grid with large holes for easier inspection of cable and pipe installations."
 	gender = PLURAL
 	singular_name = "catwalk tile"
 	desc = "A catwalk tile. Not rated for space usage."
@@ -344,7 +360,6 @@
 /obj/item/stack/tile/catwalk/grey
 	name = "grey catwalk tiles"
 	singular_name = "grey catwalk tile"
-	desc = "A grey catwalk tile. Not rated for space usage."
 	icon_state = "tile_catwalk_grey"
 	turf_type = /turf/simulated/floor/catwalk/grey
 	merge_type = /obj/item/stack/tile/catwalk/grey
@@ -352,7 +367,6 @@
 /obj/item/stack/tile/catwalk/black
 	name = "black catwalk tiles"
 	singular_name = "black catwalk tile"
-	desc = "A black catwalk tile. Not rated for space usage."
 	icon_state = "tile_catwalk_black"
 	turf_type = /turf/simulated/floor/catwalk/black
 	merge_type = /obj/item/stack/tile/catwalk/black
@@ -360,7 +374,6 @@
 /obj/item/stack/tile/catwalk/white
 	name = "white catwalk tiles"
 	singular_name = "white catwalk tile"
-	desc = "A white catwalk tile. Not rated for space usage."
 	icon_state = "tile_catwalk_white"
 	turf_type = /turf/simulated/floor/catwalk/white
 	merge_type = /obj/item/stack/tile/catwalk/white

--- a/code/game/turfs/simulated/floor/asteroid_floors.dm
+++ b/code/game/turfs/simulated/floor/asteroid_floors.dm
@@ -4,6 +4,7 @@
 /turf/simulated/floor/plating/asteroid
 	gender = PLURAL
 	name = "asteroid sand"
+	desc = "Dusty space rock with a consistency similar to terrestrial sandstone."
 	baseturf = /turf/simulated/floor/plating/asteroid
 	icon_state = "asteroid"
 	icon_plating = "asteroid"
@@ -110,6 +111,7 @@
 
 /turf/simulated/floor/plating/asteroid/basalt
 	name = "volcanic floor"
+	desc = "A thick layer of volcanic rock, specificially basalt."
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt
 	icon_state = "basalt"
 	icon_plating = "basalt"
@@ -216,7 +218,7 @@
 
 /turf/simulated/floor/plating/asteroid/snow
 	name = "snow"
-	desc = "Looks cold."
+	desc = "A cold layer of accumulated ice crystals with a consistency ranging between fluffy powder and heavy sand. As more and more snow falls, the bottom layers will eventually be compacted into solid ice."
 	icon = 'icons/turf/snow.dmi'
 	baseturf = /turf/simulated/floor/plating/asteroid/snow
 	icon_state = "snow"

--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -1,6 +1,6 @@
 /turf/simulated/floor/chasm
 	name = "chasm"
-	desc = "Watch your step."
+	desc = "A hole in the ground that's so deep that you can't see the bottom. Watch your step."
 	baseturf = /turf/simulated/floor/chasm
 	icon = 'icons/turf/floors/Chasms.dmi'
 	icon_state = "chasms-255"

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -1,9 +1,16 @@
 /turf/simulated/floor/wood
+	name = "wooden floor"
+	desc = "Flooring constructed from interlocking planks of wood fastened with screws."
 	icon_state = "wood"
 	floor_tile = /obj/item/stack/tile/wood
 	footstep = FOOTSTEP_WOOD
 	barefootstep = FOOTSTEP_WOOD_BAREFOOT
 	clawfootstep = FOOTSTEP_WOOD_CLAW
+
+/turf/simulated/floor/wood/examine(mob/user, infix, suffix)
+	. = ..()
+	. += SPAN_NOTICE("You can dismantle [src] with a screwdriver.")
+	. += SPAN_NOTICE("You can also tear [src] up with a crowbar, destroying it.")
 
 /turf/simulated/floor/wood/screwdriver_act(mob/user, obj/item/I)
 	. = TRUE
@@ -64,7 +71,8 @@
 
 // Grass
 /turf/simulated/floor/grass
-	name = "grass patch"
+	name = "grass"
+	desc = "lush green grass. Enough of this in one place can make you forget that you're in deep space."
 	icon = 'icons/turf/floors/grass.dmi'
 	icon_state = "grass"
 	base_icon_state = "grass"
@@ -121,6 +129,7 @@
 //Carpets
 /turf/simulated/floor/carpet
 	name = "carpet"
+	desc = "Textile flooring often used to try and add more class to a room."
 	icon = 'icons/turf/floors/carpet.dmi'
 	icon_state = "carpet-255"
 	base_icon_state = "carpet"
@@ -164,60 +173,80 @@
 	return list("damaged")
 
 /turf/simulated/floor/carpet/black
+	name = "black carpet"
+	desc = "Elegant black textile flooring with a gold trim around the edges."
 	icon = 'icons/turf/floors/carpet_black.dmi'
 	floor_tile = /obj/item/stack/tile/carpet/black
 	smoothing_groups = list(SMOOTH_GROUP_TURF, SMOOTH_GROUP_CARPET, SMOOTH_GROUP_CARPET_BLACK)
 	canSmoothWith = list(SMOOTH_GROUP_CARPET_BLACK)
 
 /turf/simulated/floor/carpet/blue
+	name = "blue carpet"
+	desc = "Blue textile flooring with a repeating white diamond pattern, and a thick white border around the edges."
 	icon = 'icons/turf/floors/carpet_blue.dmi'
 	floor_tile = /obj/item/stack/tile/carpet/blue
 	smoothing_groups = list(SMOOTH_GROUP_TURF, SMOOTH_GROUP_CARPET, SMOOTH_GROUP_CARPET_BLUE)
 	canSmoothWith = list(SMOOTH_GROUP_CARPET_BLUE)
 
 /turf/simulated/floor/carpet/cyan
+	name = "cyan carpet"
+	desc = "Cyan textile flooring with a thick white border and inwards-facing tassels around the edges."
 	icon = 'icons/turf/floors/carpet_cyan.dmi'
 	floor_tile = /obj/item/stack/tile/carpet/cyan
 	smoothing_groups = list(SMOOTH_GROUP_TURF, SMOOTH_GROUP_CARPET, SMOOTH_GROUP_CARPET_CYAN)
 	canSmoothWith = list(SMOOTH_GROUP_CARPET_CYAN)
 
 /turf/simulated/floor/carpet/green
+	name = "green carpet"
+	desc = "Dark green textile flooring with intricate repeating patterns and edges woven with gold colored thread."
 	icon = 'icons/turf/floors/carpet_green.dmi'
 	floor_tile = /obj/item/stack/tile/carpet/green
 	smoothing_groups = list(SMOOTH_GROUP_TURF, SMOOTH_GROUP_CARPET, SMOOTH_GROUP_CARPET_GREEN)
 	canSmoothWith = list(SMOOTH_GROUP_CARPET_GREEN)
 
 /turf/simulated/floor/carpet/orange
+	name = "orange carpet"
+	desc = "Warm orange textile flooring with a repeating gold diamond pattern, and a thick gold border around the edges."
 	icon = 'icons/turf/floors/carpet_orange.dmi'
 	floor_tile = /obj/item/stack/tile/carpet/orange
 	smoothing_groups = list(SMOOTH_GROUP_TURF, SMOOTH_GROUP_CARPET, SMOOTH_GROUP_CARPET_ORANGE)
 	canSmoothWith = list(SMOOTH_GROUP_CARPET_ORANGE)
 
 /turf/simulated/floor/carpet/purple
+	name = "purple carpet"
+	desc = "Regal purple textile flooring with a repeating white diamond pattern, and a thick white border around the edges."
 	icon = 'icons/turf/floors/carpet_purple.dmi'
 	floor_tile = /obj/item/stack/tile/carpet/purple
 	smoothing_groups = list(SMOOTH_GROUP_TURF, SMOOTH_GROUP_CARPET, SMOOTH_GROUP_CARPET_PURPLE)
 	canSmoothWith = list(SMOOTH_GROUP_CARPET_PURPLE)
 
 /turf/simulated/floor/carpet/red
+	name = "red carpet"
+	desc = "Crimson textile flooring with a repeating white diamond pattern, and a thick white border around the edges."
 	icon = 'icons/turf/floors/carpet_red.dmi'
 	floor_tile = /obj/item/stack/tile/carpet/red
 	smoothing_groups = list(SMOOTH_GROUP_TURF, SMOOTH_GROUP_CARPET, SMOOTH_GROUP_CARPET_RED)
 	canSmoothWith = list(SMOOTH_GROUP_CARPET_RED)
 
 /turf/simulated/floor/carpet/royalblack
+	name = "royal black carpet"
+	desc = "Jet-black textile flooring with a repeating gold diamond pattern, and a thick gold border around the edges."
 	icon = 'icons/turf/floors/carpet_royalblack.dmi'
 	floor_tile = /obj/item/stack/tile/carpet/royalblack
 	smoothing_groups = list(SMOOTH_GROUP_TURF, SMOOTH_GROUP_CARPET, SMOOTH_GROUP_CARPET_ROYALBLACK)
 	canSmoothWith = list(SMOOTH_GROUP_CARPET_ROYALBLACK)
 
 /turf/simulated/floor/carpet/royalblue
+	name = "royal blue carpet"
+	desc = "Royal blue textile flooring with a repeating gold diamond pattern, and a thick gold border around the edges."
 	icon = 'icons/turf/floors/carpet_royalblue.dmi'
 	floor_tile = /obj/item/stack/tile/carpet/royalblue
 	smoothing_groups = list(SMOOTH_GROUP_TURF, SMOOTH_GROUP_CARPET, SMOOTH_GROUP_CARPET_ROYALBLUE)
 	canSmoothWith = list(SMOOTH_GROUP_CARPET_ROYALBLUE)
 
 /turf/simulated/floor/carpet/grimey
+	name = "cheap carpet"
+	desc = "Cheap nasty textile flooring. Close inspection shows that this carpet is full of dirt, grease, and who knows what else. Not something you want to lie down on."
 	icon = 'icons/turf/floors/carpet_grimey.dmi'
 	floor_tile = /obj/item/stack/tile/carpet/grimey
 	smoothing_groups = list(SMOOTH_GROUP_TURF, SMOOTH_GROUP_CARPET,SMOOTH_GROUP_CARPET_GRIMEY)
@@ -243,7 +272,8 @@
 
 // Bamboo mats
 /turf/simulated/floor/bamboo
-	name = "bamboo"
+	name = "bamboo floor"
+	desc = "Lightweight hand-made flooring constructed from bamboo."
 	icon = 'icons/turf/floors/bamboo_mat.dmi'
 	icon_state = "mat-0"
 	base_icon_state = "mat"
@@ -310,6 +340,8 @@
 // End of bamboo
 
 /turf/simulated/floor/fakespace
+	name = "\proper space"
+	desc = "The infinite expanse of space. It's hazardous to traverse without proper protection."
 	icon = 'icons/turf/space.dmi'
 	icon_state = "0"
 	floor_tile = /obj/item/stack/tile/fakespace
@@ -330,6 +362,8 @@
 	return TRUE
 
 /turf/simulated/floor/carpet/arcade
+	name = "space carpet"
+	desc = "A space-themed carpet adorned with planets and rocket ships."
 	icon = 'icons/goonstation/turf/floor.dmi'
 	icon_state = "arcade"
 	floor_tile = /obj/item/stack/tile/arcade_carpet

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -72,7 +72,7 @@
 // Grass
 /turf/simulated/floor/grass
 	name = "grass"
-	desc = "lush green grass. Enough of this in one place can make you forget that you're in deep space."
+	desc = "Lush green grass. Enough of this in one place can make you forget that you're in deep space."
 	icon = 'icons/turf/floors/grass.dmi'
 	icon_state = "grass"
 	base_icon_state = "grass"

--- a/code/game/turfs/simulated/floor/indestructible.dm
+++ b/code/game/turfs/simulated/floor/indestructible.dm
@@ -2,7 +2,7 @@
 
 /turf/simulated/floor/indestructible/examine(mob/user, infix, suffix)
 	. = ..()
-	. += SPAN_NOTICE("It appears to be effectively impervious to all conventional means of destruction.")
+	. += SPAN_NOTICE("It appears to be effectively impervious to all conventional methods of destruction.")
 
 /turf/simulated/floor/indestructible/update_icon_state()
 	if(!broken && !burnt)

--- a/code/game/turfs/simulated/floor/indestructible.dm
+++ b/code/game/turfs/simulated/floor/indestructible.dm
@@ -1,5 +1,9 @@
 /turf/simulated/floor/indestructible
 
+/turf/simulated/floor/indestructible/examine(mob/user, infix, suffix)
+	. = ..()
+	. += "It appears to be effectively impervious to all conventional means of destruction."
+
 /turf/simulated/floor/indestructible/update_icon_state()
 	if(!broken && !burnt)
 		icon_state = icon_regular_floor

--- a/code/game/turfs/simulated/floor/indestructible.dm
+++ b/code/game/turfs/simulated/floor/indestructible.dm
@@ -2,7 +2,7 @@
 
 /turf/simulated/floor/indestructible/examine(mob/user, infix, suffix)
 	. = ..()
-	. += "It appears to be effectively impervious to all conventional means of destruction."
+	. += SPAN_NOTICE("It appears to be effectively impervious to all conventional means of destruction.")
 
 /turf/simulated/floor/indestructible/update_icon_state()
 	if(!broken && !burnt)

--- a/code/game/turfs/simulated/floor/lava.dm
+++ b/code/game/turfs/simulated/floor/lava.dm
@@ -5,6 +5,7 @@
  */
 /turf/simulated/floor/lava
 	name = "lava"
+	desc = "Extremely hot liquefied rock, exceptionally dangerous to anything without proper protection. It's very viscous and will slow down anything going through it."
 	icon = 'icons/turf/floors/lava.dmi'
 	icon_state = "lava-255"
 	base_icon_state = "lava"

--- a/code/game/turfs/simulated/floor/light_floor.dm
+++ b/code/game/turfs/simulated/floor/light_floor.dm
@@ -1,5 +1,6 @@
 /turf/simulated/floor/light
 	name = "light floor"
+	desc = "Highly advanced technology that combines the functions of walking surface and area lighting. What will science think of next?"
 	icon_state = "light_off"
 	floor_tile = /obj/item/stack/tile/light
 	/// Are we on
@@ -8,6 +9,10 @@
 	var/can_modify_colour = TRUE
 	/// Are we draining power
 	var/using_power = FALSE
+
+/turf/simulated/floor/light/examine(mob/user, infix, suffix)
+	. = ..()
+	. += SPAN_NOTICE("Use a multitool to change the hue of [src].")
 
 /turf/simulated/floor/light/Initialize(mapload)
 	. = ..()

--- a/code/game/turfs/simulated/floor/mineral_floors.dm
+++ b/code/game/turfs/simulated/floor/mineral_floors.dm
@@ -25,6 +25,7 @@
 //PLASMA
 /turf/simulated/floor/mineral/plasma
 	name = "plasma floor"
+	desc = "Flooring constructed from pure plasma crystal. There is absolutely nothing that can go wrong."
 	icon_state = "plasma"
 	floor_tile = /obj/item/stack/tile/mineral/plasma
 	icons = list("plasma","plasma_dam")
@@ -66,6 +67,7 @@
 //GOLD
 /turf/simulated/floor/mineral/gold
 	name = "gold floor"
+	desc = "Flooring made of solid gold. It's only a matter of time before someone tries to steal it."
 	icon_state = "gold"
 	floor_tile = /obj/item/stack/tile/mineral/gold
 	icons = list("gold","gold_dam")
@@ -78,6 +80,7 @@
 //SILVER
 /turf/simulated/floor/mineral/silver
 	name = "silver floor"
+	desc = "Flooring made of solid silver. Not quite as valuable as gold, but still very snobby to use."
 	icon_state = "silver"
 	floor_tile = /obj/item/stack/tile/mineral/silver
 	icons = list("silver","silver_dam")
@@ -100,7 +103,8 @@
 //TITANIUM (shuttle)
 
 /turf/simulated/floor/mineral/titanium
-	name = "shuttle floor"
+	name = "titanium floor"
+	desc = "Lightweight flooring made out of titanium, often used in spacecraft construction."
 	icon_state = "titanium"
 	floor_tile = /obj/item/stack/tile/mineral/titanium
 
@@ -139,7 +143,8 @@
 
 //PLASTITANIUM (syndieshuttle)
 /turf/simulated/floor/mineral/plastitanium
-	name = "shuttle floor"
+	name = "plastitanium floor"
+	desc = "Evil-looking flooring made out of plastitanium. Often used for constructing military-grade spacecraft."
 	icon_state = "plastitanium"
 	floor_tile = /obj/item/stack/tile/mineral/plastitanium
 
@@ -156,6 +161,7 @@
 
 /turf/simulated/floor/mineral/plastitanium/red/brig
 	name = "brig floor"
+	desc = "You're either taking the Big Ride, or taking someone else on it."
 
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen
 	oxygen = 0
@@ -165,6 +171,7 @@
 //BANANIUM
 /turf/simulated/floor/mineral/bananium
 	name = "bananium floor"
+	desc = "Flooring constructed from pure bananium crystal. It squeaks with every step taken on it. Pressing into it causes it to HONK!"
 	icon_state = "bananium"
 	floor_tile = /obj/item/stack/tile/mineral/bananium
 	icons = list("bananium","bananium_dam")
@@ -224,6 +231,7 @@
 //TRANQUILLITE
 /turf/simulated/floor/mineral/tranquillite
 	name = "silent floor"
+	desc = "Flooring constructed from pure tranquilite crystal. No matter how hard it is stamped on, no sound is produced."
 	icon_state = "tranquillite"
 	icons = list("tranquillite", "tranquillite_dam")
 	floor_tile = /obj/item/stack/tile/mineral/tranquillite
@@ -235,6 +243,7 @@
 //DIAMOND
 /turf/simulated/floor/mineral/diamond
 	name = "diamond floor"
+	desc = "Flooring made out of pure diamond. Considering the large variety of industrial and scientific uses for diamond, this seems extremely wasteful."
 	icon_state = "diamond"
 	floor_tile = /obj/item/stack/tile/mineral/diamond
 	icons = list("diamond","diamond_dam")
@@ -242,6 +251,7 @@
 //URANIUM
 /turf/simulated/floor/mineral/uranium
 	name = "uranium floor"
+	desc = "Flooring made from uranium. It's radioactive, IT'S RADIOACTIVE!"
 	icon_state = "uranium"
 	floor_tile = /obj/item/stack/tile/mineral/uranium
 	icons = list("uranium","uranium_dam")
@@ -283,6 +293,7 @@
 // ALIEN ALLOY
 /turf/simulated/floor/mineral/abductor
 	name = "alien floor"
+	desc = "Did we learn the secrets of building floors from an advanced alien civilization like this one?"
 	icon_state = "alienpod1"
 	floor_tile = /obj/item/stack/tile/mineral/abductor
 	icons = list("alienpod1", "alienpod2", "alienpod3", "alienpod4", "alienpod5", "alienpod6", "alienpod7", "alienpod8", "alienpod9")

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -1,4 +1,6 @@
 /turf/simulated/floor/vault
+	name = "stone floor"
+	desc = "Smooth flooring carved from solid rock. It looks sturdy."
 	icon_state = "rockvault"
 
 /turf/simulated/floor/vault/lavaland_air
@@ -43,6 +45,7 @@
 
 /turf/simulated/floor/beach
 	name = "beach"
+	desc = "The sandy seaside, waves crashing, the sun shining... It's a true paradise."
 	icon = 'icons/misc/beach.dmi'
 	footstep = FOOTSTEP_SAND
 	barefootstep = FOOTSTEP_SAND
@@ -50,6 +53,7 @@
 
 /turf/simulated/floor/desert_sand
 	name = "sand"
+	desc = "I don't like sand... It's coarse, and rough, and irritating... And it gets everywhere."
 	icon = 'icons/misc/beach.dmi'
 	icon_state = "desert"
 	footstep = FOOTSTEP_SAND
@@ -134,6 +138,7 @@
 
 /turf/simulated/floor/noslip
 	name = "high-traction floor"
+	desc = "Textured and rubberized flooring designed to maximize grip. You won't slip on this."
 	icon_state = "noslip"
 	floor_tile = /obj/item/stack/tile/noslip
 	slowdown = -0.3
@@ -156,6 +161,7 @@
 
 /turf/simulated/floor/lubed
 	name = "slippery floor"
+	desc = "This floor appears to be perpetually covered in a thick layer of slippery lubricant."
 	icon_state = "tile_standard"
 
 /turf/simulated/floor/lubed/Initialize(mapload)
@@ -254,7 +260,7 @@
 
 /turf/simulated/floor/catwalk
 	name = "catwalk"
-	desc = "A catwalk for easier inspection of cable and pipe installations."
+	desc = "Flooring made of a metal grid with large holes for easier inspection of cable and pipe installations."
 	icon = 'icons/turf/floors/catwalk_floor.dmi'
 	icon_state = "catwalk"
 	base_icon_state = "catwalk"

--- a/code/game/turfs/simulated/floor/plasteel/plasteel_floor.dm
+++ b/code/game/turfs/simulated/floor/plasteel/plasteel_floor.dm
@@ -1,4 +1,6 @@
 /turf/simulated/floor/plasteel
+	name = "steel floor"
+	desc = "Mass-produced steel flooring. Cheap, robust, easy to clean, and it can be found all across the Orion arm in one form or another."
 	icon_state = "tile_standard"
 	floor_tile = /obj/item/stack/tile/plasteel
 	rust_resistance = RUST_RESISTANCE_BASIC
@@ -30,7 +32,6 @@
 	color = rgb(255 * (1 - ratio), 0, 255 * ratio)
 
 /turf/simulated/floor/plasteel/airless
-	name = "airless floor"
 	oxygen = 0
 	nitrogen = 0
 	temperature = TCMB

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -1,5 +1,6 @@
 /turf/simulated/floor/plating
 	name = "plating"
+	desc = "Bare hull plating, normally hidden by a layer of flooring. The cavity between the floor and the plating is used to carry cables, pipes, and other utilities."
 	icon_state = "plating"
 	icon = 'icons/turf/floors/plating.dmi'
 	intact = FALSE
@@ -174,6 +175,7 @@
 
 /turf/simulated/floor/engine
 	name = "reinforced floor"
+	desc = "Hull plating reinforced with a lattice of metal rods. It's exceptionally resistant to heat and corrosion damage."
 	icon_state = "engine"
 	icon_regular_floor = "engine"
 	thermal_conductivity = 0.025
@@ -234,6 +236,7 @@
 
 /turf/simulated/floor/engine/cult
 	name = "engraved floor"
+	desc = "Tiles formed from some kind of unnaturally durable stone. Evil energies course through them whenever they're stepped on."
 	icon_state = "cult"
 	icon_regular_floor = "cult"
 
@@ -368,7 +371,8 @@
 	temperature = TCMB
 
 /turf/simulated/floor/plating/ironsand
-	name = "Iron Sand"
+	name = "iron sand"
+	desc = "Iron-rich sand, highly evocotive of Mars."
 	icon = 'icons/turf/floors/ironsand.dmi'
 	icon_state = "ironsand1"
 
@@ -381,6 +385,7 @@
 
 /turf/simulated/floor/plating/snow
 	name = "snow"
+	desc = "A cold layer of accumulated ice crystals with a consistency ranging between fluffy powder and heavy sand. As more and more snow falls, the bottom layers will eventually be compacted into solid ice."
 	icon = 'icons/turf/snow.dmi'
 	icon_state = "snow"
 	footstep = FOOTSTEP_SAND
@@ -409,6 +414,7 @@
 
 /turf/simulated/floor/plating/metalfoam
 	name = "foamed metal plating"
+	desc = "A weak floor made of metal foam, used to quickly seal hull breaches. It's a good idea to replace it with a more permanent repair."
 	icon_state = "metalfoam"
 	/// which kind of metal this will turn into
 	var/metal_kind = METAL_FOAM_ALUMINUM
@@ -463,6 +469,7 @@
 
 /turf/simulated/floor/plating/abductor
 	name = "alien floor"
+	desc = "Did we learn the secrets of building floors from an advanced alien civilization like this one?"
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "alienpod1"
 
@@ -505,6 +512,7 @@
 /turf/simulated/floor/plating/false_asteroid
 	gender = PLURAL
 	name = "volcanic floor"
+	desc = "A thick layer of volcanic rock, specificially basalt."
 	baseturf = /turf/simulated/floor/plating/false_asteroid
 	icon_state = "basalt"
 	icon_plating = "basalt"

--- a/code/game/turfs/simulated/floor/transparent.dm
+++ b/code/game/turfs/simulated/floor/transparent.dm
@@ -1,6 +1,6 @@
 /turf/simulated/floor/transparent/glass
 	name = "glass floor"
-	desc = "Don't jump on it... Or do, I'm not your mom."
+	desc = "Transparent flooring made out of regular glass. Don't jump on it... Or do, I'm not your mom."
 	icon = 'icons/turf/floors/glass.dmi'
 	icon_state = "glass-0"
 	base_icon_state = "glass"
@@ -144,7 +144,7 @@
 
 /turf/simulated/floor/transparent/glass/reinforced
 	name = "reinforced glass floor"
-	desc = "Jump on it, it can cope. Promise..."
+	desc = "Transparent flooring made of glass reinforced with metal rods. Jump on it, it can cope. Promise..."
 	icon = 'icons/turf/floors/reinf_glass.dmi'
 	icon_state = "reinf_glass-0"
 	base_icon_state = "reinf_glass"
@@ -157,7 +157,7 @@
 
 /turf/simulated/floor/transparent/glass/plasma
 	name = "plasma glass floor"
-	desc = "Wait, was space always that color?"
+	desc = "Transparent flooring made of plasma glass. It gives everything a pretty purple tinge."
 	icon = 'icons/turf/floors/plasmaglass.dmi'
 	icon_state = "plasmaglass-0"
 	base_icon_state = "plasmaglass"
@@ -166,7 +166,7 @@
 
 /turf/simulated/floor/transparent/glass/reinforced/plasma
 	name = "reinforced plasma glass floor"
-	desc = "For when you REALLY don't want your floor choice to suffocate everyone."
+	desc = "Transparent flooring made of plasma glass reinforced with metal rods. It's actually stronger than regular flooring, so don't worry about it."
 	icon = 'icons/turf/floors/reinf_plasmaglass.dmi'
 	icon_state = "reinf_plasmaglass-0"
 	base_icon_state = "reinf_plasmaglass"
@@ -175,7 +175,7 @@
 
 /turf/simulated/floor/transparent/glass/titanium
 	name = "titanium glass floor"
-	desc = "Stylish AND strong!"
+	desc = "Transparent flooring made of lightweight titanium glass. It's ideal for seeing through the floor of your shuttle."
 	icon = 'icons/turf/floors/titaniumglass.dmi'
 	icon_state = "titaniumglass-0"
 	base_icon_state = "titaniumglass"
@@ -186,6 +186,7 @@
 
 /turf/simulated/floor/transparent/glass/titanium/plasma
 	name = "plastitanium glass floor"
+	desc = "Military-grade transparent flooring made from plastitanium glass. Perfect for when you want an evil window that doubles as a floor."
 	icon = 'icons/turf/floors/plastitaniumglass.dmi'
 	icon_state = "plastitaniumglass-0"
 	base_icon_state = "plastitaniumglass"

--- a/code/game/turfs/space/space_turf.dm
+++ b/code/game/turfs/space/space_turf.dm
@@ -1,6 +1,7 @@
 /turf/space
 	icon = 'icons/turf/space.dmi'
 	name = "\proper space"
+	desc = "The infinite expanse of space. It's hazardous to traverse without proper protection."
 	icon_state = "0"
 
 	temperature = TCMB

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -85,6 +85,8 @@
 
 
 /turf/simulated/floor/vines
+	name = "vine floor"
+	desc = "A thick mat of living vines."
 	color = "#aa77aa"
 	icon_state = "vinefloor"
 

--- a/code/tests/attack_chain/test_attack_chain_reagent_containers.dm
+++ b/code/tests/attack_chain/test_attack_chain_reagent_containers.dm
@@ -326,7 +326,7 @@
 	var/obj/item/reagent_containers/glass/rag/rag = player.spawn_obj_in_hand(/obj/item/reagent_containers/glass/rag)
 	rag.wipespeed = 0
 	player.click_on(floor)
-	TEST_ASSERT_LAST_CHATLOG(player, "You clean the floor with the damp rag.")
+	TEST_ASSERT_LAST_CHATLOG(player, "You clean the steel floor with the damp rag.")
 
 	var/datum/test_puppeteer/target = player.spawn_puppet_nearby()
 	rag.reagents.add_reagent("omnizine", 10)


### PR DESCRIPTION
## What Does This PR Do
Adds a name and description to pretty much every floor.

## Why It's Good For The Game
Examining floors will now give you an actual description of what you're looking at instead of "That's a floor"

## Testing
Visual inspection.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
add: All floors have names and descriptions.
/:cl:
