### PR TITLE
Prevent a runtime on attempting to build an invalid quirk.

### DIFF
--- a/code/modules/client/preference/character.dm
+++ b/code/modules/client/preference/character.dm
@@ -2395,6 +2395,8 @@
 	quirks.Cut()
 	for(var/quirk_name in quirk_cache)
 		var/datum/quirk/chosen_quirk = GLOB.quirk_paths["[quirk_name]"]
+		if(!chosen_quirk)
+			continue
 		var/datum/quirk/quirk = new chosen_quirk.type // Don't want hard refs to the global list
 		if(!quirk)
 			continue

--- a/code/modules/client/preference/character.dm
+++ b/code/modules/client/preference/character.dm
@@ -2396,6 +2396,7 @@
 	for(var/quirk_name in quirk_cache)
 		var/datum/quirk/chosen_quirk = GLOB.quirk_paths["[quirk_name]"]
 		if(!chosen_quirk)
+			log_debug("rebuild_quirks() tried to load an invalid quirk: '[quirk_name]'")
 			continue
 		var/datum/quirk/quirk = new chosen_quirk.type // Don't want hard refs to the global list
 		if(!quirk)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Prevents a runtime when a quirk path is not found on a global lookup.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

I mean, it prevents a runtime.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled. Requesting assistance in reproducing the runtime to be absolutely sure, but based on the runtime text I've seen, this should solve the issue right away.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed a runtime when attempting to load an invalid quirk.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
