### PR TITLE
Make every labcoat selectable in the loadout

### DIFF
--- a/code/modules/client/preference/loadout/loadout_suit.dm
+++ b/code/modules/client/preference/loadout/loadout_suit.dm
@@ -116,10 +116,90 @@
 	allowed_roles = list("Quartermaster", "Explorer")
 
 //LABCOATS
-/datum/gear/suit/labcoat_emt
+/datum/gear/suit/labcoat
+	main_typepath = /datum/gear/suit/labcoat
+
+/datum/gear/suit/labcoat/generic
+	display_name = "Labcoat"
+	path = /obj/item/clothing/suit/storage/labcoat
+
+/datum/gear/suit/labcoat/mad
+	display_name = "Labcoat, mad scientist"
+	path = /obj/item/clothing/suit/storage/labcoat/mad
+
+/datum/gear/suit/labcoat/job
+	main_typepath = /datum/gear/suit/labcoat/job
+	subtype_selection_cost = FALSE
+
+/datum/gear/suit/labcoat/job/med
+	display_name = "Labcoat, medical"
+	path = /obj/item/clothing/suit/storage/labcoat/medical
+	allowed_roles = list("Chief Medical Officer", "Medical Doctor", "Chemist", "Psychiatrist", "Paramedic", "Virologist", "Coroner")
+
+/datum/gear/suit/labcoat/job/med/cmo
+	display_name = "Labcoat, cmo"
+	path = /obj/item/clothing/suit/storage/labcoat/cmo
+	allowed_roles = list("Chief Medical Officer")
+
+/datum/gear/suit/labcoat/job/med/chemist
+	display_name = "Labcoat, chemist"
+	path = /obj/item/clothing/suit/storage/labcoat/chemist
+	allowed_roles = list("Chief Medical Officer", "Chemist")
+
+/datum/gear/suit/labcoat/job/med/virologist
+	display_name = "Labcoat, virologist"
+	path = /obj/item/clothing/suit/storage/labcoat/virologist
+	allowed_roles = list("Chief Medical Officer", "Virologist")
+
+/datum/gear/suit/labcoat/job/med/mortician
+	display_name = "Labcoat, coroner"
+	path = /obj/item/clothing/suit/storage/labcoat/mortician
+	allowed_roles = list("Chief Medical Officer", "Coroner")
+
+/datum/gear/suit/labcoat/job/med/emt
 	display_name = "Labcoat, paramedic"
 	path = /obj/item/clothing/suit/storage/labcoat/emt
 	allowed_roles = list("Chief Medical Officer", "Paramedic")
+
+/datum/gear/suit/labcoat/job/med/psych
+	display_name = "Labcoat, psychiatrist"
+	path = /obj/item/clothing/suit/storage/labcoat/psych
+	allowed_roles = list("Chief Medical Officer", "Psychiatrist")
+
+/datum/gear/suit/labcoat/job/sci
+	display_name = "Labcoat, science"
+	path = /obj/item/clothing/suit/storage/labcoat/science
+	allowed_roles = list("Research Director", "Scientist", "Roboticist", "Geneticist", "Xenobiologist")
+
+/datum/gear/suit/labcoat/job/sci/genetics
+	display_name = "Labcoat, geneticist"
+	path = /obj/item/clothing/suit/storage/labcoat/genetics
+	allowed_roles = list("Research Director", "Geneticist")
+
+/datum/gear/suit/labcoat/job/sci/robowhite
+	display_name = "Labcoat, roboticist"
+	path = /obj/item/clothing/suit/storage/labcoat/robowhite
+	allowed_roles = list("Research Director", "Roboticist")
+
+/datum/gear/suit/labcoat/job/sci/roboblack
+	display_name = "Labcoat, biomechanical engineer"
+	path = /obj/item/clothing/suit/storage/labcoat/roboblack
+	allowed_roles = list("Research Director", "Roboticist")
+
+/datum/gear/suit/labcoat/job/sci/rd
+	display_name = "Labcoat, rd"
+	path = /obj/item/clothing/suit/storage/labcoat/rd
+	allowed_roles = list("Research Director")
+
+/datum/gear/suit/labcoat/job/hydro
+	display_name = "Labcoat, botanist"
+	path = /obj/item/clothing/suit/storage/labcoat/hydro
+	allowed_roles = list("Head of Personnel", "Botanist")
+
+/datum/gear/suit/labcoat/job/hydro/alt
+	display_name = "Labcoat, hydroponicist"
+	path = /obj/item/clothing/suit/storage/labcoat/hydro/alt
+	allowed_roles = list("Head of Personnel", "Botanist")
 
 //BOMBER JACKETS
 /datum/gear/suit/bomber


### PR DESCRIPTION
## What Does This PR Do

Adds every labcoats (except the paramedic's; this one was already here wondering where it's cousins had gone) to the loadout's external wear section.

The generic and mad scientist labcoat will always take up one loadout point each. 
<details><summary>The job labcoats (CMO, paramed, botanist, etc) will only take one loadout point even if you toggle all of them.</summary> Go you.. Mercantile CMO or RD, open this second-hand labcoat shop you dreamed of and earn 100-ish credits before the NTR and magistrate asks for your reseller permit.</details>

## Why It's Good For The Game

Paramedic labcoats should not be the only labcoats that can show signs of use or be custom-made. I am convinced the CMO's labcoat is just as tearable and stainable as their underling's.

(More customization options -> More depth for the characters = Better game IMO)

## Images of changes

<img width="1114" height="840" alt="The_labcoat_goblin_found_the_loadout" src="https://github.com/user-attachments/assets/651a0402-8d35-45c5-ad41-24be96926717" />

## Testing
- Checked every added labcoats are present in the loadout. They are.
- Checked job labcoats only count for 1 no matter if you have 1, 2 or all of them toggled. They do.
- Checked the generic labcoat always take up 1 loadout point. It does.
- Checked the mad scientist's labcoat always take up 1 loadout point. It does.
- Checked the labcoats' whitelists all work correctly. They do.
- Checked the labcoats' names and descriptions can be modified and will use modifications in game. They can be and do use them in game.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl: leboucliervert
add: Every labcoats are now available in the "External Wear" section of the loadout.
/:cl:
