### PR TITLE
fix barricades not returning a qdel hint

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -134,7 +134,7 @@
 
 /obj/structure/barricade/wooden/Destroy()
 	de_barricade()
-	..()
+	. = ..()
 
 /obj/structure/barricade/wooden/crowbar_act(mob/living/user, obj/item/I)
 	. = TRUE


### PR DESCRIPTION
## What Does This PR Do
Fixes wooden barricades not returning a qdel hint in their Destroy.
## Why It's Good For The Game
Bugfix.
## Images of changes
### Before
<img width="446" height="57" alt="2026_08_09__16_22_08__" src="https://github.com/user-attachments/assets/bc4a65a3-9869-4287-9c4a-6196d756de16" />

### After
It works presumably
## Testing
Visual inspection
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC