### PR TITLE
Add alt-click remove beaker shortcut to chem dispensers.

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -339,6 +339,7 @@
 			user.put_in_hands(beaker)
 		beaker = null
 		update_icon()
+		add_fingerprint(user)
 		return
 
 	if(!is_drink)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -109,7 +109,8 @@
 		. += SPAN_NOTICE("[src]'s maintenance hatch is open!")
 	if(in_range(user, src) || isobserver(user))
 		. += "<span class='notice'>The status display reads: <br>Recharging <b>[recharge_amount]</b> power units per interval.<br>Power efficiency increased by <b>[round((powerefficiency * 1000) - 100, 1)]%</b>.<span>"
-
+	if(beaker)
+		. += SPAN_NOTICE("You can <b>Alt-Click</b> to quickly remove [beaker].")
 
 /obj/machinery/chem_dispenser/process()
 	if(recharge_counter >= 4)
@@ -330,14 +331,25 @@
 	ui_interact(user)
 
 /obj/machinery/chem_dispenser/AltClick(mob/user)
-	if(!is_drink || !Adjacent(user))
+	if(!Adjacent(user))
+		return
+	if(beaker) // Getting the beaker out is probably gonna be a more common desire than turning it around.
+		beaker.forceMove(get_turf(src))
+		if(!issilicon(user) && (!user.get_active_hand() || !user.get_inactive_hand()))
+			user.put_in_hands(beaker)
+		beaker = null
+		update_icon()
+		return
+
+	if(!is_drink)
 		return
 	if(user.incapacitated())
 		to_chat(user, SPAN_WARNING("You can't do that right now!"))
 		return
 	if(anchored)
-		to_chat(user, SPAN_WARNING("[src] is anchored to the floor!"))
+		to_chat(user, SPAN_WARNING("There's no beaker inside and you can't rotate it while it's anchored!"))
 		return
+
 	pixel_x = 0
 	pixel_y = 0
 	setDir(turn(dir, 90))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Adds an alt-click-to-remove-beaker shortcut and hint to chem dispensers (including drink dispensers) to make them more consistent with other beaker-containing machines like the chem master or reagent grinder.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Consistency is good.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted, spawned in my test bar with two different drink dispensers and a chem dispenser. Put a bluespace beaker in each dispenser and used the alt-click shortcut to remove it again. Examined one while the beaker was inside to view the examine hint. Alt clicked on anchored machines without beakers inside; for the chem dispenser received no message and for the drink dispensers recieved a message about it being anchored and not having a beaker inside. Unanchored the machines, alt-click rotated the drink dispensers, and alt-click nothinged the regular chem dispenser.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Added alt-click beaker removal to chem dispensers and drink dispensers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
