### PR TITLE
Move /atom/movable/MouseEntered to a subsystem

### DIFF
--- a/code/__DEFINES/dcs/atom_signals.dm
+++ b/code/__DEFINES/dcs/atom_signals.dm
@@ -165,3 +165,6 @@
 /// When using an insert on an item that can accept an insert
 #define COMSIG_INSERT_ATTACH "insert_attach"
 #define COMSIG_MINE_EXPOSE_GIBTONITE "mine_expose_gibtonite"
+
+/// signal sent when a mouse is hovering over us, sent by atom/proc/on_mouse_entered
+#define COMSIG_ATOM_MOUSE_ENTERED "mouse_entered"

--- a/code/__DEFINES/dcs/atom_signals.dm
+++ b/code/__DEFINES/dcs/atom_signals.dm
@@ -166,5 +166,5 @@
 #define COMSIG_INSERT_ATTACH "insert_attach"
 #define COMSIG_MINE_EXPOSE_GIBTONITE "mine_expose_gibtonite"
 
-/// signal sent when a mouse is hovering over us, sent by atom/proc/on_mouse_entered
+/// Signal sent when a mouse is hovering over us, sent by atom/proc/on_mouse_entered.
 #define COMSIG_ATOM_MOUSE_ENTERED "mouse_entered"

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -129,6 +129,7 @@
 #define FIRE_PRIORITY_STATPANEL		390
 #define FIRE_PRIORITY_CHAT 			400
 #define FIRE_PRIORITY_RUNECHAT		410 // I hate how high the fire priority on this is -aa
+#define FIRE_PRIORITY_MOUSE_ENTERED 450
 #define FIRE_PRIORITY_OVERLAYS		500
 #define FIRE_PRIORITY_DELAYED_VERBS	950
 #define FIRE_PRIORITY_INPUT			1000 // This must always always be the max highest priority. Player input must never be lost.

--- a/code/controllers/subsystem/SSmouse_entered.dm
+++ b/code/controllers/subsystem/SSmouse_entered.dm
@@ -1,0 +1,23 @@
+/// Defers MouseEntered inputs to only apply to the most recently hovered over atom in the tick
+SUBSYSTEM_DEF(mouse_entered)
+	name = "MouseEntered"
+	wait = 1
+	flags = SS_NO_INIT | SS_TICKER
+	priority = FIRE_PRIORITY_MOUSE_ENTERED
+	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
+
+	var/list/hovers = list()
+
+/datum/controller/subsystem/mouse_entered/fire()
+	for (var/hovering_client in hovers)
+		var/atom/hovering_atom = hovers[hovering_client]
+		if (isnull(hovering_atom))
+			continue
+
+		hovering_atom.on_mouse_enter(hovering_client)
+
+		// This intentionally runs `= null` and not `-= hovering_client`, as we want to prevent the list from shrinking,
+		// which could cause problems given the heat of MouseEntered.
+		// Lummox has teased this for 515: https://www.byond.com/forum/post/2621745
+		// ...though you're most likely reading this on BYOND version 600.
+		hovers[hovering_client] = null

--- a/code/controllers/subsystem/SSmouse_entered.dm
+++ b/code/controllers/subsystem/SSmouse_entered.dm
@@ -1,4 +1,4 @@
-/// Defers MouseEntered inputs to only apply to the most recently hovered over atom in the tick
+/// Defers MouseEntered inputs to only apply to the most recently hovered over atom in the tick.
 SUBSYSTEM_DEF(mouse_entered)
 	name = "MouseEntered"
 	wait = 1

--- a/code/controllers/subsystem/SSmouse_entered.dm
+++ b/code/controllers/subsystem/SSmouse_entered.dm
@@ -9,9 +9,9 @@ SUBSYSTEM_DEF(mouse_entered)
 	var/list/hovers = list()
 
 /datum/controller/subsystem/mouse_entered/fire()
-	for (var/hovering_client in hovers)
+	for(var/hovering_client in hovers)
 		var/atom/hovering_atom = hovers[hovering_client]
-		if (isnull(hovering_atom))
+		if(isnull(hovering_atom))
 			continue
 
 		hovering_atom.on_mouse_enter(hovering_client)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1575,9 +1575,6 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 	if(is_station_level((get_turf(src)).z))
 		return list(ASSIGNMENT_CREW = 1)
 
-/atom/MouseEntered(location, control, params)
-	SSmouse_entered.hovers[usr.client] = src
-
 /// Fired whenever this atom is the most recent to be hovered over in the tick.
 /// Preferred over MouseEntered if you do not need information such as the position of the mouse.
 /// Especially because this is deferred over a tick, do not trust that `client` is not null.

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1590,14 +1590,14 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 
 	SEND_SIGNAL(user, COMSIG_ATOM_MOUSE_ENTERED, src)
 
-	// Update the screentip to reflect what we're hovering over
+	// Update the screentip to reflect what we're hovering over.
 	if(invisibility > user.see_invisible)
 		return
-	var/datum/hud/active_hud = user.hud_used // Don't nullcheck this stuff, if it breaks we wanna know it breaks
+	var/datum/hud/active_hud = user.hud_used // Don't nullcheck this stuff, if it breaks we wanna know it breaks.
 	var/screentip_mode = user.client.prefs.screentip_mode
 	if(screentip_mode == 0 || (flags & NO_SCREENTIPS) || isfloorturf(src))
 		active_hud.screentip_text.maptext = ""
 		return
-	//We inline a MAPTEXT() here, because there's no good way to statically add to a string like this
+	// We inline a MAPTEXT() here, because there's no good way to statically add to a string like this.
 	active_hud.screentip_text.maptext = "<span class='maptext' style='font-family: sans-serif; text-align: center; font-size: [screentip_mode]px; color: [client.prefs.screentip_color]'>[name]</span>"
 	user.client.moused_over = UID()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1575,3 +1575,29 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 	if(is_station_level((get_turf(src)).z))
 		return list(ASSIGNMENT_CREW = 1)
 
+/atom/MouseEntered(location, control, params)
+	SSmouse_entered.hovers[usr.client] = src
+
+/// Fired whenever this atom is the most recent to be hovered over in the tick.
+/// Preferred over MouseEntered if you do not need information such as the position of the mouse.
+/// Especially because this is deferred over a tick, do not trust that `client` is not null.
+/atom/proc/on_mouse_enter(client/client)
+	SHOULD_NOT_SLEEP(TRUE)
+
+	var/mob/user = client?.mob
+	if(isnull(user))
+		return
+
+	SEND_SIGNAL(user, COMSIG_ATOM_MOUSE_ENTERED, src)
+
+	// Update the screentip to reflect what we're hovering over
+	if(invisibility > user.see_invisible)
+		return
+	var/datum/hud/active_hud = user.hud_used // Don't nullcheck this stuff, if it breaks we wanna know it breaks
+	var/screentip_mode = user.client.prefs.screentip_mode
+	if(screentip_mode == 0 || (flags & NO_SCREENTIPS))
+		active_hud.screentip_text.maptext = ""
+		return
+	//We inline a MAPTEXT() here, because there's no good way to statically add to a string like this
+	active_hud.screentip_text.maptext = "<span class='maptext' style='font-family: sans-serif; text-align: center; font-size: [screentip_mode]px; color: [client.prefs.screentip_color]'>[name]</span>"
+	user.client.moused_over = UID()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1575,6 +1575,9 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 	if(is_station_level((get_turf(src)).z))
 		return list(ASSIGNMENT_CREW = 1)
 
+/atom/MouseEntered(location, control, params)
+	SSmouse_entered.hovers[usr.client] = src
+
 /// Fired whenever this atom is the most recent to be hovered over in the tick.
 /// Preferred over MouseEntered if you do not need information such as the position of the mouse.
 /// Especially because this is deferred over a tick, do not trust that `client` is not null.
@@ -1592,7 +1595,7 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 		return
 	var/datum/hud/active_hud = user.hud_used // Don't nullcheck this stuff, if it breaks we wanna know it breaks
 	var/screentip_mode = user.client.prefs.screentip_mode
-	if(screentip_mode == 0 || (flags & NO_SCREENTIPS))
+	if(screentip_mode == 0 || (flags & NO_SCREENTIPS) || isturf(src))
 		active_hud.screentip_text.maptext = ""
 		return
 	//We inline a MAPTEXT() here, because there's no good way to statically add to a string like this

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1595,7 +1595,7 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 		return
 	var/datum/hud/active_hud = user.hud_used // Don't nullcheck this stuff, if it breaks we wanna know it breaks
 	var/screentip_mode = user.client.prefs.screentip_mode
-	if(screentip_mode == 0 || (flags & NO_SCREENTIPS) || isturf(src))
+	if(screentip_mode == 0 || (flags & NO_SCREENTIPS) || isfloorturf(src))
 		active_hud.screentip_text.maptext = ""
 		return
 	//We inline a MAPTEXT() here, because there's no good way to statically add to a string like this

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1002,9 +1002,6 @@
 /atom/movable/proc/stop_deadchat_plays()
 	DeleteComponent(/datum/component/deadchat_control)
 
-/atom/movable/MouseEntered(location, control, params)
-	SSmouse_entered.hovers[usr.client] = src
-
 /atom/movable/proc/choose_crush_crit(mob/living/carbon/victim)
 	if(!length(GLOB.tilt_crits))
 		return

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1002,23 +1002,6 @@
 /atom/movable/proc/stop_deadchat_plays()
 	DeleteComponent(/datum/component/deadchat_control)
 
-//Update the screentip to reflect what we're hovering over
-/atom/movable/MouseEntered(location, control, params)
-	if(invisibility > usr.see_invisible)
-		return
-	var/datum/hud/active_hud = usr.hud_used // Don't nullcheck this stuff, if it breaks we wanna know it breaks
-	var/screentip_mode = usr.client.prefs.screentip_mode
-	if(screentip_mode == 0 || (flags & NO_SCREENTIPS))
-		active_hud.screentip_text.maptext = ""
-		return
-	//We inline a MAPTEXT() here, because there's no good way to statically add to a string like this
-	active_hud.screentip_text.maptext = "<span class='maptext' style='font-family: sans-serif; text-align: center; font-size: [screentip_mode]px; color: [usr.client.prefs.screentip_color]'>[name]</span>"
-	usr.client.moused_over = UID()
-
-/atom/movable/MouseExited(location, control, params)
-	usr.hud_used.screentip_text.maptext = ""
-	usr.client.moused_over = null
-
 /atom/movable/proc/choose_crush_crit(mob/living/carbon/victim)
 	if(!length(GLOB.tilt_crits))
 		return

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1002,6 +1002,9 @@
 /atom/movable/proc/stop_deadchat_plays()
 	DeleteComponent(/datum/component/deadchat_control)
 
+/atom/movable/MouseEntered(location, control, params)
+	SSmouse_entered.hovers[usr.client] = src
+
 /atom/movable/proc/choose_crush_crit(mob/living/carbon/victim)
 	if(!length(GLOB.tilt_crits))
 		return

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -540,18 +540,6 @@
 
 	update_icon()
 
-/turf/simulated/wall/MouseEntered(location, control, params)
-	var/datum/hud/active_hud = usr.hud_used // Don't nullcheck this stuff, if it breaks we wanna know it breaks
-	var/screentip_mode = usr.client.prefs.screentip_mode
-	if(screentip_mode == 0 || (flags & NO_SCREENTIPS))
-		active_hud.screentip_text.maptext = ""
-		return
-	//We inline a MAPTEXT() here, because there's no good way to statically add to a string like this
-	active_hud.screentip_text.maptext = "<span class='maptext' style='font-family: sans-serif; text-align: center; font-size: [screentip_mode]px; color: [usr.client.prefs.screentip_color]'>[name]</span>"
-
-/turf/simulated/wall/MouseExited(location, control, params)
-	usr.hud_used.screentip_text.maptext = ""
-
 /turf/simulated/wall/magic_rust_turf()
 	if(HAS_TRAIT(src, TRAIT_RUSTY))
 		ChangeTurf(/turf/simulated/floor/plating)// Did you know most walls baseturf is space?

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -498,6 +498,7 @@
 	if(obj_window)
 		QDEL_NULL(obj_window)
 
+	SSmouse_entered.hovers -= src
 	SSambience.ambience_listening_clients -= src
 	SSinput.processing -= src
 	SSping.current_run -= src

--- a/paradise.dme
+++ b/paradise.dme
@@ -370,6 +370,7 @@
 #include "code\controllers\subsystem\SSmachinery.dm"
 #include "code\controllers\subsystem\SSmetrics.dm"
 #include "code\controllers\subsystem\SSmobs.dm"
+#include "code\controllers\subsystem\SSmouse_entered.dm"
 #include "code\controllers\subsystem\SSnightshift.dm"
 #include "code\controllers\subsystem\SSnpcpool.dm"
 #include "code\controllers\subsystem\SSoverlays.dm"


### PR DESCRIPTION
## What Does This PR Do
This PR ports https://github.com/tgstation/tgstation/pull/63567, which moves code for displaying tooltips over hovered items to a subsystem. This may seem like overkill but MouseEntered is a native proc that runs every single time the cursor hovers over an atom, which adds up:
<img width="1126" height="162" alt="image" src="https://github.com/user-attachments/assets/4ec726c2-5925-424e-aed4-aae089b5a65a" />

Keying it to a subsystem ensures it only fires once per tick, which can apparently contribute to a 20% reduction in this being called.
## Why It's Good For The Game
Performance.
## Testing
Just brief, should be TMed.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC