### PR TITLE
Add IPC knockout chem and hunger hallucination.

### DIFF
--- a/code/__DEFINES/mob_defines.dm
+++ b/code/__DEFINES/mob_defines.dm
@@ -322,6 +322,16 @@
 #define HEALTH_HUD_OVERRIDE_CRIT 1
 #define HEALTH_HUD_OVERRIDE_DEAD 2
 #define HEALTH_HUD_OVERRIDE_HEALTHY 3
+
+// Defines icon states used in /mob/living/carbon/human/proc/handle_nutrition_alerts to override nutrition status
+#define NUTRITION_HUD_OVERRIDE_NONE null
+#define NUTRITION_HUD_OVERRIDE_FAT "fat"
+#define NUTRITION_HUD_OVERRIDE_FULL "full"
+#define NUTRITION_HUD_OVERRIDE_WELL_FED "well_fed"
+#define NUTRITION_HUD_OVERRIDE_FED "fed"
+#define NUTRITION_HUD_OVERRIDE_HUNGRY "hungry"
+#define NUTRITION_HUD_OVERRIDE_STARVING "starving"
+
 // Eye protection
 #define FLASH_PROTECTION_VERYVUNERABLE -4
 #define FLASH_PROTECTION_EXTRA_SENSITIVE -2

--- a/code/__DEFINES/mob_defines.dm
+++ b/code/__DEFINES/mob_defines.dm
@@ -323,7 +323,7 @@
 #define HEALTH_HUD_OVERRIDE_DEAD 2
 #define HEALTH_HUD_OVERRIDE_HEALTHY 3
 
-// Defines icon states used in /mob/living/carbon/human/proc/handle_nutrition_alerts to override nutrition status
+// Defines icon states used in `/mob/living/carbon/human/proc/handle_nutrition_alerts` to override nutrition status.
 #define NUTRITION_HUD_OVERRIDE_NONE null
 #define NUTRITION_HUD_OVERRIDE_FAT "fat"
 #define NUTRITION_HUD_OVERRIDE_FULL "full"

--- a/code/modules/hallucinations/effects/minor.dm
+++ b/code/modules/hallucinations/effects/minor.dm
@@ -197,6 +197,30 @@
 	return ..()
 
 /**
+  * # Hallucination - Fake Hunger
+  *
+  * Visually changes the target's nutrition status to something it shouldn't be.
+  */
+/obj/effect/hallucination/fake_nutrition
+	duration = list(10 SECONDS, 25 SECONDS)
+
+/obj/effect/hallucination/fake_nutrition/Initialize(mapload, mob/living/carbon/human/target)
+	. = ..()
+	if(target.nutrition > NUTRITION_LEVEL_FED)
+		target.nutrition_hud_override = pick(NUTRITION_HUD_OVERRIDE_HUNGRY, NUTRITION_HUD_OVERRIDE_STARVING)
+	else
+		target.nutrition_hud_override = pick(NUTRITION_HUD_OVERRIDE_FAT, NUTRITION_HUD_OVERRIDE_FULL) // You think you're full, but you're not
+	if(istype(target))
+		target.handle_nutrition_alerts()
+
+/obj/effect/hallucination/fake_nutrition/Destroy()
+	target?.nutrition_hud_override = NUTRITION_HUD_OVERRIDE_NONE
+	if(ishuman(target))
+		var/mob/living/carbon/human/human_target = target
+		human_target?.handle_nutrition_alerts()
+	return ..()
+
+/**
  * # Hallucination - Examine Hallucination
  *
  * A generic hallucination that causes the target to see unique examine descriptions

--- a/code/modules/hallucinations/effects/minor.dm
+++ b/code/modules/hallucinations/effects/minor.dm
@@ -209,7 +209,7 @@
 	if(target.nutrition > NUTRITION_LEVEL_FED)
 		target.nutrition_hud_override = pick(NUTRITION_HUD_OVERRIDE_HUNGRY, NUTRITION_HUD_OVERRIDE_STARVING)
 	else
-		target.nutrition_hud_override = pick(NUTRITION_HUD_OVERRIDE_FAT, NUTRITION_HUD_OVERRIDE_FULL) // You think you're full, but you're not
+		target.nutrition_hud_override = pick(NUTRITION_HUD_OVERRIDE_FAT, NUTRITION_HUD_OVERRIDE_FULL) // You think you're full, but you're not.
 	if(istype(target))
 		target.handle_nutrition_alerts()
 

--- a/code/modules/hallucinations/hallucinations.dm
+++ b/code/modules/hallucinations/hallucinations.dm
@@ -2,7 +2,8 @@ GLOBAL_LIST_INIT(hallucinations, alist(
 	HALLUCINATE_MINOR = list(
 		/obj/effect/hallucination/bolts = 10,
 		/obj/effect/hallucination/fake_danger = 10,
-		/obj/effect/hallucination/fake_health = 15,
+		/obj/effect/hallucination/fake_health = 10,
+		/obj/effect/hallucination/fake_nutrition = 10,
 		/obj/effect/hallucination/speech = 15,
 		/obj/effect/hallucination/audio/localized = 25,
 		/obj/effect/hallucination/trait_applier/medical_machinery = 25,

--- a/code/modules/mob/living/carbon/human/human_life.dm
+++ b/code/modules/mob/living/carbon/human/human_life.dm
@@ -782,6 +782,9 @@
 		nutrition_display.icon_state = null
 		return
 	nutrition_display.icon = dna.species.hunger_icon
+	if(nutrition_hud_override)
+		nutrition_display.icon_state = nutrition_hud_override
+		return
 	switch(nutrition)
 		if(NUTRITION_LEVEL_FULL to INFINITY)
 			nutrition_display.icon_state = "fat"

--- a/code/modules/mob/mob_vars.dm
+++ b/code/modules/mob/mob_vars.dm
@@ -203,6 +203,8 @@
 
 	/// Overrides the health HUD element state if set.
 	var/health_hud_override = HEALTH_HUD_OVERRIDE_NONE
+	/// Overrides the nutrition HUD element state if set.
+	var/nutrition_hud_override = NUTRITION_HUD_OVERRIDE_NONE
 	/// A soft reference to the location where this mob's runechat message will appear. Uses `UID()`.
 	var/runechat_msg_location
 	/// The datum receiving keyboard input. parent mob by default.

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -956,6 +956,49 @@
 			M.Paralyse(50 SECONDS)
 	return ..() | update_flags
 
+/datum/reagent/frigidi
+	name = "Frigidi"
+	id = "frigidi"
+	description = "Budget industrial coolant appropriate for large spacecraft and detrimental to smaller machines. May cause microbattery damage."
+	reagent_state = LIQUID
+	color = "#444E90"
+	metabolization_rate = 0.8
+	penetrates_skin = TRUE
+	process_flags = ORGANIC | SYNTHETIC
+	taste_mult = 0
+
+/datum/reagent/frigidi/on_mob_life(mob/living/M)
+	if(!ismachineperson(M))
+		var/update_flags = STATUS_UPDATE_NONE | M.adjustFireLoss(1 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
+		return ..() | update_flags
+	var/mob/living/carbon/human/target = M
+	switch(current_cycle)
+		if(1 to 5)
+			if(M.nutrition > NUTRITION_LEVEL_HUNGRY)
+				M.nutrition_hud_override = NUTRITION_HUD_OVERRIDE_HUNGRY
+				target.handle_nutrition_alerts()
+		if(6 to 9)
+			M.AdjustEyeBlurry(10 SECONDS)
+			M.nutrition_hud_override = NUTRITION_HUD_OVERRIDE_STARVING
+			target.handle_nutrition_alerts()
+		if(10)
+			M.emote("faint")
+			M.Weaken(10 SECONDS)
+		if(11 to INFINITY)
+			M.Paralyse(50 SECONDS)
+			if(prob(10))
+				var/obj/item/organ/internal/cell/microbattery = M.get_organ_slot("heart")
+				if(istype(microbattery))
+					microbattery.receive_damage(2, TRUE)
+	var/update_flags = STATUS_UPDATE_NONE
+	return ..() | update_flags
+
+/datum/reagent/frigidi/on_mob_delete(mob/living/M)
+	if(ismachineperson(M))
+		var/mob/living/carbon/human/target = M
+		M.nutrition_hud_override = NUTRITION_HUD_OVERRIDE_NONE
+		target.handle_nutrition_alerts()
+
 /datum/reagent/sulfonal
 	name = "Sulfonal"
 	id = "sulfonal"

--- a/code/modules/reagents/chemistry/recipes/toxins_reactions.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins_reactions.dm
@@ -177,3 +177,11 @@
 	required_reagents = list("lsd" = 1, "teslium" = 1, "methamphetamine" = 1)
 	result_amount = 3
 	mix_message = SPAN_DANGER("After sparks, fire, and the smell of LSD, the mix is constantly spinning with no stop in sight.")
+
+/datum/chemical_reaction/frigidi
+	name = "Frigidi"
+	id = "frigidi"
+	result = "frigidi"
+	required_reagents = list("cryostylane" = 1, "w33d" = 1, "lube" = 1)
+	result_amount = 3
+	mix_message = "The mixture makes the container cool to the touch."

--- a/strings/chemistry_tools.json
+++ b/strings/chemistry_tools.json
@@ -469,6 +469,7 @@
 		"concentrated_initro",
 		"heartworms",
 		"bacon_grease",
-		"lexorin"
+		"lexorin",
+		"frigidi"
 	]
 }


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Adds a knockout toxin/drug for IPCs bought from traitor uplink or mixed from w33d, cryostylane, and space lube. Also, since it involves a fake battery drain, adds hunger/battery hallucination that uses the same overlay process.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

People who play antag have told me that they enjoy the knock-out-and-drag-somewhere gameplay and that they're sad they can't do it to IPCs. This adds one method for that.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted. Spawned as a machine person and drank 50u of knockout reagent. Observed fake battery changes. Waited out entire knockout period and then checked for microbattery damage (it was present). Stood next to a uranium-238 rod until I got the fake hunger hallucination.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Added Frigidi, a reagent that knocks out IPCs.
add: Added false hunger/battery level hallucination.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
