### PR TITLE
Gives Workboots Actual Armour

### DIFF
--- a/code/modules/clothing/shoes/misc_shoes.dm
+++ b/code/modules/clothing/shoes/misc_shoes.dm
@@ -211,6 +211,8 @@
 /obj/item/clothing/shoes/workboots
 	name = "work boots"
 	desc = "Thick-soled boots for industrial work environments."
+	armor = list(MELEE = 20, BULLET = 10, LASER = 0, ENERGY = 0, BOMB = 20, RAD = 0, FIRE = 50, ACID = 100)
+	materials = list(MAT_METAL = 1000)
 	can_cut_open = 1
 	icon_state = "workboots"
 	dyeable = FALSE
@@ -219,6 +221,7 @@
 	name = "mining boots"
 	desc = "Steel-toed mining boots for mining in hazardous environments. Very good at keeping toes uncrushed."
 	icon_state = "explorer"
+	armor = list(MELEE = 20, BULLET = 10, LASER = 0, ENERGY = 0, BOMB = 20, RAD = 0, FIRE = 200, ACID = 100) // Made for Lavaland so they put some extra asbesdos in there, as a treat.
 	resistance_flags = FIRE_PROOF
 	cold_protection = FEET|LEGS
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT

--- a/code/modules/clothing/shoes/misc_shoes.dm
+++ b/code/modules/clothing/shoes/misc_shoes.dm
@@ -211,6 +211,7 @@
 /obj/item/clothing/shoes/workboots
 	name = "work boots"
 	desc = "Thick-soled boots for industrial work environments."
+	flags = THICKMATERIAL
 	armor = list(MELEE = 20, BULLET = 10, LASER = 0, ENERGY = 0, BOMB = 20, RAD = 0, FIRE = 50, ACID = 100)
 	materials = list(MAT_METAL = 1000)
 	can_cut_open = 1

--- a/code/modules/clothing/shoes/misc_shoes.dm
+++ b/code/modules/clothing/shoes/misc_shoes.dm
@@ -221,7 +221,7 @@
 	name = "mining boots"
 	desc = "Steel-toed mining boots for mining in hazardous environments. Very good at keeping toes uncrushed."
 	icon_state = "explorer"
-	armor = list(MELEE = 20, BULLET = 10, LASER = 0, ENERGY = 0, BOMB = 20, RAD = 0, FIRE = 200, ACID = 100) // Made for Lavaland so they put some extra asbesdos in there, as a treat.
+	armor = list(MELEE = 20, BULLET = 10, LASER = 0, ENERGY = 0, BOMB = 20, RAD = 0, FIRE = 200, ACID = 100) // Made for Lavaland so they put some extra asbestos in there, as a treat.
 	resistance_flags = FIRE_PROOF
 	cold_protection = FEET|LEGS
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT


### PR DESCRIPTION
## What Does This PR Do
Adds armour to work boots:
`armor = list(MELEE = 20, BULLET = 10, LASER = 0, ENERGY = 0, BOMB = 20, RAD = 0, FIRE = 50, ACID = 100)`

Adds armour to mining boots and smithing boots:
`armor = list(MELEE = 20, BULLET = 10, LASER = 0, ENERGY = 0, BOMB = 20, RAD = 0, FIRE = 200, ACID = 100) // Made for Lavaland so they put some extra asbestos in there, as a treat.`

Gives all of the above `THICKMATERIAL` to resist injection by normal syringes (autoinjectors, emagged/CMO hypo and RSG will still penetrate).

Gives all of the above 0.5 sheets of metal content when recycled.
## Why It's Good For The Game
It has always bothered me that workboots of all kinds provide the same protection as being barefoot, especially considering the number of times in real life that my feet have been harmlessly crushed by all kinds of stuff thanks to the protection that workboots provide (almost like they're protective gear).

## Testing
Spawned 2 skrell.
Gave one workboots.
Dropped a hammer on both's feet.
Observed the one with workboots suffered less damage.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog

:cl:
tweak: Workboots of all kinds now have armour.
tweak: Workboots of all kinds are now puncture resistant.
/:cl:
