### PR TITLE
Flockmind Tweaks

### DIFF
--- a/code/modules/antagonists/flockmind/flock_language.dm
+++ b/code/modules/antagonists/flockmind/flock_language.dm
@@ -38,7 +38,15 @@
 		message_body += "</font>"
 	else if(isflockworker(speaker))
 		var/mob/speaking_mob = speaker
-		message_start = list("<i><span class='game say'>[name]</i>: ", SPAN_FLOCKSAY_GRADIENT("Drone [speaking_mob.real_name]"))
+		var/flock_overmind = FALSE
+		if(isflockdrone(speaking_mob))
+			var/mob/living/basic/flock/drone/D = speaking_mob
+			if(D.controlled_by)
+				flock_overmind = TRUE
+				message_start = list("<i><font size=4><span class='game say'>[name]</i>: ", SPAN_FLOCKSAY_GRADIENT("[isflockmind(D.controlled_by) ? "" : "Flocktrace "][D.controlled_by.real_name]"))
+				message_body += "</font>"
+		if(!flock_overmind)
+			message_start = list("<i><span class='game say'>[name]</i>: ", SPAN_FLOCKSAY_GRADIENT("Drone [speaking_mob.real_name]"))
 
 	for(var/mob/M in GLOB.dead_mob_list)
 		if(!isnewplayer(M) && !isbrain(M) && speaker)
@@ -50,6 +58,8 @@
 		var/scrambled = SPAN_FLOCKSAY_GRADIENT(scramble(message))
 		var/living_msg = "[speaker.name] [get_spoken_verb(message)] \"[scrambled]\""
 		for(var/mob/M in hearers(5, get_turf(speaker)))
+			if(isflockmob(M))
+				continue
 			M.show_message(living_msg, 2)
 			if(M.client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT && ismob(speaker))
 				var/mob/speaking_mob = speaker

--- a/code/modules/antagonists/flockmind/flock_mob/flock_mob.dm
+++ b/code/modules/antagonists/flockmind/flock_mob/flock_mob.dm
@@ -99,9 +99,6 @@
 	qdel(src)
 	return TRUE
 
-/mob/living/basic/flock/Process_Spacemove(movement_dir = 0, continuous_move = FALSE)
-	return TRUE
-
 /mob/living/basic/flock/set_stat(new_stat)
 	. = ..()
 	if(stat != DEAD)

--- a/code/modules/antagonists/flockmind/flock_mob/flockdrone.dm
+++ b/code/modules/antagonists/flockmind/flock_mob/flockdrone.dm
@@ -441,7 +441,6 @@
 		master_bird.key = key
 		master_bird.mind = mind
 
-	flock_talk(null, "Control of [real_name] surrendered.", flock, involuntary = TRUE)
 	if(!dest_was_safe)
 		to_chat(master_bird, SPAN_WARNING("You feel your consciousness weaking as you are ripped further from your rift, and you retreat back to safety."))
 

--- a/code/modules/antagonists/flockmind/flock_structure/flock_cage.dm
+++ b/code/modules/antagonists/flockmind/flock_structure/flock_cage.dm
@@ -53,6 +53,7 @@
 		victim.gib()
 		var/obj/structure/flock/egg/bit/B = new /obj/structure/flock/egg/bit(get_turf(src), flock)
 		qdel(src)
+		return
 
 	victim.adjustCloneLoss(rand(2,6))
 

--- a/code/modules/antagonists/flockmind/flock_structure/flock_cage.dm
+++ b/code/modules/antagonists/flockmind/flock_structure/flock_cage.dm
@@ -11,15 +11,10 @@
 	flock_id = "Matter reprocessor"
 
 	var/tmp/mob/living/victim
-	/// Current item being munched on.
-	var/tmp/obj/item/eating
 
-	/// With this much gnesis, create an egg.
-	var/egg_gnesis_cost = 100
-	/// Rate of damage to items being consumed by the cage
-	var/absorption_rate = 4
-	/// Per point of damage, generate this much substrate.
-	var/integrity_substrate_ratio = 2
+	/// Has the nest spewed forth mobs?
+	var/hatched = FALSE
+
 	/// Timer until you can ghost from your body without penalty
 	var/ghost_timer
 
@@ -28,19 +23,16 @@
 
 /obj/structure/flock/cage/Initialize(mapload, datum/flock/join_flock)
 	. = ..()
-	create_reagents(200)
+	create_reagents(100)
+	reagents.add_reagent("gnesis_tox", 100)
 	AddComponent(/datum/component/flock_protection)
 
 /obj/structure/flock/cage/Destroy()
 	QDEL_NULL(victim)
-	QDEL_NULL(eating)
 	return ..()
 
 /obj/structure/flock/cage/deconstruct(disassembled)
-	if(disassembled)
-		spend_gnesis(TRUE)
-	else
-		reagents.reaction(get_turf(src), REAGENT_TOUCH)
+	reagents.reaction(get_turf(src), REAGENT_TOUCH)
 
 	if(victim)
 		visible_message(SPAN_WARNING("[victim] breaks free from [src]."))
@@ -53,39 +45,27 @@
 	. = ..()
 
 /obj/structure/flock/cage/process(seconds_per_tick)
-	spend_gnesis()
 
 	if(victim && flock)
 		flock.update_enemy(victim)
 
-	if(QDELETED(eating))
-		eating = null
-
-	if(!eating)
-		var/obj/item/edibles = list()
-		for(var/obj/item/edible in src)
-			edibles += edible
-
-		if(length(edibles))
-			set_eating_target(pick(edibles))
-			playsound(src, 'sound/goonstation/weapons/nano-blade-1.ogg', 50, TRUE)
-
-			if(victim?.stat == CONSCIOUS)
-				to_chat(victim, SPAN_WARNING("[eating] begins to melt away."))
-
-		else
-			chew_on_mob(seconds_per_tick)
-
-	else
-		var/added = eating.take_damage(absorption_rate * seconds_per_tick * 25, BRUTE, armor_penetration_percentage = 100)
-		reagents.add_reagent(/datum/reagent/gnesis, integrity_substrate_ratio * added)
+	victim.adjustCloneLoss(rand(2,6))
 
 	if(victim && COOLDOWN_FINISHED(src, flock_message_cd))
 		COOLDOWN_START(src, flock_message_cd, rand(10, 25) SECONDS)
+		playsound(src, 'sound/goonstation/weapons/nano-blade-1.ogg', 50, TRUE)
 		to_chat(victim, SPAN_FLOCKSAY("<i>[pick(strings("flock.json", "conversion"))]</i>"))
 
-	if(!victim) // Victim gibbed
-		deconstruct(TRUE)
+	if(victim.stat == DEAD && !hatched) // Victim killed. Make flock mobs
+		hatched = TRUE
+		var/num_bits = rand(1, 2)
+		var/num_drones = rand(1, 2)
+		for(var/i in 1 to num_bits)
+			var/obj/structure/flock/egg/bit/B = new /obj/structure/flock/egg/bit(get_turf(src), flock)
+			B.throw_at(get_random_perimeter_turf(get_turf(src), 10), 10, 3, spin = FALSE)
+		for(var/i in 1 to num_drones)
+			var/obj/structure/flock/egg/D = new /obj/structure/flock/egg(get_turf(src), flock)
+			D.throw_at(get_random_perimeter_turf(get_turf(src), 10), 10, 3, spin = FALSE)
 
 /obj/structure/flock/cage/container_resist(mob/living/user)
 	to_chat(victim, SPAN_WARNING("You resist against the confines of the cage!"))
@@ -115,125 +95,12 @@
 
 	take_damage(1, BRUTE)
 
-/obj/structure/flock/cage/flock_structure_examine(mob/user)
-	return list(
-		SPAN_FLOCKSAY("<b>Volume:</b> [reagents.get_reagent_amount(/datum/reagent/gnesis)]"),
-		SPAN_FLOCKSAY("<b>Needed volume:</b> [egg_gnesis_cost]<br>"),
-	)
-
-/// Picks an item, organ, or bodypart, to munch on.
-/obj/structure/flock/cage/proc/chew_on_mob(seconds_per_tick)
-	if(!ishuman(victim))
-		victim.adjustBruteLoss(absorption_rate * seconds_per_tick)
-		if(victim.stat == DEAD)
-			visible_message(SPAN_DANGER("[src] rips apart what remains of [victim]."))
-			victim.gib()
-			set_victim(null)
-		return
-
-	var/mob/living/carbon/human/human_victim = victim
-	var/list/items = human_victim.get_equipped_items()
-	if(length(items))
-		while(length(items) && !eating)
-			var/obj/item/candidate = pick_n_take(items)
-			if(candidate.resistance_flags & INDESTRUCTIBLE)
-				human_victim.drop_item_to_ground(candidate, TRUE, TRUE)
-				visible_message(SPAN_WARNING("[src] pulls [eating] from [human_victim] and drops it!"))
-				continue
-			human_victim.transfer_item_to(candidate, src, TRUE, TRUE)
-			if(!QDELETED(candidate))
-				set_eating_target(candidate)
-
-		if(eating)
-			visible_message(SPAN_WARNING("[src] pulls [eating] from [human_victim] and begins ripping it apart."))
-			playsound(src, 'sound/goonstation/weapons/nano-blade-1.ogg', 50, TRUE)
-		return
-
-	var/list/bodyparts = human_victim.bodyparts.Copy()
-	for(var/obj/item/organ/external/BP in bodyparts)
-		if(BP.body_part in list(HEAD, UPPER_TORSO, LOWER_TORSO))
-			bodyparts -= BP
-
-	if(length(bodyparts))
-		var/obj/item/organ/external/yummy_appendage = pick(bodyparts)
-
-		human_victim.pain(yummy_appendage.name, 85)
-		yummy_appendage.droplimb(FALSE)
-		set_eating_target(yummy_appendage)
-		eating.forceMove(src)
-
-		visible_message(SPAN_DANGER("[src] tears [eating] from [human_victim] and begins ripping it apart."))
-		return
-
-	var/list/skip_organs = list("eyes", "ears", "brain", "heart", "lungs")
-	for(var/obj/item/organ/internal/O in bodyparts)
-		if(O.slot in skip_organs)
-			bodyparts -= O
-
-	if(length(bodyparts))
-		var/obj/item/organ/internal/yummy_organ = pick(bodyparts)
-		var/organ_loc_str = yummy_organ.parent_organ
-		human_victim.pain(organ_loc_str, 85)
-		yummy_organ.remove(human_victim)
-		if(!QDELING(yummy_organ))
-			set_eating_target(yummy_organ)
-			eating.forceMove(src)
-
-		visible_message(SPAN_DANGER("[src] tears [eating] from [human_victim]'s [organ_loc_str] and begins ripping it apart."))
-		return
-
-	visible_message(SPAN_DANGER("[src] rips apart what remains of [human_victim]."))
-	set_victim(null)
-	human_victim.gib(TRUE, TRUE, TRUE)
-
 // INTO THE CAGE
 /obj/structure/flock/cage/proc/cage_mob(mob/living/L)
 	L.forceMove(src)
 	set_victim(L)
 	victim.visible_message(SPAN_DANGER("A [name] materializes around [victim],"))
 	ghost_timer = addtimer(CALLBACK(src, PROC_REF(ghost_check), L), 15 SECONDS, TIMER_UNIQUE|TIMER_STOPPABLE)
-
-/// Spends gnesis on eggs or a cube. Only spends on eggs by default.
-/obj/structure/flock/cage/proc/spend_gnesis(all = FALSE)
-	var/egg_spawn_count = 0
-	var/spend_on_cube = 0
-
-	// Get egg count and spend the gnesis.
-	while(reagents.has_reagent(/datum/reagent/gnesis, egg_gnesis_cost))
-		reagents.remove_reagent(/datum/reagent/gnesis, egg_gnesis_cost)
-		egg_spawn_count++
-
-	// Spawn eggs or pool it to the cube
-	for(var/i in 1 to egg_spawn_count)
-		if(length(flock?.drones) <= FLOCK_DRONE_LIMIT)
-			var/obj/structure/flock/egg/egg = new(drop_location(), flock)
-			egg.throw_at(get_edge_target_turf(egg, pick(GLOB.alldirs)), 6, 3)
-		else
-			spend_on_cube += egg_gnesis_cost
-
-	// If we're dumping it all, collect the remaining gnesis
-	if(all)
-		spend_on_cube += reagents.get_reagent_amount(/datum/reagent/gnesis)
-
-	// Cube
-	if(spend_on_cube && all)
-		reagents.remove_reagent(/datum/reagent/gnesis, spend_on_cube)
-
-		var/obj/item/flock_cube/cube = new
-		cube.substrate = spend_on_cube
-		cube.forceMove(drop_location())
-
-/// Setter for eating, no side effects.
-/obj/structure/flock/cage/proc/set_eating_target(obj/item/new_eating)
-	if(eating)
-		UnregisterSignal(eating, COMSIG_MOVABLE_MOVED)
-
-	eating = new_eating
-
-	if(!eating)
-		return
-
-	RegisterSignal(eating, COMSIG_MOVABLE_MOVED, PROC_REF(target_gone))
 
 /// Setter for victim, no side effects.
 /obj/structure/flock/cage/proc/set_victim(mob/living/new_victim)
@@ -255,10 +122,6 @@
 	SIGNAL_HANDLER
 	if(!QDELING(src))
 		deconstruct(FALSE)
-
-/obj/structure/flock/cage/proc/target_gone(datum/source)
-	SIGNAL_HANDLER
-	set_eating_target(null)
 
 /obj/structure/flock/cage/proc/ghost_check(mob/user)
 	victim.throw_alert("ghost_cage", /atom/movable/screen/alert/ghost/flock)

--- a/code/modules/antagonists/flockmind/flock_structure/flock_cage.dm
+++ b/code/modules/antagonists/flockmind/flock_structure/flock_cage.dm
@@ -28,6 +28,8 @@
 	AddComponent(/datum/component/flock_protection)
 
 /obj/structure/flock/cage/Destroy()
+	if(victim)
+		victim.clear_alert("ghost_cage")
 	QDEL_NULL(victim)
 	return ..()
 

--- a/code/modules/antagonists/flockmind/flock_structure/flock_cage.dm
+++ b/code/modules/antagonists/flockmind/flock_structure/flock_cage.dm
@@ -49,6 +49,11 @@
 	if(victim && flock)
 		flock.update_enemy(victim)
 
+	if(isanimal_or_basicmob(victim))
+		victim.gib()
+		var/obj/structure/flock/egg/bit/B = new /obj/structure/flock/egg/bit(get_turf(src), flock)
+		qdel(src)
+
 	victim.adjustCloneLoss(rand(2,6))
 
 	if(victim && COOLDOWN_FINISHED(src, flock_message_cd))

--- a/code/modules/antagonists/flockmind/flock_structure/flock_fabricator.dm
+++ b/code/modules/antagonists/flockmind/flock_structure/flock_fabricator.dm
@@ -57,7 +57,6 @@
 	if(QDELING(src))
 		return
 
-	flock_talk(src, "ALERT: No substrate remaining.", flock, involuntary = TRUE)
 	update_appearance(UPDATE_ICON_STATE)
 
 //


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

This PR does the following:
1. Removes the ability for flockdrones and flockbits to move freely in space. They now drift like any other mob would.
2. Flock cages no longer consume equipment, limbs, and similar. Now they deal small amounts of clone damage until the victim dies, upon which it will release a group of mobs. The cage will remain with the corpse inside until it is free.
3. Flock language is improved to reduce spam and make flockmind and flocktrace speech more clear.

## Why It's Good For The Game

Flockmind can be a bit too damaging when it comes to the cages consuming equipment. While drones will consume things dropped on the ground, the cages will consume all, which is not good. Likewise, it's too easy for flockmind to take to space to avoid damage to drones - this makes space more risky.

Finally, it makes the language less confusing for the flock to understand in the chat by filtering out the scrambled terms and enlarging flock controller speech while piloting drones.

Fixes #32558

## Testing

Spawned as flock. Caged a human. Caged a pig. Broke a cage. Spoke as a drone. Spoke as an overmind. Drifted away in space and cried when the drone depowered when it left Z.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<img width="1582" height="288" alt="image" src="https://github.com/user-attachments/assets/9a6273e6-eae8-4c88-a8d5-86c25e823dd5" />

## Changelog

:cl:
tweak: Removed flock mob spacewalking
tweak: Reworked flock cage mechanics
tweak: Adjusted flock language to be more legible
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
