### PR TITLE
Updates Wiz Diseases

### DIFF
--- a/code/datums/diseases/wizard_diseases.dm
+++ b/code/datums/diseases/wizard_diseases.dm
@@ -26,7 +26,7 @@
 	name = "Grut Gut"
 	max_stages = 5
 	stage_prob = 5
-	spread_text = "Non-contagious"
+	spread_text = "Airborne"
 	cure_text = "Pyrotech stabilizing agents"
 	agent = "Eruca Stomachum"
 	cures = list("stabilizing_agent")
@@ -99,7 +99,7 @@
 	name = "Wand Rot"
 	max_stages = 5
 	stage_prob = 5
-	spread_text = "Non-contagious"
+	spread_text = "Airborne"
 	cure_text = "Acetaldehyde"
 	agent = "nasum magicum"
 	cures = list("acetaldehyde")
@@ -168,8 +168,7 @@
 	name = "Mystic Malaise"
 	max_stages = 5
 	stage_prob = 5
-	spread_text = "Non-contagious"
-	spread_flags = SPREAD_CONTACT_GENERAL
+	spread_text = "Airborne"
 	cure_text = "liquid dark matter"
 	agent = "Spatio Ventrem"
 	cures = list("liquid_dark_matter")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Sets all wizard diseases listed contraction method to "airborne" rather than the erroneous "Non-contagious" as this was a holdover from the original design that got reworked but was accidently left in. Mystic Malaise was given airborne like the other wizard diseases.

## Why It's Good For The Game

Accurate descriptions of things are good

## Testing

Infected some skrell

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed wizard disease descriptions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
