### PR TITLE
remove quotes from python version in bootstrap request URL

### DIFF
--- a/tools/bootstrap/python_.ps1
+++ b/tools/bootstrap/python_.ps1
@@ -18,7 +18,7 @@ function ExtractVersion {
 	param([string] $Path, [string] $Key)
 	foreach ($Line in Get-Content $Path) {
 		if ($Line.StartsWith("export $Key=")) {
-			return $Line.Substring("export $Key=".Length)
+			return $Line.Substring("export $Key=".Length).Trim('"')
 		}
 	}
 	throw "Couldn't find value for $Key in $Path"
@@ -42,10 +42,9 @@ if (!(Test-Path $PythonExe -PathType Leaf)) {
 	New-Item $Cache -ItemType Directory -ErrorAction silentlyContinue | Out-Null
 
 	$Archive = "$Cache/python-$PythonVersion-embed.zip"
-	Invoke-WebRequest `
-		"https://www.python.org/ftp/python/$PythonVersion/python-$PythonVersion-embed-amd64.zip" `
-		-OutFile $Archive `
-		-ErrorAction Stop
+	$RequestUrl = "https://www.python.org/ftp/python/$PythonVersion/python-$PythonVersion-embed-amd64.zip"
+	Write-Output "Downloading from: $RequestUrl"
+	Invoke-WebRequest $RequestUrl -OutFile $Archive -ErrorAction Stop
 
 	[System.IO.Compression.ZipFile]::ExtractToDirectory($Archive, $PythonDir)
 


### PR DESCRIPTION
## What Does This PR Do
#31446 added quotes to all the values in _build_dependencies.sh, but the value for `PYTHON_VERSION` is interpolated directly into the URL when downloading bootstrap Python. This PR fixes the bootstrap python powershell script to remove the double quotes from the Python version. It also spits out the URL onto the command line so it can be sanity checked.
## Why It's Good For The Game
Tooling fix.
## Testing
Removed Bootstrap directory and ensured running python_.ps1 downloaded the correct version.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC