### PR TITLE
Fixes Flockmind Mind Transfer

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1901,6 +1901,11 @@
 		SSticker.mode.blob_overminds += src
 		special_role = SPECIAL_ROLE_BLOB_OVERMIND
 
+/datum/mind/proc/make_Flockmind()
+	if(!(src in SSticker.mode.flockminds))
+		SSticker.mode.flockminds += src
+		special_role = SPECIAL_ROLE_FLOCK
+
 /datum/mind/proc/make_mind_flayer()
 	if(!has_antag_datum(/datum/antagonist/mindflayer))
 		add_antag_datum(/datum/antagonist/mindflayer)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -38,6 +38,7 @@
 	var/list/datum/mind/xenos = list()
 	var/list/datum/mind/eventmiscs = list()
 	var/list/blob_overminds = list()
+	var/list/flockminds = list()
 	var/list/incursion_portals = list()
 
 	var/list/datum/station_goal/station_goals = list() // A list of all station goals for this game mode

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -419,6 +419,8 @@
 					dat += "<tr><td><i>Head not found!</i></td></tr>"
 			dat += "</table>"
 
+		if(length(SSticker.mode.flockminds))
+			dat += check_role_table("Flockminds", SSticker.mode.flockminds)
 
 		if(length(SSticker.mode.blob_overminds))
 			dat += check_role_table("Blob Overminds", SSticker.mode.blob_overminds)

--- a/code/modules/antagonists/flockmind/actions/partition_mind.dm
+++ b/code/modules/antagonists/flockmind/actions/partition_mind.dm
@@ -71,8 +71,7 @@
 	new_ghostbird.mind = new
 	new_ghostbird.mind.bind_to(new_ghostbird)
 	new_ghostbird.mind.set_original_mob(new_ghostbird)
-	new_ghostbird.mind.assigned_role = SPECIAL_ROLE_FLOCK
-	new_ghostbird.mind.special_role = SPECIAL_ROLE_FLOCK
+	new_ghostbird.mind.make_Flockmind()
 	var/list/messages = list()
 	messages += "<div style='font-size: 200%;text-align: center'>You are [gradient_text("The Divine Flock","#3cb5a3", "#124e43")]</div>"
 	messages += "<div style='text-align: center'>" + gradient_text("We have been partitioned by our overmind to further their goals of propogating The Signal. It is our task to assist in managing their drones to achieve their goals. Such is the will of the Monarch.", "#3cb5a3", "#1e806e") + "</div>"

--- a/code/modules/antagonists/flockmind/flock_camera/_flock_camera.dm
+++ b/code/modules/antagonists/flockmind/flock_camera/_flock_camera.dm
@@ -172,4 +172,5 @@
 	addtimer(CALLBACK(src, PROC_REF(cleanup)), 2 SECONDS)
 
 /mob/camera/flock/proc/cleanup(datum/source)
+	SSticker.mode.flockminds -= mind
 	qdel(src)

--- a/code/modules/antagonists/flockmind/flock_mob/flockdrone.dm
+++ b/code/modules/antagonists/flockmind/flock_mob/flockdrone.dm
@@ -3,8 +3,6 @@
 	hud_type = /datum/hud/flockdrone
 	ai_controller = /datum/ai_controller/flock/drone
 
-	move_force = MOVE_FORCE_WEAK
-
 	actions_to_grant = list(
 		/datum/action/cooldown/flock/release_control,
 		/datum/action/cooldown/flock/nest,
@@ -399,7 +397,8 @@
 	controlled_by.controlling_bird = src
 
 	if(controlled_by.mind)
-		controlled_by.mind.transfer_to(src, FALSE)
+		key = controlled_by.key
+		mind = controlled_by.mind
 
 	if(isflocktrace(controlled_by))
 		flock.add_notice(src, FLOCK_NOTICE_FLOCKTRACE_CONTROL)
@@ -439,7 +438,8 @@
 
 	master_bird.forceMove(destination)
 	if(mind)
-		mind.transfer_to(master_bird, FALSE)
+		master_bird.key = key
+		master_bird.mind = mind
 
 	flock_talk(null, "Control of [real_name] surrendered.", flock, involuntary = TRUE)
 	if(!dest_was_safe)

--- a/code/modules/events/flockmind_event.dm
+++ b/code/modules/events/flockmind_event.dm
@@ -13,22 +13,22 @@
 	if(!length(candidates))
 		return kill()
 
-	var/mob/C
+	var/mob/M
 	while(length(candidates))
-		C = pick_n_take(candidates)
-		if(jobban_isbanned(C, ROLE_TRAITOR))
+		M = pick_n_take(candidates)
+		if(jobban_isbanned(M, ROLE_TRAITOR))
 			continue
 		break
-	if(!C)
+	if(!M)
 		kill()
 		return
-	var/player_key = C.key
+	var/player_key = M.key
 
 	if(!player_key)
 		kill()
 		return
 
-	dust_if_respawnable(C)
+	dust_if_respawnable(M)
 	var/list/spawn_locs = list()
 	for(var/obj/effect/landmark/spawner/flock/spawn_site in GLOB.landmarks_list)
 		spawn_locs += get_turf(spawn_site)
@@ -36,10 +36,11 @@
 		kill()
 		return
 	var/mob/camera/flock/overmind/flockmind = new /mob/camera/flock/overmind(pick(spawn_locs))
-	C.mind.transfer_to(flockmind, FALSE)
+	flockmind.key = M.key
+	flockmind.mind = new
+	flockmind.mind.bind_to(flockmind)
 	flockmind.mind.set_original_mob(flockmind)
-	flockmind.mind.assigned_role = SPECIAL_ROLE_FLOCK
-	flockmind.mind.special_role = SPECIAL_ROLE_FLOCK
+	flockmind.mind.make_Flockmind()
 	var/list/messages = list()
 	messages += "<div style='font-size: 200%;text-align: center'>You are [gradient_text("The Divine Flock","#3cb5a3", "#124e43")]</div>"
 	messages += "<div style='text-align: center'>" + gradient_text("The Signal has led us here, a rift allowing a part of us through. We must build a Signal Relay to bring forth the rest of The Divine Flock. Such is the will of the Monarch.", "#3cb5a3", "#1e806e") + "</div>"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes a bug in transferring minds to/from flockmind mobs, introduced in a recent PR.

Makes SSTicker track flockmind minds/traces.

## Why It's Good For The Game

Bugs bad. Tracking good.

## Testing

Spawned as assistant. Aghosted. Became a flockmind through event spawn. Was able to enter/leave drones without issue.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed a bug that broke flockmind mind transfers if you inhabited a mob prior to becoming a flockmind
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
