### PR TITLE
[FIX] Tweaks access to cargo crates for nuclear fission reactor

### DIFF
--- a/code/modules/supply/supply_packs/pack_engineering.dm
+++ b/code/modules/supply/supply_packs/pack_engineering.dm
@@ -216,17 +216,16 @@
 	cost = 750 //So cargo thinks twice before killing themselves with it
 	containername = "supermatter shard crate"
 
-/datum/supply_packs/engineering/nuclear_supermatter_rod
+/datum/supply_packs/engineering/engine/nuclear_supermatter_rod
 	name = "Nuclear Supermatter Rod Crate"
 	contains = list(
 	/obj/item/nuclear_rod/fuel/supermatter,
 	/obj/item/nuclear_rod/fuel/supermatter,
 	)
 	cost = 400
-	containertype = /obj/structure/closet/crate/secure/engineering
 	containername = "nuclear supermatter rod crate"
 
-/datum/supply_packs/engineering/nuclear_supermatter_kit
+/datum/supply_packs/engineering/engine/nuclear_supermatter_kit
 	name = "Nuclear Supermatter Rods Starter Crate"
 	contains = list(
 	/obj/item/nuclear_rod/fuel/supermatter,
@@ -237,10 +236,9 @@
 	/obj/item/nuclear_rod/moderator/plasma_agitator
 	)
 	cost = 800
-	containertype = /obj/structure/closet/crate/secure/engineering
 	containername = "nuclear supermatter starter crate"
 
-/datum/supply_packs/engineering/nuclear_moderator_rods
+/datum/supply_packs/engineering/engine/nuclear_moderator_rods
 	name = "Forged Nuclear Moderator crate"
 	contains = list(
 		/obj/item/nuclear_rod/moderator/plasma_agitator,
@@ -249,10 +247,9 @@
 		/obj/item/nuclear_rod/moderator/aluminum_reflector
 	)
 	cost = 600
-	containertype = /obj/structure/closet/crate/secure/engineering
 	containername = "Forged Nuclear Moderator crate"
 
-/datum/supply_packs/engineering/nuclear_coolant_rods
+/datum/supply_packs/engineering/engine/nuclear_coolant_rods
 	name = "Forged Nuclear Coolant crate"
 	contains = list(
 		/obj/item/nuclear_rod/coolant/steam_hammerjet,
@@ -261,10 +258,9 @@
 		/obj/item/nuclear_rod/coolant/molten_salt
 	)
 	cost = 600
-	containertype = /obj/structure/closet/crate/secure/engineering
 	containername = "Forged Nuclear Coolant crate"
 
-/datum/supply_packs/engineering/nuclear_premium_rods
+/datum/supply_packs/engineering/engine/nuclear_premium_rods
 	name = "Forged Premium Nuclear Rods crate"
 	contains = list(
 		/obj/item/nuclear_rod/moderator/platinum_plating,
@@ -273,7 +269,6 @@
 		/obj/item/nuclear_rod/coolant/iridium_conductor,
 	)
 	cost = 1500
-	containertype = /obj/structure/closet/crate/secure/engineering
 	containername = "Forged Premium Nuclear Rods crate"
 
 /* Commented out as the TEG is fully problematic. If the syndie base is changed to be dependant on another powersource, we can look at a rework.


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Brings the cargo crates for nuclear fission reactor components in line with other engine crates by locking them behind chief engineer access.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Non-engineering crew probably shouldn't have access to highly radioactive material.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Order crates
Try to open them with no CE access, they stay closed
Try to open them with CE access, they open as expected.
<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Nuclear fission reactor crates are now locked behind CE access
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
