### PR TITLE
Tilt lightmask when tilting vendor.

### DIFF
--- a/code/datums/components/tilted.dm
+++ b/code/datums/components/tilted.dm
@@ -98,12 +98,12 @@
 
 	atom_parent.unbuckle_all_mobs(TRUE)
 
-	SEND_SIGNAL(atom_parent, COMSIG_MOVABLE_UNTILTED, user)
-
 	atom_parent.layer = initial(atom_parent.layer)
 
 	var/matrix/M = matrix()
 	M.Turn(0)
 	atom_parent.transform = M
+
+	SEND_SIGNAL(atom_parent, COMSIG_MOVABLE_UNTILTED, user)
 	if(istype(user) && user.incapacitated())
 		return COMPONENT_BLOCK_UNTILT

--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -296,7 +296,9 @@
 			. += "[icon_broken ? "[icon_broken]_broken" : "[icon_state]_broken"]"
 		return
 	if(light)
-		underlays += emissive_appearance(icon, "[icon_lightmask ? "[icon_lightmask]_lightmask" : "[icon_state]_off"]")
+		var/mutable_appearance/lightmask  = emissive_appearance(icon, "[icon_lightmask ? "[icon_lightmask]_lightmask" : "[icon_state]_off"]")
+		lightmask.transform = transform
+		underlays += lightmask
 
 /*
  * Reimp, flash the screen on and off repeatedly.
@@ -994,6 +996,7 @@
 /obj/machinery/economy/vending/proc/on_untilt(atom/source, mob/user)
 	SIGNAL_HANDLER  // COMSIG_MOVABLE_UNTILTED
 	tilted = FALSE
+	update_icon(UPDATE_OVERLAYS)
 
 //Somebody cut an important wire and now we're following a new definition of "pitch."
 /obj/machinery/economy/vending/proc/throw_item()
@@ -1055,6 +1058,10 @@
 		throw_at(get_turf(victim), 1, 1, spin = FALSE)
 
 	tilt_over(should_throw_at_target ? victim : null)
+
+/obj/machinery/economy/vending/tilt_over(turf/target, rotation_angle, should_rotate, rightable, block_interactions_until_righted)
+	. = ..()
+	update_icon(UPDATE_OVERLAYS)
 
 /obj/machinery/economy/vending/shove_impact(mob/living/target, mob/living/attacker)
 	if(HAS_TRAIT(target, TRAIT_FLATTENED))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Tells a tilted vendor's lightmask to be just as tilted as the vendor itself.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Fixes #30886.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted. Hit a vendor until it tilted over. Righted the vendor.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed vendors having odd light patterns when tilted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
