### PR TITLE
Some Flockmind Bug Fixes

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -134,7 +134,7 @@
 	if(isliving(current))
 		destroyed_body_json = json_encode(current.serialize())
 
-/datum/mind/proc/bind_to(mob/living/new_character)
+/datum/mind/proc/bind_to(mob/new_character)
 	current = new_character
 	new_character.mind = src
 	RegisterSignal(current, COMSIG_PARENT_QDELETING, PROC_REF(archive_deleted_body), override = TRUE)
@@ -147,11 +147,9 @@
 		current.mind = null
 	current = null
 
-/datum/mind/proc/transfer_to(mob/living/new_character)
+/datum/mind/proc/transfer_to(mob/new_character, transfer_actions_to_target = TRUE)
 	var/datum/atom_hud/antag/hud_to_transfer = antag_hud //we need this because leave_hud() will clear this list
-	var/mob/living/old_current = current
-	if(!istype(new_character))
-		stack_trace("transfer_to(): Some idiot has tried to transfer_to() a non mob/living mob.")
+	var/mob/old_current = current
 	if(current)					//remove ourself from our old body's mind variable
 		if(isliving(current))
 			current.med_hud_set_status()
@@ -168,19 +166,20 @@
 
 	bind_to(new_character)
 
-	for(var/a in antag_datums)	//Makes sure all antag datums effects are applied in the new body
-		var/datum/antagonist/A = a
-		A.on_body_transfer(old_current, current)
-	transfer_antag_huds(hud_to_transfer)				//inherit the antag HUD
-	transfer_actions(new_character)
-	if(martial_art)
-		for(var/datum/martial_art/MA in known_martial_arts)
-			MA.reset_combos(old_current) // Clear combos on old body
-			if(MA.temporary)
-				MA.remove(current)
-			else
-				MA.remove(current)
-				MA.teach(current)
+	if(transfer_actions_to_target)
+		for(var/a in antag_datums)	//Makes sure all antag datums effects are applied in the new body
+			var/datum/antagonist/A = a
+			A.on_body_transfer(old_current, current)
+		transfer_antag_huds(hud_to_transfer)				//inherit the antag HUD
+		transfer_actions(new_character)
+		if(martial_art)
+			for(var/datum/martial_art/MA in known_martial_arts)
+				MA.reset_combos(old_current) // Clear combos on old body
+				if(MA.temporary)
+					MA.remove(current)
+				else
+					MA.remove(current)
+					MA.teach(current)
 	if(active)
 		new_character.key = key		//now transfer the key to link the client to our new body
 	SEND_SIGNAL(src, COMSIG_MIND_TRANSER_TO, new_character)

--- a/code/modules/antagonists/flockmind/flock_mob/flockdrone.dm
+++ b/code/modules/antagonists/flockmind/flock_mob/flockdrone.dm
@@ -399,8 +399,7 @@
 	controlled_by.controlling_bird = src
 
 	if(controlled_by.mind)
-		key = controlled_by.key
-		mind = controlled_by.mind
+		controlled_by.mind.transfer_to(src, FALSE)
 
 	if(isflocktrace(controlled_by))
 		flock.add_notice(src, FLOCK_NOTICE_FLOCKTRACE_CONTROL)
@@ -440,8 +439,7 @@
 
 	master_bird.forceMove(destination)
 	if(mind)
-		master_bird.key = key
-		master_bird.mind = mind
+		mind.transfer_to(master_bird, FALSE)
 
 	flock_talk(null, "Control of [real_name] surrendered.", flock, involuntary = TRUE)
 	if(!dest_was_safe)

--- a/code/modules/antagonists/flockmind/flock_structure/flock_collector.dm
+++ b/code/modules/antagonists/flockmind/flock_structure/flock_collector.dm
@@ -86,7 +86,7 @@
 	var/area/A = get_area(src)
 	var/obj/machinery/power/apc/apc
 	if(A.apc)
-		apc = A.apc[0]
+		apc = A.get_apc()
 	return apc
 
 /// Recalculate the turf connections and tracking.

--- a/code/modules/events/flockmind_event.dm
+++ b/code/modules/events/flockmind_event.dm
@@ -36,9 +36,7 @@
 		kill()
 		return
 	var/mob/camera/flock/overmind/flockmind = new /mob/camera/flock/overmind(pick(spawn_locs))
-	flockmind.key = C.key
-	flockmind.mind = new
-	flockmind.mind.bind_to(flockmind)
+	C.mind.transfer_to(flockmind, FALSE)
 	flockmind.mind.set_original_mob(flockmind)
 	flockmind.mind.assigned_role = SPECIAL_ROLE_FLOCK
 	flockmind.mind.special_role = SPECIAL_ROLE_FLOCK


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

- Fixes a runtime in flock collector APC interactions
- Potentially fixes a nullspacing issue by refining the mind.transfer_to proc and using that.

## Why It's Good For The Game

Bugs bad

## Testing

Built a collector. No runtimes. Spawned as flock from the event and was able to hop in and out of drones repeatedly without experiencing any nullspacing or runtimes.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed a few flockmind bugs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
