### PR TITLE
Removes a Stray Light Switch and Door Controller on Kerberos

### DIFF
--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -53981,15 +53981,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/airlock_controller/access_controller{
-	ext_button_link_id = "virolab_btn_ext";
-	ext_door_link_id = "virolab_door_ext";
-	int_button_link_id = "virolab_btn_int";
-	int_door_link_id = "virolab_door_int";
-	name = "Virology Lab Access Console";
-	pixel_x = -24;
-	req_access = list(39)
-	},
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/electrical/aft_starboard)
 "fZu" = (
@@ -73183,10 +73174,6 @@
 	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "0-8"
-	},
-/obj/machinery/light_switch{
-	name = "north bump";
-	pixel_y = 24
 	},
 /obj/effect/turf_decal/tiles/department/engineering/side{
 	dir = 4


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Title.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Floating wallbumps are bad
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<img width="474" height="399" alt="image" src="https://github.com/user-attachments/assets/3ae2f390-efd6-47de-a855-0ce62237b001" />

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Visual inspection
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed floating wallbumps in the Deltastation medical electrical maintenance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
