### PR TITLE
Make abductor retrieval error messages more helpful.

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/machinery/abductor_camera.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/abductor_camera.dm
@@ -90,8 +90,8 @@
 		return
 	var/obj/machinery/abductor/console/console = target
 
-	if(!console.TeleporterRetrieve())
-		to_chat(owner, SPAN_WARNING("Error, unable to recall target. Please ensure they are not buckled, and that you have waited the required 10000 milliseconds!"))
+	if(!console.TeleporterRetrieve(owner))
+		to_chat(owner, SPAN_WARNING("Error, unable to recall target."))
 		playsound(owner, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
 
 /datum/action/innate/teleport_self

--- a/code/game/gamemodes/miniantags/abduction/machinery/console.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/console.dm
@@ -113,7 +113,7 @@
 	if(href_list["teleporter_send"])
 		TeleporterSend()
 	else if(href_list["teleporter_retrieve"])
-		TeleporterRetrieve()
+		TeleporterRetrieve(usr)
 	else if(href_list["flip_vest"])
 		FlipVest()
 	else if(href_list["toggle_vest"])
@@ -140,9 +140,20 @@
 	updateUsrDialog()
 
 
-/obj/machinery/abductor/console/proc/TeleporterRetrieve()
-	if(pad && gizmo && gizmo.marked)
-		return pad.Retrieve(gizmo.marked)
+/obj/machinery/abductor/console/proc/TeleporterRetrieve(mob/user)
+	if(!pad)
+		to_chat(user, SPAN_WARNING("You don't have a working Telepad to retrieve to!"))
+		return FALSE
+
+	if(!gizmo)
+		to_chat(user, SPAN_WARNING("You don't have a working science tool to mark your target with!"))
+		return FALSE
+
+	if(!gizmo.marked)
+		to_chat(user, SPAN_WARNING("Mark the creature you want to teleport before retrieving it!"))
+		return FALSE
+
+	return pad.Retrieve(gizmo.marked, user)
 
 /obj/machinery/abductor/console/proc/TeleporterSend()
 	if(pad)

--- a/code/game/gamemodes/miniantags/abduction/machinery/pad.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/pad.dm
@@ -6,8 +6,12 @@
 	anchored = TRUE
 	var/turf/teleport_target
 
-/obj/machinery/abductor/pad/proc/Warp(mob/living/target)
-	if(target.buckled || target.has_status_effect(STATUS_EFFECT_ABDUCTOR_COOLDOWN))
+/obj/machinery/abductor/pad/proc/Warp(mob/living/target, mob/user)
+	if(target.buckled)
+		to_chat(user, SPAN_WARNING("Please ensure the target is not buckled!"))
+		return FALSE
+	if(target.has_status_effect(STATUS_EFFECT_ABDUCTOR_COOLDOWN))
+		to_chat(user, SPAN_WARNING("Please wait at least 10,000 milliseconds before teleporting the same target again!"))
 		return FALSE
 	target.forceMove(get_turf(src))
 	target.apply_status_effect(STATUS_EFFECT_ABDUCTOR_COOLDOWN)
@@ -23,10 +27,10 @@
 		to_chat(target, SPAN_WARNING("The instability of the warp leaves you disoriented!"))
 		target.Stun(6 SECONDS)
 
-/obj/machinery/abductor/pad/proc/Retrieve(mob/living/target)
+/obj/machinery/abductor/pad/proc/Retrieve(mob/living/target, mob/user)
 	flick("alien-pad", src)
 	new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
-	return Warp(target)
+	return Warp(target, user)
 
 /obj/machinery/abductor/pad/proc/MobToLoc(place,mob/living/target)
 	new/obj/effect/temp_visual/teleport_abductor(place)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Makes the abductor's retrieval error messages more helpful. For example, if you haven't marked a target yet, it should no longer tell you to make sure your target is unbuckled instead.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Fixes #30213.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted, tried a variety of conditions that would prevent teleportation, like not having a gizmo and not marking a target.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed abductor teleportation retrieval error messages to be a little more helpful.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
