### PR TITLE
Allow mouse-dropping atoms in disposal chutes.

### DIFF
--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -331,6 +331,21 @@
 
 	. = ..()
 
+/obj/machinery/disposal/delivery_chute/MouseDrop_T(atom/movable/dropping, mob/user, params)
+	if(!Adjacent(user) || !dropping.Adjacent(user) || QDELETED(dropping))
+		return
+
+	if(!isturf(dropping.loc)) // If it's in storage or held by a mob you don't need this proc.
+		return
+
+	if(!dropping.can_be_pulled(user))
+		return
+
+	dropping.add_fingerprint(user)
+	dropping.forceMove(src)
+	flush()
+	return TRUE
+
 /obj/machinery/disposal/delivery_chute/Bumped(atom/movable/AM) //Go straight into the chute
 	if(isprojectile(AM)	|| is_ai(AM) || QDELETED(AM))
 		return


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Allows mouse-dropping atoms in disposal chutes.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

There are some maps where it's now very difficult to put body bags in the disposal chute because clicking on the tile closes the windoor. This will offer another option.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted. Dragged an adjacent body bag into an adjacent disposal unit. Closed the windoor and failed to drag the bag into the disposal. Stepped away from the disposal and failed to drag the bag inside. Stepped away from the bag and failed to drag it into the disposal.

Questions for reviewers:
- Do I need to put any more checks on this?
- Should it have a do_after?

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Added the ability to mouse-drop various things onto disposal chutes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
