### PR TITLE
Migrate extraction beacon assembly kit to the new attack chain.

### DIFF
--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -88,8 +88,8 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 			var/mutable_appearance/balloon3
 			if(isliving(A))
 				var/mob/living/M = A
-				M.Weaken(32 SECONDS) // Keep them from moving during the duration of the extraction
-				unbuckle_mob(M, force = TRUE) // Unbuckle them to prevent anchoring problems
+				M.Weaken(32 SECONDS) // Keep them from moving during the duration of the extraction.
+				unbuckle_mob(M, force = TRUE) // Unbuckle them to prevent anchoring problems.
 			else
 				A.anchored = TRUE
 				A.density = FALSE
@@ -163,12 +163,21 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 	desc = "When built, emits a signal which fulton recovery devices can lock onto. Activate in hand to unfold into a beacon."
 	icon = 'icons/obj/fulton.dmi'
 	icon_state = "folded_extraction"
+	new_attack_chain = TRUE
 
-/obj/item/fulton_core/attack_self__legacy__attackchain(mob/user)
-	if(do_after(user, 15, target = user) && !QDELETED(src))
-		new /obj/structure/extraction_point(get_turf(user))
-		playsound(loc, 'sound/items/deconstruct.ogg', 50, 1)
-		qdel(src)
+/obj/item/fulton_core/activate_self(mob/user)
+	if(..())
+		return ITEM_INTERACT_COMPLETE
+
+	if(!(do_after(user, 15, target = user) && !QDELETED(src)))
+		return ITEM_INTERACT_COMPLETE
+
+	var/obj/structure/extraction_point/new_point = new(get_turf(user))
+	playsound(loc, 'sound/items/deconstruct.ogg', 50, 1)
+	transfer_fingerprints_to(new_point)
+	new_point.add_fingerprint(user)
+	qdel(src)
+	return ITEM_INTERACT_COMPLETE
 
 /obj/structure/extraction_point
 	name = "fulton recovery beacon"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Migrates the extraction beacon assembly kit to the new attack chain.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

I heard you like attack chain migrations.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted, spawned a fulton core, picked it up, used it inhand to make an extraction beacon.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Added a few fingerprints to the fulton beacon kit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
