### PR TITLE
Fix: DNA Vault disappearing when built in an invalid location

### DIFF
--- a/code/game/machinery/machine_frame.dm
+++ b/code/game/machinery/machine_frame.dm
@@ -249,6 +249,8 @@
 		return TRUE
 	I.play_tool_sound(src)
 	var/obj/machinery/new_machine = new circuit.build_path(loc)
+	if(QDELETED(new_machine))
+		return TRUE
 	new_machine.on_construction()
 	for(var/obj/O in new_machine.component_parts)
 		qdel(O)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes a bug where assembling a DNA Vault in a blocked or invalid area causes the machine frame and all of its installed components to completely disappear
Fixes #31899

## Why It's Good For The Game

Players will no longer lose valuable components and boards due to accidental invalid placement

## Testing

Tested manual construction in both valid and invalid locations. Also verified spawning it via the admin spawn panel

## Declaration

-  [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: The DNA Machine no longer disappears when placed in an invalid location.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
