### PR TITLE
Adds gauze / brute packs to emergency boxes

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -395,10 +395,12 @@
 		new /obj/item/tank/internals/emergency_oxygen/engi(src)
 		new /obj/item/reagent_containers/hypospray/autoinjector/survival(src)
 		new /obj/item/flashlight/flare(src)
+		new /obj/item/stack/medical/bruise_pack/advanced(src)
 	else
 		new /obj/item/tank/internals/emergency_oxygen(src)
 		new /obj/item/reagent_containers/hypospray/autoinjector/epinephrine(src)
 		new /obj/item/flashlight/flare/glowstick/emergency(src)
+		new /obj/item/stack/medical/bruise_pack(src)
 
 /obj/item/storage/box/survival/empty/populate_contents()
 	return
@@ -412,9 +414,11 @@
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_PREMIUM_INTERNALS))
 		new /obj/item/reagent_containers/hypospray/autoinjector/survival(src)
 		new /obj/item/flashlight/flare(src)
+		new /obj/item/stack/medical/bruise_pack/advanced(src)
 	else
 		new /obj/item/reagent_containers/hypospray/autoinjector/epinephrine(src)
 		new /obj/item/flashlight/flare/glowstick/emergency(src)
+		new /obj/item/stack/medical/bruise_pack(src)
 
 /obj/item/storage/box/survival_vox/empty/populate_contents()
 	return
@@ -444,11 +448,13 @@
 		new /obj/item/tank/internals/emergency_oxygen/double(src)
 		new /obj/item/reagent_containers/hypospray/autoinjector/survival(src)
 		new /obj/item/flashlight/flare(src)
+		new /obj/item/stack/medical/bruise_pack/advanced(src)
 	else
 		new /obj/item/tank/internals/emergency_oxygen/engi(src)
 		new /obj/item/reagent_containers/hypospray/autoinjector/epinephrine(src)
 		new /obj/item/flashlight/flare/glowstick/emergency(src)
-
+		new /obj/item/stack/medical/bruise_pack(src)
+		
 /obj/item/storage/box/engineer/empty/populate_contents()
 	return
 
@@ -461,10 +467,12 @@
 		new /obj/item/tank/internals/emergency_oxygen/double(src)
 		new /obj/item/reagent_containers/hypospray/autoinjector/survival(src)
 		new /obj/item/flashlight/flare(src)
+		new /obj/item/stack/medical/bruise_pack/advanced(src)
 	else
 		new /obj/item/tank/internals/emergency_oxygen/engi(src)
 		new /obj/item/reagent_containers/hypospray/autoinjector/epinephrine(src)
 		new /obj/item/flashlight/flare/glowstick/emergency(src)
+		new /obj/item/stack/medical/bruise_pack(src)
 
 /obj/item/storage/box/survival_mining/empty/populate_contents()
 	return
@@ -480,6 +488,7 @@
 	new /obj/item/reagent_containers/hypospray/autoinjector/epinephrine(src)
 	new /obj/item/reagent_containers/pill/initropidril(src)
 	new /obj/item/flashlight/flare/glowstick/red(src)
+	new /obj/item/stack/medical/bruise_pack/advanced(src)
 
 /obj/item/storage/box/survival_syndie/empty/populate_contents()
 	return


### PR DESCRIPTION
## What Does This PR Do
Adds gauze to all emergency boxes. This gauze is replaced with an advanced brute kit if the 'premium internals' station trait is active. Plasmamen are not included in this, as they do not have blood, and thus have no need for gauze.
## Why It's Good For The Game
Stopping people from bleeding out is good, and there's an added bonus of being able to gauze corpses as not to drag out all their blood.
## Testing
Spawned as a human, vox, plasmaman, miner, engineer, and member of the Syndicate. Checked internals boxes accordingly.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
add: Added gauze to all internals kits excluding plasmamen; Premium Internals replaces gauze with brute kits.
/:cl:
