### PR TITLE
Adjusts antag ruleset weights

### DIFF
--- a/code/game/gamemodes/dynamic/antag_rulesets.dm
+++ b/code/game/gamemodes/dynamic/antag_rulesets.dm
@@ -214,7 +214,7 @@
 
 /datum/ruleset/traitor
 	name = "Traitor"
-	ruleset_weight = 11
+	ruleset_weight = 15
 	antag_cost = 7
 	antag_weight = 2
 	antagonist_type = /datum/antagonist/traitor
@@ -232,7 +232,7 @@
 
 /datum/ruleset/heretic
 	name = "Heretic"
-	ruleset_weight = 10
+	ruleset_weight = 6
 	antag_cost = 10
 	antagonist_type = /datum/antagonist/heretic
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Increases the ruleset weight of traitor from 10 to 15, and reduces the weight of heretic from 10 to 6

## Why It's Good For The Game

Increased diversity of antagonists. Traitors are our most diverse antag in regards to potential builds, tactics, and objectives, yet it has a less chance of spawning than vampire. This puts them higher. Likewise, heretics are a bit too common - this makes them rarer.

## Testing

Compiled

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<img width="1365" height="630" alt="image" src="https://github.com/user-attachments/assets/56a7a0a3-1a7b-4882-83a3-93d341591c6e" />

## Changelog

:cl:
tweak: Increased chance of traitors, reduced chance of heretics
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
