### PR TITLE
Resolve Prettier warnings.

### DIFF
--- a/tgui/packages/tgui-say/ChannelIterator.ts
+++ b/tgui/packages/tgui-say/ChannelIterator.ts
@@ -1,15 +1,5 @@
 export type Channel =
-  | 'Say'
-  | 'Radio'
-  | 'Whisper'
-  | 'Me'
-  | 'OOC'
-  | 'LOOC'
-  | 'Mentor'
-  | 'Admin'
-  | 'Dsay'
-  | 'Dev'
-  | 'Staff';
+  'Say' | 'Radio' | 'Whisper' | 'Me' | 'OOC' | 'LOOC' | 'Mentor' | 'Admin' | 'Dsay' | 'Dev' | 'Staff';
 
 /**
  * ### ChannelIterator

--- a/tgui/packages/tgui/interfaces/BodyScanner.jsx
+++ b/tgui/packages/tgui/interfaces/BodyScanner.jsx
@@ -173,16 +173,14 @@ const BodyScannerMainOccupant = (props) => {
 
 const BodyScannerMainAbnormalities = (props) => {
   const { occupant } = props;
-  if (
-    !(
-      occupant.hasBorer ||
-      occupant.blind ||
-      occupant.colourblind ||
-      occupant.nearsighted ||
-      occupant.hasVirus ||
-      occupant.paraplegic
-    )
-  ) {
+  if (!(
+    occupant.hasBorer ||
+    occupant.blind ||
+    occupant.colourblind ||
+    occupant.nearsighted ||
+    occupant.hasVirus ||
+    occupant.paraplegic
+  )) {
     return (
       <Section title="Abnormalities">
         <Box color="label">No abnormalities found.</Box>

--- a/tgui/packages/tgui/interfaces/ReagentsEditor.tsx
+++ b/tgui/packages/tgui/interfaces/ReagentsEditor.tsx
@@ -52,24 +52,20 @@ export class ReagentsEditor extends Component<{}, ReagentsEditorState> {
     } = useBackend<ReagentsEditorData>();
 
     let reagents = Object.entries(reagentsInContainer)
-      .map(
-        ([reagentID, reagent]): FilteredReagentInformation => ({
-          ...reagent,
-          ...reagentsInformation[reagentID],
-          id: reagentID,
-        })
-      )
+      .map(([reagentID, reagent]): FilteredReagentInformation => ({
+        ...reagent,
+        ...reagentsInformation[reagentID],
+        id: reagentID,
+      }))
       .sort((a, b) => a.name.localeCompare(b.name));
     if (this.state.searchText !== '') {
       reagents = reagents.concat(
         Object.entries(reagentsInformation)
           .filter(([reagentID, _]) => reagentsInContainer[reagentID] === undefined)
-          .map(
-            ([reagentID, reagent]): FilteredReagentInformation => ({
-              ...reagent,
-              id: reagentID,
-            })
-          )
+          .map(([reagentID, reagent]): FilteredReagentInformation => ({
+            ...reagent,
+            id: reagentID,
+          }))
           .sort((a, b) => a.name.localeCompare(b.name))
       );
     }


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Runs Prettier on several files to make it stop complaining on every lint of other pull requests.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

This is a really annoying reason for every PR to fail linters.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Ran Prettier. Compiled, hosted. Viewed a nearsighted character in the body scanner. Used the edit reagents menu to add coffee to a mug.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
