### PR TITLE
Fix Double Plasma Window in BoxStation Supermatter Submap

### DIFF
--- a/_maps/map_files/stations/submaps/boxstation.dmm
+++ b/_maps/map_files/stations/submaps/boxstation.dmm
@@ -518,9 +518,6 @@
 /obj/structure/window/plasmareinforced{
 	dir = 8
 	},
-/obj/structure/window/plasmareinforced{
-	dir = 8
-	},
 /obj/machinery/power/rad_collector{
 	anchored = 1
 	},


### PR DESCRIPTION
## What Does This PR Do
Fixes a duplicated plasma window in Box's SM submap.
## Why It's Good For The Game
Quantum windows bad.
## Images of changes
<img width="96" height="96" alt="image" src="https://github.com/user-attachments/assets/0abb4ebf-2ead-48ef-b259-a3cf95a29dac" />

## Testing
Visual inspection.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Fixed a duplicated window in box's SM submap.
/:cl: