### PR TITLE
Fix floor light pixel offsets.

### DIFF
--- a/code/modules/power/lights.dm
+++ b/code/modules/power/lights.dm
@@ -38,23 +38,14 @@
 
 /obj/machinery/light_construct/Initialize(mapload, ndir, building)
 	. = ..()
-	switch(dir)
-		if(NORTH)
-			pixel_x = 0
-			pixel_y = 20
-		if(SOUTH)
-			pixel_x = 0
-			pixel_y = 0
-		if(EAST)
-			pixel_x = 8
-			pixel_y = 4
-		if(WEST)
-			pixel_x = -8
-			pixel_y = 4
+	offset_by_dir()
 	update_icon(UPDATE_ICON_STATE)
 
 /obj/machinery/light_construct/setDir(newdir)
 	. = ..()
+	offset_by_dir()
+
+/obj/machinery/light_construct/proc/offset_by_dir()
 	switch(dir)
 		if(NORTH)
 			pixel_x = 0
@@ -216,6 +207,9 @@
 	sheets_refunded = 3
 	construct_type = /obj/machinery/light/floor/built
 
+/obj/machinery/light_construct/floor/offset_by_dir()
+	return
+
 /obj/machinery/light_construct/clockwork/small
 	name = "small brass light fixture frame"
 	desc = "A small brass light fixture under construction."
@@ -233,6 +227,9 @@
 	fixture_type = "clockwork_floor"
 	sheets_refunded = 3
 	construct_type = /obj/machinery/light/clockwork/floor/built
+
+/obj/machinery/light_construct/clockwork/floor/offset_by_dir()
+	return
 
 #undef LIGHT_CONSTRUCT_EMPTY_FRAME
 #undef LIGHT_CONSTRUCT_WIRED
@@ -407,19 +404,7 @@
 	if(A && !A.requires_power)
 		on = TRUE
 
-	switch(dir)
-		if(NORTH)
-			pixel_x = 0
-			pixel_y = 20
-		if(SOUTH)
-			pixel_x = 0
-			pixel_y = 0
-		if(EAST)
-			pixel_x = 8
-			pixel_y = 4
-		if(WEST)
-			pixel_x = -8
-			pixel_y = 4
+	offset_by_dir()
 
 	switch(base_state)
 		if("tube")
@@ -440,6 +425,27 @@
 		brightness_color = A.area_light_color
 	if(A.area_nightlight_color)
 		nightshift_light_color = A.area_nightlight_color
+
+/obj/machinery/light/proc/offset_by_dir()
+	switch(dir)
+		if(NORTH)
+			pixel_x = 0
+			pixel_y = 20
+		if(SOUTH)
+			pixel_x = 0
+			pixel_y = 0
+		if(EAST)
+			pixel_x = 8
+			pixel_y = 4
+		if(WEST)
+			pixel_x = -8
+			pixel_y = 4
+
+/obj/machinery/light/floor/offset_by_dir()
+	return
+
+/obj/machinery/light/clockwork/floor/offset_by_dir()
+	return
 
 /obj/machinery/light/proc/on_security_level_change_planned(datum/source, previous_level_number, new_level_number)
 	SIGNAL_HANDLER
@@ -1034,19 +1040,7 @@
 
 /obj/machinery/light/setDir(newdir)
 	. = ..()
-	switch(dir)
-		if(NORTH)
-			pixel_x = 0
-			pixel_y = 20
-		if(SOUTH)
-			pixel_x = 0
-			pixel_y = 0
-		if(EAST)
-			pixel_x = 8
-			pixel_y = 4
-		if(WEST)
-			pixel_x = -8
-			pixel_y = 4
+	offset_by_dir()
 
 /obj/item/light/proc/on_atom_entered(datum/source, atom/movable/entered)
 	var/mob/living/living_entered = entered


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes the directional offsets of floor lights that were introduced by wallening.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

The floor lights are on the floor, not the walls, so they don't need to be offset to fit nicely on the walls.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

Trust me that these lights were all built from different directions or mapped in with varedited directions.

<img width="533" height="561" alt="floor lights" src="https://github.com/user-attachments/assets/f1d9ee46-dd23-4fac-8622-38c0296340e5" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

Made a map with 'directional' floor lights, compiled, hosted. Built floor lights in each of the four directions as well. Observed that the lights on the walls were still offset by their respective directions.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed floor lights suddenly jumping to a different part of the floor tile when built.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
