### PR TITLE
Replaces the TSF Viper Infiltrator's Jackboots With Combat Boots

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -1559,7 +1559,7 @@
 	back = /obj/item/storage/backpack/satchel
 	belt = /obj/item/storage/belt/viper
 	gloves = /obj/item/clothing/gloves/color/black
-	shoes = /obj/item/clothing/shoes/jackboots
+	shoes = /obj/item/clothing/shoes/combat
 	head = null // will end up being the bandana
 	mask = /obj/item/clothing/mask/bandana/black // will end up being a cigar
 	l_ear = /obj/item/radio/headset/ert/alt/solgov


### PR DESCRIPTION
## What Does This PR Do
Replaces the jackboots of the TSF Viper Infiltrator with Combat Boots.

## Why It's Good For The Game
Actual soldier should have actual soldier boots. This allows the knife they spawn with to be stored in the boot knife slot, which jackboots do not have. Bootknives are a very important part of the aesthetic.

## Testing
Spawned as an infiltrator. Saw I had combat boots. Put my knife inside, lit a cigar, smoked like a badass.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
tweak: TSF Viper Infiltrators now have combat boots instead of jackboots.
/:cl:
