### PR TITLE
Fix embedded object messages for characters who feel no pain.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_life.dm
+++ b/code/modules/mob/living/carbon/human/human_life.dm
@@ -814,14 +814,18 @@
 		var/obj/item/organ/external/BP = X
 		for(var/obj/item/I in BP.embedded_objects)
 			if(prob(I.embedded_pain_chance))
-				BP.receive_damage(I.w_class*I.embedded_pain_multiplier)
-				to_chat(src, SPAN_USERDANGER("[I] embedded in your [BP.name] hurts!"))
+				BP.receive_damage(I.w_class * I.embedded_pain_multiplier)
+				to_chat(src, SPAN_USERDANGER("[I] embedded in your [BP.name] [can_feel_pain() ? "hurts" : "crunches"]!"))
 
 			if(prob(I.embedded_fall_chance))
-				BP.receive_damage(I.w_class*I.embedded_fall_pain_multiplier)
+				BP.receive_damage(I.w_class * I.embedded_fall_pain_multiplier)
 				BP.remove_embedded_object(I)
 				I.forceMove(get_turf(src))
-				visible_message(SPAN_DANGER("[I] falls out of [name]'s [BP.name]!"),SPAN_USERDANGER("[I] falls out of your [BP.name]!"))
+				visible_message(
+					SPAN_DANGER("[I] falls out of [name]'s [BP.name]!"),
+					SPAN_USERDANGER("[I] falls out of your [BP.name]!"),
+					SPAN_HEAR("Something clatters to the floor!")
+				)
 				if(!has_embedded_objects())
 					clear_alert("embeddedobject")
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Makes it so that characters who can't feel pain don't get messages about how embedded objects "hurt". 

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Canonically, we have characters who are supposed to feel no pain, IPCs for example. It would be nice if the ingame messages support that canon.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted, spawned as an IPC. Set off frag grenades until I got embedded objects without dying and waited for the "pain" messages. Spawned as a human and repeated the process.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed embedded objects "hurting" for characters who shouldn't feel pain.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
