### PR TITLE
Fixes a small issue with playing web sounds

### DIFF
--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -136,6 +136,11 @@ USER_VERB(play_sound_tgchat, R_SOUNDS, "Play Global Sound", "Play a sound to be 
 
 		// Prepare the body
 		var/list/request_body = list("url" = web_sound_input)
+		// Patch around the YTDLP server breaking in its current form
+		// Making these empty dicts overrides the default on the YTDLP server where it tries to parse with invalid args
+		request_body["opts"] = alist()
+		request_body["opts"]["extractor_args"] = alist()
+
 		// Send the request off
 		var/datum/http_request/media_poll_request = new()
 		// The fact we are using GET with a body offends me


### PR DESCRIPTION
## What Does This PR Do
We use https://github.com/Absolucy/ss13-yt-wrap as the backend for yt-dlp because we are not invoking shell commands for this - end of.

However, the above has a bug where the default extractor options fail to parse because "e" is not a language, even though it specifies "en".
<img width="1005" height="215" alt="image" src="https://github.com/user-attachments/assets/f05de531-0961-4de3-9a72-b0b1062c2893" />

Meanwhile the code is ``"extractor_args": {"youtube": {"lang": "en", "skip": ["translated_subs"]}},``

So all this time I have just had a patch on the server to do this

```diff
diff --git a/main.py b/main.py
index e56458e..552d80c 100644
--- a/main.py
+++ b/main.py
@@ -23,7 +23,7 @@ class Media(BaseModel):
                "noplaylist": True,
                "wait_for_video": False,
                "encoding": "utf-8",
-               "extractor_args": {"youtube": {"lang": "en", "skip": ["translated_subs"]}},
+               #"extractor_args": {"youtube": {"lang": "en", "skip": ["translated_subs"]}},
        }
```

This is horrendous, and is a blocker before I can do infra cleanup. However, this is just defaults on the request model. If you override those defaults on request to a blank dict, it works with no code changes.
<img width="553" height="623" alt="image" src="https://github.com/user-attachments/assets/64f1f8fc-8b57-4a88-8caa-d8882a16cc1f" />


## Why It's Good For The Game
Bodges are bad - things should be done properly.

## Testing
Prototyped the list stuff with the bot in coderbus, then made sure the code compiled still.

<img width="587" height="358" alt="image" src="https://github.com/user-attachments/assets/04e4aaae-f5ae-49ca-9163-d18fb17a5a5a" />



## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
NPFC