### PR TITLE
Adds knocking on doors

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -262,9 +262,11 @@
 		return
 	user.changeNext_move(CLICK_CD_MELEE)
 	playsound(src, 'sound/magic/hereticknock.ogg', 50, 1)
-	user.visible_message("[user] knocks on [src].", \
-						"You knock on [src].", \
-						"You hear a knocking sound.")
+	user.visible_message(
+		SPAN_NOTICE("[user] knocks on [src]."),
+		SPAN_NOTICE("You knock on [src]."),
+		SPAN_HEAR("You hear a knocking sound.")
+	)
 	add_fingerprint(user)
 
 /obj/machinery/door/proc/try_to_activate_door(mob/user)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -65,7 +65,7 @@
 
 /obj/machinery/door/examine(mob/user)
 	. = ..()
-	. += SPAN_NOTICE("<b>Alt-Click</b> to knock on it.") // i don't know a better way to handle this. sorry.
+	. += SPAN_NOTICE("<b>Alt-Click</b> to knock on it.")
 
 /obj/machinery/door/Initialize(mapload)
 	. = ..()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -261,7 +261,7 @@
 	if(user.stat || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !Adjacent(user))
 		return
 	user.changeNext_move(CLICK_CD_MELEE)
-	playsound(src, 'sound/effects/glassknock.ogg', 50, 1)
+	playsound(src, 'sound/magic/hereticknock.ogg', 50, 1)
 	user.visible_message("[user] knocks on [src].", \
 						"You knock on [src].", \
 						"You hear a knocking sound.")

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -63,6 +63,9 @@
 	/// Blocks the door from making sparks when on cooldown. Lag preventor, disabled by disable_door_sparks for 3 seconds
 	COOLDOWN_DECLARE(spark_block_cooldown)
 
+/obj/machinery/door/examine(mob/user)
+	. = ..()
+	. += SPAN_NOTICE("<b>Alt-Click</b> to knock on it.") // i don't know a better way to handle this. sorry.
 
 /obj/machinery/door/Initialize(mapload)
 	. = ..()
@@ -253,6 +256,16 @@
 	if(!allowed(null))
 		return
 	..()
+
+/obj/machinery/door/AltClick(mob/user)
+	if(user.stat || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !Adjacent(user))
+		return
+	user.changeNext_move(CLICK_CD_MELEE)
+	playsound(src, 'sound/effects/glassknock.ogg', 50, 1)
+	user.visible_message("[user] knocks on [src].", \
+						"You knock on [src].", \
+						"You hear a knocking sound.")
+	add_fingerprint(user)
 
 /obj/machinery/door/proc/try_to_activate_door(mob/user)
 	add_fingerprint(user)


### PR DESCRIPTION
## What Does This PR Do
You can now knock on doors by alt-clicking them.
## Why It's Good For The Game
It'd be nice to knock on someone's door.
## Testing
Spawned many door variants. Alt-clicked them.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
add: Alt-click an airlock or door to knock on it.
/:cl: