### PR TITLE
Fix a cigarette message.

### DIFF
--- a/code/game/objects/items/cigs.dm
+++ b/code/game/objects/items/cigs.dm
@@ -144,17 +144,21 @@ LIGHTERS ARE IN LIGHTERS.DM
 
 	// If the target has no cig, try to give them the cig.
 	var/mob/living/carbon_target = target
-	if(user.zone_selected == "mouth" && !carbon_target.wear_mask && user.a_intent == INTENT_HELP)
-		user.drop_item_to_ground(src, force = TRUE)
-		carbon_target.equip_to_slot_if_possible(src, ITEM_SLOT_MASK)
-		if(target != user)
-			user.visible_message(
-				SPAN_NOTICE("[user] slips \a [name] into the mouth of [carbon_target]."),
-				SPAN_NOTICE("You slip [src] into the mouth of [carbon_target].")
-			)
-		else
-			to_chat(user, SPAN_NOTICE("You put [src] into your mouth."))
-		return FINISH_ATTACK
+	if(user.zone_selected == "mouth" && user.a_intent == INTENT_HELP)
+		if(!carbon_target.wear_mask)
+			user.drop_item_to_ground(src, force = TRUE)
+			carbon_target.equip_to_slot_if_possible(src, ITEM_SLOT_MASK)
+			if(target != user)
+				user.visible_message(
+					SPAN_NOTICE("[user] slips \a [name] into the mouth of [carbon_target]."),
+					SPAN_NOTICE("You slip [src] into the mouth of [carbon_target].")
+				)
+			else
+				to_chat(user, SPAN_NOTICE("You put [src] into your mouth."))
+			return FINISH_ATTACK
+		if(!lit)
+			to_chat(user, SPAN_WARNING("You can't put [src] in [carbon_target]'s mouth with [carbon_target.wear_mask] in the way!"))
+			return FINISH_ATTACK
 
 	// If they DO have a cig, try to light it with your own cig.
 	if(cigarette_lighter_act(user, carbon_target))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes a message that incorrectly tells you that the cigarette you're trying to light with your unlit cigarette is already lit, as though it's possible to light a cigarette with an unlit cigarette in the first place.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Fixes #30723.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted, spawned cigarettes, put one in the mouth of an npc and lit it. Tried to put another in their mouth with mouth targeting and got the message that there was already one in the way.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Tweaked a message from mouth-targeting a lit cigarette with an unlit cigarette.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
