### PR TITLE
Fixes Wrapped Stuff Throwing off Orbital Ghosts

### DIFF
--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -50,7 +50,7 @@
 				stowaway.forceMove(O)
 	var/turf/T = get_turf(src)
 	for(var/atom/movable/AM in src)
-		AM.loc = T
+		AM.forceMove(T)
 	qdel(src)
 
 /obj/structure/big_delivery/item_interaction(mob/living/user, obj/item/W, list/modifiers)
@@ -229,7 +229,7 @@
 			if(user.client)
 				user.client.screen -= O
 		P.wrapped = O
-		O.loc = P
+		O.forceMove(P)
 		var/i = round(O.w_class)
 		if(i in list(1,2,3,4,5))
 			P.icon_state = "deliverycrate[i]"
@@ -290,7 +290,7 @@
 	for(var/mob/living/stowaway in C)
 		stowaway.forceMove(P)
 	P.wrapped = C
-	C.loc = P
+	C.forceMove(P)
 	return P
 
 /obj/item/dest_tagger
@@ -405,10 +405,10 @@
 
 	if(isobj(AM))
 		var/obj/O = AM
-		O.loc = src
+		O.forceMove(src)
 	else if(ismob(AM))
 		var/mob/M = AM
-		M.loc = src
+		M.forceMove(src)
 	flush()
 
 /obj/machinery/disposal/delivery_chute/flush()


### PR DESCRIPTION
## What Does This PR Do
Changes several instances of `foo.loc = bar` to `foo.forceMove(bar)`.
## Why It's Good For The Game
Fixes #20071 (probably).
## Testing
I can't test the ghost orbiting part, but this does work for other stuff.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Orbiting ghosts no longer get kicked off objects that get wrapped.
/:cl:
