### PR TITLE
Fix storing several recently-migrated items.

### DIFF
--- a/code/game/objects/items/devices/bodyanalyzer.dm
+++ b/code/game/objects/items/devices/bodyanalyzer.dm
@@ -71,6 +71,9 @@
 	if(user.incapacitated() || !user.Adjacent(target))
 		return ITEM_INTERACT_COMPLETE
 
+	if(!ismob(target))
+		return NONE
+
 	add_fingerprint(user)
 	if(!ready)
 		to_chat(user, SPAN_WARNING("The scanner beeps angrily at you! It's currently recharging - [round((time_to_use - world.time) * 0.1)] seconds remaining."))

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -138,6 +138,9 @@
 		target.AdjustConfused(power)
 
 /obj/item/flash/interact_with_atom(atom/target, mob/living/user, list/modifiers)
+	if(!istype(target, /obj/machinery/camera) && !iscarbon(target) && !issilicon(target))
+		return NONE
+
 	if(!try_use_flash(user))
 		return NONE
 

--- a/code/game/objects/items/devices/gasanalyzer.dm
+++ b/code/game/objects/items/devices/gasanalyzer.dm
@@ -106,6 +106,12 @@
 
 /obj/item/analyzer/interact_with_atom(atom/target, mob/living/user, list/modifiers)
 	..()
+	if(!isturf(target.loc))
+		return NONE
+
+	if(isstorage(target))
+		return NONE
+
 	if(target.return_analyzable_air())
 		atmos_scan(user, target, detailed = show_detailed)
 	else

--- a/code/game/objects/items/devices/handheld_defib.dm
+++ b/code/game/objects/items/devices/handheld_defib.dm
@@ -36,7 +36,7 @@
 
 /obj/item/handheld_defibrillator/interact_with_atom(atom/target, mob/living/user, list/modifiers)
 	if(!ishuman(target))
-		return ITEM_INTERACT_COMPLETE
+		return ..()
 
 	if(cooldown)
 		to_chat(user, SPAN_WARNING("[src] is still charging!"))

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -48,6 +48,12 @@
 	diode = new /obj/item/stock_parts/micro_laser/ultra(src)
 
 /obj/item/laser_pointer/interact_with_atom(atom/target, mob/living/user, list/modifiers)
+	if(!isturf(target.loc))
+		return NONE
+
+	if(isstorage(target))
+		return NONE
+
 	laser_act(target, user, modifiers)
 	add_fingerprint(user)
 	return ITEM_INTERACT_COMPLETE

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -126,8 +126,7 @@
 					qdel(bulb)
 
 		if(!found_lightbulbs)
-			to_chat(user, SPAN_WARNING("[container] contains no bulbs!"))
-			return ITEM_INTERACT_COMPLETE
+			return ..()
 
 		if(!replaced_something && uses == max_uses)
 			to_chat(user, SPAN_WARNING("[src] is full!"))
@@ -220,8 +219,7 @@
 		return ITEM_INTERACT_COMPLETE
 
 	if(isitem(target))
-		item_interaction(user, target)
-		return ITEM_INTERACT_COMPLETE
+		return item_interaction(user, target)
 
 	var/turf/replace_turf = get_turf(target)
 	if(!istype(replace_turf))

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -65,9 +65,17 @@
 	. += status_string()
 
 /obj/item/lightreplacer/item_interaction(mob/user, obj/item/used, list/modifiers)
+	if(fill_replacer(user, used))
+		return ITEM_INTERACT_COMPLETE
+	return ..()
+
+/obj/item/lightreplacer/proc/fill_replacer(mob/user, obj/item/used)
+	if(!istype(used))
+		return FALSE
+
 	if(uses >= max_uses)
 		to_chat(user, SPAN_WARNING("[src] is full!"))
-		return ITEM_INTERACT_COMPLETE
+		return TRUE
 
 	if(istype(used, /obj/item/stack/sheet/glass))
 		var/obj/item/stack/sheet/glass/stack = used
@@ -77,23 +85,23 @@
 			to_chat(user, SPAN_NOTICE("You insert some glass into [src]. You have [uses] light\s remaining."))
 		else
 			to_chat(user, SPAN_WARNING("You need one sheet of glass to replace lights!"))
-		return ITEM_INTERACT_COMPLETE
+		return TRUE
 
 	if(istype(used, /obj/item/shard))
 		if(!user.drop_item_to_ground(used))
 			to_chat(user, SPAN_WARNING("[used] is stuck to your hand!"))
-			return ITEM_INTERACT_COMPLETE
+			return TRUE
 
 		AddUses(increment)
 		to_chat(user, SPAN_NOTICE("You insert a shard of glass into [src]. You have [uses] light\s remaining."))
 		qdel(used)
-		return ITEM_INTERACT_COMPLETE
+		return TRUE
 
 	if(istype(used, /obj/item/light))
 		var/obj/item/light/bulb = used
 		if(!user.drop_item_to_ground(bulb))
 			to_chat(user, SPAN_WARNING("[bulb] is stuck to your hand!"))
-			return ITEM_INTERACT_COMPLETE
+			return TRUE
 
 		if(bulb.status == LIGHT_OK)
 			AddUses(1)
@@ -126,15 +134,15 @@
 					qdel(bulb)
 
 		if(!found_lightbulbs)
-			return ..()
+			return FALSE
 
 		if(!replaced_something && uses == max_uses)
 			to_chat(user, SPAN_WARNING("[src] is full!"))
-			return ITEM_INTERACT_COMPLETE
+			return TRUE
 
 		to_chat(user, SPAN_NOTICE("You fill [src] with lights from [container]. " + status_string() + ""))
-		return ITEM_INTERACT_COMPLETE
-	return ..()
+		return TRUE
+	return FALSE
 
 /obj/item/lightreplacer/emag_act(user as mob)
 	if(!emagged)
@@ -219,7 +227,11 @@
 		return ITEM_INTERACT_COMPLETE
 
 	if(isitem(target))
-		return item_interaction(user, target)
+		if(isstorage(target) && uses >= max_uses)
+			return ..()
+		if(fill_replacer(user, target))
+			return ITEM_INTERACT_COMPLETE
+		return ..()
 
 	var/turf/replace_turf = get_turf(target)
 	if(!istype(replace_turf))

--- a/code/game/objects/items/weapons/garrote.dm
+++ b/code/game/objects/items/weapons/garrote.dm
@@ -55,8 +55,8 @@
 	STOP_PROCESSING(SSobj, src)
 
 /obj/item/garrote/interact_with_atom(mob/living/carbon/human/target, mob/living/carbon/human/user, list/modifiers)
-	if(..())
-		return ITEM_INTERACT_COMPLETE
+	if(!ismob(target))
+		return NONE
 
 	if(garrote_time > world.time) // Cooldown.
 		return ITEM_INTERACT_COMPLETE

--- a/code/modules/detective_work/evidence.dm
+++ b/code/modules/detective_work/evidence.dm
@@ -12,6 +12,11 @@
 	if(loc == target)
 		return ITEM_INTERACT_COMPLETE
 
+	if(isstorage(target))
+		var/obj/item/storage/target_storage = target
+		if(istype(target_storage, /obj/item/storage/box) || target_storage.w_class > WEIGHT_CLASS_NORMAL)
+			return NONE
+
 	evidencebag_equip(target, user)
 	return ITEM_INTERACT_COMPLETE
 

--- a/code/modules/surgery/organs/organ_extractor.dm
+++ b/code/modules/surgery/organs/organ_extractor.dm
@@ -52,6 +52,10 @@
 	if(in_use)
 		to_chat(user, SPAN_WARNING("[src] is already busy!"))
 		return ITEM_INTERACT_COMPLETE
+
+	if(!ismob(target))
+		return NONE
+
 	if(!iscarbon(target))
 		to_chat(user, SPAN_WARNING("ERROR: [target] has no organs to harvest!"))
 		return ITEM_INTERACT_COMPLETE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes an oversight that prevents storing the following items by clicking on storage containers with them inhand: body analyzer, flash, gas analyzer, laser pointer, garrote, evidence bag, organ extractor, light replacer and handheld defibrillator.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

It is expected behavior to be able to store something in, say, your backpack, when you click on the backpack with it inhand.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted, spawned a light replacer and handheld defibrillator. Stored both in backpack by clicking. Used them both on structures, mobs, items, and valid light replacing tiles to make sure they still functioned as intended in those cases. Repeated the same steps with all other items involved.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed an oversight that prevented storing several items: body analyzer, flash, gas analyzer, laser pointer, garrote, evidence bag, organ extractor, light replacer and handheld defibrillator.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
