### PR TITLE
Prevent a runtime when experiencing a blob zombie hallucination.

### DIFF
--- a/code/modules/hallucinations/effects/major.dm
+++ b/code/modules/hallucinations/effects/major.dm
@@ -442,7 +442,7 @@
 	name = "blob zombie"
 	var/image/I = image('icons/mob/blob.dmi', src, "blob_head")
 	I.color = blob.color
-	target.client.images += I
+	target.client?.images += I
 	owning_hallucination = blob
 	blob.chaser_blob_head = I
 

--- a/code/modules/hallucinations/effects/major.dm
+++ b/code/modules/hallucinations/effects/major.dm
@@ -472,7 +472,7 @@
 	. = ..()
 	var/image/I = image('icons/mob/blob.dmi', target, icon_state = "blob_head")
 	I.color = blob.color
-	target.client.images += I
+	target.client?.images += I
 	blob.target_blob_head = I
 
 /**


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Prevents a runtime when a clientless mob experiences a blob zombie hallucination.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Well, it prevents a runtime.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted, put a bunch of clientless human mobs next to the supermatter and activated it. Ran it for like 10 minutes, watching them all hallucinate relentlessly, and received no runtimes.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
