### PR TITLE
Fix Missing Scrubber Pipe in Box Station Engineering Maint

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -79314,6 +79314,9 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
 "sXh" = (


### PR DESCRIPTION
## What Does This PR Do
Fixes a missing pipe in Box Engi Maint.
## Why It's Good For The Game
Pipes should not be missing. No idea why the linters never complained about this.
## Images of changes
<img width="96" height="96" alt="image" src="https://github.com/user-attachments/assets/8054e4a8-35ab-4e49-bb96-d95d39e6e1f6" />

## Testing
Visual inspection.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog

:cl:
fix: Fixed a missing scrubber pipe in Box engi maint.
/:cl:
