### PR TITLE
Fixes Medical Gripper Being Unable to add Stuff to Smartfridges

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -188,6 +188,9 @@
 	if(istype(used, /obj/item/autochef_remote))
 		return
 
+	if(istype(used, /obj/item/gripper))
+		return ..()
+
 	if(stat & (BROKEN|NOPOWER))
 		to_chat(user, SPAN_NOTICE("[src] is unpowered and useless."))
 		return ITEM_INTERACT_COMPLETE


### PR DESCRIPTION
## What Does This PR Do
Adds a check for the borg gripper in smart fridge's `item_interaction()` which returns `..()` if found, allowing the gripper's `interact_with_atom()` to pass the interaction off to the held item.
## Why It's Good For The Game
The gripper can hold pills and stuff, let them go in the fridge instead of being all over the floor.
## Testing
Spawned as borg.
Made a 100u mannitol pill.
Grabbed it.
Put it into the fridge.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Fixed borg grippers being unable to add things to smart fridges.
/:cl:
