### PR TITLE
Fix latejoin command as quirk-blacklisted character.

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -145,6 +145,10 @@
 /datum/job/proc/barred_by_quirk(client/C)
 	if(!C || !length(blacklisted_disabilities)) // If there's no disability locks, there won't be a quirk lock either.
 		return FALSE
+	if(!length(C.prefs.active_character.quirks)) // If there's no quirks, don't bother
+		return FALSE
+	if(istext(C.prefs.active_character.quirks[1])) // These quirks were not properly built after loading from database.
+		C.prefs.active_character.rebuild_quirks()
 	for(var/datum/quirk/quirk in C.prefs.active_character.quirks)
 		if(quirk.blacklisted)
 			return TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes an oversight where quirks are not properly built before checking if they count against someone latejoining as command.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Fixes #31959.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Followed the reproduction steps in #31959 and found that command and security positions are now properly absent from the list of allowed roles.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed latejoining as command or security with a quirk-disabled character.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
