### PR TITLE
Removes Burzah and Others from CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -199,6 +199,7 @@ Each role inherits the lower role's responsibilities
 `Headcoders` are the overarching "administrators" of the repository. People
 included in this role are:
 
+- [Burzah](https://github.com/Burzah)
 - [DGamerL](https://github.com/DGamerL)
 - [PollardTheDragon](https://github.com/PollardTheDragon)
 
@@ -208,7 +209,10 @@ included in this role are:
 PRs. People included in this role are:
 
 - [AffectedArc07](https://github.com/AffectedArc07)
+- [Charliminator](https://github.com/hal9000PR)
+- [FunnyMan3595](https://github.com/FunnyMan3595)
 - [lewcc](https://github.com/lewcc)
+- [SteelSlayer](https://github.com/SteelSlayer)
 - [Warriorstar](https://github.com/warriorstar-orion)
 
 ---
@@ -217,6 +221,8 @@ PRs. People included in this role are:
 affect mergeability status. People included in this role are:
 
 - [JimKil3](https://github.com/JimKil3)
+- [Pooble](https://github.com/poobsie)
+- [Sirryan2002](https://github.com/Sirryan2002)
 - [Wilkson](https://github.com/BiancaWilkson)
 
 ---

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -199,7 +199,6 @@ Each role inherits the lower role's responsibilities
 `Headcoders` are the overarching "administrators" of the repository. People
 included in this role are:
 
-- [Burzah](https://github.com/Burzah)
 - [DGamerL](https://github.com/DGamerL)
 - [PollardTheDragon](https://github.com/PollardTheDragon)
 
@@ -209,10 +208,7 @@ included in this role are:
 PRs. People included in this role are:
 
 - [AffectedArc07](https://github.com/AffectedArc07)
-- [Charliminator](https://github.com/hal9000PR)
-- [FunnyMan3595](https://github.com/FunnyMan3595)
 - [lewcc](https://github.com/lewcc)
-- [SteelSlayer](https://github.com/SteelSlayer)
 - [Warriorstar](https://github.com/warriorstar-orion)
 
 ---
@@ -221,8 +217,6 @@ PRs. People included in this role are:
 affect mergeability status. People included in this role are:
 
 - [JimKil3](https://github.com/JimKil3)
-- [Pooble](https://github.com/poobsie)
-- [Sirryan2002](https://github.com/Sirryan2002)
 - [Wilkson](https://github.com/BiancaWilkson)
 
 ---


### PR DESCRIPTION
## What Does This PR Do
Removes myself and some other from the CONTRIBUTING.md documents. These are all members of the dev team who have now since retired.

Thank you all for having me. It was a good time. I wish you all the best for your future endeavors. 

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
NPFC