### PR TITLE
Fixes Remote Deconstruction of Useless Items in the Scientific Analyzer

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -275,6 +275,10 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		var/choice = alert(user, "This item does not raise tech levels. Proceed destroying loaded item anyway?", "Are you sure you want to destroy this item?", "Proceed", "Cancel")
 		if(choice == "Cancel" || !linked_analyzer)
 			return
+		// Prevent remote activation of the scanner, unless you're someone that's supposed to be able to do that.
+		if(!Adjacent(user) && !issilicon(user))
+			to_chat(user, SPAN_WARNING("You moved too far away from [src]!"))
+			return
 
 	linked_analyzer.busy = TRUE
 	add_wait_message("Processing and Updating Database...", DECONSTRUCT_DELAY)


### PR DESCRIPTION
## What Does This PR Do
Adds an `Adjacent()` check for non-silicons when trying to deconstruct a useless item in the scientific analyzer.
## Why It's Good For The Game
Fixes #32190.
## Testing
Became human scientist. Analyzed a matter bin. Analyzed another matter bin, clicked confirmation prompt while adjacent, analysis successful. Analyzed another matter bin, walked away, clicked confirmation prompt, analysis failed.

Repeated the above as silicon, succeeded in both cases.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Fixed the scientific analyzer being able to analyze useless items at long range.
/:cl: