### PR TITLE
Disable some machines when unpowered.

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -105,6 +105,9 @@
 		else
 			M.forceMove(loc)
 
+	if(!has_power())
+		return
+
 	if(occupant)
 		if(auto_eject_dead && occupant.stat == DEAD)
 			playsound(loc, 'sound/machines/buzz-sigh.ogg', 40)

--- a/code/game/machinery/autoclave.dm
+++ b/code/game/machinery/autoclave.dm
@@ -195,7 +195,7 @@
 	return TRUE
 
 /obj/machinery/autoclave/proc/try_start()
-	if(work_timer_id || !occupant || panel_open)
+	if(work_timer_id || !occupant || panel_open || !has_power())
 		return FALSE
 
 	soundloop.start()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Disables the autoclave and the sleeper when they don't have power.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Well, it'll be more annoying, but I believe this is the intention of machines that require power.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted, spawned in the medbay. Gave a test mob a nicotine addiction. Turned off the power and put them in the sleeper. Waited several minutes and noticed no addiction cure. Turned the power back on, put them back in, and their addiciton was cured in short order. Put a surgical tray in a powered autoclave and turned it on. Turned off the power in a room, put a surgical tray in the unpowered autoclave, and failed to turn it on.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed some medical machines operating with no power.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
