### PR TITLE
Migrate candles to the new attack chain.

### DIFF
--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -117,6 +117,7 @@
 		return ..()
 	user.visible_message(SPAN_NOTICE("[user] snuffs out [src]."))
 	unlight()
+	add_fingerprint(user)
 	return ITEM_INTERACT_COMPLETE
 
 /obj/item/candle/lit

--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -16,6 +16,7 @@
 	var/infinite = FALSE
 	var/start_lit = FALSE
 	var/flickering = FALSE
+	new_attack_chain = TRUE
 
 /obj/item/candle/Initialize(mapload)
 	. = ..()
@@ -40,11 +41,11 @@
 	else
 		return TRUE
 
-/obj/item/candle/attackby__legacy__attackchain(obj/item/W, mob/user, params)
-	if(W.get_heat())
-		light(SPAN_NOTICE("[user] lights [src] with [W]."))
-		return
-	return ..()
+/obj/item/candle/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	if(!used.get_heat())
+		return ..()
+	light(SPAN_NOTICE("[user] lights [src] with [used]."))
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/candle/welder_act(mob/user, obj/item/I)
 	. = TRUE
@@ -111,11 +112,12 @@
 		update_icon(UPDATE_ICON_STATE)
 		set_light(0)
 
-
-/obj/item/candle/attack_self__legacy__attackchain(mob/user)
-	if(lit)
-		user.visible_message(SPAN_NOTICE("[user] snuffs out [src]."))
-		unlight()
+/obj/item/candle/activate_self(mob/user)
+	if(!lit)
+		return ..()
+	user.visible_message(SPAN_NOTICE("[user] snuffs out [src]."))
+	unlight()
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/candle/lit
 	start_lit = TRUE
@@ -139,8 +141,10 @@
 	desc = "A candle. It smells like magic, so that would explain why it burns brighter."
 	start_lit = TRUE
 
-/obj/item/candle/eternal/wizard/attack_self__legacy__attackchain(mob/user)
-	return
+/obj/item/candle/eternal/wizard/activate_self(mob/user)
+	if(!user)
+		return ..()
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/candle/eternal/wizard/process()
 	return
@@ -149,7 +153,6 @@
 	. = ..()
 	if(lit)
 		set_light(CANDLE_LUM * 2)
-
 
 /obj/item/candle/extinguish_light(force)
 	if(!force)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Migrates candles to the new attack chain.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

I heard you like attack chain migrations.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted, spawned. Lit a candle with a welder and snuffed it inhand. Lit a candle with a cheap lighter and snuffed it inhand. Spawned a wizard candle and failed to snuff it inhand.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Added a fingerprint to candle snuffing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
