### PR TITLE
Migrate ashtrays to the new attack chain and tweak.

### DIFF
--- a/code/game/objects/items/ashtray.dm
+++ b/code/game/objects/items/ashtray.dm
@@ -4,31 +4,47 @@
 	var/icon_half = ""
 	var/icon_full = ""
 	var/material = /obj/item/stack/sheet/metal
+	new_attack_chain = TRUE
 
-/obj/item/ashtray/attackby__legacy__attackchain(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/cigbutt) || istype(I, /obj/item/clothing/mask/cigarette) || istype(I, /obj/item/match))
-		if(length(contents) >= max_butts)
-			to_chat(user, "This ashtray is full.")
-			return
-		if(!user.unequip(I))
-			return
-		I.forceMove(src)
+/obj/item/ashtray/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	if(!(istype(used, /obj/item/cigbutt) || istype(used, /obj/item/clothing/mask/cigarette) || istype(used, /obj/item/match)))
+		return ..()
 
-		if(istype(I, /obj/item/clothing/mask/cigarette))
-			var/obj/item/clothing/mask/cigarette/cig = I
-			if(cig.lit)
-				visible_message("[user] crushes [cig] in [src], putting it out.")
-				var/obj/item/butt = new cig.butt_type(src)
-				cig.transfer_fingerprints_to(butt)
-				qdel(cig)
-			else
-				to_chat(user, "You place [cig] in [src] without even smoking it. Why would you do that?")
+	if(length(contents) >= max_butts)
+		to_chat(user, SPAN_WARNING("[src] is full!"))
+		return ITEM_INTERACT_COMPLETE
 
-		visible_message("[user] places [I] in [src].")
+	if(!user.unequip(used))
+		return ITEM_INTERACT_COMPLETE
+
+	if(istype(used, /obj/item/cigbutt) || istype(used, /obj/item/match))
+		user.visible_message(SPAN_NOTICE("[user] places [used] in [src]."),
+			SPAN_NOTICE("You put [used] in [src]."),
+			SPAN_HEAR("You hear a soft tap."))
+		used.forceMove(src)
 		add_fingerprint(user)
 		update_appearance(UPDATE_DESC|UPDATE_ICON_STATE)
-	else
-		return ..()
+		return ITEM_INTERACT_COMPLETE
+
+	var/obj/item/clothing/mask/cigarette/cig = used
+	if(cig.lit)
+		user.visible_message(SPAN_NOTICE("[user] crushes [cig] in [src], putting it out."),
+			SPAN_NOTICE("You crush [cig] in [src], putting it out."),
+			SPAN_HEAR("You hear the crumpling of a snuffed cigarette."))
+		var/obj/item/butt = new cig.butt_type(src)
+		cig.transfer_fingerprints_to(butt)
+		qdel(cig)
+		add_fingerprint(user)
+		update_appearance(UPDATE_DESC|UPDATE_ICON_STATE)
+		return ITEM_INTERACT_COMPLETE
+
+	used.forceMove(src)
+	user.visible_message(SPAN_NOTICE("[user] places an entire unlit [cig] in [src]."),
+		SPAN_NOTICE("You place [cig] in [src] without even smoking it. Why would you do that?"),
+		SPAN_HEAR("You hear a soft tap."))
+	add_fingerprint(user)
+	update_appearance(UPDATE_DESC|UPDATE_ICON_STATE)
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/ashtray/update_icon_state()
 	if(length(contents) == max_butts)
@@ -58,13 +74,37 @@
 	empty_tray()
 	return ..()
 
-/obj/item/ashtray/wrench_act(mob/user, obj/item/I)
+/obj/item/ashtray/wrench_act(mob/user, obj/item/used)
 	. = TRUE
-	if(!I.use_tool(src, user, volume = I.tool_volume))
+	if(!used.use_tool(src, user, volume = used.tool_volume))
 		return
 	empty_tray()
 	new material(drop_location(), 1)
 	deconstruct()
+
+// Do you want to get your entire unlit cigarette back out without dumping the whole tray? Well now you can.
+/obj/item/ashtray/AltClick()
+	if(!length(contents))
+		return ..()
+	if(!Adjacent(usr))
+		return ..()
+	if(!isliving(usr))
+		return ..()
+	var/atom/movable/choice = tgui_input_list(usr, "Choose a butt to remove.", "Ashtray fishing", contents)
+	if(!choice)
+		return
+	if(!Adjacent(usr))
+		to_chat(usr, SPAN_WARNING("You can't reach that far!"))
+		return
+
+	usr.visible_message(SPAN_NOTICE("[usr] fishes [choice] out of [src]."),
+		SPAN_NOTICE("You [length(contents) > max_butts * 0.5 ? "get ash on yourself, but you fish" : "pick"] [choice] out of [src]."),
+		SPAN_HEAR("You hear soot rustling."))
+	choice.forceMove(get_turf(src))
+	choice.add_fingerprint(usr)
+	if(ishuman(usr))
+		var/mob/living/carbon/human/user = usr
+		user.equip_to_slot_if_possible(choice, (user.hand ? ITEM_SLOT_LEFT_HAND : ITEM_SLOT_RIGHT_HAND), disable_warning = TRUE)
 
 /obj/item/ashtray/plastic
 	name = "plastic ashtray"

--- a/code/game/objects/items/ashtray.dm
+++ b/code/game/objects/items/ashtray.dm
@@ -102,6 +102,7 @@
 		SPAN_HEAR("You hear soot rustling."))
 	choice.forceMove(get_turf(src))
 	choice.add_fingerprint(usr)
+	add_fingerprint(usr)
 	if(ishuman(usr))
 		var/mob/living/carbon/human/user = usr
 		user.equip_to_slot_if_possible(choice, (user.hand ? ITEM_SLOT_LEFT_HAND : ITEM_SLOT_RIGHT_HAND), disable_warning = TRUE)

--- a/code/game/objects/items/ashtray.dm
+++ b/code/game/objects/items/ashtray.dm
@@ -62,12 +62,13 @@
 
 /obj/item/ashtray/update_desc()
 	. = ..()
+	desc = initial(desc)
 	if(length(contents) == max_butts)
-		desc = initial(desc) + " It's stuffed full."
+		desc += " It's stuffed full."
 	else if(length(contents) > max_butts * 0.5)
-		desc = initial(desc) + " It's half-filled."
-	else
-		desc = initial(desc)
+		desc += " It's half-filled."
+	if(length(contents))
+		desc += " You can use <b>Alt-Click</b> to fish through the contents."
 
 /obj/item/ashtray/proc/empty_tray()
 	for(var/obj/item/I in contents)

--- a/code/game/objects/items/ashtray.dm
+++ b/code/game/objects/items/ashtray.dm
@@ -18,9 +18,11 @@
 		return ITEM_INTERACT_COMPLETE
 
 	if(istype(used, /obj/item/cigbutt) || istype(used, /obj/item/match))
-		user.visible_message(SPAN_NOTICE("[user] places [used] in [src]."),
+		user.visible_message(
+			SPAN_NOTICE("[user] places [used] in [src]."),
 			SPAN_NOTICE("You put [used] in [src]."),
-			SPAN_HEAR("You hear a soft tap."))
+			SPAN_HEAR("You hear a soft tap.")
+		)
 		used.forceMove(src)
 		add_fingerprint(user)
 		update_appearance(UPDATE_DESC|UPDATE_ICON_STATE)
@@ -28,9 +30,11 @@
 
 	var/obj/item/clothing/mask/cigarette/cig = used
 	if(cig.lit)
-		user.visible_message(SPAN_NOTICE("[user] crushes [cig] in [src], putting it out."),
+		user.visible_message(
+			SPAN_NOTICE("[user] crushes [cig] in [src], putting it out."),
 			SPAN_NOTICE("You crush [cig] in [src], putting it out."),
-			SPAN_HEAR("You hear the crumpling of a snuffed cigarette."))
+			SPAN_HEAR("You hear the crumpling of a snuffed cigarette.")
+		)
 		var/obj/item/butt = new cig.butt_type(src)
 		cig.transfer_fingerprints_to(butt)
 		qdel(cig)
@@ -39,9 +43,11 @@
 		return ITEM_INTERACT_COMPLETE
 
 	used.forceMove(src)
-	user.visible_message(SPAN_NOTICE("[user] places an entire unlit [cig] in [src]."),
+	user.visible_message(
+		SPAN_NOTICE("[user] places an entire unlit [cig] in [src]."),
 		SPAN_NOTICE("You place [cig] in [src] without even smoking it. Why would you do that?"),
-		SPAN_HEAR("You hear a soft tap."))
+		SPAN_HEAR("You hear a soft tap.")
+	)
 	add_fingerprint(user)
 	update_appearance(UPDATE_DESC|UPDATE_ICON_STATE)
 	return ITEM_INTERACT_COMPLETE
@@ -97,9 +103,11 @@
 		to_chat(usr, SPAN_WARNING("You can't reach that far!"))
 		return
 
-	usr.visible_message(SPAN_NOTICE("[usr] fishes [choice] out of [src]."),
+	usr.visible_message(
+		SPAN_NOTICE("[usr] fishes [choice] out of [src]."),
 		SPAN_NOTICE("You [length(contents) > max_butts * 0.5 ? "get ash on yourself, but you fish" : "pick"] [choice] out of [src]."),
-		SPAN_HEAR("You hear soot rustling."))
+		SPAN_HEAR("You hear soot rustling.")
+	)
 	choice.forceMove(get_turf(src))
 	choice.add_fingerprint(usr)
 	add_fingerprint(usr)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Changes some ashtray messages. Allows one to pick individual butts out of the tray without spilling the whole thing. Migrates to the new attack chain.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

I was having a good time.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted. Put unlit cigarettes in ashtray. Put lit cigarettes in ashtry. Put cigarette butts in ashtray. Attempted to put items in a full ashtray. Threw ashtray. Picked cigarettes and butts out of ashtray.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Added the ability to fish a single item out of an ashtray.
tweak: Tweaked some ashtray messages.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
