### PR TITLE
Adds epidermal applicator to lifelike

### DIFF
--- a/code/game/objects/items/tools/epidermal_applicator.dm
+++ b/code/game/objects/items/tools/epidermal_applicator.dm
@@ -208,7 +208,6 @@
 
 	applying = FALSE
 
-
 /obj/item/epidermal_applicator/aftermarket
 	name = "aftermarket applicator"
 	desc = "A Zeng-Hu Pharmaceuticals epidermal applicator. This one looks a bit cheaply made."

--- a/code/game/objects/items/tools/epidermal_applicator.dm
+++ b/code/game/objects/items/tools/epidermal_applicator.dm
@@ -207,3 +207,9 @@
 			to_chat(target, SPAN_NOTICE("You feel a thin layer of synthetic skin form over your [affected.name]."))
 
 	applying = FALSE
+
+
+/obj/item/epidermal_applicator/aftermarket
+	name = "aftermarket applicator"
+	desc = "A Zeng-Hu Pharmaceuticals epidermal applicator. This one looks a bit cheaply made."
+	origin_tech = "biotech=1;materials=2;engineering=1"

--- a/code/modules/client/preference/quirks/positive_quirks.dm
+++ b/code/modules/client/preference/quirks/positive_quirks.dm
@@ -42,7 +42,7 @@
 			For IPCs, this covers all body parts, making them look human (except monitor-shaped heads). \
 			For all others, it covers prosthetic limbs."
 	cost = 4
-	item_to_give = /obj/item/epidermal_applicator
+	item_to_give = /obj/item/epidermal_applicator/aftermarket
 
 /datum/quirk/lifelike/apply_quirk_effects(mob/living/carbon/human/target, character)
 	. = ..(target, character)

--- a/code/modules/client/preference/quirks/positive_quirks.dm
+++ b/code/modules/client/preference/quirks/positive_quirks.dm
@@ -42,6 +42,7 @@
 			For IPCs, this covers all body parts, making them look human (except monitor-shaped heads). \
 			For all others, it covers prosthetic limbs."
 	cost = 4
+	item_to_give = /obj/item/epidermal_applicator
 
 /datum/quirk/lifelike/apply_quirk_effects(mob/living/carbon/human/target, character)
 	. = ..(target, character)


### PR DESCRIPTION
## What Does This PR Do
The lifelike quirk now grants an epidermal applicator to the user on top of its original benefits of applying synthetic skin. The epidermal applicator granted by this quirk does not come pre-loaded, and metal sheets must be supplied by the user. 
## Why It's Good For The Game
The main goal of this PR is convenience for lifelike users.
- Currently, lifelike is the only 4 point quirk you can actually lose;
- It is very simple to lose; synthetic skin is removed once a limb reaches 100% damage;
- Having to ask R&D for an item and then spend 5 metal and 10 seconds per body part (hands/feet excluded, as they are considered parts of the arms/legs) to regain the quirk you spent 4 points on is not enjoyable. 
## Testing
Took the lifelike quirk. Spawned. Checked bag.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
add: The lifelike quirk now grants an epidermal applicator.
/:cl: