### PR TITLE
Fix crayon eating simultaneously attacking the user.

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -145,24 +145,27 @@
 					qdel(src)
 		busy = FALSE
 
-/obj/item/toy/crayon/attack(mob/living/target, mob/living/carbon/human/user)
-	if(..() || !consumable)
-		return FINISH_ATTACK
-	if(target == user)
-		if(ishuman(user))
-			var/mob/living/carbon/human/H = user
-			if(!H.check_has_mouth())
-				to_chat(user, SPAN_WARNING("You do not have a mouth!"))
-				return
-		times_eaten++
-		playsound(loc, 'sound/items/eatfood.ogg', 50, 0)
-		user.adjust_nutrition(5)
-		user.reagents.add_reagent_list(list_reagents)
-		if(times_eaten < max_bites)
-			to_chat(user, SPAN_NOTICE("You take a bite of the [name]. [flavor]"))
-		else
-			to_chat(user, SPAN_WARNING("There is no more of [name] left!"))
-			qdel(src)
+/obj/item/toy/crayon/interact_with_atom(atom/target, mob/living/user, list/modifiers)
+	if(!consumable)
+		return ..()
+	if(target != user)
+		return ..()
+
+	if(ishuman(user))
+		var/mob/living/carbon/human/human_user = user
+		if(!human_user.check_has_mouth())
+			to_chat(user, SPAN_WARNING("You do not have a mouth!"))
+			return ITEM_INTERACT_COMPLETE
+	times_eaten++
+	playsound(loc, 'sound/items/eatfood.ogg', 50, 0)
+	user.adjust_nutrition(5)
+	user.reagents.add_reagent_list(list_reagents)
+	if(times_eaten < max_bites)
+		to_chat(user, SPAN_NOTICE("You take a bite of the [name]. [flavor]"))
+	else
+		to_chat(user, SPAN_WARNING("There is no more of [name] left!"))
+		qdel(src)
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/toy/crayon/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes an issue where a user eating a crayon would also attack the user.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Fixes #27745 

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted, spawned crayons. Clicked my own mob while holding the crayon and simply took a bite out of it. Clicked another mob while holding a crayon and colored them with it.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed an issue where eating a crayon would also attack the eater with the crayon.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
