### PR TITLE
Fixes Ghosts Disrupting Table Unflips

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -412,8 +412,8 @@
 		return 0
 
 	var/can_flip = 1
-	for(var/mob/A in oview(src,0))//loc)
-		if(istype(A))
+	for(var/mob/A in oview(src, 0)) // Our loc.
+		if(istype(A) && !isobserver(A))
 			can_flip = 0
 	if(!can_flip)
 		return 0


### PR DESCRIPTION
## What Does This PR Do
Adds a check for observers when unflipping tables. They can no longer prevent a table from being unflipped.
## Why It's Good For The Game
Fixes #29925.
## Testing
Spawned a ghost on a table. Flipped it, unflipped it, the ghost didn't prevent this from occurring.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Ghosts cannot disrupt table unflips.
/:cl: