### PR TITLE
prevent irradiated mice from spawning in airlock vents

### DIFF
--- a/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse.dm
+++ b/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse.dm
@@ -16,7 +16,7 @@
 		return
 
 	var/mob/candidate = pick(candidates)
-	var/obj/vents = get_valid_vent_spawns(TRUE, TRUE, 0) // find an unwelded vent with nobody nearby
+	var/obj/vents = get_valid_vent_spawns(TRUE, TRUE, 3) // find an unwelded vent with nobody nearby
 	if(!length(vents))
 		message_admins("Warning: No suitable vents detected for spawning an irradiated mouse.")
 		return


### PR DESCRIPTION
## What Does This PR Do
Sets the minimum atmos machine size for spawning irradiated mice to 3. This cuts off any airlock vents, which will either have two or three attached machines depending on their size. Fixes #32159.
## Why It's Good For The Game
Midrounds getting stuck in airlocks/pipenets they can't escape isn't fun.
## Testing
Double checked logic of `/proc/get_valid_vent_spawns`.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Irradiated mouse midrounds should no longer spawn in airlock vents.
/:cl: