### PR TITLE
Allow lighting IPC cigarettes with welder by targeting mouth.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -93,7 +93,7 @@ emp_act
 		return TRUE
 	var/obj/item/organ/external/S = bodyparts_by_name[user.zone_selected]
 	if(!S)
-		if(ismachineperson(src))
+		if(ismachineperson(src) && !(user.zone_selected == "mouth" && istype(src.wear_mask, /obj/item/clothing/mask/cigarette/)))
 			to_chat(user, SPAN_NOTICE("[p_they(TRUE)] [p_are()] missing that limb!"))
 			return TRUE
 		return


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Allows lighting the cigarette worn on an IPC face with a welder by targeting the "mouth", like with organics.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Some IPC players were disappointed that the badassery failed because "x is missing that limb!" Fixes #32303 .

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted, spawned some cigarettes, an IPC and a welder. Put the cigarette on the IPC's face slot and lit it with the welder by targeting their "mouth". Targeted their "eyes" with the welder and got the usual missing limb message. Removed the cigarette and targeted their "mouth" with the welder and got the usual missing limb message.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed others being unable to light an IPC's worn cigarette with a welding tool.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
