### PR TITLE
Restore attack animation to slapper/parry.

### DIFF
--- a/code/game/objects/items/hand_item.dm
+++ b/code/game/objects/items/hand_item.dm
@@ -65,7 +65,7 @@
 	force = 5
 	flags = DROPDEL | ABSTRACT | NODROP
 	attack_verb = list("slapped", "backhanded", "smacked", "discombobulated")
-	table_smacks_left = 10 //Much more smackitude
+	table_smacks_left = 10 // Much more smackitude.
 
 /obj/item/slapper/parry/Initialize(mapload)
 	AddComponent(/datum/component/parry, _stamina_constant = 2, _stamina_coefficient = 0.5, _parryable_attack_types = NON_PROJECTILE_ATTACKS, _parry_cooldown = (4 / 3) SECONDS) //75% uptime
@@ -86,14 +86,15 @@
 		UnregisterSignal(owner, COMSIG_MOB_WEAPON_APPEARS)
 	return ..()
 
-/obj/item/slapper/parry/attack(mob/M, mob/living/carbon/human/user)
-	if(!isliving(M))
+/obj/item/slapper/parry/after_attack(atom/target, mob/user, proximity_flag, click_parameters)
+	if(!isliving(target))
 		return ..()
-	var/mob/living/creature = M
+	var/mob/living/creature = target
 	SEND_SOUND(creature, sound('sound/weapons/flash_ring.ogg'))
 	creature.Confused(10 SECONDS) // SMACK CAM!
 	creature.EyeBlind(2 SECONDS) // OH GOD MY EARS ARE RINGING!
 	creature.Deaf(4 SECONDS) // OH MY HEAD!
+	return FINISH_ATTACK
 
 /obj/item/slapper/run_pointed_on_item(mob/pointer_mob, atom/target_atom)
 	if(target_atom == src)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Applies suggestion from CRUNCH issue comment: move slapper/parry's special effects to `after_attack()`.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Fixes #32404

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted, read CQC manual, dropped into a defensive stance, and slapped the heck out of another mob. It did damage, played the animation, and induced the special effects. If this isn't right, let me know.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed CQC defensive slap not playing an animation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
