### PR TITLE
Migrate latex balloon to the new attack chain.

### DIFF
--- a/code/game/objects/items/latexballoon.dm
+++ b/code/game/objects/items/latexballoon.dm
@@ -27,6 +27,7 @@
 	user.update_inv_l_hand()
 	to_chat(user, SPAN_NOTICE("You blow up [src] with [tank]."))
 	air_contents = tank.remove_air_volume(3)
+	add_fingerprint(user)
 
 /obj/item/latexballon/proc/burst()
 	if(!air_contents || icon_state != "latexballon_blow")

--- a/code/game/objects/items/latexballoon.dm
+++ b/code/game/objects/items/latexballoon.dm
@@ -67,4 +67,4 @@
 		return ITEM_INTERACT_COMPLETE
 	if(used.sharp || used.get_heat() || is_pointed(used))
 		burst()
-		return ITEM_INTERACT_COMPLETE
+	return ITEM_INTERACT_COMPLETE

--- a/code/game/objects/items/latexballoon.dm
+++ b/code/game/objects/items/latexballoon.dm
@@ -10,6 +10,7 @@
 	cares_about_temperature = TRUE
 	var/state
 	var/datum/gas_mixture/air_contents = null
+	new_attack_chain = TRUE
 
 /obj/item/latexballon/Destroy()
 	QDEL_NULL(air_contents)
@@ -59,10 +60,11 @@
 	if(exposed_temperature > T0C+100)
 		burst()
 
-/obj/item/latexballon/attackby__legacy__attackchain(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/tank))
-		var/obj/item/tank/T = W
-		blow(T, user)
-		return
-	if(W.sharp || W.get_heat() || is_pointed(W))
+/obj/item/latexballon/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	if(istype(used, /obj/item/tank))
+		var/obj/item/tank/tank = used
+		blow(tank, user)
+		return ITEM_INTERACT_COMPLETE
+	if(used.sharp || used.get_heat() || is_pointed(used))
 		burst()
+		return ITEM_INTERACT_COMPLETE

--- a/code/game/objects/items/latexballoon.dm
+++ b/code/game/objects/items/latexballoon.dm
@@ -65,6 +65,8 @@
 		var/obj/item/tank/tank = used
 		blow(tank, user)
 		return ITEM_INTERACT_COMPLETE
+
 	if(used.sharp || used.get_heat() || is_pointed(used))
 		burst()
+
 	return ITEM_INTERACT_COMPLETE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Migrates latex balloon to the new attack chain.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

I heard you like attack chain migrations.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted, spawned a balloon. Inflated the balloon with an oxygen tank. Burst the balloon with a kitchen knife.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Added some fingerprints to inflating latex balloon.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
