### PR TITLE
Migrate mods and modsuits to the new attack chain.

### DIFF
--- a/code/modules/mod/mod_construction.dm
+++ b/code/modules/mod/mod_construction.dm
@@ -143,130 +143,197 @@
 			display_text = "All it's missing is <b>external plating</b>..."
 	. += SPAN_NOTICE("[display_text]")
 
-/obj/item/mod/construction/shell/attackby__legacy__attackchain(obj/item/part, mob/user, params)
-	. = ..()
+/obj/item/mod/construction/shell/screwdriver_act(mob/living/user, obj/item/screwdriver/tool)
+	switch(construction_step)
+		if(CORE_STEP)
+			if(tool.use_tool(src, user, 0, volume = 30))
+				to_chat(user, SPAN_NOTICE("Core screwed."))
+				construction_step = SCREWED_CORE_STEP
+				update_icon(UPDATE_ICON_STATE)
+				return ITEM_INTERACT_COMPLETE
+
+		if(SCREWED_CORE_STEP)
+			if(tool.use_tool(src, user, 0, volume = 30))
+				to_chat(user, SPAN_NOTICE("Core unscrewed."))
+				construction_step = CORE_STEP
+				update_icon(UPDATE_ICON_STATE)
+				return ITEM_INTERACT_COMPLETE
+
+		if(WRENCHED_ASSEMBLY_STEP)
+			if(tool.use_tool(src, user, 0, volume = 30))
+				to_chat(user, SPAN_NOTICE("Assembly screwed."))
+				construction_step = SCREWED_ASSEMBLY_STEP
+				update_icon(UPDATE_ICON_STATE)
+				return ITEM_INTERACT_COMPLETE
+
+		if(SCREWED_ASSEMBLY_STEP)
+			if(tool.use_tool(src, user, 0, volume = 30))
+				to_chat(user, SPAN_NOTICE("Assembly unscrewed."))
+				construction_step = WRENCHED_ASSEMBLY_STEP
+				update_icon(UPDATE_ICON_STATE)
+				return ITEM_INTERACT_COMPLETE
+
+/obj/item/mod/construction/shell/crowbar_act(mob/living/user, obj/item/crowbar/tool)
+	switch(construction_step)
+		if(CORE_STEP)
+			if(tool.use_tool(src, user, 0, volume = 30))
+				core.forceMove(drop_location())
+				to_chat(user, SPAN_NOTICE("Core removed."))
+				construction_step = START_STEP
+				update_icon(UPDATE_ICON_STATE)
+				return ITEM_INTERACT_COMPLETE
+
+		if(HELMET_STEP)
+			if(tool.use_tool(src, user, 0, volume = 30))
+				helmet.forceMove(drop_location())
+				to_chat(user, SPAN_NOTICE("Helmet removed."))
+				helmet = null
+				construction_step = SCREWED_CORE_STEP
+				update_icon(UPDATE_ICON_STATE)
+				return ITEM_INTERACT_COMPLETE
+
+		if(CHESTPLATE_STEP)
+			if(tool.use_tool(src, user, 0, volume = 30))
+				chestplate.forceMove(drop_location())
+				to_chat(user, SPAN_NOTICE("Chestplate removed."))
+				chestplate = null
+				construction_step = HELMET_STEP
+				update_icon(UPDATE_ICON_STATE)
+				return ITEM_INTERACT_COMPLETE
+
+		if(GAUNTLETS_STEP)
+			if(tool.use_tool(src, user, 0, volume = 30))
+				gauntlets.forceMove(drop_location())
+				to_chat(user, SPAN_NOTICE("Gauntlets removed."))
+				gauntlets = null
+				construction_step = CHESTPLATE_STEP
+				update_icon(UPDATE_ICON_STATE)
+				return ITEM_INTERACT_COMPLETE
+
+		if(BOOTS_STEP)
+			if(tool.use_tool(src, user, 0, volume = 30))
+				boots.forceMove(drop_location())
+				to_chat(user, SPAN_NOTICE("Boots removed."))
+				boots = null
+				construction_step = GAUNTLETS_STEP
+				update_icon(UPDATE_ICON_STATE)
+				return ITEM_INTERACT_COMPLETE
+
+/obj/item/mod/construction/shell/wrench_act(mob/living/user, obj/item/wrench/tool)
+	if(construction_step == BOOTS_STEP)
+		if(tool.use_tool(src, user, 0, volume = 30))
+			to_chat(user, SPAN_NOTICE("Assembly secured."))
+			construction_step = WRENCHED_ASSEMBLY_STEP
+			update_icon(UPDATE_ICON_STATE)
+			return ITEM_INTERACT_COMPLETE
+
+	if(construction_step == WRENCHED_ASSEMBLY_STEP)
+		if(tool.use_tool(src, user, 0, volume = 30))
+			to_chat(user, SPAN_NOTICE("Assembly unsecured."))
+			construction_step = BOOTS_STEP
+			update_icon(UPDATE_ICON_STATE)
+			return ITEM_INTERACT_COMPLETE
+
+/obj/item/mod/construction/shell/item_interaction(mob/living/user, obj/item/part, list/modifiers)
 	switch(construction_step)
 		if(START_STEP)
 			if(!istype(part, /obj/item/mod/core))
-				return
+				return ..()
+
 			if(!user.drop_item())
 				to_chat(user, SPAN_WARNING("[part] is stuck to you and cannot be placed into [src]."))
-				return
+				return ITEM_INTERACT_COMPLETE
+
 			playsound(src, 'sound/machines/click.ogg', 30, TRUE)
 			to_chat(user, SPAN_NOTICE("Core inserted."))
 			core = part
 			core.forceMove(src)
 			construction_step = CORE_STEP
-		if(CORE_STEP)
-			if(part.tool_behaviour == TOOL_SCREWDRIVER) //Construct
-				if(part.use_tool(src, user, 0, volume = 30))
-					to_chat(user, SPAN_NOTICE("Core screwed."))
-				construction_step = SCREWED_CORE_STEP
-			else if(part.tool_behaviour == TOOL_CROWBAR) //Deconstruct
-				if(part.use_tool(src, user, 0, volume = 30))
-					core.forceMove(drop_location())
-					to_chat(user, SPAN_NOTICE("Core removed."))
-				construction_step = START_STEP
+			update_icon(UPDATE_ICON_STATE)
+			return ITEM_INTERACT_COMPLETE
+
 		if(SCREWED_CORE_STEP)
-			if(istype(part, /obj/item/mod/construction/helmet)) //Construct
-				if(!user.drop_item())
-					to_chat(user, SPAN_WARNING("[part] is stuck to you and cannot be placed into [src]."))
-					return
-				playsound(src, 'sound/machines/click.ogg', 30, TRUE)
-				to_chat(user, SPAN_NOTICE("Helmet added."))
-				helmet = part
-				helmet.forceMove(src)
-				construction_step = HELMET_STEP
-			else if(part.tool_behaviour == TOOL_SCREWDRIVER) //Deconstruct
-				if(part.use_tool(src, user, 0, volume = 30))
-					to_chat(user, SPAN_NOTICE("Core unscrewed."))
-					construction_step = CORE_STEP
+			if(!istype(part, /obj/item/mod/construction/helmet))
+				return ..()
+
+			if(!user.drop_item())
+				to_chat(user, SPAN_WARNING("[part] is stuck to you and cannot be placed into [src]."))
+				return ITEM_INTERACT_COMPLETE
+
+			playsound(src, 'sound/machines/click.ogg', 30, TRUE)
+			to_chat(user, SPAN_NOTICE("Helmet added."))
+			helmet = part
+			helmet.forceMove(src)
+			construction_step = HELMET_STEP
+			update_icon(UPDATE_ICON_STATE)
+			return ITEM_INTERACT_COMPLETE
+
 		if(HELMET_STEP)
-			if(istype(part, /obj/item/mod/construction/chestplate)) //Construct
-				if(!user.drop_item())
-					to_chat(user, SPAN_WARNING("[part] is stuck to you and cannot be placed into [src]."))
-					return
-				playsound(src, 'sound/machines/click.ogg', 30, TRUE)
-				to_chat(user, SPAN_NOTICE("Chestplate added."))
-				forceMove(src)
-				chestplate = part
-				chestplate.forceMove(src)
-				construction_step = CHESTPLATE_STEP
-			else if(part.tool_behaviour == TOOL_CROWBAR) //Deconstruct
-				if(part.use_tool(src, user, 0, volume = 30))
-					helmet.forceMove(drop_location())
-					to_chat(user, SPAN_NOTICE("Helmet removed."))
-					helmet = null
-					construction_step = SCREWED_CORE_STEP
+			if(!istype(part, /obj/item/mod/construction/chestplate))
+				return ..()
+
+			if(!user.drop_item())
+				to_chat(user, SPAN_WARNING("[part] is stuck to you and cannot be placed into [src]."))
+				return ITEM_INTERACT_COMPLETE
+
+			playsound(src, 'sound/machines/click.ogg', 30, TRUE)
+			to_chat(user, SPAN_NOTICE("Chestplate added."))
+			forceMove(src)
+			chestplate = part
+			chestplate.forceMove(src)
+			construction_step = CHESTPLATE_STEP
+			update_icon(UPDATE_ICON_STATE)
+			return ITEM_INTERACT_COMPLETE
+
 		if(CHESTPLATE_STEP)
-			if(istype(part, /obj/item/mod/construction/gauntlets)) //Construct
-				if(!user.drop_item())
-					to_chat(user, SPAN_WARNING("[part] is stuck to you and cannot be placed into [src]."))
-					return
-				playsound(src, 'sound/machines/click.ogg', 30, TRUE)
-				to_chat(user, SPAN_NOTICE("Gauntlets added."))
-				gauntlets = part
-				gauntlets.forceMove(src)
-				construction_step = GAUNTLETS_STEP
-			else if(part.tool_behaviour == TOOL_CROWBAR) //Deconstruct
-				if(part.use_tool(src, user, 0, volume = 30))
-					chestplate.forceMove(drop_location())
-					to_chat(user, SPAN_NOTICE("Chestplate removed."))
-					chestplate = null
-					construction_step = HELMET_STEP
+			if(!istype(part, /obj/item/mod/construction/gauntlets))
+				return ..()
+
+			if(!user.drop_item())
+				to_chat(user, SPAN_WARNING("[part] is stuck to you and cannot be placed into [src]."))
+				return ITEM_INTERACT_COMPLETE
+
+			playsound(src, 'sound/machines/click.ogg', 30, TRUE)
+			to_chat(user, SPAN_NOTICE("Gauntlets added."))
+			gauntlets = part
+			gauntlets.forceMove(src)
+			construction_step = GAUNTLETS_STEP
+			update_icon(UPDATE_ICON_STATE)
+			return ITEM_INTERACT_COMPLETE
+
 		if(GAUNTLETS_STEP)
-			if(istype(part, /obj/item/mod/construction/boots)) //Construct
-				if(!user.drop_item())
-					to_chat(user, SPAN_WARNING("[part] is stuck to you and cannot be placed into [src]."))
-					return
-				playsound(src, 'sound/machines/click.ogg', 30, TRUE)
-				to_chat(user, SPAN_NOTICE("Boots added."))
-				boots = part
-				boots.forceMove(src)
-				construction_step = BOOTS_STEP
-			else if(part.tool_behaviour == TOOL_CROWBAR) //Deconstruct
-				if(part.use_tool(src, user, 0, volume = 30))
-					gauntlets.forceMove(drop_location())
-					to_chat(user, SPAN_NOTICE("Gauntlets removed."))
-					gauntlets = null
-					construction_step = CHESTPLATE_STEP
-		if(BOOTS_STEP)
-			if(part.tool_behaviour == TOOL_WRENCH) //Construct
-				if(part.use_tool(src, user, 0, volume = 30))
-					to_chat(user, SPAN_NOTICE("Assembly secured."))
-					construction_step = WRENCHED_ASSEMBLY_STEP
-			else if(part.tool_behaviour == TOOL_CROWBAR) //Deconstruct
-				if(part.use_tool(src, user, 0, volume = 30))
-					boots.forceMove(drop_location())
-					to_chat(user, SPAN_NOTICE("Boots removed."))
-					boots = null
-					construction_step = GAUNTLETS_STEP
-		if(WRENCHED_ASSEMBLY_STEP)
-			if(part.tool_behaviour == TOOL_SCREWDRIVER) //Construct
-				if(part.use_tool(src, user, 0, volume = 30))
-					to_chat(user, SPAN_NOTICE("Assembly screwed."))
-					construction_step = SCREWED_ASSEMBLY_STEP
-			else if(part.tool_behaviour == TOOL_WRENCH) //Deconstruct
-				if(part.use_tool(src, user, 0, volume = 30))
-					to_chat(user, SPAN_NOTICE("Assembly unsecured."))
-					construction_step = BOOTS_STEP
+			if(!istype(part, /obj/item/mod/construction/boots))
+				return ..()
+
+			if(!user.drop_item())
+				to_chat(user, SPAN_WARNING("[part] is stuck to you and cannot be placed into [src]."))
+				return ITEM_INTERACT_COMPLETE
+
+			playsound(src, 'sound/machines/click.ogg', 30, TRUE)
+			to_chat(user, SPAN_NOTICE("Boots added."))
+			boots = part
+			boots.forceMove(src)
+			construction_step = BOOTS_STEP
+			update_icon(UPDATE_ICON_STATE)
+			return ITEM_INTERACT_COMPLETE
+
 		if(SCREWED_ASSEMBLY_STEP)
-			if(istype(part, /obj/item/mod/construction/plating)) //Construct
-				var/obj/item/mod/construction/plating/external_plating = part
-				if(!user.drop_item())
-					return
-				playsound(src, 'sound/machines/click.ogg', 30, TRUE)
-				var/obj/item/mod = new /obj/item/mod/control(drop_location(), external_plating.theme, null, core)
-				core = null
-				qdel(external_plating)
-				qdel(src)
-				user.put_in_hands(mod)
-				to_chat(user, SPAN_NOTICE("Suit finished!"))
-			else if(part.tool_behaviour == TOOL_SCREWDRIVER) //Construct
-				if(part.use_tool(src, user, 0, volume = 30))
-					to_chat(user, SPAN_NOTICE("Assembly unscrewed."))
-					construction_step = SCREWED_ASSEMBLY_STEP
-	update_icon(UPDATE_ICON_STATE)
+			if(!istype(part, /obj/item/mod/construction/plating))
+				return ..()
+
+			var/obj/item/mod/construction/plating/external_plating = part
+			if(!user.drop_item())
+				return ITEM_INTERACT_COMPLETE
+
+			playsound(src, 'sound/machines/click.ogg', 30, TRUE)
+			var/obj/item/mod = new /obj/item/mod/control(drop_location(), external_plating.theme, null, core)
+			core = null
+			qdel(external_plating)
+			qdel(src)
+			user.put_in_hands(mod)
+			to_chat(user, SPAN_NOTICE("Suit finished!"))
+			update_icon(UPDATE_ICON_STATE)
+			return ITEM_INTERACT_COMPLETE
 
 /obj/item/mod/construction/shell/update_icon_state()
 	. = ..()

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -8,6 +8,7 @@
 	desc = "You should not see this, yell at a coder!"
 	icon = 'icons/obj/clothing/modsuit/mod_clothing.dmi'
 	worn_icon = 'icons/mob/clothing/modsuit/mod_clothing.dmi'
+	new_attack_chain = TRUE
 
 /obj/item/mod/control
 	name = "MOD control unit"
@@ -450,49 +451,61 @@
 	playsound(src, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
 	return FALSE
 
-/obj/item/mod/control/attackby__legacy__attackchain(obj/item/attacking_item, mob/living/user, params)
-	if(istype(attacking_item, /obj/item/mod/module))
+/obj/item/mod/control/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	if(istype(used, /obj/item/mod/module))
 		if(!open)
 			to_chat(user, SPAN_WARNING("Open the cover first!"))
 			playsound(src, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
-			return FALSE
-		install(attacking_item, user)
+			return ITEM_INTERACT_COMPLETE
+
+		install(used, user)
 		SEND_SIGNAL(src, COMSIG_MOD_MODULE_ADDED, user)
-		return TRUE
-	else if(istype(attacking_item, /obj/item/mod/core))
+		return ITEM_INTERACT_COMPLETE
+
+	if(istype(used, /obj/item/mod/core))
 		if(!open)
 			to_chat(user, SPAN_WARNING("Open the cover first!"))
 			playsound(src, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
-			return FALSE
+			return ITEM_INTERACT_COMPLETE
+
 		if(core)
 			to_chat(user, SPAN_WARNING("Core already installed!"))
 			playsound(src, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
-			return FALSE
-		var/obj/item/mod/core/attacking_core = attacking_item
+			return ITEM_INTERACT_COMPLETE
+
+		var/obj/item/mod/core/attacking_core = used
 		playsound(src, 'sound/machines/click.ogg', 50, TRUE, SILENCED_SOUND_EXTRARANGE)
 		user.drop_item()
 		attacking_core.install(src)
 		update_charge_alert()
-		return TRUE
-	else if(open && attacking_item.GetID())
-		update_access(user, attacking_item.GetID())
-		return TRUE
-	else if(istype(attacking_item, /obj/item/stock_parts/cell))
+		return ITEM_INTERACT_COMPLETE
+
+	if(open && used.GetID())
+		update_access(user, used.GetID())
+		return ITEM_INTERACT_COMPLETE
+
+	if(istype(used, /obj/item/stock_parts/cell))
+		if(!core)
+			to_chat(user, SPAN_WARNING("There is no core installed!"))
+			playsound(src, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
+			return ITEM_INTERACT_COMPLETE
+		core.on_attackby(used, user, list2params(modifiers))
+		return ITEM_INTERACT_COMPLETE
+
+	if(istype(used, /obj/item/stack/ore/plasma) || istype(used, /obj/item/stack/sheet/mineral/plasma))
 		if(!core)
 			to_chat(user, SPAN_WARNING("There is no core installed!"))
 			playsound(src, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
 			return FALSE
-		core.on_attackby(attacking_item, user, params)
-	else if(istype(attacking_item, /obj/item/stack/ore/plasma) || istype(attacking_item, /obj/item/stack/sheet/mineral/plasma))
-		if(!core)
-			to_chat(user, SPAN_WARNING("There is no core installed!"))
-			playsound(src, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
-			return FALSE
-		core.on_attackby(attacking_item, user, params)
-	else if(istype(attacking_item, /obj/item/mod/skin_applier))
+		core.on_attackby(used, user, list2params(modifiers))
+		return ITEM_INTERACT_COMPLETE
+
+	if(istype(used, /obj/item/mod/skin_applier))
 		return ..()
-	else if(bag && istype(attacking_item))
-		bag.attackby__legacy__attackchain(attacking_item, user, params)
+
+	if(bag && istype(used))
+		bag.attackby__legacy__attackchain(used, user, list2params(modifiers))
+		return ITEM_INTERACT_COMPLETE
 
 	return ..()
 

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -489,7 +489,7 @@
 			to_chat(user, SPAN_WARNING("There is no core installed!"))
 			playsound(src, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
 			return ITEM_INTERACT_COMPLETE
-		core.on_attackby(used, user, list2params(modifiers))
+		core.item_interaction(used, user, modifiers)
 		return ITEM_INTERACT_COMPLETE
 
 	if(istype(used, /obj/item/stack/ore/plasma) || istype(used, /obj/item/stack/sheet/mineral/plasma))
@@ -497,7 +497,7 @@
 			to_chat(user, SPAN_WARNING("There is no core installed!"))
 			playsound(src, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
 			return FALSE
-		core.on_attackby(used, user, list2params(modifiers))
+		core.item_interaction(used, user, modifiers)
 		return ITEM_INTERACT_COMPLETE
 
 	if(istype(used, /obj/item/mod/skin_applier))

--- a/code/modules/mod/mod_core.dm
+++ b/code/modules/mod/mod_core.dm
@@ -252,9 +252,9 @@
 	/// Associated list of charge sources, only stacks allowed.
 	var/list/charger_list = list(/obj/item/stack/ore/plasma, /obj/item/stack/sheet/mineral/plasma)
 
-/obj/item/mod/core/plasma/attackby__legacy__attackchain(obj/item/attacking_item, mob/user, params)
-	if(charge_plasma(attacking_item, user))
-		return TRUE
+/obj/item/mod/core/plasma/item_interaction(mob/user, obj/item/used, list/modifiers)
+	if(charge_plasma(used, user))
+		return ITEM_INTERACT_COMPLETE
 	return ..()
 
 /obj/item/mod/core/plasma/charge_source()

--- a/code/modules/mod/mod_core.dm
+++ b/code/modules/mod/mod_core.dm
@@ -258,11 +258,6 @@
 	/// Associated list of charge sources, only stacks allowed.
 	var/list/charger_list = list(/obj/item/stack/ore/plasma, /obj/item/stack/sheet/mineral/plasma)
 
-/obj/item/mod/core/plasma/item_interaction(mob/user, obj/item/used, list/modifiers)
-	if(charge_plasma(used, user))
-		return ITEM_INTERACT_COMPLETE
-	return ..()
-
 /obj/item/mod/core/plasma/charge_source()
 	return src
 

--- a/code/modules/mod/mod_core.dm
+++ b/code/modules/mod/mod_core.dm
@@ -99,8 +99,8 @@
 		on_wearer_unset(mod, mod.wearer)
 	return ..()
 
-/obj/item/mod/core/proc/on_attackby(obj/item/attacking_item, mob/user, params)
-	return
+/obj/item/mod/core/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	return NONE
 
 /obj/item/mod/core/standard/charge_source()
 	return cell
@@ -204,23 +204,29 @@
 	user.put_in_hands(cell_to_move)
 	mod.update_charge_alert()
 
-/obj/item/mod/core/standard/on_attackby(obj/item/attacking_item, mob/user, params)
-	if(istype(attacking_item, /obj/item/stock_parts/cell))
-		if(!mod.open)
-			to_chat(user, SPAN_WARNING("Open the cover first!"))
-			playsound(mod, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
-			return NONE
-		if(cell)
-			to_chat(user, SPAN_WARNING("Cell already installed!"))
-			playsound(mod, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
-			return COMPONENT_SKIP_AFTERATTACK
-		user.drop_item()
-		install_cell(attacking_item)
-		to_chat(user, SPAN_NOTICE("You install the cell."))
-		playsound(mod, 'sound/machines/click.ogg', 50, TRUE, SILENCED_SOUND_EXTRARANGE)
-		mod.update_charge_alert()
-		return COMPONENT_SKIP_AFTERATTACK
-	return NONE
+/obj/item/mod/core/standard/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	if(!istype(used, /obj/item/stock_parts/cell))
+		return NONE
+
+	if(!mod)
+		return NONE
+
+	if(!mod.open)
+		to_chat(user, SPAN_WARNING("Open the cover first!"))
+		playsound(mod, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
+		return ITEM_INTERACT_COMPLETE
+
+	if(cell)
+		to_chat(user, SPAN_WARNING("Cell already installed!"))
+		playsound(mod, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
+		return ITEM_INTERACT_COMPLETE
+
+	user.drop_item()
+	install_cell(used)
+	to_chat(user, SPAN_NOTICE("You install the cell."))
+	playsound(mod, 'sound/machines/click.ogg', 50, TRUE, SILENCED_SOUND_EXTRARANGE)
+	mod.update_charge_alert()
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/mod/core/standard/proc/on_wearer_set(datum/source, mob/user)
 	SIGNAL_HANDLER
@@ -291,8 +297,15 @@
 		else
 			mod.wearer.throw_alert("mod_charge", /atom/movable/screen/alert/emptycell)
 
-/obj/item/mod/core/plasma/on_attackby(obj/item/attacking_item, mob/user, params)
-	charge_plasma(attacking_item, user)
+/obj/item/mod/core/plasma/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	if(!istype(used, /obj/item/stack))
+		return NONE
+
+	if(!mod)
+		return NONE
+
+	charge_plasma(used, user)
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/mod/core/plasma/proc/charge_plasma(obj/item/stack/plasma, mob/user)
 	var/charge_given = is_type_in_list(plasma, charger_list)

--- a/code/modules/mod/modules/_modules.dm
+++ b/code/modules/mod/modules/_modules.dm
@@ -405,20 +405,24 @@
 		return FALSE
 	return TRUE
 
-/obj/item/mod/module/anomaly_locked/attackby__legacy__attackchain(obj/item/item, mob/living/user, params)
-	if(item.type in accepted_anomalies)
-		if(core)
-			to_chat(user, SPAN_WARNING("A core is already installed!"))
-			return
-		if(!user.drop_item())
-			return
-		core = item
-		to_chat(user, SPAN_NOTICE("You install [item]."))
-		playsound(src, 'sound/machines/click.ogg', 30, TRUE)
-		update_icon(UPDATE_ICON_STATE)
-		core.forceMove(src)
-	else
+/obj/item/mod/module/anomaly_locked/item_interaction(mob/user, obj/item/used, list/modifiers)
+	if(!(used.type in accepted_anomalies))
 		return ..()
+
+	if(core)
+		to_chat(user, SPAN_WARNING("A core is already installed!"))
+		return ITEM_INTERACT_COMPLETE
+
+	if(!user.drop_item())
+		to_chat(user, SPAN_WARNING("[used] is stuck to your hand!"))
+		return ITEM_INTERACT_COMPLETE
+
+	core = used
+	to_chat(user, SPAN_NOTICE("You install [used] in [src]."))
+	playsound(src, 'sound/machines/click.ogg', 30, TRUE)
+	update_icon(UPDATE_ICON_STATE)
+	core.forceMove(src)
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/mod/module/anomaly_locked/screwdriver_act(mob/living/user, obj/item/tool)
 	. = ..()

--- a/code/modules/mod/modules/module_pathfinder.dm
+++ b/code/modules/mod/modules/module_pathfinder.dm
@@ -32,21 +32,28 @@
 	else
 		. += SPAN_WARNING("The implant is missing.")
 
-/obj/item/mod/module/pathfinder/attack__legacy__attackchain(mob/living/target, mob/living/user, params)
+/obj/item/mod/module/pathfinder/interact_with_atom(atom/target, mob/living/user, list/modifiers)
 	if(!ishuman(target) || !implant)
-		return
+		return ..()
+
 	if(!do_after(user, 1.5 SECONDS, target = target))
-		return
+		return ITEM_INTERACT_COMPLETE
+
 	if(!implant.implant(target, user))
 		to_chat(user, SPAN_WARNING("Unable to implant [target]!"))
-		return
+		return ITEM_INTERACT_COMPLETE
+
 	if(target == user)
 		to_chat(user, SPAN_NOTICE("You implant yourself with [implant]."))
 	else
-		target.visible_message(SPAN_NOTICE("[user] implants [target]."), SPAN_NOTICE("[user] implants you with [implant]."))
+		target.visible_message(
+			SPAN_NOTICE("[user] implants [target]."),
+			SPAN_NOTICE("[user] implants you with [implant].")
+		)
 	playsound(src, 'sound/effects/spray.ogg', 30, TRUE, -6)
 	icon_state = "pathfinder_empty"
 	implant = null
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/mod/module/pathfinder/proc/attach(mob/user)
 	if(!ishuman(user))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Migrate modsuits and their mods to the new attack chain.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

It also fixes a modsuit construction bug where it's impossible to work backwards after the SCREWED_ASSEMBLY_STEP.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, hosted, spawned in robotics, printed a bunch of modsuit parts. Added core to shell. Crowbared core out of shell. Screwed and unscrewed core. Added and crowbared helmet from shell. Added and crowbared chestplate from shell. Added and crowbared gauntlets from shell. Added and crowbared boots from shell. Secured and unsecured the assembly with wrench. Screwed and unscrewed the assembly. Applied external plating. Attempted many construction steps out of order and was unable to fudge them. Applied pathfinder module to myself and to the modsuit, then used it to retrieve the modsuit.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
tweak: Tweaked a few modsuit messages.
fix: Fixed a bug where modsuits become undeconstructable after screwing the assembly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
