### PR TITLE
fix closets not being able to be fultoned

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -343,6 +343,8 @@
 		return ITEM_INTERACT_COMPLETE
 	else if(istype(W, /obj/item/stack/package_wrap))
 		return
+	else if(istype(W, /obj/item/extraction_pack))
+		return
 	else if(user.a_intent != INTENT_HARM)
 		closed_item_click(user)
 		return ITEM_INTERACT_COMPLETE


### PR DESCRIPTION
## What Does This PR Do
This fixes closets not being able to be fultoned. This got broken some time ago and I only noticed it on a recent round.
## Why It's Good For The Game
Bugfix.
## Testing
Spawned a fulton beacon and extraction pack, set up beacon on station, teleported to Lavaland, spawned a closet, welded it shut, used the extraction pack on it.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Lockers can now be fultoned properly.
/:cl: