### PR TITLE
Make chargers reflect cell charge from roundstart.

### DIFF
--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -7,18 +7,18 @@
 	idle_power_consumption = 4
 	active_power_consumption = 200
 	pass_flags = PASSTABLE
-	var/obj/item/stock_parts/cell/charging = null
+	var/obj/item/stock_parts/cell/cell_inside = null
 	var/chargelevel = -1
 	/// Charge rate multiplier.
 	var/recharge_coeff = 1
 
 /obj/machinery/cell_charger/examine(mob/user)
 	. = ..()
-	. += SPAN_NOTICE("There's [charging ? "\a [charging.name]" : "no cell"] in [src].")
-	if(charging && !(stat & (NOPOWER|BROKEN)))
-		. += SPAN_NOTICE("Current charge: <b>[round(charging.percent(), 1)]%</b>")
-		if(charging.percent() < 100)
-			. += SPAN_NOTICE("- Recharging <b>[((charging.chargerate * recharge_coeff) / charging.maxcharge) * 100]%</b> cell charge per cycle.")
+	. += SPAN_NOTICE("There's [cell_inside ? "\a [cell_inside.name]" : "no cell"] in [src].")
+	if(cell_inside && !(stat & (NOPOWER|BROKEN)))
+		. += SPAN_NOTICE("Current charge: <b>[round(cell_inside.percent(), 1)]%</b>")
+		if(cell_inside.percent() < 100)
+			. += SPAN_NOTICE("- Recharging <b>[((cell_inside.chargerate * recharge_coeff) / cell_inside.maxcharge) * 100]%</b> cell charge per cycle.")
 
 /obj/machinery/cell_charger/Initialize(mapload)
 	. = ..()
@@ -31,27 +31,26 @@
 
 	for(var/obj/item/stock_parts/cell/I in get_turf(src)) //suck any cells in at roundstart
 		I.forceMove(src)
-		charging = I
-		check_level()
+		cell_inside = I
 		update_icon(UPDATE_OVERLAYS)
 		break
 
 /obj/machinery/cell_charger/deconstruct()
-	if(charging)
-		charging.forceMove(drop_location())
+	if(cell_inside)
+		cell_inside.forceMove(drop_location())
 	return ..()
 
 /obj/machinery/cell_charger/Destroy()
-	QDEL_NULL(charging)
+	QDEL_NULL(cell_inside)
 	return ..()
 
 /obj/machinery/cell_charger/update_overlays()
 	. = ..()
-	if(!charging)
+	if(!cell_inside)
 		return
-	. += "[charging.icon_state]"
+	. += "[cell_inside.icon_state]"
 
-	switch(charging.charge / charging.maxcharge)
+	switch(cell_inside.charge / cell_inside.maxcharge)
 		if(0.1 to 0.995)
 			. += "cell-o1"
 		if(0.995 to 1)
@@ -59,6 +58,7 @@
 
 	if(stat & (BROKEN|NOPOWER))
 		return
+	check_level()
 	. += "ccharger-o[chargelevel]"
 
 /obj/machinery/cell_charger/item_interaction(mob/living/user, obj/item/used, list/modifiers)
@@ -69,7 +69,7 @@
 		if(!anchored)
 			to_chat(user, SPAN_WARNING("[src] isn't attached to the ground!"))
 			return ITEM_INTERACT_COMPLETE
-		if(charging)
+		if(cell_inside)
 			to_chat(user, SPAN_WARNING("There is already a cell in the charger!"))
 			return ITEM_INTERACT_COMPLETE
 		else
@@ -83,52 +83,51 @@
 				return ITEM_INTERACT_COMPLETE
 
 			used.forceMove(src)
-			charging = used
+			cell_inside = used
 			user.visible_message("[user] inserts a cell into the charger.", SPAN_NOTICE("You insert a cell into the charger."))
-			check_level()
 			update_icon(UPDATE_OVERLAYS)
 			return ITEM_INTERACT_COMPLETE
 
 	return ..()
 
 /obj/machinery/cell_charger/crowbar_act(mob/user, obj/item/I)
-	if(panel_open && !charging && default_deconstruction_crowbar(user, I))
+	if(panel_open && !cell_inside && default_deconstruction_crowbar(user, I))
 		return TRUE
 
 /obj/machinery/cell_charger/screwdriver_act(mob/user, obj/item/I)
-	if(anchored && !charging && default_deconstruction_screwdriver(user, icon_state, icon_state, I))
+	if(anchored && !cell_inside && default_deconstruction_screwdriver(user, icon_state, icon_state, I))
 		return TRUE
 
 /obj/machinery/cell_charger/wrench_act(mob/user, obj/item/I)
 	. = TRUE
-	if(charging)
+	if(cell_inside)
 		to_chat(user, SPAN_WARNING("Remove the cell first!"))
 		return
 	default_unfasten_wrench(user, I, 0)
 
 /obj/machinery/cell_charger/proc/removecell()
-	charging.update_icon()
-	charging = null
+	cell_inside.update_icon()
+	cell_inside = null
 	chargelevel = -1
 	update_icon(UPDATE_OVERLAYS)
 
 /obj/machinery/cell_charger/attack_hand(mob/user)
-	if(!charging)
+	if(!cell_inside)
 		return
 
-	user.put_in_hands(charging)
-	charging.add_fingerprint(user)
+	user.put_in_hands(cell_inside)
+	cell_inside.add_fingerprint(user)
 
-	user.visible_message("[user] removes [charging] from [src].", SPAN_NOTICE("You remove [charging] from [src]."))
+	user.visible_message("[user] removes [cell_inside] from [src].", SPAN_NOTICE("You remove [cell_inside] from [src]."))
 
 	removecell()
 
 /obj/machinery/cell_charger/attack_tk(mob/user)
-	if(!charging)
+	if(!cell_inside)
 		return
 
-	charging.forceMove(loc)
-	to_chat(user, SPAN_NOTICE("You telekinetically remove [charging] from [src]."))
+	cell_inside.forceMove(loc)
+	to_chat(user, SPAN_NOTICE("You telekinetically remove [cell_inside] from [src]."))
 
 	removecell()
 
@@ -139,8 +138,8 @@
 	if(stat & (BROKEN|NOPOWER))
 		return
 
-	if(charging)
-		charging.emp_act(severity)
+	if(cell_inside)
+		cell_inside.emp_act(severity)
 
 	..(severity)
 
@@ -149,20 +148,20 @@
 		recharge_coeff = C.rating
 
 /obj/machinery/cell_charger/process()
-	if(!charging || !anchored || (stat & (BROKEN|NOPOWER)))
+	if(!cell_inside || !anchored || (stat & (BROKEN|NOPOWER)))
 		return
 
-	if(charging.percent() >= 100)
+	if(cell_inside.percent() >= 100)
 		return
 
-	use_power(charging.chargerate * recharge_coeff)
-	charging.give(charging.chargerate * recharge_coeff)
+	use_power(cell_inside.chargerate * recharge_coeff)
+	cell_inside.give(cell_inside.chargerate * recharge_coeff)
 
 	if(check_level())
 		update_icon(UPDATE_OVERLAYS)
 
 /obj/machinery/cell_charger/proc/check_level()
-	var/newlevel = 	round(charging.percent() * 4 / 100)
+	var/newlevel = round(cell_inside.percent() * 4 / 100)
 	if(chargelevel != newlevel)
 		chargelevel = newlevel
 		return TRUE

--- a/code/game/objects/items/robot/cyborg_gripper.dm
+++ b/code/game/objects/items/robot/cyborg_gripper.dm
@@ -145,10 +145,10 @@
 	// Removing cells from cell chargers.
 	if(istype(target, /obj/machinery/cell_charger))
 		var/obj/machinery/cell_charger/cell_charger = target
-		if(cell_charger.charging)
-			gripped_item = cell_charger.charging
-			cell_charger.charging.add_fingerprint(user)
-			cell_charger.charging.forceMove(src)
+		if(cell_charger.cell_inside)
+			gripped_item = cell_charger.cell_inside
+			cell_charger.cell_inside.add_fingerprint(user)
+			cell_charger.cell_inside.forceMove(src)
 			cell_charger.removecell()
 		user.visible_message(
 			SPAN_NOTICE("[user] removes the cell from [cell_charger]."),

--- a/code/modules/mob/living/basic/hostile/demons/pulse_demon_interactions.dm
+++ b/code/modules/mob/living/basic/hostile/demons/pulse_demon_interactions.dm
@@ -143,21 +143,21 @@
 
 /obj/machinery/cell_charger/attack_pulsedemon(mob/living/basic/demon/pulse_demon/user)
 	user.forceMove(src)
-	if(!charging)
+	if(!cell_inside)
 		to_chat(user, SPAN_WARNING("There is no cell charging. Click again to retry."))
 		return
 	to_chat(user, SPAN_NOTICE("You are now attempting to hijack [src], this will take approximately [user.hijack_time / 10] seconds."))
-	if(charging.rigged)
-		to_chat(user, SPAN_NOTICE("You are now inside [charging]. Click on a hijacked APC to return."))
-		user.forceMove(charging)
+	if(cell_inside.rigged)
+		to_chat(user, SPAN_NOTICE("You are now inside [cell_inside]. Click on a hijacked APC to return."))
+		user.forceMove(cell_inside)
 		return
 	if(!do_after(user, user.hijack_time, FALSE, src))
 		return
-	if(!charging)
+	if(!cell_inside)
 		to_chat(src, SPAN_WARNING("Failed to hijack [src]."))
 		return
-	to_chat(user, SPAN_NOTICE("You are now inside [charging]. Click on a hijacked APC to return."))
-	user.forceMove(charging)
+	to_chat(user, SPAN_NOTICE("You are now inside [cell_inside]. Click on a hijacked APC to return."))
+	user.forceMove(cell_inside)
 
 /obj/machinery/recharge_station/attack_pulsedemon(mob/living/basic/demon/pulse_demon/user)
 	user.forceMove(src)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -37,6 +37,8 @@
 		// State of charge is in kJ so we multiply it by 1000 to get Joules
 		desc += SPAN_NOTICE("It can store [DisplayJoules(maxcharge * 1000)]. Doctors recommend that you do not swallow it.")
 	update_icon(UPDATE_OVERLAYS)
+	if(istype(loc, /obj/machinery/cell_charger))
+		loc.update_icon(UPDATE_OVERLAYS)
 
 /obj/item/stock_parts/cell/Destroy()
 	STOP_PROCESSING(SSobj, src)

--- a/code/tests/attack_chain/test_attack_chain_machinery.dm
+++ b/code/tests/attack_chain/test_attack_chain_machinery.dm
@@ -131,7 +131,7 @@
 	TEST_ASSERT_LAST_CHATLOG(player, "already a cell in the charger")
 	qdel(cell2)
 	player.click_on(cell_charger)
-	TEST_ASSERT_NULL(cell_charger.charging, "cell charger still charging")
+	TEST_ASSERT_NULL(cell_charger.cell_inside, "cell charger still charging")
 	qdel(cell)
 	player.retrieve(screwdriver)
 	player.click_on(cell_charger)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Modifies how cell chargers update their icons so that they reflect a battery's charge percent accurately even if the cell was pulled in at roundstart before everything was initialized. Also, changes the `charging` var to `cell_inside` because that tripped me up more than once while determining how to fix.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

It's just nice to know when your batteries are charged and your chargers are working.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Mapped a cell charger and cell onto the same table. Compiled, hosted. Spawned in and observed that the battery level and power status were correct.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed cell chargers looking like they contain depleted batteries if they start with full batteries.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
