### PR TITLE
[s] Fixes a shadow demon exploit

### DIFF
--- a/code/modules/mob/living/basic/hostile/demons/demon_powers.dm
+++ b/code/modules/mob/living/basic/hostile/demons/demon_powers.dm
@@ -82,6 +82,14 @@
 	invocation_type = "none"
 	invocation = null
 
+/datum/spell/fireball/shadow_grapple/can_cast(mob/user, charge_check, show_message)
+	// Prevents casting while shadow crawling.
+	if(istype(user.loc, /obj/effect/dummy/slaughter))
+		to_chat(user, SPAN_WARNING("You need to manifest before you can use this ability!"))
+		return FALSE
+	
+	return ..()
+
 /datum/spell/fireball/shadow_grapple/update_spell_icon()
 	return
 


### PR DESCRIPTION
## What Does This PR Do
Fixes a shadow demon exploit.
## Why It's Good For The Game
Exploit bad.
## Testing
Tried to cast ability in shadow crawl, couldn't. Readied ability and entered shadow crawl, couldn't cast until leaving shadow crawl.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog

:cl:
fix: Fixes a shadow demon exploit.
/:cl: