### PR TITLE
Increases delay on heretic blade break

### DIFF
--- a/code/modules/antagonists/heretic/items/heretic_blades.dm
+++ b/code/modules/antagonists/heretic/items/heretic_blades.dm
@@ -48,7 +48,7 @@
 /// Attempts to teleport the passed mob to somewhere safe on the station, if they can use the blade.
 /obj/item/melee/sickly_blade/proc/seek_safety(mob/user)
 	to_chat(user, SPAN_WARNING("You begin to break the blade..."))
-	if(!do_after(user, 1 SECONDS, target = src, allow_moving = TRUE, must_be_held = TRUE))
+	if(!do_after(user, 2.5 SECONDS, target = src, allow_moving = TRUE, must_be_held = TRUE))
 		to_chat(user, SPAN_WARNING("You fail to break the blade!"))
 		return
 	var/turf/safe_turf = find_safe_turf(blacklist_areas = GLOB.blacklisted_heretic_areas)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Increases the time it takes for a heretic to snap their blade from 1 second to 2.5 seconds.

## Why It's Good For The Game

Heretic blade break is nearly instant, and is faster than methods of detaining them are capable of handling it unless the heretic gets floored. This allows for more counterplay.

## Testing

I broke a blade.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<img width="512" height="139" alt="image" src="https://github.com/user-attachments/assets/43043c56-14b7-4764-b0d5-1900f7b45628" />

## Changelog

:cl:
tweak: Increased blade break do-after time by 150%
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
