### PR TITLE
Irradiated Mouse Gameplay Rework

### DIFF
--- a/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse.dm
+++ b/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse.dm
@@ -71,9 +71,11 @@
 	/// How many times have we bitten a valid mob (for upgrades).
 	var/mousebites = 0
 	/// How many bites are required per available upgrade.
-	var/mousebites_per_upgrade = 10
+	var/mousebites_per_upgrade = 8
+	/// How many additional mousebites required we require on every levelup
+	var/mousebite_increment = 1
 	/// How much health do we gain/restore per upgrade.
-	var/health_increase = 25
+	var/health_increase = 20
 	/// How much do we resize per level gained.
 	var/resize_factor = 1.1
 
@@ -91,7 +93,7 @@
 	var/radiation_amount = 100
 
 	/// How much speed is increased (bigger negative = faster).
-	var/speed_per_level = -0.5
+	var/speed_per_level = -0.4
 
 	/// How much damage is increased ever level.
 	var/damage_per_level = 3
@@ -177,6 +179,8 @@
 	radiation_amount += 100
 	if(radiation_level < GAMMA_RAD)
 		radiation_level = round_down(1 + (radiation_level / 2)) // One level up every two levels.
+	if(!(radiation_level % 2))
+		to_chat(src, SPAN_NOTICE("Your radiation becomes more lethal!"))
 
 /mob/living/basic/mouse/irradiated_mouse/proc/upgrade_speed()
 	speed_upgrades++
@@ -209,6 +213,7 @@
 /mob/living/basic/mouse/irradiated_mouse/proc/on_upgrade()
 	maxHealth += health_increase
 	health += health_increase
+	mousebites_per_upgrade += mousebite_increment
 	update_health_hud()
 	var/matrix/mouse_transform = matrix(transform)
 	mouse_transform.Scale(resize_factor)

--- a/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse.dm
+++ b/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse.dm
@@ -96,12 +96,16 @@
 
 	/// How much speed is increased (bigger negative = faster).
 	var/speed_per_level = -0.4
-
 	/// How much damage is increased ever level.
 	var/damage_per_level = 3
 
 	/// How much does cheese heal us?
 	var/cheese_heal = 2
+
+	/// contains a list of UIDs of mobs who have been bitten and their ammount.
+	var/list/bitten_mobs = list()
+	/// The maximum mousebite points one mob will provide
+	var/max_bites_per_mob = 10
 
 	var/datum/spell/irradiated_mouse_spell/upgrade_radiation/upgrade_radiation_spell
 	var/datum/spell/irradiated_mouse_spell/upgrade_speed/upgrade_speed_spell
@@ -126,7 +130,15 @@
 		var/mob/living/L = target
 		contaminate_target(target, src, radiation_amount, radiation_level)
 		if(ishuman(L) && L.mind && !(L.stat & DEAD)) // Only living, sentient crew should qualify for this
-			mousebites++
+			var/mob_UID = L.UID()
+			if(!(mob_UID in bitten_mobs))
+				bitten_mobs.Add(mob_UID)
+				mousebites++
+			else if((bitten_mobs[mob_UID] < max_bites_per_mob))
+				bitten_mobs[mob_UID] += 1
+				mousebites++
+			else
+				to_chat(src, SPAN_DANGER("You have obtained all the useful biomatter from this one!"))
 		else
 			to_chat(src, SPAN_WARNING("You wont be able to obtain any usable biomatter from this one."))
 		if(mousebites >= mousebites_per_upgrade)

--- a/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse.dm
+++ b/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse.dm
@@ -219,7 +219,7 @@
 	health += health_increase
 	mousebites_per_upgrade += mousebite_increment
 	update_health_hud()
-	if(radiation_upgrades + speed_upgrades + damage_upgrades == 7)
+	if(radiation_upgrades + speed_upgrades + damage_upgrades == 6) // Make rad easier to shoot
 		density = TRUE
 		pass_flags &= ~PASSMOB
 		to_chat(src, SPAN_BOLDNOTICE("You feel as if you've grown large enough to be easier to shoot at!"))

--- a/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse.dm
+++ b/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse.dm
@@ -176,7 +176,7 @@
 	on_upgrade()
 	radiation_amount += 100
 	if(radiation_level < GAMMA_RAD)
-		radiation_level = round_down(1 + (radiation_level / 2)) // one level up every two levels
+		radiation_level = round_down(1 + (radiation_level / 2)) // One level up every two levels.
 
 /mob/living/basic/mouse/irradiated_mouse/proc/upgrade_speed()
 	speed_upgrades++

--- a/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse.dm
+++ b/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse.dm
@@ -178,7 +178,7 @@
 	on_upgrade()
 	radiation_amount += 100
 	if(radiation_level < GAMMA_RAD)
-		radiation_level = round_down(1 + (radiation_level / 2)) // One level up every two levels.
+		radiation_level = round_down(1 + (radiation_upgrades / 2)) // One level up every two levels.
 	if(!(radiation_level % 2))
 		to_chat(src, SPAN_NOTICE("Your radiation becomes more lethal!"))
 

--- a/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse.dm
+++ b/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse.dm
@@ -63,6 +63,7 @@
 	a_intent = INTENT_HARM
 	melee_damage_lower = 3
 	melee_damage_upper = 5
+	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB | PASSDOOR
 	appearance_flags = LONG_GLIDE | PIXEL_SCALE
 	attack_verb_simple = "bites"
 	attack_verb_continuous = "bites"
@@ -91,7 +92,7 @@
 	/// What type of radiation are we currently giving off.
 	var/radiation_level = ALPHA_RAD
 	/// How intense is our radiation?
-	var/radiation_amount = 100
+	var/radiation_amount = 10
 
 	/// How much speed is increased (bigger negative = faster).
 	var/speed_per_level = -0.4
@@ -169,7 +170,9 @@
 	messages.Add(SPAN_SPECIALNOTICE("Your radioactive nature has made your body unstable! Bite crew to irradiate them and gain points towards useful upgrades."))
 	messages.Add(SPAN_SPECIALNOTICE("Mindless bodies or corpses will not benefit you towards your upgrades."))
 	messages.Add(SPAN_SPECIALNOTICE("As you upgrade yourself, you will slowly grow in size and health."))
+	messages.Add(SPAN_SPECIALNOTICE("At a certian size, guns will no longer shoot over you and require more evasion to avoid!"))
 	messages.Add(SPAN_SPECIALNOTICE("Be wary of mousetraps! They will kill you instantly."))
+	messages.Add(SPAN_SPECIALNOTICE("Use your 'hide' ability to make yourself appear underneath objects, and allow you to pass under doors unobstructed."))
 	messages.Add(mind.prepare_announce_objectives(FALSE))
 	messages.Add(SPAN_MOTD("For more information, check the wiki page: ([GLOB.configuration.url.wiki_url]/index.php/Irradiated_Mouse)"))
 	to_chat(src, chat_box_red(messages.Join("<br>")))
@@ -177,7 +180,7 @@
 /mob/living/basic/mouse/irradiated_mouse/proc/upgrade_radiation()
 	radiation_upgrades++
 	on_upgrade()
-	radiation_amount += 100
+	radiation_amount += 10
 	if(radiation_level < GAMMA_RAD)
 		radiation_level = round_down(1 + (radiation_upgrades / 2)) // One level up every two levels.
 	if(!(radiation_level % 2))
@@ -216,6 +219,10 @@
 	health += health_increase
 	mousebites_per_upgrade += mousebite_increment
 	update_health_hud()
+	if(radiation_upgrades + speed_upgrades + damage_upgrades == 7)
+		density = TRUE
+		pass_flags &= ~PASSMOB
+		to_chat(src, SPAN_BOLDNOTICE("You feel as if you've grown large enough to be easier to shoot at!"))
 	var/matrix/mouse_transform = matrix(transform)
 	mouse_transform.Scale(resize_factor)
 	animate(src, transform = mouse_transform, time = 1, pixel_y = pixel_y += 2, easing = EASE_IN|EASE_OUT)

--- a/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse.dm
+++ b/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse.dm
@@ -46,7 +46,7 @@
 	spawned_mouse.give_intro_text()
 
 /datum/objective/irradiated_mouse_objective
-	explanation_text = "Enjoy the remainder of your life the best you can! Whether by gorging on cheese, pestering the crew or exploring the station."
+	explanation_text = "Punish the tall ones who have hunted you with mousetraps for so long!"
 	completed = TRUE
 	needs_target = FALSE
 
@@ -61,29 +61,42 @@
 	mouse_color = "green"
 	icon_state = "mouse_green"
 	a_intent = INTENT_HARM
+	melee_damage_lower = 3
+	melee_damage_upper = 5
+	appearance_flags = LONG_GLIDE | PIXEL_SCALE
+	attack_verb_simple = "bites"
+	attack_verb_continuous = "bites"
+	attack_sound = 'sound/weapons/bite.ogg'
+
+	/// How many times have we bitten a valid mob (for upgrades).
+	var/mousebites = 0
+	/// How many bites are required per available upgrade.
+	var/mousebites_per_upgrade = 10
+	/// How much health do we gain/restore per upgrade.
+	var/health_increase = 25
+	/// How much do we resize per level gained.
+	var/resize_factor = 1.1
 
 	var/available_upgrades = 0
-	var/upgrade_cooldown_in_seconds = 120
+
+	/// The highest level a spell may be upgraded.
+	var/level_cap = 4
 	var/radiation_upgrades = 0
 	var/speed_upgrades = 0
 	var/damage_upgrades = 0
-	var/level_cap = 3
 
-	var/alpha_rad = 0
-	var/beta_rad = 0
-	var/gamma_rad = 0
-	var/alpha_rad_per_level = 400
-	var/beta_rad_per_level = 400
-	var/gamma_rad_per_level = 0
-	var/radiation_cooldown = 0.1
-	var/produce_radioactive_sludge = FALSE
+	/// What type of radiation are we currently giving off.
+	var/radiation_level = ALPHA_RAD
+	/// How intense is our radiation?
+	var/radiation_amount = 100
 
+	/// How much speed is increased (bigger negative = faster).
 	var/speed_per_level = -0.5
-	var/speed_capstone_alpha = 125
 
-	var/has_exited_vents = FALSE
-	var/seconds_time_till_death = 60 * 15
+	/// How much damage is increased ever level.
+	var/damage_per_level = 3
 
+	/// How much does cheese heal us?
 	var/cheese_heal = 2
 
 	var/datum/spell/irradiated_mouse_spell/upgrade_radiation/upgrade_radiation_spell
@@ -102,96 +115,83 @@
 	AddSpell(upgrade_speed_spell)
 	AddSpell(upgrade_damage_spell)
 
+// irradiate anyone we bite
+/mob/living/basic/mouse/irradiated_mouse/melee_attack(atom/target, list/modifiers, ignore_cooldown)
+	. = ..()
+	if(isliving(target))
+		var/mob/living/L = target
+		contaminate_target(target, src, radiation_amount, radiation_level)
+		if(ishuman(L) && L.mind && !(L.stat & DEAD)) // Only living, sentient crew should qualify for this
+			mousebites++
+		else
+			to_chat(src, SPAN_WARNING("You wont be able to obtain any usable biomatter from this one."))
+		if(mousebites >= mousebites_per_upgrade)
+			mousebites -= mousebites_per_upgrade
+			available_upgrades++
+
+/mob/living/basic/mouse/irradiated_mouse/attack_hand(mob/living/carbon/human/M as mob)
+	if(M.a_intent == INTENT_HELP)
+		to_chat(M, SPAN_DANGER("Your hand burns as you try to grab onto the mouse!"))
+		M.adjustFireLoss(5)
+	..()
+
 /mob/living/basic/mouse/irradiated_mouse/try_consume_cheese(obj/item/food/sliced/cheesewedge/cheese)
-	if(health >= maxHealth)
-		return
 
 	visible_message(
 		SPAN_NOTICE("[src] gorges on [cheese]."),
 		SPAN_NOTICE("You gorge on [cheese][health < maxHealth ? ", restoring your health" : ""].")
 	)
 
-	adjustBruteLoss(-cheese_heal)
 	qdel(cheese)
+
+	// One can gorge on cheese without healing if they wish.
+	if(health >= maxHealth)
+		return
+	adjustBruteLoss(-cheese_heal)
 
 /mob/living/basic/mouse/irradiated_mouse/update_desc()
 	. = ..()
-	desc = initial(desc) // we dont want the standard description auto added by mice
+	desc = initial(desc) // we dont want the standard description auto added by mice.
+
+/mob/living/basic/mouse/irradiated_mouse/get_status_tab_items()
+	var/list/status_tab_data = ..()
+	. = status_tab_data
+	status_tab_data[++status_tab_data.len] = list("Upgrades available:", "[format_si_suffix(available_upgrades)]")
+	status_tab_data[++status_tab_data.len] = list("Bites until next upgrade:", "[format_si_suffix(mousebites_per_upgrade - mousebites)] bites")
 
 /mob/living/basic/mouse/irradiated_mouse/proc/give_intro_text()
 	var/list/messages = list()
 	messages.Add(SPAN_USERDANGER("<center>You are an Irradiated Mouse!</center>"))
-	messages.Add("<center>[SPAN_NOTICE("Due to your proximity to radioactive material laying around you've started rapidly mutating! Unfortunately this comes at the cost of your life: [SPAN_BOLDNOTICE("once you exit the vents you will have 15 minutes to live.")]")]</center>")
+	messages.Add(SPAN_NOTICE("Due to your proximity to radioactive material laying around you've started rapidly mutating! You're slowly growing larger, meaning, and angrier! Its time to take it out on the crew for the years of being hunted by mousetraps!"))
+	messages.Add(SPAN_SPECIALNOTICE("Your radioactive nature has made your body unstable! Bite crew to irradiate them and gain points towards useful upgrades."))
+	messages.Add(SPAN_SPECIALNOTICE("Mindless bodies or corpses will not benefit you towards your upgrades."))
+	messages.Add(SPAN_SPECIALNOTICE("As you upgrade yourself, you will slowly grow in size and health."))
+	messages.Add(SPAN_SPECIALNOTICE("Be wary of mousetraps! They will kill you instantly."))
 	messages.Add(mind.prepare_announce_objectives(FALSE))
-	messages.Add("<center>[SPAN_MOTD("For more information, check the wiki page: ([GLOB.configuration.url.wiki_url]/index.php/Irradiated_Mouse) ")]</center>")
+	messages.Add(SPAN_MOTD("For more information, check the wiki page: ([GLOB.configuration.url.wiki_url]/index.php/Irradiated_Mouse)"))
 	to_chat(src, chat_box_red(messages.Join("<br>")))
-
-/mob/living/basic/mouse/irradiated_mouse/remove_ventcrawl()
-	. = ..()
-	start_death_countdown()
-
-/mob/living/basic/mouse/irradiated_mouse/proc/start_death_countdown()
-	if(!has_exited_vents)
-		upgrade_radiation()
-		upgrade_speed()
-		upgrade_damage()
-	has_exited_vents = TRUE
-
-/mob/living/basic/mouse/irradiated_mouse/Life(seconds, times_fired)
-	. = ..()
-	if(stat != CONSCIOUS)
-		return
-
-	if(!has_exited_vents)
-		if(admin_spawned)
-			start_death_countdown()
-		else
-			return
-
-	// telegraph the radiation by giving tiles harmless alpha radiation
-	for(var/turf/turf in range(1, src))
-		contaminate_target(turf, src, alpha_rad, ALPHA_RAD)
-
-	// reduce health by a constant so the mouse eventually dies
-	adjustBruteLoss(maxHealth * seconds / seconds_time_till_death)
-
-	// subtract time after you've left a vent
-	upgrade_cooldown_in_seconds -= seconds
-	if(upgrade_cooldown_in_seconds <= 0)
-		upgrade_cooldown_in_seconds += initial(upgrade_cooldown_in_seconds)
-		available_upgrades++
-		to_chat(src, SPAN_NOTICE("You have [available_upgrades] upgrades available."))
-
-	if(!produce_radioactive_sludge)
-		return
-
-	var/chance = 50 - (health/maxHealth * 50)  // more likely as health drops, fastest you can get this is after 6 minutes, giving a 20% spawn chance per 2 seconds
-	if(prob(chance))
-		new /obj/effect/decal/cleanable/radioactive_sludge(get_turf(src))
 
 /mob/living/basic/mouse/irradiated_mouse/proc/upgrade_radiation()
 	radiation_upgrades++
-	alpha_rad = alpha_rad_per_level * radiation_upgrades
-	beta_rad = beta_rad_per_level * radiation_upgrades
-	gamma_rad = gamma_rad_per_level * radiation_upgrades
-
-	// update your radiation component
-	DeleteComponentsType(/datum/component/inherent_radioactivity)
-	AddComponent(/datum/component/inherent_radioactivity, alpha_rad, beta_rad, gamma_rad, radiation_cooldown)
+	on_upgrade()
+	radiation_amount += 100
+	if(radiation_level < GAMMA_RAD)
+		radiation_level = round_down(1 + (radiation_level / 2)) // one level up every two levels
 
 /mob/living/basic/mouse/irradiated_mouse/proc/upgrade_speed()
 	speed_upgrades++
-	speed = initial(speed) + speed_per_level * speed_upgrades // this will tend towards a negative value (due to speed_per_level being negative) which is faster
-	if(speed_upgrades > level_cap)
-		alpha = speed_capstone_alpha
-		RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(on_movement)) // handles afterimages
+	on_upgrade()
+	speed = initial(speed) + speed_per_level * speed_upgrades // This will tend towards a negative value (due to speed_per_level being negative) which is faster
+	if(speed_upgrades == level_cap)
+		RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(on_movement)) // Handles afterimages.
 
 /mob/living/basic/mouse/irradiated_mouse/proc/upgrade_damage()
 	damage_upgrades++
-	melee_damage_lower = damage_upgrades * 5
+	on_upgrade()
+	melee_damage_lower += damage_per_level
 	melee_damage_upper = melee_damage_lower + 5
-	if(damage_upgrades > level_cap)
-		environment_smash = ENVIRONMENT_SMASH_WALLS // what allows wall smashing
+	if(damage_upgrades == level_cap) // Allows wall smashing at max level.
+		environment_smash = ENVIRONMENT_SMASH_WALLS
 
 /mob/living/basic/mouse/irradiated_mouse/proc/on_movement(mob/living/mob, atom/old_loc)
 	if(stat != CONSCIOUS)
@@ -204,5 +204,15 @@
 
 /obj/effect/temp_visual/decoy/irradiated_mouse_afterimage/Initialize(mapload, atom/mimiced_atom)
 	. = ..()
-	animate(src, alpha = 0, time = duration, easing = EASE_OUT) // gradually fading out after image
+	animate(src, alpha = 0, time = duration, easing = EASE_OUT) // Gradually fading out after image.
 
+/mob/living/basic/mouse/irradiated_mouse/proc/on_upgrade()
+	maxHealth += health_increase
+	health += health_increase
+	update_health_hud()
+	var/matrix/mouse_transform = matrix(transform)
+	mouse_transform.Scale(resize_factor)
+	animate(src, transform = mouse_transform, time = 1, pixel_y = pixel_y += 2, easing = EASE_IN|EASE_OUT)
+	if(radiation_upgrades == level_cap && speed_upgrades == level_cap && damage_upgrades == level_cap)
+		to_chat(src, SPAN_BOLDNOTICE("You feel like your fur is trying to slough off your body!"))
+		AddSpell(new /datum/spell/mouse_sludge_ejection)

--- a/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse.dm
+++ b/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse.dm
@@ -67,6 +67,7 @@
 	attack_verb_simple = "bites"
 	attack_verb_continuous = "bites"
 	attack_sound = 'sound/weapons/bite.ogg'
+	can_be_scooped = FALSE
 
 	/// How many times have we bitten a valid mob (for upgrades).
 	var/mousebites = 0

--- a/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse.dm
+++ b/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse.dm
@@ -134,7 +134,7 @@
 			if(!(mob_UID in bitten_mobs))
 				bitten_mobs.Add(mob_UID)
 				mousebites++
-			else if((bitten_mobs[mob_UID] < max_bites_per_mob))
+			else if(bitten_mobs[mob_UID] < max_bites_per_mob)
 				bitten_mobs[mob_UID] += 1
 				mousebites++
 			else

--- a/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse.dm
+++ b/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse.dm
@@ -162,7 +162,7 @@
 /mob/living/basic/mouse/irradiated_mouse/proc/give_intro_text()
 	var/list/messages = list()
 	messages.Add(SPAN_USERDANGER("<center>You are an Irradiated Mouse!</center>"))
-	messages.Add(SPAN_NOTICE("Due to your proximity to radioactive material laying around you've started rapidly mutating! You're slowly growing larger, meaning, and angrier! Its time to take it out on the crew for the years of being hunted by mousetraps!"))
+	messages.Add(SPAN_NOTICE("Due to your proximity to radioactive material laying around you've started rapidly mutating! You're slowly growing larger, meaner, and angrier! Its time to take it out on the crew for the years of being hunted by mousetraps!"))
 	messages.Add(SPAN_SPECIALNOTICE("Your radioactive nature has made your body unstable! Bite crew to irradiate them and gain points towards useful upgrades."))
 	messages.Add(SPAN_SPECIALNOTICE("Mindless bodies or corpses will not benefit you towards your upgrades."))
 	messages.Add(SPAN_SPECIALNOTICE("As you upgrade yourself, you will slowly grow in size and health."))

--- a/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse_spells.dm
+++ b/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse_spells.dm
@@ -14,7 +14,7 @@
 
 /datum/spell/irradiated_mouse_spell/upgrade_radiation
 	name = "Upgrade Radiation"
-	desc = "Upgrade the amount of radiation you emit. You will start producing radioactive sludge at level 3."
+	desc = "Upgrade the amount and type of radiation you contaminate humans with."
 	action_icon_state = "irradiated_mouse_radiation"
 
 /datum/spell/irradiated_mouse_spell/upgrade_radiation/cast(list/targets, mob/living/basic/mouse/irradiated_mouse/user)
@@ -26,14 +26,12 @@
 
 	user.available_upgrades--
 	user.upgrade_radiation()
-	if(user.radiation_upgrades > user.level_cap)
+	if(user.radiation_upgrades == user.level_cap)
 		user.RemoveSpell(user.upgrade_radiation_spell)
-		user.produce_radioactive_sludge = TRUE
-		to_chat(user, SPAN_NOTICE("You feel like shedding some weight."))
 
 /datum/spell/irradiated_mouse_spell/upgrade_speed
 	name = "Upgrade Speed"
-	desc = "Upgrade your speed. You will become semi-transparent at level 3."
+	desc = "Upgrade your speed. You will begin forming after-images at maximum level."
 	action_icon_state = "irradiated_mouse_speed"
 
 /datum/spell/irradiated_mouse_spell/upgrade_speed/cast(list/targets, mob/living/basic/mouse/irradiated_mouse/user)
@@ -45,13 +43,13 @@
 
 	user.available_upgrades--
 	user.upgrade_speed()
-	if(user.speed_upgrades > user.level_cap)
+	if(user.speed_upgrades == user.level_cap)
 		user.RemoveSpell(user.upgrade_speed_spell)
 		to_chat(user, SPAN_NOTICE("You feel like the wind."))
 
 /datum/spell/irradiated_mouse_spell/upgrade_damage
 	name = "Upgrade Damage"
-	desc = "Upgrade your damage. You will become able to damage walls and windows at level 3."
+	desc = "Upgrade your damage. You will become able to damage walls and windows at maximum level"
 	action_icon_state = "irradiated_mouse_damage"
 
 /datum/spell/irradiated_mouse_spell/upgrade_damage/cast(list/targets, mob/living/basic/mouse/irradiated_mouse/user)
@@ -63,7 +61,25 @@
 
 	user.available_upgrades--
 	user.upgrade_damage()
-	if(user.damage_upgrades > user.level_cap)
+	if(user.damage_upgrades == user.level_cap)
 		user.RemoveSpell(user.upgrade_damage_spell)
 		to_chat(user, SPAN_NOTICE("You feel much stronger."))
 
+/datum/spell/mouse_sludge_ejection
+	name = "Eject Radioactive Sludge"
+	desc = "Partially liquify your fur"
+	action_icon = 'icons/effects/effects.dmi'
+	action_icon_state = "greenglow"
+	action_background_icon_state = "bg_irradiated_mouse"
+	clothes_req = FALSE
+	base_cooldown = 3 MINUTES
+
+/datum/spell/mouse_sludge_ejection/cast(list/targets, mob/user)
+	. = ..()
+	to_chat(user, SPAN_NOTICE("You shed part of your fur into a semi-liquid puddle on the floor!"))
+	new /obj/effect/decal/cleanable/radioactive_sludge(get_turf(user))
+	var/turf/turf = get_turf(user)
+	contaminate_target(turf, user, 500, GAMMA_RAD)
+
+/datum/spell/mouse_sludge_ejection/create_new_targeting()
+	return new /datum/spell_targeting/self

--- a/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse_spells.dm
+++ b/code/game/gamemodes/miniantags/irradiated_mouse/irradiated_mouse_spells.dm
@@ -76,6 +76,9 @@
 
 /datum/spell/mouse_sludge_ejection/cast(list/targets, mob/user)
 	. = ..()
+	if(!isturf(user.loc)) // No making sludge from pipes.
+		revert_cast()
+		return
 	to_chat(user, SPAN_NOTICE("You shed part of your fur into a semi-liquid puddle on the floor!"))
 	new /obj/effect/decal/cleanable/radioactive_sludge(get_turf(user))
 	var/turf/turf = get_turf(user)

--- a/code/modules/mob/living/basic/friendly/mouse.dm
+++ b/code/modules/mob/living/basic/friendly/mouse.dm
@@ -37,6 +37,8 @@
 	var/cable_zap_prob = 85
 	/// Food types that mice eat
 	var/static/list/food_types = list(/obj/item/food/sliced/cheesewedge, /obj/item/food/sliceable/cheesewheel)
+	/// Can this rat be picked up?
+	var/can_be_scooped = TRUE
 
 /mob/living/basic/mouse/Initialize(mapload)
 	. = ..()
@@ -61,7 +63,7 @@
 	desc = "It's a small [mouse_color] rodent, often seen hiding in maintenance areas and making a nuisance of itself."
 
 /mob/living/basic/mouse/attack_hand(mob/living/carbon/human/M as mob)
-	if(M.a_intent == INTENT_HELP)
+	if(M.a_intent == INTENT_HELP && can_be_scooped)
 		get_scooped(M, TRUE)
 	..()
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Irradiated mouse has received a major overhaul to its core gameplay loop. These mice now revolve around upgrades being obtained through biting at crew. After 10 bites (subject to change) they will gain 1 upgrade they may spend between upgrading their radiation strength/type, their damage, and their speed. The primary gameplay loop of the mouse will now revolve around skirmishing and biting crew to obtain higher abilities, instead of only needing to run away. This now provides irradiated mice with a direct reason to interact with crew and cause issues. 

- Mice no longer passively spread patches of radiation. Instead, biting crew will irradiate them. 
- Maxing all skill trees will unlock a special ability to spread radioactive sludge on a 3 minute cooldown.
- Mice now start with 3-5 damage by default.
- Mice now grow slightly with every upgrade.
- Mice now get extra max health with every upgrade.
- Mice no longer have a slow drain on their health.
- Mice can no longer be picked up by crew.
- 

## Why It's Good For The Game

Irradiated mouse has several issues, including ruining the current Time Dilation of the server, being too easy to escape any conflict, and otherwise turning the entire station into an irradiated hellzone for everyone. Theres virtually no method of cleaning all of it, resulting in these mice creating massive areas of uninhabitable space crew cannot go through. To put it simplely: its not fun.

## Images of changes

An irradiate mouse at maximum level
<img width="301" height="150" alt="image" src="https://github.com/user-attachments/assets/b40b86c9-3926-4ef0-bd04-4718c10a120e" />


## Testing

 - Spawned as a mouse through the event panel, recieved proper message and spawned in pipes
 - bit a LOT of skrell
 - leveled up my abilities
 - noticed how TD was not dying
 - maxed out abilities, received goop ability
 - noticed how mouse was now very large, and had more health
 - ensured sludge was radioactive, and was on a 3 minute cooldown.

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

<img width="599" height="194" alt="image" src="https://github.com/user-attachments/assets/9ac50639-2202-4358-9cc3-ad36ae2e49a2" />

<img width="628" height="94" alt="image" src="https://github.com/user-attachments/assets/51bd10e5-bf88-44df-9018-43b5c495d615" />


## Changelog

:cl:
tweak: Reworked Irradiated mouse core game loop
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
