### PR TITLE
Kills unused var/unique_pet

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -41,7 +41,6 @@
 	icon_resting = "cat_rest"
 	gender = FEMALE
 	gold_core_spawnable = NO_SPAWN
-	unique_pet = TRUE
 	var/list/family = list()
 	var/list/children = list() //Actual mob instances of children
 
@@ -189,7 +188,6 @@
 /mob/living/simple_animal/pet/cat/proc_cat
 	name = "Proc"
 	gold_core_spawnable = NO_SPAWN
-	unique_pet = TRUE
 
 /mob/living/simple_animal/pet/cat/var_cat
 	name = "Var"

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -327,7 +327,6 @@
 	var/turns_since_scan = 0
 	var/obj/movement_target
 	gold_core_spawnable = NO_SPAWN
-	unique_pet = TRUE
 	var/age = 0
 	var/record_age = 1
 	var/saved_head //path
@@ -486,7 +485,6 @@
 	faction = list("neutral", "cult")
 	gold_core_spawnable = NO_SPAWN
 	nofur = TRUE
-	unique_pet = TRUE
 
 /mob/living/simple_animal/pet/dog/corgi/narsie/Life()
 	..()
@@ -544,7 +542,6 @@
 	gender = FEMALE
 	desc = "It's a corgi with a cute pink bow."
 	gold_core_spawnable = NO_SPAWN
-	unique_pet = TRUE
 	icon_state = "lisa"
 	icon_living = "lisa"
 	icon_dead = "lisa_dead"

--- a/code/modules/mob/living/simple_animal/friendly/fox.dm
+++ b/code/modules/mob/living/simple_animal/friendly/fox.dm
@@ -25,7 +25,6 @@
 /mob/living/simple_animal/pet/dog/fox/renault
 	name = "Renault"
 	desc = "Renault, the Captain's trustworthy fox. I wonder what it says?"
-	unique_pet = TRUE
 	gold_core_spawnable = NO_SPAWN
 
 /mob/living/simple_animal/pet/dog/fox/renault/Initialize(mapload)
@@ -41,7 +40,6 @@
 	icon_dead = "Syndifox_dead"
 	icon_resting = "Syndifox_rest"
 	faction = list("syndicate")
-	unique_pet = TRUE
 	gold_core_spawnable = NO_SPAWN
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -759,7 +759,6 @@
 		"The reactor is going supercritical!",
 		"Danger! Reactor core chamber meltdown in progress! Integrity: 79.47%"
 		)
-	unique_pet = TRUE
 	gold_core_spawnable = NO_SPAWN
 	available_channels = list(":e")
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -83,9 +83,6 @@
 	/// Higher speed is slower, negative speed is faster
 	var/speed = 1
 
-	/// If the mob can be renamed
-	var/unique_pet = FALSE
-
 	/// Hot simple_animal baby making vars
 	var/list/childtype = null
 	var/next_scan_time = 0


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Deletes unused var/unique_pet

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

idk

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

<!-- How did you test the PR, if at all? -->

Compiled build, no related runtimes found

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

Players won't care about that

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
