### PR TITLE
Migrate welding tools to the new attack chain.

### DIFF
--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -40,6 +40,7 @@
 	var/progress_flash_divisor = 1 SECONDS
 	/// If FALSE, welding tools wont appear prefilled by default
 	var/prefilled = TRUE
+	new_attack_chain = TRUE
 
 /obj/item/weldingtool/Initialize(mapload)
 	. = ..()
@@ -89,16 +90,20 @@
 		return
 	remove_fuel(maximum_fuel)
 
-/obj/item/weldingtool/attack_self__legacy__attackchain(mob/user)
+/obj/item/weldingtool/activate_self(mob/user)
+	if(..())
+		return ITEM_INTERACT_COMPLETE
 	if(tool_enabled) //Turn off the welder if it's on
 		to_chat(user, SPAN_NOTICE("You switch off [src]."))
 		toggle_welder()
-		return
-	else if(GET_FUEL) //The welder is off, but we need to check if there is fuel in the tank
+		return ITEM_INTERACT_COMPLETE
+	if(GET_FUEL) //The welder is off, but we need to check if there is fuel in the tank
 		to_chat(user, SPAN_NOTICE("You switch on [src]."))
 		toggle_welder()
-	else //The welder is off and unfuelled
-		to_chat(user, SPAN_NOTICE("[src] is out of fuel!"))
+		return ITEM_INTERACT_COMPLETE
+	//The welder is off and unfuelled
+	to_chat(user, SPAN_NOTICE("[src] is out of fuel!"))
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/weldingtool/proc/toggle_welder(turn_off = FALSE) //Turn it on or off, forces it to deactivate
 	tool_enabled = turn_off ? FALSE : !tool_enabled
@@ -149,17 +154,17 @@
 	remove_fuel(amount)
 	return TRUE
 
-/obj/item/weldingtool/afterattack__legacy__attackchain(atom/target, mob/user, proximity, params)
+/obj/item/weldingtool/after_attack(mob/user, atom/target, params, proximity_flag = 1)
 	. = ..()
 	if(!tool_enabled)
 		return
-	if(!proximity || isturf(target)) // We don't want to take away fuel when we hit something far away
+	if(!proximity_flag || isturf(target)) // We don't want to take away fuel when we hit something far away
 		return
 	remove_fuel(0.5)
 
-/obj/item/weldingtool/attack__legacy__attackchain(mob/living/target, mob/living/user, def_zone)
+/obj/item/weldingtool/attack(mob/living/target, mob/living/user, params)
 	if(cigarette_lighter_act(user, target))
-		return
+		return FINISH_ATTACK
 	if(tool_enabled && target.IgniteMob())
 		message_admins("[key_name_admin(user)] set [key_name_admin(target)] on fire")
 		log_game("[key_name(user)] set [key_name(target)] on fire")

--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -93,19 +93,19 @@
 /obj/item/weldingtool/activate_self(mob/user)
 	if(..())
 		return ITEM_INTERACT_COMPLETE
-	if(tool_enabled) //Turn off the welder if it's on
+	if(tool_enabled) // Turn off the welder if it's on.
 		to_chat(user, SPAN_NOTICE("You switch off [src]."))
 		toggle_welder()
 		return ITEM_INTERACT_COMPLETE
-	if(GET_FUEL) //The welder is off, but we need to check if there is fuel in the tank
+	if(GET_FUEL) // The welder is off, but we need to check if there is fuel in the tank.
 		to_chat(user, SPAN_NOTICE("You switch on [src]."))
 		toggle_welder()
 		return ITEM_INTERACT_COMPLETE
-	//The welder is off and unfuelled
+	// The welder is off and out of fuel.
 	to_chat(user, SPAN_NOTICE("[src] is out of fuel!"))
 	return ITEM_INTERACT_COMPLETE
 
-/obj/item/weldingtool/proc/toggle_welder(turn_off = FALSE) //Turn it on or off, forces it to deactivate
+/obj/item/weldingtool/proc/toggle_welder(turn_off = FALSE) // Turn it on or off, forces it to deactivate.
 	tool_enabled = turn_off ? FALSE : !tool_enabled
 	if(tool_enabled)
 		START_PROCESSING(SSobj, src)
@@ -154,17 +154,16 @@
 	remove_fuel(amount)
 	return TRUE
 
-/obj/item/weldingtool/after_attack(mob/user, atom/target, params, proximity_flag = 1)
+/obj/item/weldingtool/interact_with_atom(atom/target, mob/living/user, list/modifiers)
 	. = ..()
 	if(!tool_enabled)
 		return
-	if(!proximity_flag || isturf(target)) // We don't want to take away fuel when we hit something far away
-		return
+	if(cigarette_lighter_act(user, target))
+		remove_fuel(0.5)
+		return ITEM_INTERACT_COMPLETE
 	remove_fuel(0.5)
 
 /obj/item/weldingtool/attack(mob/living/target, mob/living/user, params)
-	if(cigarette_lighter_act(user, target))
-		return FINISH_ATTACK
 	if(tool_enabled && target.IgniteMob())
 		message_admins("[key_name_admin(user)] set [key_name_admin(target)] on fire")
 		log_game("[key_name(user)] set [key_name(target)] on fire")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Migrates welding tools to the new attack chain.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

I heard you like attack chain migrations.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted. Attacked a mob with a welder. Lit another mob's cigarette with a welder. Lit own mob's cigarette with a welder. Repaired damage on an IPC with a welder. 

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
