### PR TITLE
Migrate whetstone to the new attack chain.

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -644,7 +644,7 @@
 /obj/item/whetstone/cult/item_interaction(mob/living/user, obj/item/used, list/modifiers)
 	..()
 	if(used_up)
-		to_chat(user, SPAN_NOTICE("[src] crumbles to ashes."))
+		to_chat(user, SPAN_WARNING("[src] crumbles to ashes!"))
 		qdel(src)
 		return ITEM_INTERACT_COMPLETE
 

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -639,13 +639,14 @@
 	claw_damage_increase = 4
 
 /obj/item/whetstone/cult/update_icon_state()
-	icon_state = "cult_sharpener[used ? "_used" : ""]"
+	icon_state = "cult_sharpener[used_up ? "_used" : ""]"
 
-/obj/item/whetstone/cult/attackby__legacy__attackchain(obj/item/I, mob/user, params)
+/obj/item/whetstone/cult/item_interaction(mob/living/user, obj/item/used, list/modifiers)
 	..()
-	if(used)
+	if(used_up)
 		to_chat(user, SPAN_NOTICE("[src] crumbles to ashes."))
 		qdel(src)
+		return ITEM_INTERACT_COMPLETE
 
 /obj/item/reagent_containers/drinks/bottle/unholywater
 	name = "flask of unholy water"

--- a/code/game/objects/items/weapons/whetstone.dm
+++ b/code/game/objects/items/weapons/whetstone.dm
@@ -5,67 +5,91 @@
 	desc = "A block of stone used to sharpen things."
 	w_class = WEIGHT_CLASS_SMALL
 	usesound = 'sound/items/screwdriver.ogg'
-	var/used = FALSE
+	var/used_up = FALSE
 	var/increment = 4
 	var/max = 30
 	var/prefix = "sharpened"
 	var/requires_sharpness = TRUE
 	var/claw_damage_increase = 2
+	new_attack_chain = TRUE
 
-
-/obj/item/whetstone/attackby__legacy__attackchain(obj/item/I, mob/user, params)
-	if(used)
+/obj/item/whetstone/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	if(used_up)
 		to_chat(user, SPAN_WARNING("The whetstone is too worn to use again!"))
-		return
-	if(requires_sharpness && !I.sharp)
-		to_chat(user, SPAN_WARNING("You can only sharpen items that are already sharp, such as knives!"))
-		return
-	var/signal_out = SEND_SIGNAL(I, COMSIG_ITEM_SHARPEN_ACT, increment, max)
+		return ITEM_INTERACT_COMPLETE
 
-	if((signal_out & COMPONENT_BLOCK_SHARPEN_MAXED) || I.force >= max || I.throwforce >= max) //If the item's components enforce more limits on maximum power from sharpening,  we fail
-		to_chat(user, SPAN_WARNING("[I] is much too powerful to sharpen further!"))
-		return
+	if(requires_sharpness && !used.sharp)
+		to_chat(user, SPAN_WARNING("You can only sharpen items have a sharpenable edge, such as knives!"))
+		return ITEM_INTERACT_COMPLETE
+	var/signal_out = SEND_SIGNAL(used, COMSIG_ITEM_SHARPEN_ACT, increment, max)
+
+	if((signal_out & COMPONENT_BLOCK_SHARPEN_MAXED) || used.force >= max || used.throwforce >= max) // If the item's components enforce more limits on maximum power from sharpening,  we fail.
+		to_chat(user, SPAN_WARNING("[used] is much too powerful to sharpen further!"))
+		return ITEM_INTERACT_COMPLETE
+
 	if(signal_out & COMPONENT_BLOCK_SHARPEN_BLOCKED)
-		to_chat(user, SPAN_WARNING("[I] is not able to be sharpened right now!"))
-		return
-	if((signal_out & COMPONENT_BLOCK_SHARPEN_ALREADY) || (I.force > initial(I.force) && !(signal_out & COMPONENT_SHARPEN_APPLIED))) //No sharpening stuff twice
-		to_chat(user, SPAN_WARNING("[I] has already been refined before. It cannot be sharpened further!"))
-		return
+		to_chat(user, SPAN_WARNING("[used] is not able to be sharpened right now!"))
+		return ITEM_INTERACT_COMPLETE
 
-	if(!(signal_out & COMPONENT_SHARPEN_APPLIED)) //If the item has a relevant component and COMPONENT_BLOCK_SHARPEN_APPLIED is returned, the item only gets the throw force increase
-		I.force = clamp(I.force + increment, 0, max)
+	if((signal_out & COMPONENT_BLOCK_SHARPEN_ALREADY) || (used.force > initial(used.force) && !(signal_out & COMPONENT_SHARPEN_APPLIED))) // No sharpening stuff twice.
+		to_chat(user, SPAN_WARNING("[used] has already been refined before. It cannot be sharpened further!"))
+		return ITEM_INTERACT_COMPLETE
 
-	user.visible_message(SPAN_NOTICE("[user] sharpens [I] with [src]!"), SPAN_NOTICE("You sharpen [I], making it much more deadly than before."))
+	if(!(signal_out & COMPONENT_SHARPEN_APPLIED)) // If the item has a relevant component and COMPONENT_BLOCK_SHARPEN_APPLIED is returned, the item only gets the throw force increase.
+		used.force = clamp(used.force + increment, 0, max)
+
+	user.visible_message(
+		SPAN_NOTICE("[user] sharpens [used] with [src]!"),
+		SPAN_NOTICE("You sharpen [used], making it much more deadly than before."),
+		SPAN_HEAR("You hear metal gliding along stone, refining to a perfect edge.")
+	)
 	if(!requires_sharpness)
 		set_sharpness(TRUE)
-	I.throwforce = clamp(I.throwforce + increment, 0, max)
-	I.name = "[prefix] [I.name]"
+	used.throwforce = clamp(used.throwforce + increment, 0, max)
+	used.name = "[prefix] [used.name]"
 	playsound(get_turf(src), usesound, 50, TRUE)
 	name = "worn out [name]"
 	desc = "[desc] At least, it used to."
-	used = TRUE
+	used_up = TRUE
 	update_icon()
+	add_fingerprint(user)
+	used.add_fingerprint(user)
+	return ITEM_INTERACT_COMPLETE
 
-/obj/item/whetstone/attack_self__legacy__attackchain(mob/user)
-	if(used)
+/obj/item/whetstone/activate_self(mob/living/carbon/human/user)
+	if(..())
+		return ITEM_INTERACT_COMPLETE
+
+	if(used_up)
 		to_chat(user, SPAN_WARNING("The whetstone is too worn to use again!"))
-		return
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		var/datum/unarmed_attack/attack = H.get_unarmed_attack()
-		if(istype(attack, /datum/unarmed_attack/claws))
-			var/datum/unarmed_attack/claws/C = attack
-			if(!C.has_been_sharpened)
-				C.has_been_sharpened = TRUE
-				attack.damage += claw_damage_increase
-				H.visible_message(SPAN_NOTICE("[H] sharpens [H.p_their()] claws on [src]!"), SPAN_NOTICE("You sharpen your claws on [src]."))
-				playsound(get_turf(H), usesound, 50, 1)
-				name = "worn out [name]"
-				desc = "[desc] At least, it used to."
-				used = TRUE
-				update_icon()
-			else
-				to_chat(user, SPAN_WARNING("You can not sharpen your claws any further!"))
+		return ITEM_INTERACT_COMPLETE
+
+	if(!ishuman(user))
+		return ITEM_INTERACT_COMPLETE
+
+	var/datum/unarmed_attack/attack = user.get_unarmed_attack()
+	if(!istype(attack, /datum/unarmed_attack/claws))
+		return ITEM_INTERACT_COMPLETE
+
+	var/datum/unarmed_attack/claws/claw_attack = attack
+	if(claw_attack.has_been_sharpened)
+		to_chat(user, SPAN_WARNING("You can not sharpen your claws any further!"))
+		return ITEM_INTERACT_COMPLETE
+
+	claw_attack.has_been_sharpened = TRUE
+	attack.damage += claw_damage_increase
+	user.visible_message(
+		SPAN_NOTICE("[user] sharpens [user.p_their()] claws on [src]!"),
+		SPAN_NOTICE("You sharpen your claws on [src]."),
+		SPAN_HEAR("You hear keratin gliding along stone, refining to a perfect edge.")
+	)
+	playsound(get_turf(user), usesound, 50, 1)
+	name = "worn out [name]"
+	desc = "[desc] At least, it used to."
+	used_up = TRUE
+	update_icon()
+	add_fingerprint(user)
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/whetstone/super
 	name = "super whetstone block"

--- a/code/game/objects/items/weapons/whetstone.dm
+++ b/code/game/objects/items/weapons/whetstone.dm
@@ -69,11 +69,12 @@
 
 	var/datum/unarmed_attack/attack = user.get_unarmed_attack()
 	if(!istype(attack, /datum/unarmed_attack/claws))
+		to_chat(user, SPAN_WARNING("You don't have claws to sharpen!"))
 		return ITEM_INTERACT_COMPLETE
 
 	var/datum/unarmed_attack/claws/claw_attack = attack
 	if(claw_attack.has_been_sharpened)
-		to_chat(user, SPAN_WARNING("You can not sharpen your claws any further!"))
+		to_chat(user, SPAN_WARNING("You cannot sharpen your claws any further!"))
 		return ITEM_INTERACT_COMPLETE
 
 	claw_attack.has_been_sharpened = TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Migrates the whetstone to the new attack chain.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

I heard you like attack chain migrations.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted. Sharpened a knife on a whetstone. Failed to sharpen claws on the worn-out whetstone. Sharpened claws on a fresh whetstone. 

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Added some fingerprints to whetstone sharpening.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
