### PR TITLE
Make spiders ignore SSD players as wrapping targets.

### DIFF
--- a/code/modules/mob/living/basic/hostile/giant_spider/giant_spider.dm
+++ b/code/modules/mob/living/basic/hostile/giant_spider/giant_spider.dm
@@ -103,6 +103,8 @@
 				continue
 			if(L.stat != DEAD)
 				continue
+			if(isLivingSSD(L))
+				continue
 			if(istype(L, /mob/living/basic/giant_spider))
 				continue
 			if(Adjacent(L))
@@ -117,7 +119,7 @@
 		if(length(choices))
 			cocoon_target = tgui_input_list(src, "What do you wish to cocoon?", "Cocoon Wrapping", choices)
 		else
-			to_chat(src, "<span class='warning'>No suitable dead prey or wrappable objects found nearby.")
+			to_chat(src, SPAN_WARNING("No suitable dead prey or wrappable objects found nearby."))
 			return
 
 	if(cocoon_target)

--- a/code/modules/mob/living/basic/hostile/giant_spider/giant_spider_ai.dm
+++ b/code/modules/mob/living/basic/hostile/giant_spider/giant_spider_ai.dm
@@ -182,7 +182,7 @@
 	var/list/food = list()
 	var/list/can_see = view(scan_range, spider)
 	for(var/mob/living/C in can_see)
-		if(C.stat && !istype(C, /mob/living/basic/giant_spider) && !C.anchored)
+		if(C.stat && !istype(C, /mob/living/basic/giant_spider) && !C.anchored && !isLivingSSD(C))
 			food += C
 	if(length(food))
 		controller.set_blackboard_key(target_key, pick(food))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Makes giant spiders skip over SSD players when considering wrapping targets.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Fixes #24670. Previously they would just keep producing empty cocoons under the SSD person indefinitely.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted. Spawned a giant spider nurse in a minimal room with two player controlled mobs. Went SSD with one of the mobs. Stayed connected with the other so the spider would continue running behaviors. Watched the spider kill and wrap the connected player. Watched the spider make webs all over the floor, totally ignoring the SSD player.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed giant spiders producing infinite cocoons under SSD players.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
