### PR TITLE
Match the type of vent a spider can smash to the pipe it's in.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
@@ -311,14 +311,12 @@
 	if(valid_supply && valid_supply.welded)
 		valid_supply.welded = FALSE
 		valid_supply.update_icon()
-		valid_supply.update_pipe_image()
 		forceMove(valid_supply.loc)
 		valid_supply.visible_message(SPAN_DANGER("[src] smashes the welded cover off [valid_supply]!"))
 		return
 	if(valid_scrubber && valid_scrubber.welded)
 		valid_scrubber.welded = FALSE
 		valid_scrubber.update_icon()
-		valid_scrubber.update_pipe_image()
 		forceMove(valid_scrubber.loc)
 		valid_scrubber.visible_message(SPAN_DANGER("[src] smashes the welded cover off [valid_scrubber]!"))
 		return

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
@@ -293,33 +293,37 @@
 		stop_automated_movement = FALSE
 
 /mob/living/simple_animal/hostile/poison/terror_spider/proc/DoVentSmash()
-	var/valid_target = FALSE
+	var/obj/machinery/atmospherics/unary/vent_pump/valid_supply = null
+	var/obj/machinery/atmospherics/unary/vent_pump/valid_scrubber = null
+	var/valid_target_type = -1
+	if(istype(loc, /obj/machinery/atmospherics))
+		var/obj/machinery/atmospherics/pipe_loc = loc
+		valid_target_type = pipe_loc.connected_to
 	for(var/obj/machinery/atmospherics/unary/vent_pump/P in range(1, get_turf(src)))
-		if(P.welded)
-			valid_target = TRUE
+		if(P.welded && (!istype(loc, /obj/machinery/atmospherics) || valid_target_type == CONNECT_TYPE_SUPPLY))
+			valid_supply = P
 	for(var/obj/machinery/atmospherics/unary/vent_scrubber/C in range(1, get_turf(src)))
-		if(C.welded)
-			valid_target = TRUE
-	if(!valid_target)
+		if(C.welded && (!istype(loc, /obj/machinery/atmospherics) || valid_target_type == CONNECT_TYPE_SCRUBBER))
+			valid_scrubber = C
+	if(!(valid_supply || valid_scrubber))
 		to_chat(src, SPAN_WARNING("No welded vent or scrubber nearby!"))
 		return
 	playsound(get_turf(src), 'sound/machines/airlock_alien_prying.ogg', 50, 0)
-	if(do_after(src, 40, target = loc))
-		for(var/obj/machinery/atmospherics/unary/vent_pump/P in range(1, get_turf(src)))
-			if(P.welded)
-				P.welded = FALSE
-				P.update_icon()
-				P.update_pipe_image()
-				forceMove(P.loc)
-				P.visible_message(SPAN_DANGER("[src] smashes the welded cover off [P]!"))
-				return
-		for(var/obj/machinery/atmospherics/unary/vent_scrubber/C in range(1, get_turf(src)))
-			if(C.welded)
-				C.welded = FALSE
-				C.update_icon()
-				C.update_pipe_image()
-				forceMove(C.loc)
-				C.visible_message(SPAN_DANGER("[src] smashes the welded cover off [C]!"))
-				return
-		to_chat(src, SPAN_DANGER("There is no welded vent or scrubber close enough to do this."))
+	if(!do_after(src, 40, target = loc))
+		return
+	if(valid_supply && valid_supply.welded)
+		valid_supply.welded = FALSE
+		valid_supply.update_icon()
+		valid_supply.update_pipe_image()
+		forceMove(valid_supply.loc)
+		valid_supply.visible_message(SPAN_DANGER("[src] smashes the welded cover off [valid_supply]!"))
+		return
+	if(valid_scrubber && valid_scrubber.welded)
+		valid_scrubber.welded = FALSE
+		valid_scrubber.update_icon()
+		valid_scrubber.update_pipe_image()
+		forceMove(valid_scrubber.loc)
+		valid_scrubber.visible_message(SPAN_DANGER("[src] smashes the welded cover off [valid_scrubber]!"))
+		return
+	to_chat(src, SPAN_WARNING("There is no welded vent or scrubber close enough to do this!"))
 

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
@@ -295,15 +295,12 @@
 /mob/living/simple_animal/hostile/poison/terror_spider/proc/DoVentSmash()
 	var/obj/machinery/atmospherics/unary/vent_pump/valid_supply = null
 	var/obj/machinery/atmospherics/unary/vent_pump/valid_scrubber = null
-	var/valid_target_type = -1
-	if(istype(loc, /obj/machinery/atmospherics))
-		var/obj/machinery/atmospherics/pipe_loc = loc
-		valid_target_type = pipe_loc.connected_to
+	var/obj/machinery/atmospherics/pipe/pipe_loc = loc
 	for(var/obj/machinery/atmospherics/unary/vent_pump/P in range(1, get_turf(src)))
-		if(P.welded && (!istype(loc, /obj/machinery/atmospherics) || valid_target_type == CONNECT_TYPE_SUPPLY))
+		if(P.welded && (!istype(pipe_loc, /obj/machinery/atmospherics) || pipe_loc.parent == P.parent))
 			valid_supply = P
 	for(var/obj/machinery/atmospherics/unary/vent_scrubber/C in range(1, get_turf(src)))
-		if(C.welded && (!istype(loc, /obj/machinery/atmospherics) || valid_target_type == CONNECT_TYPE_SCRUBBER))
+		if(C.welded && (!istype(pipe_loc, /obj/machinery/atmospherics) || pipe_loc.parent == C.parent))
 			valid_scrubber = C
 	if(!(valid_supply || valid_scrubber))
 		to_chat(src, SPAN_WARNING("No welded vent or scrubber nearby!"))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Checks if a brown terror spider is in a particular pipe net, and if so, restricts the vents it can smash to the ones that exist on that pipe net. Also fixes vent appearance code while I'm in the neighborhood.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Fixes #20963. Fixes #31509.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted. Spawned as chief engineer and welded a lot of scrubbers and vents. Spawned a brown terror spider and took control of it. Smashed both vent types from outside the pipe network. Smashed a scrubber vent from inside a scrubber pipe and failed to smash a supply vent. Smashed a supply vent from inside a supply pipe and failed to smash a scrubber vent. Also entered a maintenance pipe and failed to smash the dedicated supply and scrubber vents and vice versa. Broke vents open as a brown spider and revisted them as other spiders, saw that they correctly appeared unwelded.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed brown terrors' ability to smash supply vents from inside the scrubber pipes and vice versa.
fix: Fixed vents looking welded to other spiders in the pipe networks even after a brown terror smashed them open.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
