### PR TITLE
Adds fistbumps as an emote

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -210,6 +210,7 @@
 #define STATUS_EFFECT_OFFERING_EFTPOS /datum/status_effect/high_five/offering_eftpos
 #define STATUS_EFFECT_HANDSHAKE /datum/status_effect/high_five/handshake
 #define STATUS_EFFECT_RPS /datum/status_effect/high_five/rps
+#define STATUS_EFFECT_FISTBUMP /datum/status_effect/high_five/fistbump
 
 #define STATUS_EFFECT_CHARGING /datum/status_effect/charging
 

--- a/code/datums/keybindings/emote_keybinds.dm
+++ b/code/datums/keybindings/emote_keybinds.dm
@@ -457,6 +457,10 @@
 	linked_emote = /datum/emote/living/carbon/human/highfive/handshake
 	name = "Handshake"
 
+/datum/keybinding/emote/carbon/human/fistbump
+	linked_emote = /datum/emote/living/carbon/human/highfive/fistbump
+	name = "Fistbump"
+
 /datum/keybinding/emote/carbon/human/snap
 	linked_emote = /datum/emote/living/carbon/human/snap
 	name = "Snap"

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -267,6 +267,22 @@
 	)
 	return show_radial_menu(user, user, move_icons)
 
+/datum/status_effect/high_five/fistbump
+	id = "fistbump"
+	critical_success = "give each other an AWESOME fistbump!"
+	success = "give each other a fistbump!"
+	request = "requests a fistbump!"
+	sound_effect = "sound/weapons/thudswoosh.ogg"
+
+/datum/status_effect/high_five/fistbump/get_missed_message()
+	var/list/missed_messages = list(
+		"drops [owner.p_their()] fist.",
+		"taps [owner.p_their()] outstretched fist with [owner.p_their()] other hand and gives [owner.p_themselves()] a fistbump.",
+		"fistbumps [owner.p_themselves()] shamefully."
+	)
+
+	return pick(missed_messages)
+
 /// A status effect that can have a certain amount of "bonus" duration added, which extends the duration every tick,
 /// although there is a maximum amount of bonus time that can be active at any given time.
 /datum/status_effect/limited_bonus

--- a/code/modules/mob/living/carbon/human/human_emote.dm
+++ b/code/modules/mob/living/carbon/human/human_emote.dm
@@ -440,6 +440,11 @@
 	key_third_person = "handshakes"
 	status = STATUS_EFFECT_HANDSHAKE
 
+/datum/emote/living/carbon/human/highfive/fistbump
+	key = "fistbump"
+	key_third_person = "fistbumps"
+	status = STATUS_EFFECT_FISTBUMP
+
 /datum/emote/living/carbon/human/highfive/rps
 	key = "rps"
 	param_desc = "r,p,s"


### PR DESCRIPTION
## What Does This PR Do
Adds fistbumps as an interactive emote similar to handshakes.
## Why It's Good For The Game
Sometimes, you just gotta fistbump someone.
## Testing
Opened a local server. Joined with two clients. Did *fistbump.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
add: The *fistbump emote, which lets you fistbump your co-workers, has been added.
/:cl: