### PR TITLE
attempt to fix qdel failures for dynamic airlock helpers

### DIFF
--- a/code/modules/mapping/dynamic_airlocks.dm
+++ b/code/modules/mapping/dynamic_airlocks.dm
@@ -39,6 +39,12 @@
 
 	qdel(src)
 
+/obj/effect/map_effect/dynamic_airlock/Destroy()
+	. = ..()
+
+	LAZYCLEARLIST(sibling_items)
+	LAZYCLEARLIST(neighbor_helpers)
+
 /obj/effect/map_effect/dynamic_airlock/proc/collect_sibling_item(atom/A)
 	if(is_type_in_list(A, valid_siblings))
 		LAZYADD(sibling_items, A)
@@ -55,6 +61,12 @@
 /obj/effect/map_effect/dynamic_airlock/door
 	var/list/buttons = list()
 	var/obj/machinery/door/airlock/external/airlock
+
+/obj/effect/map_effect/dynamic_airlock/door/Destroy()
+	. = ..()
+
+	buttons.Cut()
+	airlock = null
 
 /obj/effect/map_effect/dynamic_airlock/door/proc/assign_access(datum/dynamic_airlock_linker/linker)
 	for(var/obj/machinery/access_button/button in buttons)


### PR DESCRIPTION
## What Does This PR Do
This PR clears some internal bookkeeping from dynamic airlock helpers that may have been preventing them from qdel'ing cleanly.
## Why It's Good For The Game
Objects should qdel cleanly.
## Testing
Used FIND_REFERENCES and set the airlock helpers to return QDEL_HINT_IFFAIL_FINDREFERENCE on Destroy, and find_references didn't proc for them, though it's possible I didn't wait long enough or don't understand how that's meant to work.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC