### PR TITLE
Migrate knuckleduster and kitchen tools to the new attack chain.

### DIFF
--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -18,6 +18,7 @@
 	icon = 'icons/obj/kitchen.dmi'
 	origin_tech = "materials=1"
 	materials = list(MAT_METAL = 100)
+	new_attack_chain = TRUE
 
 /*
  * Utensils
@@ -36,7 +37,6 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, RAD = 0, FIRE = 50, ACID = 30)
 	materials = list(MAT_METAL = 100)
 	var/max_contents = 1
-	new_attack_chain = TRUE
 
 /obj/item/kitchen/utensil/Initialize(mapload)
 	//Initialize(mapload)

--- a/code/game/objects/items/weapons/knuckledusters.dm
+++ b/code/game/objects/items/weapons/knuckledusters.dm
@@ -34,7 +34,7 @@
 		return ITEM_INTERACT_COMPLETE
 
 	gripped = FALSE
-	to_chat(SPAN_NOTICE(user, "You relax your grip on [src]."))
+	to_chat(user, SPAN_NOTICE("You relax your grip on [src]."))
 	set_nodrop(FALSE, user)
 	REMOVE_TRAIT(src, TRAIT_SKIP_EXAMINE, "knuckledusters")
 	return ITEM_INTERACT_COMPLETE

--- a/code/game/objects/items/weapons/knuckledusters.dm
+++ b/code/game/objects/items/weapons/knuckledusters.dm
@@ -49,7 +49,7 @@
 	hitsound = pick('sound/weapons/punch1.ogg', 'sound/weapons/punch2.ogg', 'sound/weapons/punch3.ogg', 'sound/weapons/punch4.ogg')
 	return ..()
 
-/obj/item/melee/knuckleduster/after_attack(atom/target, mob/user, proximity_flag, click_parameters)
+/obj/item/melee/knuckleduster/after_attack(mob/living/carbon/human/target, mob/user, proximity_flag, click_parameters)
 	if(!ishuman(target) || QDELETED(target))
 		return FINISH_ATTACK
 

--- a/code/game/objects/items/weapons/knuckledusters.dm
+++ b/code/game/objects/items/weapons/knuckledusters.dm
@@ -51,7 +51,7 @@
 
 /obj/item/melee/knuckleduster/after_attack(mob/living/carbon/human/target, mob/user, proximity_flag, click_parameters)
 	if(!ishuman(target) || QDELETED(target))
-		return FINISH_ATTACK
+		return ..()
 
 	var/obj/item/organ/external/punched = target.get_organ(user.zone_selected)
 	if(!length(punched.internal_organs))

--- a/code/game/objects/items/weapons/knuckledusters.dm
+++ b/code/game/objects/items/weapons/knuckledusters.dm
@@ -18,18 +18,24 @@
 	var/elite = FALSE
 	/// How much organ damage can the weapon do?
 	var/trauma = 5
+	new_attack_chain = TRUE
 
-/obj/item/melee/knuckleduster/attack_self__legacy__attackchain(mob/user)
+/obj/item/melee/knuckleduster/activate_self(mob/user)
+	if(..())
+		return ITEM_INTERACT_COMPLETE
+
 	if(!gripped)
 		gripped = TRUE
 		to_chat(user, "You tighten your grip on [src], ensuring you won't drop it.")
 		set_nodrop(TRUE, user)
 		ADD_TRAIT(src, TRAIT_SKIP_EXAMINE, "knuckledusters")
-	else
-		gripped = FALSE
-		to_chat(user, "You relax your grip on [src].")
-		set_nodrop(FALSE, user)
-		REMOVE_TRAIT(src, TRAIT_SKIP_EXAMINE, "knuckledusters")
+		return ITEM_INTERACT_COMPLETE
+
+	gripped = FALSE
+	to_chat(user, "You relax your grip on [src].")
+	set_nodrop(FALSE, user)
+	REMOVE_TRAIT(src, TRAIT_SKIP_EXAMINE, "knuckledusters")
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/melee/knuckleduster/dropped(mob/user, silent)
 	. = ..()
@@ -37,21 +43,24 @@
 	set_nodrop(FALSE, user)
 	REMOVE_TRAIT(src, TRAIT_SKIP_EXAMINE, "knuckledusters")
 
-/obj/item/melee/knuckleduster/attack__legacy__attackchain(mob/living/target, mob/living/user)
-	. = ..()
+/obj/item/melee/knuckleduster/pre_attack(atom/target, mob/living/user, params)
 	hitsound = pick('sound/weapons/punch1.ogg', 'sound/weapons/punch2.ogg', 'sound/weapons/punch3.ogg', 'sound/weapons/punch4.ogg')
+
+/obj/item/melee/knuckleduster/attack(mob/living/target, mob/living/carbon/human/user)
+	. = ..()
 	if(!ishuman(target) || QDELETED(target))
-		return
+		return FINISH_ATTACK
 
 	var/obj/item/organ/external/punched = target.get_organ(user.zone_selected)
 	if(!length(punched.internal_organs))
-		return
+		return FINISH_ATTACK
 
 	var/obj/item/organ/internal/squishy = pick(punched.internal_organs)
 	if(gripped && elite)
 		squishy.receive_damage(trauma)
 	if(punched.is_broken())
 		squishy.receive_damage(trauma) // Probably not so good for your organs to have your already broken ribs punched hard by a metal object
+	return FINISH_ATTACK
 
 /obj/item/melee/knuckleduster/syndie
 	name = "syndicate knuckleduster"

--- a/code/game/objects/items/weapons/knuckledusters.dm
+++ b/code/game/objects/items/weapons/knuckledusters.dm
@@ -50,6 +50,8 @@
 	return ..()
 
 /obj/item/melee/knuckleduster/after_attack(mob/living/carbon/human/target, mob/user, proximity_flag, click_parameters)
+	if(..())
+		return FINISH_ATTACK
 	if(!ishuman(target) || QDELETED(target))
 		return ..()
 

--- a/code/game/objects/items/weapons/knuckledusters.dm
+++ b/code/game/objects/items/weapons/knuckledusters.dm
@@ -53,7 +53,7 @@
 	if(..())
 		return FINISH_ATTACK
 	if(!ishuman(target) || QDELETED(target))
-		return ..()
+		return FINISH_ATTACK
 
 	var/obj/item/organ/external/punched = target.get_organ(user.zone_selected)
 	if(!length(punched.internal_organs))

--- a/code/game/objects/items/weapons/knuckledusters.dm
+++ b/code/game/objects/items/weapons/knuckledusters.dm
@@ -28,13 +28,13 @@
 
 	if(!gripped)
 		gripped = TRUE
-		to_chat(user, "You tighten your grip on [src], ensuring you won't drop it.")
+		to_chat(user, SPAN_NOTICE("You tighten your grip on [src], ensuring you won't drop it."))
 		set_nodrop(TRUE, user)
 		ADD_TRAIT(src, TRAIT_SKIP_EXAMINE, "knuckledusters")
 		return ITEM_INTERACT_COMPLETE
 
 	gripped = FALSE
-	to_chat(user, "You relax your grip on [src].")
+	to_chat(SPAN_NOTICE(user, "You relax your grip on [src]."))
 	set_nodrop(FALSE, user)
 	REMOVE_TRAIT(src, TRAIT_SKIP_EXAMINE, "knuckledusters")
 	return ITEM_INTERACT_COMPLETE
@@ -47,9 +47,9 @@
 
 /obj/item/melee/knuckleduster/pre_attack(atom/target, mob/living/user, params)
 	hitsound = pick('sound/weapons/punch1.ogg', 'sound/weapons/punch2.ogg', 'sound/weapons/punch3.ogg', 'sound/weapons/punch4.ogg')
+	return ..()
 
-/obj/item/melee/knuckleduster/attack(mob/living/target, mob/living/carbon/human/user)
-	. = ..()
+/obj/item/melee/knuckleduster/after_attack(atom/target, mob/user, proximity_flag, click_parameters)
 	if(!ishuman(target) || QDELETED(target))
 		return FINISH_ATTACK
 

--- a/code/game/objects/items/weapons/knuckledusters.dm
+++ b/code/game/objects/items/weapons/knuckledusters.dm
@@ -24,6 +24,8 @@
 	if(..())
 		return ITEM_INTERACT_COMPLETE
 
+	add_fingerprint(user)
+
 	if(!gripped)
 		gripped = TRUE
 		to_chat(user, "You tighten your grip on [src], ensuring you won't drop it.")

--- a/code/modules/ruins/lavalandruin_code/sin_ruins.dm
+++ b/code/modules/ruins/lavalandruin_code/sin_ruins.dm
@@ -186,7 +186,6 @@
 	inhand_icon_state = "knife"
 	force = 18
 	w_class = WEIGHT_CLASS_NORMAL
-	new_attack_chain = TRUE
 
 /obj/item/kitchen/knife/envy/after_attack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()

--- a/code/modules/smithing/smithed_items/knives.dm
+++ b/code/modules/smithing/smithed_items/knives.dm
@@ -7,7 +7,6 @@
 	slot_flags = ITEM_SLOT_BELT
 	embedded_ignore_throwspeed_threshold = TRUE
 
-	new_attack_chain = TRUE
 	/// The quality of the item
 	var/datum/smith_quality/quality
 	/// The material of the item


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Migrates knuckledusters and kitchen tools to the new attack chain. Kitchen tools had no remaining legacy procs.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

I heard you like attack chain migrations.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted. Spawned a knuckleduster. Gripped it and ungripped it inhand. Beat somebody up with it.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Added fingerprint to gripping knuckleduster.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
