### PR TITLE
Migrate garrote to the new attack chain.

### DIFF
--- a/code/game/objects/items/weapons/garrote.dm
+++ b/code/game/objects/items/weapons/garrote.dm
@@ -104,6 +104,7 @@
 	garrote_time = world.time + 10
 	START_PROCESSING(SSobj, src)
 	strangling = target
+	add_fingerprint(user)
 	update_icon(UPDATE_ICON_STATE)
 
 	playsound(loc, 'sound/weapons/cablecuff.ogg', 15, TRUE, -10, ignore_walls = FALSE)

--- a/code/game/objects/items/weapons/garrote.dm
+++ b/code/game/objects/items/weapons/garrote.dm
@@ -14,6 +14,7 @@
 	var/mob/living/carbon/human/strangling
 	var/improvised = FALSE
 	var/garrote_time
+	new_attack_chain = TRUE
 
 /obj/item/garrote/Initialize(mapload)
 	. = ..()
@@ -40,78 +41,80 @@
 	. = ..()
 	AddComponent(/datum/component/two_handed, wield_callback = CALLBACK(src, PROC_REF(wield)))
 
-
 /obj/item/garrote/proc/wield(obj/item/source, mob/living/carbon/user)
 	if(!strangling)
 		return
-	user.visible_message(SPAN_NOTICE("[user] removes [src] from [strangling]'s neck."),
-			SPAN_WARNING("You remove [src] from [strangling]'s neck."))
+	user.visible_message(
+		SPAN_NOTICE("[user] removes [src] from [strangling]'s neck."),
+		SPAN_WARNING("You remove [src] from [strangling]'s neck."),
+		SPAN_HEAR("You hear the wire slip free!")
+	)
 
 	strangling = null
 	update_icon(UPDATE_ICON_STATE)
 	STOP_PROCESSING(SSobj, src)
 
+/obj/item/garrote/attack(mob/living/carbon/human/target, mob/living/carbon/human/user)
+	if(garrote_time > world.time) // Cooldown.
+		return NONE
 
-/obj/item/garrote/attack__legacy__attackchain(mob/living/carbon/M as mob, mob/user as mob)
-	if(garrote_time > world.time) // Cooldown
-		return
-
-	if(!ishuman(user)) // spap_hand is a proc of /mob/living, user is simply /mob
-		return
-
-	var/mob/living/carbon/human/U = user
+	if(!ishuman(user)) // spap_hand is a proc of /mob/living, user is simply /mob.
+		return NONE
 
 	if(!HAS_TRAIT(src, TRAIT_WIELDED))
-		to_chat(user, "<span class = 'warning'>You must use both hands to garrote [M]!</span>")
-		return
+		to_chat(user, SPAN_WARNING("You must use both hands to garrote [target]!"))
+		return NONE
 
-	if(!ishuman(M))
-		to_chat(user, "<span class = 'warning'>You don't think that garroting [M] would be very effective...</span>")
-		return
+	if(!ishuman(target))
+		to_chat(user, SPAN_WARNING("You don't think that garroting [target] would be very effective...!"))
+		return NONE
 
-	if(M == U)
-		U.suicide() // This will display a prompt for confirmation first.
-		return
+	if(target == user)
+		user.suicide() // This will display a prompt for confirmation first.
+		return NONE
 
-	if(M.dir != U.dir && !M.incapacitated())
-		to_chat(user, SPAN_WARNING("You cannot use [src] on [M] from that angle!"))
-		return
+	if(target.dir != user.dir && !target.incapacitated())
+		to_chat(user, SPAN_WARNING("You cannot use [src] on [target] from that angle!"))
+		return NONE
 
-	if(improvised && ((M.head && (M.head.flags_cover & HEADCOVERSMOUTH)) || (M.wear_mask && (M.wear_mask.flags_cover & MASKCOVERSMOUTH)))) // Improvised garrotes are blocked by mouth-covering items.
-		to_chat(user, "<span class = 'warning'>[M]'s neck is blocked by something [M.p_theyre()] wearing!</span>")
+	if(improvised && ((target.head && (target.head.flags_cover & HEADCOVERSMOUTH)) || (target.wear_mask && (target.wear_mask.flags_cover & MASKCOVERSMOUTH)))) // Improvised garrotes are blocked by mouth-covering items.
+		to_chat(user, SPAN_WARNING("[target]'s neck is blocked by something [target.p_theyre()] wearing!"))
+		return NONE
 
 	if(strangling)
-		to_chat(user, "<span class = 'warning'>You cannot use [src] on two people at once!</span>")
-		return
+		to_chat(user, SPAN_WARNING("You cannot use [src] on two people at once!"))
+		return NONE
 
-	attack_self__legacy__attackchain(user)
+	activate_self(user)
 
-	U.swap_hand() // For whatever reason the grab will not properly work if we don't have the free hand active.
-	var/obj/item/grab/G = M.grabbedby(U, 1)
-	U.swap_hand()
+	user.swap_hand() // For whatever reason the grab will not properly work if we don't have the free hand active.
+	var/obj/item/grab/grab = target.grabbedby(user, TRUE)
+	user.swap_hand()
 
-	if(G && istype(G))
+	if(grab && istype(grab))
 		if(improvised) // Improvised garrotes start you off with a passive grab, but will lock you in place. A quick stun to drop items but not to make it unescapable
-			M.Stun(1 SECONDS)
-			M.Immobilize(2 SECONDS)
+			target.Stun(1 SECONDS)
+			target.Immobilize(2 SECONDS)
 		else
-			G.state = GRAB_NECK
-			G.hud.icon_state = "kill"
-			G.hud.name = "kill"
-			M.AdjustSilence(2 SECONDS)
+			grab.state = GRAB_NECK
+			grab.hud.icon_state = "kill"
+			grab.hud.name = "kill"
+			target.AdjustSilence(2 SECONDS)
 
 	garrote_time = world.time + 10
 	START_PROCESSING(SSobj, src)
-	strangling = M
+	strangling = target
 	update_icon(UPDATE_ICON_STATE)
 
 	playsound(loc, 'sound/weapons/cablecuff.ogg', 15, TRUE, -10, ignore_walls = FALSE)
 
-	M.visible_message(SPAN_DANGER("[U] comes from behind and begins garroting [M] with [src]!"), \
-				SPAN_USERDANGER("[U] begins garroting you with [src]![improvised ? "" : " You are unable to speak!"]"), \
-				"You hear struggling and wire strain against flesh!")
+	target.visible_message(
+		SPAN_DANGER("[user] comes from behind and begins garroting [target] with [src]!"),
+		SPAN_USERDANGER("[user] begins garroting you with [src]![improvised ? "" : " You are unable to speak!"]"),
+		SPAN_HEAR("You hear struggling and wire strain against flesh!")
+		)
 
-	return
+	return FINISH_ATTACK
 
 /obj/item/garrote/process()
 	if(!strangling)
@@ -119,7 +122,6 @@
 		update_icon(UPDATE_ICON_STATE)
 		STOP_PROCESSING(SSobj, src)
 		return
-
 
 	if(!ishuman(loc))
 		strangling = null
@@ -137,8 +139,11 @@
 		G = user.r_hand
 
 	else
-		user.visible_message(SPAN_WARNING("[user] loses [user.p_their()] grip on [strangling]'s neck."), \
-				SPAN_WARNING("You lose your grip on [strangling]'s neck."))
+		user.visible_message(
+			SPAN_WARNING("[user] loses [user.p_their()] grip on [strangling]'s neck!"),
+			SPAN_WARNING("You lose your grip on [strangling]'s neck!"),
+			SPAN_HEAR("You hear the wire slip free!")
+		)
 
 		strangling = null
 		update_icon(UPDATE_ICON_STATE)
@@ -147,8 +152,11 @@
 		return
 
 	if(!G.affecting)
-		user.visible_message(SPAN_WARNING("[user] loses [user.p_their()] grip on [strangling]'s neck."), \
-				SPAN_WARNING("You lose your grip on [strangling]'s neck."))
+		user.visible_message(
+			SPAN_WARNING("[user] loses [user.p_their()] grip on [strangling]'s neck!"),
+			SPAN_WARNING("You lose your grip on [strangling]'s neck!"),
+			SPAN_HEAR("You hear the wire slip free!")
+		)
 
 		strangling = null
 		update_icon(UPDATE_ICON_STATE)
@@ -164,13 +172,11 @@
 		strangling.apply_damage(2, OXY, "head")
 		return
 
-
 	strangling.AbsoluteSilence(6 SECONDS) // Non-improvised effects
 	if(G.state == GRAB_KILL)
 		strangling.PreventOxyHeal(6 SECONDS)
 		strangling.AdjustLoseBreath(6 SECONDS)
 		strangling.apply_damage(4, OXY, "head")
-
 
 /obj/item/garrote/suicide_act(mob/user)
 	user.visible_message(SPAN_SUICIDE("[user] is wrapping [src] around [user.p_their()] neck and pulling the handles! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/game/objects/items/weapons/garrote.dm
+++ b/code/game/objects/items/weapons/garrote.dm
@@ -55,6 +55,9 @@
 	STOP_PROCESSING(SSobj, src)
 
 /obj/item/garrote/attack(mob/living/carbon/human/target, mob/living/carbon/human/user)
+	if(..())
+		return FINISH_ATTACK
+
 	if(garrote_time > world.time) // Cooldown.
 		return NONE
 

--- a/code/game/objects/items/weapons/garrote.dm
+++ b/code/game/objects/items/weapons/garrote.dm
@@ -54,39 +54,40 @@
 	update_icon(UPDATE_ICON_STATE)
 	STOP_PROCESSING(SSobj, src)
 
-/obj/item/garrote/attack(mob/living/carbon/human/target, mob/living/carbon/human/user)
+/obj/item/garrote/interact_with_atom(mob/living/carbon/human/target, mob/living/carbon/human/user, list/modifiers)
 	if(..())
-		return FINISH_ATTACK
+		return ITEM_INTERACT_COMPLETE
 
 	if(garrote_time > world.time) // Cooldown.
-		return NONE
+		return ITEM_INTERACT_COMPLETE
 
-	if(!ishuman(user)) // spap_hand is a proc of /mob/living, user is simply /mob.
-		return NONE
+	if(!ishuman(user))
+		to_chat(user, SPAN_WARNING("You lack the dexterity to use this!"))
+		return ITEM_INTERACT_COMPLETE
 
 	if(!HAS_TRAIT(src, TRAIT_WIELDED))
 		to_chat(user, SPAN_WARNING("You must use both hands to garrote [target]!"))
-		return NONE
+		return ITEM_INTERACT_COMPLETE
 
 	if(!ishuman(target))
 		to_chat(user, SPAN_WARNING("You don't think that garroting [target] would be very effective...!"))
-		return NONE
+		return ITEM_INTERACT_COMPLETE
 
 	if(target == user)
 		user.suicide() // This will display a prompt for confirmation first.
-		return NONE
+		return ITEM_INTERACT_COMPLETE
 
 	if(target.dir != user.dir && !target.incapacitated())
 		to_chat(user, SPAN_WARNING("You cannot use [src] on [target] from that angle!"))
-		return NONE
+		return ITEM_INTERACT_COMPLETE
 
 	if(improvised && ((target.head && (target.head.flags_cover & HEADCOVERSMOUTH)) || (target.wear_mask && (target.wear_mask.flags_cover & MASKCOVERSMOUTH)))) // Improvised garrotes are blocked by mouth-covering items.
 		to_chat(user, SPAN_WARNING("[target]'s neck is blocked by something [target.p_theyre()] wearing!"))
-		return NONE
+		return ITEM_INTERACT_COMPLETE
 
 	if(strangling)
 		to_chat(user, SPAN_WARNING("You cannot use [src] on two people at once!"))
-		return NONE
+		return ITEM_INTERACT_COMPLETE
 
 	activate_self(user)
 
@@ -104,7 +105,7 @@
 			grab.hud.name = "kill"
 			target.AdjustSilence(2 SECONDS)
 
-	garrote_time = world.time + 10
+	garrote_time = world.time + 1 SECONDS
 	START_PROCESSING(SSobj, src)
 	strangling = target
 	add_fingerprint(user)
@@ -118,7 +119,7 @@
 		SPAN_HEAR("You hear struggling and wire strain against flesh!")
 		)
 
-	return FINISH_ATTACK
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/garrote/process()
 	if(!strangling)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Migrates the garrote to the new attack chain.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

I heard you like attack chain migrations.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted. Used garrote inhand to wield it. Seemed to strangle people alright but I would like others who are more familiar with this item to also test it.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Add a fingerprint to the garrote.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
