### PR TITLE
Fix centrifuge eating unlimited fuel rods.

### DIFF
--- a/code/modules/power/engines/fission/reactor_machines.dm
+++ b/code/modules/power/engines/fission/reactor_machines.dm
@@ -77,6 +77,9 @@
 	if(power_state == ACTIVE_POWER_USE) // dont start a new cycle when on
 		to_chat(user, SPAN_WARNING("There is already a fuel rod being processed!"))
 		return ITEM_INTERACT_COMPLETE
+	if(held_rod)
+		to_chat(user, SPAN_WARNING("There is already a rod inside [src]!"))
+		return ITEM_INTERACT_COMPLETE
 	var/obj/item/nuclear_rod/fuel/rod = used
 	var/list/enrichment_to_name = list()
 	var/list/radial_list = list()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes an issue where the fuel enrichment centrifuge would accept new rods when it already had a rod inside.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Fixes #32405.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted. Spawned a centrifuge and a couple uranium 238 rods. Prepared one rod for enrichment and put it in the machine. Waited for it to finish enriching. Attempted putting a second rod in the machine at the same time. It refused the rod.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed the fuel enrichment centrifuge eating untold numbers of enriched rods.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
