### PR TITLE
fix mail crates with no recipients

### DIFF
--- a/code/__DEFINES/departments_defines.dm
+++ b/code/__DEFINES/departments_defines.dm
@@ -42,3 +42,15 @@
 #define DEP_MAIL_LIST_SERVICE list("Clown", "Mime", "Head of Personnel", "Chaplain")
 #define DEP_MAIL_LIST_COMMAND list("Captain", "Magistrate", "Nanotrasen Representative", "Blueshield", "Internal Affairs Agent", "Nanotrasen Career Trainer")
 #define DEP_MAIL_LIST_MISC list("Assistant")
+
+GLOBAL_LIST_INIT(mail_crate_possible_contents, list(
+	/obj/item/envelope/security = DEP_MAIL_LIST_SECURITY,
+	/obj/item/envelope/science = DEP_MAIL_LIST_SCIENCE,
+	/obj/item/envelope/supply = DEP_MAIL_LIST_SUPPLY,
+	/obj/item/envelope/medical = DEP_MAIL_LIST_MEDICAL,
+	/obj/item/envelope/engineering = DEP_MAIL_LIST_ENGINEERING,
+	/obj/item/envelope/bread = DEP_MAIL_LIST_BREAD,
+	/obj/item/envelope/circuses = DEP_MAIL_LIST_SERVICE,
+	/obj/item/envelope/command = DEP_MAIL_LIST_COMMAND,
+	/obj/item/envelope/misc = DEP_MAIL_LIST_MISC,
+))

--- a/code/controllers/subsystem/SSshuttles.dm
+++ b/code/controllers/subsystem/SSshuttles.dm
@@ -334,7 +334,33 @@ SUBSYSTEM_DEF(shuttle)
 
 	QDEL_LIST_CONTENTS(remove_images)
 
+/datum/controller/subsystem/shuttle/proc/prepare_mail_delivery()
+	. = list()
+
+	var/list/narrowed_contents = GLOB.mail_crate_possible_contents.Copy()
+	for(var/envelope_type in narrowed_contents)
+		var/found = FALSE
+		for(var/datum/mind/recipient in SSticker.minds)
+			var/turf/recipient_turf = get_turf(recipient.current)
+			if(recipient.offstation_role || !ishuman(recipient.current) || is_admin_level(recipient_turf.z))
+				continue
+			if(recipient.assigned_role in narrowed_contents[envelope_type])
+				found = TRUE
+				break
+		if(!found)
+			narrowed_contents -= envelope_type
+
+	// Scale number of letters with number of crew.
+	var/envelope_count = min(length(narrowed_contents), (ceil(length(GLOB.crew_list) / 20) + rand(1, 5)))
+	for(var/i in 1 to envelope_count)
+		. += pick(narrowed_contents)
+
 /datum/controller/subsystem/shuttle/proc/mail_delivery()
+	var/list/envelope_types = prepare_mail_delivery()
+	if(!length(envelope_types))
+		log_debug("no recipients found for mail delivery, cancelling mail crate")
+		return
+
 	for(var/obj/machinery/requests_console/console in GLOB.allRequestConsoles)
 		if(console.department != "Cargo Bay")
 			continue
@@ -349,7 +375,7 @@ SUBSYSTEM_DEF(shuttle)
 		stack_trace("There were no available turfs on the Supply Shuttle to spawn a mail crate in!")
 		return
 	var/turf/spawn_location = pick(supply_shuttle_turfs)
-	new /obj/structure/closet/crate/mail(spawn_location)
+	new /obj/structure/closet/crate/mail(spawn_location, envelope_types)
 
 /// Loads a shuttle from the template into a cordon. Returns its docking port if successful.
 /datum/controller/subsystem/shuttle/proc/load_template(datum/map_template/shuttle/template)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -617,34 +617,16 @@
 	icon_closed = "mailsealed"
 	material_drop = /obj/item/stack/sheet/plastic
 	material_drop_amount = 4
-	var/list/possible_contents = list(/obj/item/envelope/security = DEP_MAIL_LIST_SECURITY,
-										/obj/item/envelope/science = DEP_MAIL_LIST_SCIENCE,
-										/obj/item/envelope/supply = DEP_MAIL_LIST_SUPPLY,
-										/obj/item/envelope/medical = DEP_MAIL_LIST_MEDICAL,
-										/obj/item/envelope/engineering = DEP_MAIL_LIST_ENGINEERING,
-										/obj/item/envelope/bread = DEP_MAIL_LIST_BREAD,
-										/obj/item/envelope/circuses = DEP_MAIL_LIST_SERVICE,
-										/obj/item/envelope/command = DEP_MAIL_LIST_COMMAND,
-										/obj/item/envelope/misc = DEP_MAIL_LIST_MISC)
+	var/list/envelope_types = list()
+
+/obj/structure/closet/crate/mail/Initialize(mapload, envelope_types_)
+	envelope_types = envelope_types_
+	. = ..()
 
 /obj/structure/closet/crate/mail/populate_contents()
 	. = ..()
-	var/list/narrowed_contents = possible_contents.Copy()
-	for(var/envelope_type in narrowed_contents)
-		var/found = FALSE
-		for(var/datum/mind/recipient in SSticker.minds)
-			var/turf/recipient_turf = get_turf(recipient.current)
-			if(recipient.offstation_role || !ishuman(recipient.current) || is_admin_level(recipient_turf.z))
-				continue
-			if(recipient.assigned_role in narrowed_contents[envelope_type])
-				found = TRUE
-				break
-		if(!found)
-			narrowed_contents -= envelope_type
-
-	for(var/i in 1 to (ceil(length(GLOB.crew_list) / 20) + rand(1, 5))) // Scale number of letters with number of crew.
-		var/item = pick(narrowed_contents)
-		new item(src)
+	for(var/envelope_type in envelope_types)
+		new envelope_type(src)
 
 /obj/structure/closet/crate/tape/populate_contents()
 	if(prob(10))


### PR DESCRIPTION
## What Does This PR Do
This PR refactors mail delivery code to ensure that no envelopes attempt to be spawned when there are no recipients, and the mail crate itself (and the delivery announcement) don't fire if there are no letters to mail. Should be TMed for sanity.
## Why It's Good For The Game
Prevents a runtime from occurring, which not only pollutes Kibana, but also causes runtime exceptions locally, which can be frustrating when letting the game run for long periods of time and trying to debug something unrelated.
## Testing
I didn't. Should be TMed for sanity.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC