### PR TITLE
Fixes Unsealed Painting Bludgeoning

### DIFF
--- a/code/modules/antagonists/heretic/items/unsealed_arts.dm
+++ b/code/modules/antagonists/heretic/items/unsealed_arts.dm
@@ -47,8 +47,8 @@
 		return FINISH_ATTACK
 
 /obj/structure/unsealed_art/wrench_act(mob/living/user, obj/item/I)
-	. = ..()
 	default_unfasten_wrench(user, I, 3 SECONDS)
+	return TRUE
 
 /// This proc triggers when the art has been covered by sheets, going inert
 /obj/structure/unsealed_art/proc/on_cover()
@@ -74,7 +74,7 @@
 
 /obj/structure/unsealed_art/beauty/examine_more(mob/user)
 	. = ..()
-	. += "<span class='notice'>This unsealed art will bewitch any non-heretic that lays their eyes on it, forcing them to stare deeply upon its beauty. They cannot look away.</span"
+	. += SPAN_NOTICE("This unsealed art will bewitch any non-heretic that lays their eyes on it, forcing them to stare deeply upon its beauty. They cannot look away.")
 
 /obj/structure/unsealed_art/beauty/Destroy()
 	QDEL_NULL(eyeobj)


### PR DESCRIPTION
## What Does This PR Do
Makes unsealed art `return TRUE` on `wrench_act()`
## Why It's Good For The Game
Fixes #31604.
## Testing
Wrenched some unsealed art. Saw I didn't hit it.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Fixed wrenches bludgeoning unsealed art.
/:cl: