### PR TITLE
Migrate watcher hatchling to the new attack chain.

### DIFF
--- a/code/modules/awaymissions/mission_code/ruins/watcher_grave.dm
+++ b/code/modules/awaymissions/mission_code/ruins/watcher_grave.dm
@@ -93,7 +93,7 @@
 	desc = "A newly born watcher, apparently free of the Necropolis' corruption. Perhaps one of the last."
 	icon = 'icons/mob/lavaland/lavaland_monsters.dmi'
 	icon_state = "watcher_baby"
-	/// No. The child will not die to lava.
+	// No. The child will not die to lava.
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
 	// Pocket monster. Plus doesn't work in bag.
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/awaymissions/mission_code/ruins/watcher_grave.dm
+++ b/code/modules/awaymissions/mission_code/ruins/watcher_grave.dm
@@ -93,23 +93,30 @@
 	desc = "A newly born watcher, apparently free of the Necropolis' corruption. Perhaps one of the last."
 	icon = 'icons/mob/lavaland/lavaland_monsters.dmi'
 	icon_state = "watcher_baby"
-	resistance_flags = LAVA_PROOF | FIRE_PROOF //No. The child will not die to lava.
-	w_class = WEIGHT_CLASS_SMALL //pocket monster. Plus doesn't work in bag.
-	/// The effect we create when out and about
+	/// No. The child will not die to lava.
+	resistance_flags = LAVA_PROOF | FIRE_PROOF
+	// Pocket monster. Plus doesn't work in bag.
+	w_class = WEIGHT_CLASS_SMALL
+	/// The effect we create when out and about.
 	var/obj/effect/watcher_orbiter/orbiter
 	/// Who are we orbiting?
 	var/mob/living/owner
+	new_attack_chain = TRUE
 
-/obj/item/watcher_hatchling/attack_self__legacy__attackchain(mob/user, modifiers)
-	. = ..()
+/obj/item/watcher_hatchling/activate_self(mob/user)
+	if(..())
+		return ITEM_INTERACT_COMPLETE
+
 	if(!isnull(orbiter))
 		watcher_return()
-		return
+		return ITEM_INTERACT_COMPLETE
+
 	orbiter = new (get_turf(src))
 	orbiter.follow(user)
 	owner = user
 	RegisterSignal(owner, COMSIG_PARENT_QDELETING, PROC_REF(remove_owner))
 	RegisterSignal(orbiter, COMSIG_PARENT_QDELETING, PROC_REF(our_remove_orbiter))
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/watcher_hatchling/Moved(atom/old_loc, movement_dir, forced)
 	. = ..()
@@ -119,18 +126,18 @@
 	if(holder != owner)
 		watcher_return()
 
-/// If the guy we are orbiting is deleted but somehow we aren't
+/// If the guy we are orbiting is deleted but somehow we aren't.
 /obj/item/watcher_hatchling/proc/remove_owner()
 	SIGNAL_HANDLER
 	UnregisterSignal(owner, COMSIG_PARENT_QDELETING)
 	owner = null
 
-/// In the more likely event that our orbiter is deleted, stop holding a reference to it
+/// In the more likely event that our orbiter is deleted, stop holding a reference to it.
 /obj/item/watcher_hatchling/proc/our_remove_orbiter()
 	SIGNAL_HANDLER
-	orbiter = null // No need to unregister signal because we only call this when it deletes
+	orbiter = null // No need to unregister signal because we only call this when it deletes.
 
-/// Get back in your ball pikachu
+/// Get back in your ball pikachu.
 /obj/item/watcher_hatchling/proc/watcher_return()
 	qdel(orbiter)
 	remove_owner()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Migrates the watcher hatchling to the new attack chain.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Nobody stopped me?

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted, spawned a hatchling, used it inhand a couple of times. 

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
