### PR TITLE
Fixes ORM checking access for extracting materials if the ID wire is hacked

### DIFF
--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -381,7 +381,7 @@
 	. = TRUE
 	switch(action)
 		if("sheet", "alloy")
-			if(scan_id && !allowed(usr) )
+			if(scan_id && !allowed(usr))
 				to_chat(usr, SPAN_WARNING("Required access not found."))
 				return FALSE
 			var/id = params["id"]

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -283,7 +283,7 @@
 /obj/machinery/mineral/ore_redemption/emag_act(mob/user)
 	if(emagged)
 		return FALSE
-	
+
 	to_chat(user, SPAN_NOTICE("You short out the ID scanner on [src], allowing anyone to access it."))
 	scan_id = FALSE
 	emagged = TRUE
@@ -326,10 +326,10 @@
 /obj/machinery/mineral/ore_redemption/proc/is_electrified()
 	if(!is_powered())
 		return FALSE
-	
+
 	if(wires.is_cut(WIRE_ELECTRIFY) || !COOLDOWN_FINISHED(src, temp_shock))
 		return TRUE
-	
+
 	return FALSE
 
 // MARK: UI
@@ -381,7 +381,7 @@
 	. = TRUE
 	switch(action)
 		if("sheet", "alloy")
-			if(!allowed(usr))
+			if(scan_id && !allowed(usr) )
 				to_chat(usr, SPAN_WARNING("Required access not found."))
 				return FALSE
 			var/id = params["id"]
@@ -590,7 +590,7 @@
 	give_points(inserted_type, inserted)
 	SStgui.update_uis(src)
 
-// MARK: Wires 
+// MARK: Wires
 /datum/wires/ore_redemption
 	holder_type = /obj/machinery/mineral/ore_redemption
 	wire_count = 3
@@ -642,7 +642,7 @@
 	var/obj/machinery/mineral/ore_redemption/orm = holder
 	. += "The orange light is [(orm.is_electrified()) ? "off" : "on"]."
 	. += "The red light is [(orm.throw_inventory && orm.is_powered()) ? "off" : "blinking"]."
-	. += "The ID scanner light is [(orm.scan_id && !orm.emagged && orm.is_powered()) ? "off" : "on"]."
+	. += "The ID scanner light is [(orm.scan_id && !orm.emagged && orm.is_powered()) ? "on" : "off"]."
 
 /obj/machinery/mineral/ore_redemption/get_internal_wires()
 	return wires


### PR DESCRIPTION
## What Does This PR Do

The intent of #32074 was to allow you to hack the ORM to get materials out even if you don't have access.
However it was missed that the material extraction was missed, dunno how, but stuff happens.
Also the wire light for the ID scanner was flipped

## Why It's Good For The Game
Fixes #32127

## Testing
Tested if i could extract materials with an ID, could
Tested if i could extract materials without an ID, could not
Pulsed the ID scan wire then repeated the extractions, with and without an ID, both could.
Looked at the wire light when pulsing, watched it change correctly

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
fix: Fixed the ORM ID scan hack not correctly removing ID access for extracting materials. As well as flipped the wire ID light
/:cl:
