### PR TITLE
fix CI dupe icon check

### DIFF
--- a/tools/ci/check_icons.py
+++ b/tools/ci/check_icons.py
@@ -10,7 +10,7 @@ def check_duplicate_names(dmi: DMI) -> list[str]:
     for state in dmi.states():
         # Movement states have the same name as their non-movement counterparts
         if (state.name, state.movement) in states:
-            duplicates.append(f"duplicate state name `{state.name}`")
+            failures.append(f"duplicate state name `{state.name}`")
         states.add((state.name, state.movement))
     return failures
 


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the check_icons CI check.
## Why It's Good For The Game
Bugfix.
## Testing
Added a duplicate icon state, ran check:
```> .\tools\bootstrap\python_.ps1 .\tools\ci\check_icons.py
check_icons started
icons\mob\ai.dmi: duplicate state name `ai`

check_icons checked 1378 files in 3.36s
```
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC