### PR TITLE
Migrate enginepicker to the new attack chain.

### DIFF
--- a/code/game/objects/items/devices/enginepicker.dm
+++ b/code/game/objects/items/devices/enginepicker.dm
@@ -13,19 +13,23 @@
 
 	var/list/list_enginebeacons = list()
 	var/isactive = FALSE
+	new_attack_chain = TRUE
 
 /obj/item/enginepicker/Destroy()
 	list_enginebeacons.Cut()
 	return ..()
 
-/obj/item/enginepicker/attack_self__legacy__attackchain(mob/living/carbon/user)
+/obj/item/enginepicker/activate_self(mob/living/carbon/user)
+	if(..())
+		return ITEM_INTERACT_COMPLETE
+
 	if(user.incapacitated())
-		return
+		return ITEM_INTERACT_COMPLETE
 
 	if(!isactive)
-		isactive = TRUE	//Self-attack spam exploit prevention
+		isactive = TRUE// Self-attack spam exploit prevention.
 	else
-		return
+		return ITEM_INTERACT_COMPLETE
 
 	locatebeacons()
 	var/E = tgui_input_list(user, "Select the station's Engine", "[src]", list_enginebeacons)
@@ -33,23 +37,23 @@
 		processchoice(E, user)
 	else
 		isactive = FALSE
-		return
+	return ITEM_INTERACT_COMPLETE
 
-//This proc re-assigns all of engine beacons in the global list to a local list.
+/// This proc re-assigns all of engine beacons in the global list to a local list.
 /obj/item/enginepicker/proc/locatebeacons()
 	LAZYCLEARLIST(list_enginebeacons)
 	for(var/obj/item/beacon/engine/B in GLOB.engine_beacon_list)
-		if(B && !QDELETED(B))	//This ensures that the input pop-up won't have any qdeleted beacons
+		if(B && !QDELETED(B)) // This ensures that the input pop-up won't have any qdeleted beacons.
 			list_enginebeacons += B
 
-//Spawns and logs / announces the appropriate engine based on the choice made
+/// Spawns and logs / announces the appropriate engine based on the choice made.
 /obj/item/enginepicker/proc/processchoice(obj/item/beacon/engine/choice, mob/living/carbon/user)
-	var/issuccessful = FALSE	//Check for a successful choice
-	var/engtype					//Engine type
-	var/G						//Generator that will be spawned
+	var/issuccessful = FALSE	// Check for a successful choice.
+	var/engtype					// Engine type.
+	var/G						// Generator that will be spawned.
 	var/turf/T = get_turf(choice)
 
-	if(length(choice.enginetype) > 1)	//If the beacon has multiple engine types
+	if(length(choice.enginetype) > 1)	// If the beacon has multiple engine types.
 		var/E = tgui_input_list(user, "You have selected a combined beacon, which option would you prefer?", "[src]", choice.enginetype)
 		if(E)
 			engtype = E
@@ -58,41 +62,41 @@
 			isactive = FALSE
 			return
 
-	if(!engtype)				//If it has only one type
-		engtype = DEFAULTPICK(choice.enginetype, null)	//This should(?) account for a possibly scrambled list with a single entry
+	if(!engtype)				// If it has only one type.
+		engtype = DEFAULTPICK(choice.enginetype, null)	// This should(?) account for a possibly scrambled list with a single entry.
 	switch(engtype)
 		if(ENGTYPE_TESLA)
 			G = /obj/machinery/the_singularitygen/tesla
 		if(ENGTYPE_SING)
 			G = /obj/machinery/the_singularitygen
 
-	if(G)	//This can only be not-null if the switch operation was successful
+	if(G)	// This can only be not-null if the switch operation was successful.
 		issuccessful = TRUE
 
 	if(issuccessful)
-		clearturf(T) 	//qdels all items / gibs all mobs on the turf. Let's not have an SM shard spawn on top of a poor sod.
-		new G(T)		//Spawns the switch-selected engine on the chosen beacon's turf
+		clearturf(T) 	// qdels all items / gibs all mobs on the turf. Let's not have an SM shard spawn on top of a poor sod.
+		new G(T)		// Spawns the switch-selected engine on the chosen beacon's turf.
 
 		var/ailist[] = list()
 		for(var/mob/living/silicon/ai/A in GLOB.ai_list)
 			ailist += A
 		if(length(ailist))
 			var/mob/living/silicon/ai/announcer = pick(ailist)
-			announcer.say(";Engine delivery detected. Type: [engtype].")	//Let's announce the terrible choice to everyone
+			announcer.say(";Engine delivery detected. Type: [engtype].")	// Let's announce the terrible choice to everyone.
 
-		visible_message(SPAN_NOTICE("\The [src] begins to violently vibrate and hiss, then promptly disintegrates!"))
-		qdel(src)	//Self-destructs to prevent crew from spawning multiple engines.
+		visible_message(SPAN_NOTICE("[src] begins to violently vibrate and hiss, then promptly disintegrates!"))
+		qdel(src)	// Self-destructs to prevent crew from spawning multiple engines.
 	else
-		visible_message(SPAN_NOTICE("\The [src] buzzes! No beacon found or selected!"))
+		visible_message(SPAN_NOTICE("[src] buzzes! No beacon found or selected!"))
 		isactive = FALSE
 		return
 
-//Deletes objects and mobs from the beacon's turf.
+// Deletes objects and mobs from the beacon's turf.
 /obj/item/enginepicker/proc/clearturf(turf/T)
 	for(var/obj/item/I in T)
-		I.visible_message("\The [I] gets crushed to dust!")
+		I.visible_message("[I] gets crushed to dust!")
 		qdel(I)
 
 	for(var/mob/living/M in T)
-		M.visible_message("\The [M] gets obliterated!")
+		M.visible_message("[M] gets obliterated!")
 		M.gib()

--- a/code/game/objects/items/devices/enginepicker.dm
+++ b/code/game/objects/items/devices/enginepicker.dm
@@ -48,9 +48,12 @@
 
 /// Spawns and logs / announces the appropriate engine based on the choice made.
 /obj/item/enginepicker/proc/processchoice(obj/item/beacon/engine/choice, mob/living/carbon/user)
-	var/issuccessful = FALSE	// Check for a successful choice.
-	var/engtype					// Engine type.
-	var/G						// Generator that will be spawned.
+	/// Check for a successful choice.
+	var/issuccessful = FALSE
+	/// Engine type.
+	var/engtype
+	/// Generator that will be spawned.			
+	var/G						
 	var/turf/T = get_turf(choice)
 
 	if(length(choice.enginetype) > 1)	// If the beacon has multiple engine types.
@@ -84,19 +87,19 @@
 			var/mob/living/silicon/ai/announcer = pick(ailist)
 			announcer.say(";Engine delivery detected. Type: [engtype].")	// Let's announce the terrible choice to everyone.
 
-		visible_message(SPAN_NOTICE("[src] begins to violently vibrate and hiss, then promptly disintegrates!"))
+		visible_message(SPAN_WARNING("[src] begins to violently vibrate and hiss, then promptly disintegrates!"))
 		qdel(src)	// Self-destructs to prevent crew from spawning multiple engines.
 	else
-		visible_message(SPAN_NOTICE("[src] buzzes! No beacon found or selected!"))
+		visible_message(SPAN_WARNING("[src] buzzes! No beacon found or selected!"))
 		isactive = FALSE
 		return
 
 // Deletes objects and mobs from the beacon's turf.
 /obj/item/enginepicker/proc/clearturf(turf/T)
 	for(var/obj/item/I in T)
-		I.visible_message("[I] gets crushed to dust!")
+		I.visible_message(SPAN_WARNING("[I] gets crushed to dust!"))
 		qdel(I)
 
 	for(var/mob/living/M in T)
-		M.visible_message("[M] gets obliterated!")
+		M.visible_message(SPAN_DANGER("[M] gets obliterated!"))
 		M.gib()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Migrates the engine picker to the new attack chain.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

I dunno. Is this even used anywhere? Well it's gonna be on the new attack chain now.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted. Spawned an engine beacon for the tesla. Used the engine picker to summon the tesla. Watched it crush everything on that turf.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
