### PR TITLE
Nerfs Human Mob Literacy

### DIFF
--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -2201,7 +2201,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 		makeCluwne()
 
 /mob/living/carbon/human/is_literate()
-	return getBrainLoss() < 90
+	return getBrainLoss() < 50
 
 
 /mob/living/carbon/human/fakefire(fire_icon = "Generic_mob_burning")


### PR DESCRIPTION
## What Does This PR Do
Reduces the brain damage threshold to make a human mob illiterate from 90 to 50.

## Why It's Good For The Game
When you have 90 brain damage you are basically already dead, so the check is unlikely to come into play. Meanwhile 60 brainloss makes you forget how to use machinery.

## Testing
Drank brain hurting juice.
Forgot how to read.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
tweak: Reduces the brain damage threshold to make a human mob illiterate from 90 to 50.
/:cl: