### PR TITLE
Fix skipping language keys in favor of partial radio keys.

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -747,7 +747,6 @@
 			set_default_language(null)
 		else
 			var/datum/language/L = GLOB.all_languages[href_list["default_lang"]]
-			message_admins("language selected is [L]")
 			if(L)
 				set_default_language(L)
 		check_languages()

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -673,7 +673,7 @@
 	speech_verb = "states"
 	ask_verb = "queries"
 	exclaim_verbs = list("declares")
-	key = "]"
+	key = "|"
 	flags = RESTRICTED | NOLIBRARIAN
 	follow = TRUE
 	syllables = list ("beep", "boop")
@@ -747,6 +747,7 @@
 			set_default_language(null)
 		else
 			var/datum/language/L = GLOB.all_languages[href_list["default_lang"]]
+			message_admins("language selected is [L]")
 			if(L)
 				set_default_language(L)
 		check_languages()

--- a/code/modules/mob/mob_say_base.dm
+++ b/code/modules/mob/mob_say_base.dm
@@ -142,7 +142,10 @@
 		return standard_mode
 
 	if(length(message) >= 2)
-		var/channel_prefix = copytext_char(message, 1, 3)
+		var/channel_prefix = trim_right(copytext_char(message, 1, 4))
+		var/datum/language/L = GLOB.language_keys[channel_prefix]
+		if(L != null && can_speak_language(L))
+			return null // Deconflict your language/radio keys if this causes problems.
 		return GLOB.department_radio_keys[channel_prefix]
 
 	return null


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes a bug where a two-character language key could be skipped in favor of a one-character radio key, for example, Syndicate radio channel instead of Terror Spider Hivemind. Also assigns drone talk a new key, since :] wasn't working out. Now it's :| (pipe).

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Fixes #26854. Fixes #27631. Fixes #28008.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted, spawned as a terror spider princess, changed my default language to common, spoke in hivemind using :ts. Spawned as a human and used a book of babel to speak several languages mentioned in #27631. Spawned as a drone and used the new drone talk key. Ran a small script to show what languages would have conflicted with radio keys before this change (partial conflict) and what ones wholly conflict before and after the change (whole conflicts), and tested the whole conflicts. :w Did not make my human character speak as zombie and :z did not make them speak as swarmer.

<details><summary>Details</summary>
<p>

Script and results.

```js
for(var/each_key in GLOB.language_keys)
	var/possible_conflict = copytext_char(each_key, 1, 3)
	if(GLOB.department_radio_keys[possible_conflict])
		message_admins("Potential partial conflict: [each_key] could trigger [GLOB.department_radio_keys[possible_conflict]] or [GLOB.language_keys[each_key]]")
	if(GLOB.department_radio_keys[each_key])
		message_admins("Potential whole conflict: [each_key] could trigger [GLOB.department_radio_keys[each_key]] or [GLOB.language_keys[each_key]]")

ADMIN LOG: Potential partial conflict: :st could trigger Security or Stok
ADMIN LOG: Potential partial conflict: .st could trigger Security or Stok
ADMIN LOG: Potential partial conflict: #st could trigger Security or Stok
ADMIN LOG: Potential partial conflict: :ne could trigger Science or Neara
ADMIN LOG: Potential partial conflict: .ne could trigger Science or Neara
ADMIN LOG: Potential partial conflict: #ne could trigger Science or Neara
ADMIN LOG: Potential partial conflict: :mo could trigger Medical or Chimpanzee
ADMIN LOG: Potential partial conflict: .mo could trigger Medical or Chimpanzee
ADMIN LOG: Potential partial conflict: #mo could trigger Medical or Chimpanzee
ADMIN LOG: Potential partial conflict: :ts could trigger Syndicate or Spider Hivemind
ADMIN LOG: Potential partial conflict: .ts could trigger Syndicate or Spider Hivemind
ADMIN LOG: Potential partial conflict: #ts could trigger Syndicate or Spider Hivemind
ADMIN LOG: Potential partial conflict: :zw could trigger Service or Golem Mindlink
ADMIN LOG: Potential partial conflict: .zw could trigger Service or Golem Mindlink
ADMIN LOG: Potential partial conflict: #zw could trigger Service or Golem Mindlink
ADMIN LOG: Potential partial conflict: :w could trigger whisper or Zombie
ADMIN LOG: Potential whole conflict: :w could trigger whisper or Zombie
ADMIN LOG: Potential partial conflict: .w could trigger whisper or Zombie
ADMIN LOG: Potential whole conflict: .w could trigger whisper or Zombie
ADMIN LOG: Potential partial conflict: #w could trigger whisper or Zombie
ADMIN LOG: Potential whole conflict: #w could trigger whisper or Zombie
ADMIN LOG: Potential partial conflict: :z could trigger Service or Swarmer
ADMIN LOG: Potential whole conflict: :z could trigger Service or Swarmer
ADMIN LOG: Potential partial conflict: .z could trigger Service or Swarmer
ADMIN LOG: Potential whole conflict: .z could trigger Service or Swarmer
ADMIN LOG: Potential partial conflict: #z could trigger Service or Swarmer
ADMIN LOG: Potential whole conflict: #z could trigger Service or Swarmer
```

</p>
</details> 

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed some two-letter language keys not working.
fix: Changed drone language key from :] to :| (pipe) because :] wasn't working.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
