### PR TITLE
fix wrong dir firelocks on wrecked cargoship

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/wreckedcargoship.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/wreckedcargoship.dmm
@@ -550,7 +550,7 @@
 /area/ruin/space/wreck_cargoship)
 "tB" = (
 /obj/machinery/door/firedoor/border_only/closed{
-	dir = 4
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/wreck_cargoship)
@@ -668,7 +668,7 @@
 /area/ruin/space/wreck_cargoship)
 "Bo" = (
 /obj/machinery/door/firedoor/border_only/closed{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plating,
@@ -706,7 +706,7 @@
 /area/ruin/space/wreck_cargoship)
 "Co" = (
 /obj/machinery/door/firedoor/border_only/closed{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the directional firelocks on the wrecked cargoship, since they are facing the wrong direction and open the ship to space roundstart.
## Why It's Good For The Game
Map fix.
## Images of changes
See MDB.
## Testing
Visual inspection.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
:cl:
fix: The wrecked cargo ship's directional airlocks are properly aligned with the ship's hull.
/:cl: