### PR TITLE
Reworks the Wisp Latern

### DIFF
--- a/code/modules/mining/lavaland/loot/ashdragon_loot.dm
+++ b/code/modules/mining/lavaland/loot/ashdragon_loot.dm
@@ -159,7 +159,6 @@
 /obj/effect/wisp/ghost
 	name = "mischievous wisp"
 	desc = "A wisp that seems to want to get up to shenanigans. It often seems disappointed, for some reason."
-	light_range = 0
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /obj/effect/wisp/ghost/Initialize(mapload, mob/dead/observer/ghost)

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -196,13 +196,13 @@
 // MARK: Wisp Lantern
 /obj/item/wisp_lantern
 	name = "spooky lantern"
-	desc = "This spooky lantern is home to a friendly wisp."
+	desc = "This spooky lantern is home to a friendly wisp. You can let it out, but it'll return if you don't hold the lanern in your hands or on your belt."
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "lantern-blue"
 	inhand_icon_state = "lantern"
 	light_range = 7
 	slot_flags = ITEM_SLOT_BELT
-	materials = list(MAT_METAL = 2000, MAT_GLASS = 1000)
+	materials = list(MAT_METAL = 4000, MAT_GLASS = 2000)
 	origin_tech = "biotech=6;magnets=5"
 	new_attack_chain = TRUE
 	var/obj/effect/wisp/wisp
@@ -230,53 +230,54 @@
 	if(!wisp)
 		wisp = new(src)
 
-	if(wisp.loc == src)
+	if(!wisp_friend)
 		wisp_friend = user
-		icon_state = "lantern"
+		update_appearance(UPDATE_ICON_STATE)
 		set_light(0)
 		wisp.orbit(wisp_friend, 20, lock_in_orbit = TRUE)
-		wisp.set_light(2)
-		to_chat(wisp_friend, SPAN_NOTICE("You release the wisp. It begins to bob around your head."))
+		to_chat(wisp_friend, SPAN_NOTICE("You release the wisp. It begins to bob around your head as [src] darkens."))
 		to_chat(wisp_friend, SPAN_NOTICE("The wisp enhances your vision."))
-		RegisterSignal(wisp_friend, COMSIG_MOB_UPDATE_SIGHT, PROC_REF(update_user_sight))
+		RegisterSignal(src, COMSIG_MOB_UPDATE_SIGHT, PROC_REF(update_user_sight), TRUE)
 		wisp_friend.update_sight()
 		SSblackbox.record_feedback("tally", "wisp_lantern", 1, "Freed") // freed
 		return ITEM_INTERACT_COMPLETE
 
-	send_wisp_home(user)
+	to_chat(user, SPAN_NOTICE("You return the wisp to [src]."))
+	send_wisp_home()
 
-// You can't just throw away the wisp's house. You're carrying that with you!
-/obj/item/wisp_lantern/dropped(mob/user, silent)
+/obj/item/wisp_lantern/update_icon_state()
 	. = ..()
+	if(wisp_friend)
+		icon_state = "lantern"
+	else
+		icon_state = "lantern-blue"
+
+// The lantern is the wisp's house. You must keep it with you or the wisp will leave.
+/obj/item/wisp_lantern/dropped()
+	. = ..()
+
 	if(!wisp_friend)
 		return
 
-	// It's in our hands (dropped is called when items are removed from inventory slots WHYYYY!?)
-	if(user.is_holding(src))
+	if(loc == wisp_friend)
 		return
 
-	// You can put it in your storage, but it must remain on your person.
-	if(isstorage(loc))
-		if(loc.loc == wisp_friend)
-			return
+	send_wisp_home()
 
-		send_wisp_home()
-
-/obj/item/wisp_lantern/proc/send_wisp_home(mob/user)
-	if(user)
-		to_chat(user, SPAN_NOTICE("You return the wisp to [src]."))
+/obj/item/wisp_lantern/proc/send_wisp_home()
 	UnregisterSignal(wisp_friend, COMSIG_MOB_UPDATE_SIGHT)
 	wisp.stop_orbit()
-	wisp.set_light(0)
 	wisp.forceMove(src)
-	set_light(initial(light_range))
 	wisp_friend.update_sight()
 	to_chat(wisp_friend, SPAN_WARNING("Your vision returns to normal as the wisp returns to [src]."))
-	icon_state = "lantern-blue"
+	set_light(initial(light_range))
+	visible_message(SPAN_NOTICE("[src] begins to glow brightly as the wisp returns to it."))
 	SSblackbox.record_feedback("tally", "wisp_lantern", 1, "Returned") // returned
 	wisp_friend = null
+	update_appearance(UPDATE_ICON_STATE)
 
 /obj/item/wisp_lantern/proc/update_user_sight(mob/user)
+	SIGNAL_HANDLER // COMSIG_MOB_UPDATE_SIGHT
 	user.sight |= sight_flags
 	if(!isnull(lighting_alpha))
 		user.lighting_alpha = min(user.lighting_alpha, lighting_alpha)
@@ -286,7 +287,6 @@
 	desc = "Happy to light your way."
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "orb"
-	light_range = 7
 	layer = ABOVE_ALL_MOB_LAYER
 
 // MARK: Warp Cubes

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -237,9 +237,9 @@
 		wisp.orbit(wisp_friend, 20, lock_in_orbit = TRUE)
 		wisp.set_light(2)
 		to_chat(wisp_friend, SPAN_NOTICE("You release the wisp. It begins to bob around your head."))
-		wisp_friend.update_sight()
 		to_chat(wisp_friend, SPAN_NOTICE("The wisp enhances your vision."))
 		RegisterSignal(wisp_friend, COMSIG_MOB_UPDATE_SIGHT, PROC_REF(update_user_sight))
+		wisp_friend.update_sight()
 		SSblackbox.record_feedback("tally", "wisp_lantern", 1, "Freed") // freed
 		return ITEM_INTERACT_COMPLETE
 
@@ -248,11 +248,17 @@
 // You can't just throw away the wisp's house. You're carrying that with you!
 /obj/item/wisp_lantern/dropped(mob/user, silent)
 	. = ..()
-	if(wisp?.loc != src)
-		// You can put it in your storage, but it must remain on your person.
-		if(isstorage(loc))
-			if(loc.loc == wisp_friend)
-				return
+	if(!wisp_friend)
+		return
+
+	// It's in our hands (dropped is called when items are removed from inventory slots WHYYYY!?)
+	if(user.is_holding(src))
+		return
+
+	// You can put it in your storage, but it must remain on your person.
+	if(isstorage(loc))
+		if(loc.loc == wisp_friend)
+			return
 
 		send_wisp_home()
 

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -240,7 +240,6 @@
 		to_chat(wisp_friend, SPAN_NOTICE("You release the wisp. It begins to bob around your head as [src] darkens."))
 		to_chat(wisp_friend, SPAN_NOTICE("The wisp enhances your vision."))
 		update_appearance(UPDATE_ICON_STATE)
-		SSblackbox.record_feedback("tally", "wisp_lantern", 1, "Freed") // freed
 		return ITEM_INTERACT_COMPLETE
 
 	to_chat(user, SPAN_NOTICE("You return the wisp to [src]."))
@@ -271,7 +270,6 @@
 	to_chat(wisp_friend, SPAN_WARNING("Your vision returns to normal as the wisp returns to [src]."))
 	set_light(initial(light_range), initial(light_power), initial(light_color))
 	visible_message(SPAN_NOTICE("[src] begins to glow brightly as the wisp returns to it."))
-	SSblackbox.record_feedback("tally", "wisp_lantern", 1, "Returned") // returned
 	wisp_friend = null
 	update_appearance(UPDATE_ICON_STATE)
 

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -1,6 +1,5 @@
-//Shared Bag
-
-//Internal
+// MARK: Paradox Bag
+// External storage.
 /obj/item/storage/backpack/shared
 	name = "paradox bag"
 	desc = "Somehow, it's in two places at once."
@@ -11,7 +10,7 @@
 /obj/item/storage/backpack/shared/Adjacent(atom/neighbor, recurse = 1)
 	return red?.Adjacent(neighbor, recurse) || blue?.Adjacent(neighbor, recurse)
 
-//External
+// Internal storage.
 /obj/item/shared_storage
 	name = "paradox bag"
 	desc = "Somehow, it's in two places at once."
@@ -99,8 +98,7 @@
 
 			add_fingerprint(M)
 
-//Book of Babel
-
+// MARK: Book of Babel
 /obj/item/book_of_babel
 	name = "Book of Babel"
 	desc = "An ancient tome written in countless tongues."
@@ -114,8 +112,7 @@
 	new /obj/effect/decal/cleanable/ash(get_turf(user))
 	qdel(src)
 
-//Boat
-
+// MARK: Lava Boat
 /obj/vehicle/lavaboat
 	name = "lava boat"
 	desc = "A boat used for traversing lava."
@@ -174,8 +171,7 @@
 	time = 50
 	category = CAT_PRIMAL
 
-//Dragon Boat
-
+// MARK: Ship in Bottle
 /obj/item/ship_in_a_bottle
 	name = "ship in a bottle"
 	desc = "A tiny ship inside a bottle."
@@ -197,49 +193,23 @@
 	generic_pixel_x = 1
 	vehicle_move_delay = 1
 
-//Wisp Lantern
+// MARK: Wisp Lantern
 /obj/item/wisp_lantern
 	name = "spooky lantern"
-	desc = "This lantern gives off no light, but is home to a friendly wisp."
+	desc = "This spooky lantern is home to a friendly wisp."
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "lantern-blue"
 	inhand_icon_state = "lantern"
 	light_range = 7
+	slot_flags = ITEM_SLOT_BELT
+	materials = list(MAT_METAL = 2000, MAT_GLASS = 1000)
+	origin_tech = "biotech=6;magnets=5"
+	new_attack_chain = TRUE
 	var/obj/effect/wisp/wisp
+	/// Tracks who the wisp is orbiting.
+	var/mob/living/wisp_friend
 	var/sight_flags = SEE_MOBS
 	var/lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
-
-/obj/item/wisp_lantern/attack_self__legacy__attackchain(mob/user)
-	if(!wisp)
-		to_chat(user, SPAN_WARNING("The wisp has gone missing!"))
-		icon_state = "lantern"
-		return
-
-	if(wisp.loc == src)
-		RegisterSignal(user, COMSIG_MOB_UPDATE_SIGHT, PROC_REF(update_user_sight))
-
-		to_chat(user, SPAN_NOTICE("You release the wisp. It begins to bob around your head."))
-		icon_state = "lantern"
-		wisp.orbit(user, 20, lock_in_orbit = TRUE)
-		set_light(0)
-
-		user.update_sight()
-		to_chat(user, SPAN_NOTICE("The wisp enhances your vision."))
-
-		SSblackbox.record_feedback("tally", "wisp_lantern", 1, "Freed") // freed
-	else
-		UnregisterSignal(user, COMSIG_MOB_UPDATE_SIGHT)
-
-		to_chat(user, SPAN_NOTICE("You return the wisp to the lantern."))
-		wisp.stop_orbit()
-		wisp.forceMove(src)
-		set_light(initial(light_range))
-
-		user.update_sight()
-		to_chat(user, SPAN_NOTICE("Your vision returns to normal."))
-
-		icon_state = "lantern-blue"
-		SSblackbox.record_feedback("tally", "wisp_lantern", 1, "Returned") // returned
 
 /obj/item/wisp_lantern/Initialize(mapload)
 	. = ..()
@@ -247,11 +217,58 @@
 
 /obj/item/wisp_lantern/Destroy()
 	if(wisp)
-		if(wisp.loc == src)
+		if(wisp.loc != src)
+			send_wisp_home()
 			qdel(wisp)
-		else
-			wisp.visible_message(SPAN_NOTICE("[wisp] has a sad feeling for a moment, then it passes."))
+
 	return ..()
+
+/obj/item/wisp_lantern/activate_self(mob/user)
+	if(..())
+		return ITEM_INTERACT_COMPLETE
+
+	if(!wisp)
+		wisp = new(src)
+
+	if(wisp.loc == src)
+		wisp_friend = user
+		icon_state = "lantern"
+		set_light(0)
+		wisp.orbit(wisp_friend, 20, lock_in_orbit = TRUE)
+		wisp.set_light(2)
+		to_chat(wisp_friend, SPAN_NOTICE("You release the wisp. It begins to bob around your head."))
+		wisp_friend.update_sight()
+		to_chat(wisp_friend, SPAN_NOTICE("The wisp enhances your vision."))
+		RegisterSignal(wisp_friend, COMSIG_MOB_UPDATE_SIGHT, PROC_REF(update_user_sight))
+		SSblackbox.record_feedback("tally", "wisp_lantern", 1, "Freed") // freed
+		return ITEM_INTERACT_COMPLETE
+
+	send_wisp_home(user)
+
+// You can't just throw away the wisp's house. You're carrying that with you!
+/obj/item/wisp_lantern/dropped(mob/user, silent)
+	. = ..()
+	if(wisp?.loc != src)
+		// You can put it in your storage, but it must remain on your person.
+		if(isstorage(loc))
+			if(loc.loc == wisp_friend)
+				return
+
+		send_wisp_home()
+
+/obj/item/wisp_lantern/proc/send_wisp_home(mob/user)
+	if(user)
+		to_chat(user, SPAN_NOTICE("You return the wisp to [src]."))
+	UnregisterSignal(wisp_friend, COMSIG_MOB_UPDATE_SIGHT)
+	wisp.stop_orbit()
+	wisp.set_light(0)
+	wisp.forceMove(src)
+	set_light(initial(light_range))
+	wisp_friend.update_sight()
+	to_chat(wisp_friend, SPAN_WARNING("Your vision returns to normal as the wisp returns to [src]."))
+	icon_state = "lantern-blue"
+	SSblackbox.record_feedback("tally", "wisp_lantern", 1, "Returned") // returned
+	wisp_friend = null
 
 /obj/item/wisp_lantern/proc/update_user_sight(mob/user)
 	user.sight |= sight_flags
@@ -266,7 +283,7 @@
 	light_range = 7
 	layer = ABOVE_ALL_MOB_LAYER
 
-//Red/Blue Cubes
+// MARK: Warp Cubes
 /obj/item/warp_cube
 	name = "blue cube"
 	desc = "A mysterious blue cube."
@@ -330,8 +347,7 @@
 		linked = blue
 		blue.linked = src
 
-//Meat Hook
-
+// MARK: Meat Hook
 /obj/item/gun/magic/hook
 	name = "meat hook"
 	desc = "Mid or feed."
@@ -386,8 +402,7 @@
 	QDEL_NULL(chain)
 	return ..()
 
-//Immortality Talisman
-
+// MARK: Immortality Talisman
 /obj/item/immortality_talisman
 	name = "\improper Immortality Talisman"
 	desc = "A dread talisman that can render you completely invulnerable."

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -201,6 +201,7 @@
 	icon_state = "lantern-blue"
 	inhand_icon_state = "lantern"
 	light_range = 7
+	light_color = "#4882E9"
 	slot_flags = ITEM_SLOT_BELT
 	materials = list(MAT_METAL = 4000, MAT_GLASS = 2000)
 	origin_tech = "biotech=6;magnets=5"
@@ -232,13 +233,13 @@
 
 	if(!wisp_friend)
 		wisp_friend = user
-		update_appearance(UPDATE_ICON_STATE)
-		set_light(0)
+		RegisterSignal(wisp_friend, COMSIG_MOB_UPDATE_SIGHT, PROC_REF(update_user_sight))
+		wisp_friend.update_sight()
+		set_light(2, 2, "#8AFFFF")
 		wisp.orbit(wisp_friend, 20, lock_in_orbit = TRUE)
 		to_chat(wisp_friend, SPAN_NOTICE("You release the wisp. It begins to bob around your head as [src] darkens."))
 		to_chat(wisp_friend, SPAN_NOTICE("The wisp enhances your vision."))
-		RegisterSignal(src, COMSIG_MOB_UPDATE_SIGHT, PROC_REF(update_user_sight), TRUE)
-		wisp_friend.update_sight()
+		update_appearance(UPDATE_ICON_STATE)
 		SSblackbox.record_feedback("tally", "wisp_lantern", 1, "Freed") // freed
 		return ITEM_INTERACT_COMPLETE
 
@@ -252,10 +253,8 @@
 	else
 		icon_state = "lantern-blue"
 
-// The lantern is the wisp's house. You must keep it with you or the wisp will leave.
 /obj/item/wisp_lantern/dropped()
 	. = ..()
-
 	if(!wisp_friend)
 		return
 
@@ -270,7 +269,7 @@
 	wisp.forceMove(src)
 	wisp_friend.update_sight()
 	to_chat(wisp_friend, SPAN_WARNING("Your vision returns to normal as the wisp returns to [src]."))
-	set_light(initial(light_range))
+	set_light(initial(light_range), initial(light_power), initial(light_color))
 	visible_message(SPAN_NOTICE("[src] begins to glow brightly as the wisp returns to it."))
 	SSblackbox.record_feedback("tally", "wisp_lantern", 1, "Returned") // returned
 	wisp_friend = null


### PR DESCRIPTION
## What Does This PR Do
Reworks the wisp lantern:
* The lantern now fits in the belt slot.
* The lantern's thermal vision effect only works if the lantern is held in the user's hand or belt slot. Dropping it or putting it in storage will return the wisp to the lantern.
* If the lantern has no wisp, it will generate a new one upon use.
* The lantern now has materials content (2 sheets metal, 1 sheet glass) and tech levels (biological 6, electromagnetic 5).
* The lantern now has a dark blue light when the wisp is stowed inside.
* The lantern now has a cyan light when the wisp is orbiting a user.

## Why It's Good For The Game
Currently the lantern is free thermal vision without effort. You can throw the lantern away or destroy it and the wisp will remain with you forever. This requires the user to keep it in their hands or sacrifice their belt slot to store it, and allows other people to remove the lantern and therefore the wisp.

Tech levels create incentive to share the lantern with RND instead of hoarding it.

## Images of changes
Deployed wisp
<img width="895" height="851" alt="image" src="https://github.com/user-attachments/assets/045a04d0-df3f-4f4d-a6b7-4805fba34835" />
Hidden wisp
<img width="1733" height="1699" alt="image" src="https://github.com/user-attachments/assets/57dca8ad-634b-4d0e-a94a-1067f32113b1" />

## Testing
Toggled the lantern, gained thermal vision and an orbiting wisp. Toggled again, lost thermal vision, wisp returned.

Dropped, threw lantern, lost thermal vision and wisp.

Stole lantern as a skrell, the spessman lost thermal vision and wisp.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Spooky lantern now has 2 metal sheets and 1 glass sheet of material content.
tweak: Spooky lantern now has bio 6 and magnets 5.
tweak: Spooky lantern can now be held in the belt slot.
tweak: Spooky lantern must be held in hands or belt slot to have an orbiting wisp.
tweak: Spooky lantern now has differently coloured lights depending on if the wisp is inside or not.
tweak: Spooky lantern can generate a wisp if it doesn't have one.
/:cl:
