### PR TITLE
Allows Prisoner IDs to Redeem Points From Gulag ORM

### DIFF
--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -185,7 +185,7 @@
 			to_chat(user, SPAN_WARNING("There are no points to claim!"));
 			return ITEM_INTERACT_COMPLETE
 
-		if(scan_id)
+		if(scan_id && length(req_access_claim))
 			var/accepted
 			for(var/req in req_access_claim)
 				if(req in ID.GetAccess())


### PR DESCRIPTION
## What Does This PR Do
Cancels all access checks on an ORM for points redemption if there's no entries in the required access list.
## Why It's Good For The Game
Fixes #32222.
## Testing
Spawned gulag ORM, inserted ore, spawned gulag ID, claimed points.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Gulag prisoners can claim ORM points.
/:cl: