### PR TITLE
Fixes Missing Access on Box Secure Storage

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -39055,13 +39055,6 @@
 	c_tag = "Engineering West";
 	dir = 4
 	},
-/obj/machinery/door_control{
-	desc = "A remote control-switch for secure storage.";
-	id = "Secure Storage";
-	name = "Engineering Secure Storage";
-	pixel_x = -24;
-	req_access = list(56)
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -39252,6 +39245,13 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/door_control{
+	desc = "A remote control-switch for secure storage.";
+	id = "Secure Storage";
+	name = "Engineering Secure Storage";
+	req_access = list(32);
+	pixel_y = 32
 	},
 /turf/simulated/floor/catwalk,
 /area/station/engineering/secure_storage)


### PR DESCRIPTION
## What Does This PR Do
Changes the access of the secure storage button on Box from Engineer to General Engineering, allowing atmos techs to use it (as on other stations).
## Why It's Good For The Game
Fixes #32182.
## Images of changes
<img width="96" height="96" alt="image" src="https://github.com/user-attachments/assets/a4150e86-bb25-41e2-b51e-71dc9bda22a8" />

## Testing
Spawned as atmos tech. Pressed button. Access granted.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Atmos techs can access Box secure engi storage.
/:cl: