### PR TITLE
Migrate electropack to the new attack chain.

### DIFF
--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -46,19 +46,15 @@
 	return ITEM_INTERACT_COMPLETE
 
 /obj/item/electropack/item_interaction(mob/living/user, obj/item/used, list/modifiers)
-	..()
-
 	if(!istype(used, /obj/item/clothing/head/helmet))
-		return NONE
+		return ..()
 
 	attach_helmet(used, user)
 	return ITEM_INTERACT_COMPLETE
 
 /obj/item/electropack/interact_with_atom(atom/target, mob/living/user, list/modifiers)
-	..()
-
 	if(!istype(target, /obj/item/clothing/head/helmet))
-		return NONE
+		return ..()
 
 	attach_helmet(target, user)
 	return ITEM_INTERACT_COMPLETE

--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -21,11 +21,11 @@
 
 	if(istype(loc, /obj/item/assembly/shock_kit))
 		var/obj/item/assembly/shock_kit/S = loc
-		if(S.part1 == src)
-			S.part1 = null
+		if(S.attached_helmet == src)
+			S.attached_helmet = null
 
-		else if(S.part2 == src)
-			S.part2 = null
+		else if(S.attached_electropack == src)
+			S.attached_electropack = null
 
 		master = null
 
@@ -51,26 +51,42 @@
 	if(!istype(used, /obj/item/clothing/head/helmet))
 		return NONE
 
+	attach_helmet(used, user)
+	return ITEM_INTERACT_COMPLETE
+
+/obj/item/electropack/interact_with_atom(atom/target, mob/living/user, list/modifiers)
+	..()
+
+	if(!istype(target, /obj/item/clothing/head/helmet))
+		return NONE
+
+	attach_helmet(target, user)
+	return ITEM_INTERACT_COMPLETE
+
+/obj/item/electropack/proc/attach_helmet(obj/item/clothing/head/helmet/used, mob/living/user)
+	if(!istype(used))
+		return FALSE
+
 	var/obj/item/assembly/shock_kit/kit = new /obj/item/assembly/shock_kit(user)
 	kit.icon = 'icons/obj/assemblies.dmi'
 
 	if(!user.unequip(used))
 		to_chat(user, SPAN_WARNING("[used] is stuck to your hand, you cannot attach it to [src]!"))
-		return ITEM_INTERACT_COMPLETE
+		return FALSE
 
 	used.forceMove(kit)
 	used.master = kit
-	kit.part1 = used
+	kit.attached_helmet = used
 
 	user.transfer_item_to(src, kit)
 	master = kit
-	kit.part2 = src
+	kit.attached_electropack = src
 
 	user.put_in_hands(kit)
 	kit.add_fingerprint(user)
 	if(src.flags & NODROP)
 		kit.set_nodrop(TRUE)
-	return ITEM_INTERACT_COMPLETE
+	return TRUE
 
 /obj/item/electropack/proc/handle_shock()
 	if(istype(master, /obj/item/assembly/shock_kit))

--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -98,7 +98,7 @@
 
 // This should honestly just proxy the UI to the internal signaler
 /obj/item/electropack/ui_state(mob/user)
-	return GLOB.inventory_state
+	return GLOB.deep_inventory_state
 
 /obj/item/electropack/ui_interact(mob/user, datum/tgui/ui = null)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -9,6 +9,7 @@
 	materials = list(MAT_METAL = 10000, MAT_GLASS = 2500)
 	/// The integrated signaler
 	var/obj/item/assembly/signaler/electropack/integrated_signaler
+	new_attack_chain = TRUE
 
 /obj/item/electropack/Initialize(mapload)
 	. = ..()
@@ -37,33 +38,39 @@
 
 	..()
 
-/obj/item/electropack/attack_self__legacy__attackchain(mob/user)
+/obj/item/electropack/activate_self(mob/user)
+	if(..())
+		return ITEM_INTERACT_COMPLETE
 	ui_interact(user)
+	add_fingerprint(user)
+	return ITEM_INTERACT_COMPLETE
 
-/obj/item/electropack/attackby__legacy__attackchain(obj/item/W, mob/user, params)
+/obj/item/electropack/item_interaction(mob/living/user, obj/item/used, list/modifiers)
 	..()
 
-	if(istype(W, /obj/item/clothing/head/helmet))
-		var/obj/item/assembly/shock_kit/A = new /obj/item/assembly/shock_kit(user)
-		A.icon = 'icons/obj/assemblies.dmi'
+	if(!istype(used, /obj/item/clothing/head/helmet))
+		return NONE
 
-		if(!user.unequip(W))
-			to_chat(user, SPAN_NOTICE("\the [W] is stuck to your hand, you cannot attach it to \the [src]!"))
-			return
+	var/obj/item/assembly/shock_kit/kit = new /obj/item/assembly/shock_kit(user)
+	kit.icon = 'icons/obj/assemblies.dmi'
 
-		W.forceMove(A)
-		W.master = A
-		A.part1 = W
+	if(!user.unequip(used))
+		to_chat(user, SPAN_WARNING("[used] is stuck to your hand, you cannot attach it to [src]!"))
+		return ITEM_INTERACT_COMPLETE
 
-		user.transfer_item_to(src, A)
-		master = A
-		A.part2 = src
+	used.forceMove(kit)
+	used.master = kit
+	kit.part1 = used
 
-		user.put_in_hands(A)
-		A.add_fingerprint(user)
-		if(src.flags & NODROP)
-			A.set_nodrop(TRUE)
+	user.transfer_item_to(src, kit)
+	master = kit
+	kit.part2 = src
 
+	user.put_in_hands(kit)
+	kit.add_fingerprint(user)
+	if(src.flags & NODROP)
+		kit.set_nodrop(TRUE)
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/electropack/proc/handle_shock()
 	if(istype(master, /obj/item/assembly/shock_kit))

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -15,7 +15,7 @@
 	if(sk)
 		shocker = sk
 
-	if(isnull(shocker)) //This e-chair was not custom built
+	if(isnull(shocker)) // This e-chair was not custom built.
 		shocker = new(src)
 		var/obj/item/clothing/head/helmet/attached_helmet = new(shocker)
 		var/obj/item/electropack/attached_electropack = new(shocker)

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -3,7 +3,7 @@
 	desc = "Looks absolutely SHOCKING!"
 	icon_state = "echair0"
 	item_chair = null
-	var/obj/item/assembly/shock_kit/part = null
+	var/obj/item/assembly/shock_kit/shocker = null
 	var/last_time = 1.0
 	var/delay_time = 50
 	var/shocking = FALSE
@@ -13,17 +13,17 @@
 	update_icon(UPDATE_OVERLAYS)
 
 	if(sk)
-		part = sk
+		shocker = sk
 
-	if(isnull(part)) //This e-chair was not custom built
-		part = new(src)
-		var/obj/item/clothing/head/helmet/part1 = new(part)
-		var/obj/item/electropack/part2 = new(part)
-		part2.integrated_signaler.frequency = 1445
-		part2.integrated_signaler.code = 6
-		part2.master = part
-		part.part1 = part1
-		part.part2 = part2
+	if(isnull(shocker)) //This e-chair was not custom built
+		shocker = new(src)
+		var/obj/item/clothing/head/helmet/attached_helmet = new(shocker)
+		var/obj/item/electropack/attached_electropack = new(shocker)
+		attached_electropack.integrated_signaler.frequency = 1445
+		attached_electropack.integrated_signaler.code = 6
+		attached_electropack.master = shocker
+		shocker.attached_helmet = attached_helmet
+		shocker.attached_electropack = attached_electropack
 
 /obj/structure/chair/e_chair/examine(mob/user)
 	. = ..()
@@ -34,9 +34,9 @@
 	var/obj/structure/chair/C = new /obj/structure/chair(loc)
 	I.play_tool_sound(src, 50)
 	C.dir = dir
-	part.loc = loc
-	part.master = null
-	part = null
+	shocker.loc = loc
+	shocker.master = null
+	shocker = null
 	visible_message(SPAN_WARNING("[user] deconstructs [src]."))
 	qdel(src)
 

--- a/code/modules/assembly/shock_kit.dm
+++ b/code/modules/assembly/shock_kit.dm
@@ -30,7 +30,10 @@
 
 /obj/item/assembly/shock_kit/screwdriver_act(mob/user, obj/item/I)
 	status = !status
-	to_chat(user, SPAN_NOTICE("[src] is now [status ? "secured" : "unsecured"]!"))
+	if(status)
+		to_chat(user, SPAN_NOTICE("You ready and secure [src]!"))
+	else
+		to_chat(user, SPAN_NOTICE("You unsecure [src] with [I] so it can be attached!"))
 	add_fingerprint(user)
 	return TRUE
 
@@ -40,7 +43,7 @@
 	if(!part1 || !part2)
 		return
 	part1.activate_self(user)
-	part2.attack_self__legacy__attackchain(user, status)
+	part2.activate_self(user)
 	add_fingerprint(user)
 
 /obj/item/assembly/shock_kit/proc/shock_invoke()

--- a/code/modules/assembly/shock_kit.dm
+++ b/code/modules/assembly/shock_kit.dm
@@ -3,14 +3,14 @@
 	desc = "This appears to be made from both an electropack and a helmet."
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "shock_kit"
-	var/obj/item/clothing/head/helmet/part1 = null
-	var/obj/item/electropack/part2 = null
+	var/obj/item/clothing/head/helmet/attached_helmet = null
+	var/obj/item/electropack/attached_electropack = null
 	var/status = FALSE
 	w_class = WEIGHT_CLASS_HUGE
 
 /obj/item/assembly/shock_kit/Destroy()
-	QDEL_NULL(part1)
-	QDEL_NULL(part2)
+	QDEL_NULL(attached_helmet)
+	QDEL_NULL(attached_electropack)
 	return ..()
 
 /obj/item/assembly/shock_kit/wrench_act(mob/living/user, obj/item/I)
@@ -18,12 +18,12 @@
 		return
 	. = TRUE
 	var/turf/T = get_turf(src)
-	part1?.forceMove(T)
-	part2?.forceMove(T)
-	part1?.master = null
-	part2?.master = null
-	part1 = null
-	part2 = null
+	attached_helmet?.forceMove(T)
+	attached_electropack?.forceMove(T)
+	attached_helmet?.master = null
+	attached_electropack?.master = null
+	attached_helmet = null
+	attached_electropack = null
 	visible_message(SPAN_NOTICE("[user] disassembles [src]."))
 	qdel(src)
 	return TRUE
@@ -40,11 +40,12 @@
 /obj/item/assembly/shock_kit/activate_self(mob/user)
 	if(!user)
 		return ..()
-	if(!part1 || !part2)
-		return
-	part1.activate_self(user)
-	part2.activate_self(user)
+	if(!attached_helmet || !attached_electropack)
+		return NONE
+	attached_helmet.activate_self(user)
+	attached_electropack.activate_self(user)
 	add_fingerprint(user)
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/assembly/shock_kit/proc/shock_invoke()
 	if(istype(loc, /obj/structure/chair/e_chair))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Migrates electropacks to the new attack chain.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

I heard you like attack chain migrations.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted. Spawned a durathread helmet and an electropack. Used the electropack inhand to open the interface. Attached the electropack to the helmet to make a shock kit. Used the shock kit inhand and it opened the electropack interface.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Tweaked some shock kit messages.
tweak: Made it so you can assemble a shock kit by holding an electropack and clicking on a helmet as well.
fix: Made it possible to open electropack interface when it's inside a shock kit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
