### PR TITLE
allow admins to choose lavaland theme for next round

### DIFF
--- a/code/controllers/subsystem/non_firing/SSmapping.dm
+++ b/code/controllers/subsystem/non_firing/SSmapping.dm
@@ -22,8 +22,14 @@ SUBSYSTEM_DEF(mapping)
 	var/list/existing_station_areas
 	/// Types of areas that exist on the station this shift
 	var/list/existing_station_areas_types
-	///What do we have as the lavaland theme today?
+
+	/// The type of the Lavaland theme for the next round, if selected.
+	var/next_lavaland_theme
+	/// The type of the current Lavaland theme.
+	var/current_lavaland_theme
+	/// The [/datum/lavaland_theme] instantiated for the current round.
 	var/datum/lavaland_theme/lavaland_theme
+
 	///What primary cave theme we have picked for cave generation today.
 	var/datum/caves_theme/caves_theme
 	// Tells if all maintenance airlocks have emergency access enabled
@@ -75,6 +81,13 @@ SUBSYSTEM_DEF(mapping)
 		fdel("data/last_map.txt") // Remove to avoid the same map existing forever
 	else
 		last_map = new /datum/map/cerestation // Assume cerestation if non-existent
+	if(fexists("data/next_lavaland_theme.txt"))
+		var/list/lines = file2list("data/next_lavaland_theme.txt")
+		try
+			current_lavaland_theme = text2path(lines[1])
+		catch
+			log_startup_progress("invalid data/next_lavaland_theme.txt, choosing randomly on init")
+		fdel("data/next_lavaland_theme.txt")
 
 /datum/controller/subsystem/mapping/Shutdown()
 	if(next_map) // Save map for next round
@@ -83,7 +96,9 @@ SUBSYSTEM_DEF(mapping)
 	if(map_datum) // Save which map was this round as the last map
 		var/F = file("data/last_map.txt")
 		F << map_datum.type
-
+	if(next_lavaland_theme)
+		var/F = file("data/next_lavaland_theme.txt")
+		F << "[next_lavaland_theme]"
 
 /datum/controller/subsystem/mapping/Initialize()
 	environments = list()
@@ -91,11 +106,13 @@ SUBSYSTEM_DEF(mapping)
 	environments[ENVIRONMENT_TEMPERATE] = create_environment(oxygen = MOLES_O2STANDARD, nitrogen = MOLES_N2STANDARD, temperature = T20C)
 	environments[ENVIRONMENT_COLD] = create_environment(oxygen = MOLES_O2STANDARD, nitrogen = MOLES_N2STANDARD, temperature = 180)
 
-	var/datum/lavaland_theme/lavaland_theme_type = pick(subtypesof(/datum/lavaland_theme))
-	ASSERT(lavaland_theme_type)
-	lavaland_theme = new lavaland_theme_type
+	if(!current_lavaland_theme)
+		current_lavaland_theme = pick(subtypesof(/datum/lavaland_theme))
+
+	ASSERT(current_lavaland_theme)
+	lavaland_theme = new current_lavaland_theme
 	log_startup_progress("We're in the mood for [lavaland_theme.name] today...") //We load this first. In the event some nerd ever makes a surface map, and we don't have it in lavaland in the event lavaland is disabled.
-	SSblackbox.record_feedback("text", "procgen_settings", 1, "[lavaland_theme_type]")
+	SSblackbox.record_feedback("text", "procgen_settings", 1, "[current_lavaland_theme]")
 
 	var/caves_theme_type = pick(subtypesof(/datum/caves_theme))
 	ASSERT(caves_theme_type)

--- a/code/modules/admin/event_verbs.dm
+++ b/code/modules/admin/event_verbs.dm
@@ -694,3 +694,14 @@ USER_CONTEXT_MENU(headset_message, R_SERVER|R_EVENT, "\[Admin\] Headset Message"
 	H.create_log(MISC_LOG, "Headset Message: [input]", "From: [key_name_admin(src)]")
 	to_chat(H, "<span class = 'specialnotice bold'>Incoming priority transmission from [sender == "Syndicate" ? "your benefactor" : "Central Command"].  Message as follows[sender == "Syndicate" ? ", agent." : ":"]</span><span class = 'specialnotice'> [input]</span>")
 	SEND_SOUND(H, 'sound/effects/headset_message.ogg')
+
+USER_VERB(set_next_round_lavaland, R_ADMIN, "Set Next Round Lavaland", "Set the Lavaland theme for the next round", VERB_CATEGORY_EVENT)
+	if(!SSmapping)
+		to_chat(client, SPAN_WARNING("SSmapping is not initialized yet."))
+		return
+
+	var/list/lavaland_themes = subtypesof(/datum/lavaland_theme)
+	var/choice = tgui_input_list(client, "Select the Lavaland theme for next round.", "Next Lavaland Theme", lavaland_themes)
+	if(choice)
+		SSmapping.next_lavaland_theme = choice
+		message_admins("[key_name_admin(client)] set the Lavaland theme for next round to [choice].")


### PR DESCRIPTION
## What Does This PR Do
Allow admins to choose the Lavaland theme for the next round. Available under the Events tab for anyone with R_ADMIN.
## Why It's Good For The Game
Gives admins slightly more control over Lavaland for the purposes of event rounds, allows devs to easily set the Lavaland theme if they need to test something locally.
## Images of changes
<img width="280" height="259" alt="2026_08_10__11_18_40__Paradise Station 13" src="https://github.com/user-attachments/assets/d4c250a7-96a5-4418-9c78-b82a1abaff4f" />
<img width="346" height="395" alt="2026_08_10__11_18_46__Paradise Station 13" src="https://github.com/user-attachments/assets/8cc49c38-de93-48fc-9666-ace8afc6fc60" />

## Testing
Ran DD locally, used new user verb, ensured new file was created on server shutdown, read and deleted on server restart.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
NPFC