### PR TITLE
Fixes Missing Firelocks in Box/Delta/Emerald Security

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -2550,6 +2550,9 @@
 	id_tag = "Secure Armory";
 	name = "Secure Armory Shutters"
 	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
 "ama" = (
@@ -11351,7 +11354,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/fore)
 "aRr" = (
 /obj/structure/disposalpipe/segment{
@@ -48436,6 +48439,7 @@
 /obj/effect/mapping_helpers/airlock/windoor/access/any/security/armory{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/station/security/warden)
 "foC" = (
@@ -56133,6 +56137,9 @@
 	name = "Security Blast Door"
 	},
 /obj/effect/turf_decal/tiles/department/security,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/security/lobby)
 "iIA" = (
@@ -82476,6 +82483,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/windoor/access/any/security/armory{
 	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -19750,6 +19750,9 @@
 	name = "Prison Lockdown Blast Doors"
 	},
 /obj/effect/turf_decal/tiles/department/security/side,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison/cell_block/a)
 "bCT" = (
@@ -88986,6 +88989,9 @@
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 1
 	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison/cell_block/a)
 "tTf" = (
@@ -90787,6 +90793,9 @@
 	},
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
@@ -94183,6 +94192,9 @@
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 1
 	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison/cell_block/a)
 "vQW" = (
@@ -95232,6 +95244,9 @@
 	},
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison/cell_block/a)

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -17952,6 +17952,9 @@
 	id_tag = "Secure Armory";
 	name = "Secure Armory Shutters"
 	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
 "bwF" = (
@@ -18701,6 +18704,9 @@
 	dir = 2;
 	id_tag = "Secure Armory";
 	name = "Secure Armory Shutters"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
@@ -57958,7 +57964,8 @@
 /obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/fsmaint)
 "hFR" = (
 /obj/structure/bed/amb_trolley{
@@ -77098,7 +77105,7 @@
 	id_tag = "Secure Gate";
 	name = "Security Blast Door"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/fsmaint)
 "prT" = (
 /obj/structure/cable{
@@ -77259,6 +77266,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/windoor/access/any/security/armory{
 	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
@@ -89783,6 +89793,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/turf_decal/tiles/department/security/corner{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -5919,6 +5919,7 @@
 /obj/effect/mapping_helpers/airlock/windoor/access/any/security/doors{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
 "blo" = (
@@ -16975,6 +16976,9 @@
 	name = "Security Reception"
 	},
 /obj/effect/mapping_helpers/airlock/windoor/access/any/security/general,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/lobby)
 "dsA" = (
@@ -33152,7 +33156,10 @@
 	},
 /obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot,
 /obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig,
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block)
 "gDQ" = (
 /obj/machinery/firealarm/directional/north,
@@ -48622,6 +48629,7 @@
 	id_tag = "Secure Armory";
 	name = "Secure Armory Shutters"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
 "jHZ" = (
@@ -71406,7 +71414,8 @@
 	name = "Security Atmospherics Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
 /area/station/maintenance/security/aft_starboard)
 "okn" = (
 /obj/structure/closet/secure_closet/evidence/detective,


### PR DESCRIPTION
## What Does This PR Do
Adds missing firelocks for desks, plastic flaps, and armoury shutters on Box/Delta/Emerald, and Delta's holding cells.

## Why It's Good For The Game
Most desks have firelocks on them, ditto for plastic flaps and shutters.

All brigs except Delta have firelocks for holding cells.

Consistency is good.
## Images of changes
Box:
<img width="192" height="160" alt="image" src="https://github.com/user-attachments/assets/9b4d832b-9b1b-4f74-99a9-fe740cd4d94e" />
<img width="128" height="96" alt="image" src="https://github.com/user-attachments/assets/adbd41ba-ee94-421b-b682-93e06d235769" />
<img width="96" height="96" alt="image" src="https://github.com/user-attachments/assets/2e1d2c24-6e54-4555-add5-809b9be5ed92" />

Delta:
<img width="160" height="96" alt="image" src="https://github.com/user-attachments/assets/e5ed457f-60d5-48c9-98f3-583b5759177f" />
<img width="96" height="96" alt="image" src="https://github.com/user-attachments/assets/bb798531-54f1-4525-9430-79085021d181" />
<img width="96" height="160" alt="image" src="https://github.com/user-attachments/assets/20601c6e-e8f8-4244-a646-82d5ba9cec0d" />
<img width="352" height="96" alt="image" src="https://github.com/user-attachments/assets/cc76c805-bf16-4b36-a916-170ff09bf6e9" />

Emerald:
<img width="96" height="96" alt="image" src="https://github.com/user-attachments/assets/d096a71b-2714-46e9-bd70-34f9ab9e4e9d" />
<img width="96" height="96" alt="image" src="https://github.com/user-attachments/assets/5fda2e38-a1a0-4e86-ba2b-c1be3d625cbd" />
<img width="96" height="128" alt="image" src="https://github.com/user-attachments/assets/ed2aaf69-97f9-42b4-bea0-7bbbc0568c1c" />
<img width="96" height="96" alt="image" src="https://github.com/user-attachments/assets/2602cc4a-5122-475b-99a9-67104552f1ce" />

## Testing
Visual inspection.

Pulled fire alarms to verify the existence of the firelocks.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Added several missing firelocks to Box/Delta/Emerald Security.
/:cl: