### PR TITLE
Fix mineral haul shuttle loan.

### DIFF
--- a/code/modules/events/shuttle_loan/shuttle_loan_datum.dm
+++ b/code/modules/events/shuttle_loan/shuttle_loan_datum.dm
@@ -167,7 +167,7 @@
 		/datum/supply_packs/materials/glass50,
 		/datum/supply_packs/materials/sandstone30,
 	)
-	for(var/datum/supply_packs/crate in crate_types)
+	for(var/crate in crate_types)
 		var/datum/supply_packs/new_crate = new crate()
 		new_crate.create_package(pick_n_take(empty_shuttle_turfs))
 

--- a/code/modules/events/shuttle_loan/shuttle_loan_datum.dm
+++ b/code/modules/events/shuttle_loan/shuttle_loan_datum.dm
@@ -185,9 +185,7 @@
 	)
 	for(var/i in 1 to 5)
 		var/mineral_type = pick(mineral_types)
-		var/obj/item/stack/sheet/mineral/new_mineral = new mineral_type()
-		new_mineral.amount = 10
-		new new_mineral(pick_n_take(empty_shuttle_turfs))
+		new mineral_type(pick_n_take(empty_shuttle_turfs), 10)
 
 /datum/shuttle_loan_situation/honk
 	sender = "Central Command Entertainment Division"


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the mineral haul shuttle loan event. The existing code tries to create a new instance from an instance that was just created. This fixes it. It also sets the amount in the initializer, which all `/obj/item/stack/sheet/mineral` subtypes support.

Also fixes a bad typecast that would cause the material supply packs not to be created either.
## Why It's Good For The Game
Bugfix.
## Images of changes
Before:
<img width="773" height="35" alt="2026_08_04__15_29_29__Paradise Station 13" src="https://github.com/user-attachments/assets/9d32896c-e7e5-4ae9-8e8c-8539a4e4a757" />
## Testing
I didn't, honestly. But I mean, look at it.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: The mineral haul shuttle loan event should work as expected.
/:cl: