### PR TITLE
ERT names now match their species

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -449,6 +449,7 @@
 	flags = RESTRICTED
 	syllables = list("ba","da","ka","ki","to","ta","sa","so","a","e","i","o","u","am","on","na","in",
 					"ko",)
+	english_names = 1
 
 // Galactic common languages (systemwide accepted standards).
 /datum/language/trader

--- a/code/modules/response_team/ert.dm
+++ b/code/modules/response_team/ert.dm
@@ -181,7 +181,7 @@ GLOBAL_LIST_EMPTY(ert_request_messages)
 	if(M.gender != FEMALE) // no beard for women pls
 		head_organ.f_style = random_facial_hair_style(head_organ.dna.species.name)
 
-	M.rename_character(M.real_name, "[pick("Corporal", "Sergeant", "Staff Sergeant", "Sergeant First Class", "Master Sergeant", "Sergeant Major")] [pick(GLOB.last_names)]")
+	M.rename_character(M.real_name, "[pick("Corporal", "Sergeant", "Staff Sergeant", "Sergeant First Class", "Master Sergeant", "Sergeant Major")] [pick(S.get_random_name(M.gender))]")
 	M.age = rand(23,35)
 	M.update_dna()
 	M.regenerate_icons()

--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -45,7 +45,7 @@
 /datum/outfit/job/response_team/commander/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 
-	H.rename_character(H.real_name, "[pick("Lieutenant", "Captain", "Major")] [pick(GLOB.last_names)]")
+	H.rename_character(H.real_name, "[pick("Lieutenant", "Captain", "Major")] [pick(H.dna.species.get_random_name(H.gender))]")
 	H.age = rand(35, 45)
 
 /datum/outfit/job/response_team/commander/amber


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

ERTs that are spawned now have their names follow species naming conventions, preceded by their rank.

## Why It's Good For The Game

Consistency in naming.

## Testing

Spawned as a nian ERT commander. Had nian name.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: ERT now follow species naming conventions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
