### PR TITLE
Fixes HUDs resetting on aghost or similar

### DIFF
--- a/code/datums/atom_hud.dm
+++ b/code/datums/atom_hud.dm
@@ -129,8 +129,8 @@ GLOBAL_LIST_INIT(huds, alist(
 			serv_huds += serv.thrallhud
 
 	for(var/datum/atom_hud/hud in (GLOB.all_huds|serv_huds))//|gang_huds))
-		var/list/hudusers = hud.hudusers[src]
-		if(src in hudusers)
+		if(src in hud.hudusers)
+			var/list/hudusers = hud.hudusers[src]
 			hud.add_hud_to(src, hudusers[1])
 
 /mob/new_player/reload_huds()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes an issue where when you have a HUD and ghost, sometimes it gets rid of your ghost hud.

## Why It's Good For The Game

Bugs bad

## Testing

Spawned as a traitor assistant. Aghosted. Reincarnated as an NNO. Aghosted. Still had all HUDs.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
fix: Fixed a bug that sometimes reset your ghost hud visibility
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
