### PR TITLE
Prevents Cyborgs From Grabbing Their Own Modules

### DIFF
--- a/code/game/objects/items/robot/cyborg_gripper.dm
+++ b/code/game/objects/items/robot/cyborg_gripper.dm
@@ -106,6 +106,10 @@
 	// Is the gripper interacting with an item?
 	if(isitem(target))
 		var/obj/item/I = target
+		if(I.is_robot_module())
+			to_chat(user, SPAN_WARNING("You can't grab your own modules!"))
+			return ITEM_INTERACT_COMPLETE
+
 		// Make sure the item is something the gripper can hold
 		if(can_hold_all_items || is_type_in_typecache(I, can_hold))
 			to_chat(user, SPAN_NOTICE("You collect [I]."))

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -2,7 +2,7 @@
 	name = "robot module"
 	icon = 'icons/obj/module.dmi'
 	icon_state = "std_mod"
-	w_class = 100
+	w_class = WEIGHT_CLASS_GIGANTIC
 	flags = CONDUCT
 	var/module_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, RAD = 0, FIRE = 0, ACID = 0)
 
@@ -950,6 +950,9 @@
 
 /// Checks whether this item is a module of the robot it is located in.
 /obj/item/proc/is_robot_module()
+	if(istype(loc, obj/item/robot_module))
+		return TRUE
+
 	if(!isrobot(loc))
 		return FALSE
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -950,7 +950,7 @@
 
 /// Checks whether this item is a module of the robot it is located in.
 /obj/item/proc/is_robot_module()
-	if(istype(loc, obj/item/robot_module))
+	if(istype(loc, /obj/item/robot_module))
 		return TRUE
 
 	if(!isrobot(loc))


### PR DESCRIPTION
## What Does This PR Do
Makes it impossible for the cyborg gripper to grab their own modules.
Adds an extra check to `is_robot_module()` to avoid the check returning false negatives.
## Why It's Good For The Game
#32234 had an issue with borgs being able to grab their own beaker. This also led to the discovery that mining borgs can grab their own drill. This is bad, this fix ensures that nothing like this can ever happen again.
Fixes #27751. Probably.
## Testing
Became a mining borg.
Tried to grab my own drill. I was unable to.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Robots cannot grab their own modules anymore.
/:cl:
