### PR TITLE
Remove Throwforce From Brain

### DIFF
--- a/code/modules/surgery/organs/brain.dm
+++ b/code/modules/surgery/organs/brain.dm
@@ -2,7 +2,6 @@
 	name = "brain"
 	max_damage = 120
 	icon_state = "brain2"
-	throwforce = 1.0
 	throw_speed = 3
 	throw_range = 5
 	origin_tech = "biotech=5"


### PR DESCRIPTION
## What Does This PR Do
Removes the 1 damage throwforce from brains.
## Why It's Good For The Game
Fixes #26208.

Brains are the only organ with throwforce, notably IPC brains lack throwforce already.

Brains are very squishy, if a harder organ can't do damage, neither should brains.
## Testing
Threw brain at skrell. Skrell was unharmed.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
## Changelog
:cl:
tweak: Brains do no damage when thrown.
/:cl: