### PR TITLE
Flash tweak + Attack Chain Issue Fix

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -27,6 +27,8 @@
 	var/flash_timer
 	/// How long do we have between flashes
 	var/time_between_flashes = 5 SECONDS
+	/// Is this a cyborg's flash?
+	var/borg_flash = FALSE
 	new_attack_chain = TRUE
 
 	var/use_sound = 'sound/weapons/flash.ogg'
@@ -88,6 +90,9 @@
 		deltimer(flash_timer)
 		flash_timer = addtimer(CALLBACK(src, PROC_REF(flash_recharge)), 10 SECONDS, TIMER_STOPPABLE)
 
+	if(borg_flash)
+		new /obj/effect/temp_visual/borgflash(get_turf(src))
+
 	playsound(loc, use_sound, 100, TRUE)
 
 	flick("[initial(icon_state)]2", src)
@@ -143,6 +148,7 @@
 
 	if(!try_use_flash(user))
 		return ITEM_INTERACT_COMPLETE
+
 
 	if(istype(target, /obj/machinery/camera))
 		var/obj/machinery/camera/camera = target
@@ -250,22 +256,8 @@
 	return TRUE
 
 /obj/item/flash/cyborg
-	origin_tech = null
 	can_overcharge = FALSE
-
-/obj/item/flash/cyborg/interact_with_atom(atom/target, mob/living/user, list/modifiers)
-	if(!..())
-		return ITEM_INTERACT_COMPLETE
-
-	new /obj/effect/temp_visual/borgflash(get_turf(src))
-	return ITEM_INTERACT_COMPLETE
-
-/obj/item/flash/cyborg/activate_self(mob/user)
-	if(!..())
-		return ITEM_INTERACT_COMPLETE
-	
-	new /obj/effect/temp_visual/borgflash(get_turf(src))
-	return ITEM_INTERACT_COMPLETE
+	borg_flash = TRUE
 
 /obj/item/flash/cyborg/cyborg_recharge(coeff, emagged)
 	if(broken)

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -138,11 +138,11 @@
 		target.AdjustConfused(power)
 
 /obj/item/flash/interact_with_atom(atom/target, mob/living/user, list/modifiers)
-	if(!istype(target, /obj/machinery/camera) && !iscarbon(target) && !issilicon(target))
+	if(!ismob(target) && !istype(target, /obj/machinery/camera))
 		return NONE
 
 	if(!try_use_flash(user))
-		return NONE
+		return ITEM_INTERACT_COMPLETE
 
 	if(istype(target, /obj/machinery/camera))
 		var/obj/machinery/camera/camera = target
@@ -190,6 +190,7 @@
 		SPAN_WARNING("You fail to blind [target] with [src]!"),
 		SPAN_HEAR("A click and a rising high pitched tone fills the air!")
 	)
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/flash/activate_self(mob/user)
 	if(..())
@@ -253,12 +254,18 @@
 	can_overcharge = FALSE
 
 /obj/item/flash/cyborg/interact_with_atom(atom/target, mob/living/user, list/modifiers)
-	..()
+	if(!..())
+		return ITEM_INTERACT_COMPLETE
+
 	new /obj/effect/temp_visual/borgflash(get_turf(src))
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/flash/cyborg/activate_self(mob/user)
-	..()
+	if(!..())
+		return ITEM_INTERACT_COMPLETE
+	
 	new /obj/effect/temp_visual/borgflash(get_turf(src))
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/flash/cyborg/cyborg_recharge(coeff, emagged)
 	if(broken)


### PR DESCRIPTION
## What Does This PR Do
* Fixes an issue where borg flashes perform a melee attack on mobs due to not returning `ITEM_INTERACT_COMPLETE`.
* Fixes infinite temp effect spam from the borg flash, including when clicking non-mobs.
* Flashes will now attempt to flash non carbon, non silicon mobs. This will always return a failed flash attempt, as basic/simple mobs don't have a flash proc, but it looks better than hitting them (and I swear that they used to do this before the migration).
## Why It's Good For The Game
* Fixes unintentional changes caused by attack chain migration.
* Fixes a longstanding bug where borgs could spam the temp flash effect even during cooldown.
## Testing
Tested the flash against a naked skrell, a naked skrell with sunglasses, ian, a cyborg, a light tube, and a wall.
This test was performed with both human and borg flashes.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: Borg flashes no longer melee attack mobs.
fix: Borgs cannot spam the temp flash effect during cooldown anymore.
tweak: Flashes will try to flash non-carbon, non-slicon mobs instead of melee attacking with the flash. This will not actually flash the mob, as simple/basic mobs are not vulnerable to flashes.
/:cl: