### PR TITLE
Fixes flock relay detonation bug

### DIFF
--- a/code/modules/antagonists/flockmind/flock_structure/flock_relay.dm
+++ b/code/modules/antagonists/flockmind/flock_structure/flock_relay.dm
@@ -224,5 +224,7 @@
 	for(var/obj/machinery/telecomms/T in SSmachines.get_by_type(/obj/machinery/telecomms))
 		T.emp_act(EMP_HEAVY)
 
+	if(SSshuttle.emergency.mode >= SHUTTLE_DOCKED)
+		return
 	SSshuttle.emergency.request(null, 0.3)
 	SSshuttle.emergency.canRecall = FALSE // Cannot recall


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes a bug that kept rounds from ending when a flock relay detonated while the emergency shuttle was docked.

## Why It's Good For The Game

Bugs bad.

## Testing

Set off a relay detonation with the shuttle docked. No error.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed a bug preventing rounds from ending if a flockmind relay exploded while the shuttle was docked.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
