### PR TITLE
Reduced legion mob lag

### DIFF
--- a/code/modules/mob/living/basic/mining/hivelord.dm
+++ b/code/modules/mob/living/basic/mining/hivelord.dm
@@ -218,8 +218,12 @@
 		if(stored_mob)
 			stored_mob.forceMove(get_turf(src))
 			stored_mob = null
-		else
+		else if(HAS_TRAIT(src, TRAIT_FROM_TENDRIL))
 			new /obj/effect/mob_spawn/human/corpse/charredskeleton(T)
+		else if(dwarf_mob)
+			new /obj/effect/mob_spawn/human/corpse/charredskeleton/legioninfested/dwarf(T)
+		else
+			new /obj/effect/mob_spawn/human/corpse/charredskeleton/legioninfested(T)
 	..(gibbed)
 
 // Legion skull
@@ -339,17 +343,16 @@
 
 // Legion infested mobs
 
-/obj/effect/mob_spawn/human/corpse/damaged/legioninfested/dwarf/equip(mob/living/carbon/human/H)
+/obj/effect/mob_spawn/human/corpse/charredskeleton/legioninfested/dwarf/equip(mob/living/carbon/human/H)
 	. = ..()
 	H.dna.SetSEState(GLOB.smallsizeblock, TRUE, TRUE)
 	singlemutcheck(H, GLOB.smallsizeblock, MUTCHK_FORCED)
 	H.update_mutations()
 
-/obj/effect/mob_spawn/human/corpse/damaged/legioninfested/Initialize(mapload)
+/obj/effect/mob_spawn/human/corpse/charredskeleton/legioninfested/Initialize(mapload)
 	var/type = pickweight(list("Miner" = 66, "Ashwalker" = 10, "Golem" = 10,"Clown" = 10, pick("Shadow", "YeOlde", "Cultist") = 4))
 	switch(type)
 		if("Miner")
-			mob_species = pickweight(list(/datum/species/human = 72, /datum/species/unathi = 28))
 			uniform = /obj/item/clothing/under/rank/cargo/miner/lavaland
 			if(prob(4))
 				belt = pickweight(list(/obj/item/storage/belt/mining = 2, /obj/item/storage/belt/mining/alt = 2))
@@ -368,7 +371,6 @@
 			if(prob(10))
 				l_pocket = pickweight(list(/obj/item/stack/spacecash/c200 = 7, /obj/item/reagent_containers/hypospray/autoinjector/survival = 2, /obj/item/borg/upgrade/modkit/cooldown = 1 ))
 		if("Ashwalker")
-			mob_species = /datum/species/unathi/ashwalker
 			uniform = /obj/item/clothing/under/costume/gladiator/ash_walker
 			if(prob(95))
 				head = /obj/item/clothing/head/helmet/gladiator
@@ -398,7 +400,6 @@
 			if(prob(10))
 				r_pocket = /obj/item/bio_chip_implanter/sad_trombone
 		if("Golem")
-			mob_species = pick(/datum/species/golem/adamantine, /datum/species/golem/plasma, /datum/species/golem/diamond, /datum/species/golem/gold, /datum/species/golem/silver, /datum/species/golem/plasteel, /datum/species/golem/titanium, /datum/species/golem/plastitanium)
 			if(prob(30))
 				glasses = pickweight(list(/obj/item/clothing/glasses/meson = 2, /obj/item/clothing/glasses/hud/health = 2, /obj/item/clothing/glasses/hud/diagnostic =2, /obj/item/clothing/glasses/science = 2, /obj/item/clothing/glasses/welding = 2, /obj/item/clothing/glasses/night = 1))
 			if(prob(10))

--- a/code/modules/mob/living/basic/mining/hivelord.dm
+++ b/code/modules/mob/living/basic/mining/hivelord.dm
@@ -218,12 +218,8 @@
 		if(stored_mob)
 			stored_mob.forceMove(get_turf(src))
 			stored_mob = null
-		else if(HAS_TRAIT(src, TRAIT_FROM_TENDRIL))
-			new /obj/effect/mob_spawn/human/corpse/charredskeleton(T)
-		else if(dwarf_mob)
-			new /obj/effect/mob_spawn/human/corpse/damaged/legioninfested/dwarf(T)
 		else
-			new /obj/effect/mob_spawn/human/corpse/damaged/legioninfested(T)
+			new /obj/effect/mob_spawn/human/corpse/charredskeleton(T)
 	..(gibbed)
 
 // Legion skull


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Legion mobs will now always drop a charred skeleton on death instead of a random bashed up corpse when they die. This does not affect legions made of player corpses.

## Why It's Good For The Game

We noticed that legions have a 20x lag impact on death thanks to the random corpses. This should fix some of the TiDi.

## Testing

Killed a legion. It died.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Legions now drop charred skeletons instead of random corpses
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
