### PR TITLE
add radios to spatial grid

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -211,53 +211,6 @@
 /proc/is_same_root_atom(atom/one, atom/two)
 	return get_atom_on_turf(one) == get_atom_on_turf(two)
 
-/proc/get_mobs_in_radio_ranges(list/obj/item/radio/radios)
-	. = list()
-	// Returns a list of mobs who can hear any of the radios given in @radios
-	var/list/speaker_coverage = list()
-	for(var/obj/item/radio/R in radios)
-		if(R)
-			//Cyborg checks. Receiving message uses a bit of cyborg's charge.
-			var/obj/item/radio/borg/BR = R
-			if(istype(BR) && BR.myborg)
-				var/mob/living/silicon/robot/borg = BR.myborg
-				var/datum/robot_component/CO = borg.get_component("radio")
-				if(!CO)
-					continue //No radio component (Shouldn't happen)
-				if(!borg.is_component_functioning("radio"))
-					continue //No power.
-
-			var/turf/speaker = get_turf(R)
-			if(speaker)
-				for(var/turf/T in hear(R.canhear_range,speaker))
-					var/obj/item/radio/oldR = speaker_coverage[T]
-					if(!istype(oldR))
-						speaker_coverage[T] = R
-						continue
-					if(oldR.canhear_range < R.canhear_range)
-						speaker_coverage[T] = R
-
-	// Try to find all the players who can hear the message
-	for(var/A in GLOB.player_list + GLOB.hear_radio_list)
-		var/mob/M = A
-		if(!M)
-			continue
-		var/turf/ear = get_turf(M)
-		if(!ear)
-			continue
-		// Ghostship is magic: Ghosts can hear radio chatter from anywhere
-		if(isobserver(M) && M.get_preference(PREFTOGGLE_CHAT_GHOSTRADIO))
-			. |= M
-			continue
-		if(!speaker_coverage[ear])
-			continue
-		var/obj/item/radio/R = speaker_coverage[ear]
-		if(!istype(R) || R.canhear_range > 0)
-			. |= M
-			continue
-		if(is_same_root_atom(M, speaker_coverage[ear]))
-			. |= M
-
 /proc/inLineOfSight(X1,Y1,X2,Y2,Z=1,PX1=16.5,PY1=16.5,PX2=16.5,PY2=16.5)
 	var/turf/T
 	if(X1==X2)

--- a/code/__HELPERS/spatial_info.dm
+++ b/code/__HELPERS/spatial_info.dm
@@ -205,8 +205,24 @@
 
 /proc/get_hearers_in_radio_ranges(list/obj/item/radio/radios)
 	. = list()
+
+	// TODO: Put this somewhere else for fuck sake
+	for(var/mob/dead/observer in GLOB.player_list)
+		if(observer.get_preference(PREFTOGGLE_CHAT_GHOSTRADIO))
+			. |= observer
+
 	// Returns a list of mobs who can hear any of the radios given in @radios
 	for(var/obj/item/radio/radio as anything in radios)
+		//Cyborg checks. Receiving message uses a bit of cyborg's charge.
+		var/obj/item/radio/borg/BR = radio
+		if(istype(BR) && BR.myborg)
+			var/mob/living/silicon/robot/borg = BR.myborg
+			var/datum/robot_component/CO = borg.get_component("radio")
+			if(!CO)
+				continue //No radio component (Shouldn't happen)
+			if(!borg.is_component_functioning("radio"))
+				continue //No power.
+
 		. |= get_hearers_in_LOS(radio.canhear_range, radio)
 
 /proc/is_in_sight(atom/first_atom, atom/second_atom)

--- a/code/datums/wires/radio_wires.dm
+++ b/code/datums/wires/radio_wires.dm
@@ -17,26 +17,27 @@
 	var/obj/item/radio/R = holder
 	switch(wire)
 		if(WIRE_RADIO_SIGNAL)
-			R.listening = !R.listening && !is_cut(WIRE_RADIO_RECEIVER)
-			R.broadcasting = R.listening && !is_cut(WIRE_RADIO_TRANSMIT)
+			R.set_listening(!R.get_listening() && !is_cut(WIRE_RADIO_RECEIVER))
+			R.set_broadcasting(R.get_listening() && !is_cut(WIRE_RADIO_TRANSMIT))
 
 		if(WIRE_RADIO_RECEIVER)
-			R.listening = !R.listening && !is_cut(WIRE_RADIO_SIGNAL)
+			R.set_listening(!R.get_listening() && !is_cut(WIRE_RADIO_SIGNAL))
 
 		if(WIRE_RADIO_TRANSMIT)
-			R.broadcasting = !R.broadcasting && !is_cut(WIRE_RADIO_SIGNAL)
+			R.set_broadcasting(!R.get_broadcasting() && !is_cut(WIRE_RADIO_SIGNAL))
+
 	..()
 
 /datum/wires/radio/on_cut(wire, mend)
 	var/obj/item/radio/R = holder
 	switch(wire)
 		if(WIRE_RADIO_SIGNAL)
-			R.listening = mend && !is_cut(WIRE_RADIO_RECEIVER)
-			R.broadcasting = mend && !is_cut(WIRE_RADIO_TRANSMIT)
+			R.set_listening(mend && !is_cut(WIRE_RADIO_RECEIVER))
+			R.set_broadcasting(mend && !is_cut(WIRE_RADIO_TRANSMIT))
 
 		if(WIRE_RADIO_RECEIVER)
-			R.listening = mend && !is_cut(WIRE_RADIO_SIGNAL)
+			R.set_listening(mend && !is_cut(WIRE_RADIO_SIGNAL))
 
 		if(WIRE_RADIO_TRANSMIT)
-			R.broadcasting = mend && !is_cut(WIRE_RADIO_SIGNAL)
+			R.set_broadcasting(mend && !is_cut(WIRE_RADIO_SIGNAL))
 	..()

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -233,7 +233,8 @@ CONTENTS:
 	for(var/obj/I in all_items)
 		if(isradio(I))
 			var/obj/item/radio/R = I
-			R.listening = FALSE // Prevents the radio from buzzing due to the EMP, preserving possible stealthiness.
+			// Prevents the radio from buzzing due to the EMP, preserving possible stealthiness.
+			R.set_listening(FALSE)
 			R.emp_act(EMP_HEAVY)
 
 /obj/item/gun/energy/alien

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -87,7 +87,7 @@ GLOBAL_VAR(bomb_set)
 		STOP_PROCESSING(SSradiation, radioactivity)//Let us not irradiate the vault by default.
 	update_icon(UPDATE_OVERLAYS)
 	radio = new(src)
-	radio.listening = FALSE
+	radio.set_listening(FALSE)
 	radio.follow_target = src
 	radio.config(list("Special Ops" = 0))
 

--- a/code/game/machinery/computer/id_card_console.dm
+++ b/code/game/machinery/computer/id_card_console.dm
@@ -65,7 +65,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 /obj/machinery/computer/card/Initialize(mapload)
 	. = ..()
 	Radio = new /obj/item/radio(src)
-	Radio.listening = FALSE
+	Radio.set_listening(FALSE)
 	Radio.config(list("Command" = 0))
 	Radio.follow_target = src
 

--- a/code/game/machinery/computer/singulo_monitor.dm
+++ b/code/game/machinery/computer/singulo_monitor.dm
@@ -23,7 +23,7 @@
 /obj/machinery/computer/singulo_monitor/Initialize(mapload)
 	. = ..()
 	singu_radio = new(src)
-	singu_radio.listening = FALSE
+	singu_radio.set_listening(FALSE)
 	singu_radio.follow_target = src
 	singu_radio.config(list("[warning_channel]" = 0, "[breach_channel]" = 0))
 

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -41,7 +41,7 @@
 
 	GLOB.celltimers_list += src
 	Radio = new /obj/item/radio(src)
-	Radio.listening = FALSE
+	Radio.set_listening(FALSE)
 	Radio.config(list("Security" = 0))
 	Radio.follow_target = src
 	return INITIALIZE_HINT_LATELOAD

--- a/code/game/machinery/radar.dm
+++ b/code/game/machinery/radar.dm
@@ -54,7 +54,7 @@
 	))
 
 	radio = new(src)
-	radio.listening = FALSE
+	radio.set_listening(FALSE)
 	radio.follow_target = src
 	radio.config(list("Supply" = 0))
 

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -95,7 +95,7 @@ GLOBAL_LIST_EMPTY(allRequestConsoles)
 
 /obj/machinery/requests_console/Initialize(mapload)
 	Radio = new /obj/item/radio(src)
-	Radio.listening = TRUE
+	Radio.set_listening(TRUE)
 	Radio.config(list("Engineering", "Medical", "Supply", "Command", "Science", "Service", "Security", "AI Private" = FALSE))
 	Radio.follow_target = src
 	. = ..()

--- a/code/game/machinery/tcomms/tcomms_base.dm
+++ b/code/game/machinery/tcomms/tcomms_base.dm
@@ -329,12 +329,20 @@ GLOBAL_LIST_EMPTY(tcomms_machines)
 	var/list/heard_garbled	= list() // garbled message (ie "f*c* **u, **i*er!")
 	var/list/heard_gibberish= list() // completely screwed over message (ie "F%! (O*# *#!<>&**%!")
 
-	for(var/M in receive)
+	for(var/atom/M as anything in receive) // as anything to skip type checks
 		if(isnull(M))
 			log_debug("null found in list of radio hearers")
 			continue
 
+		// TODO: things other than mobs can be hearing-atoms
+		//
+		// ultimately hearing should be moved down to type-specific procs for
+		// handling (e.g. /atom/proc/hear) but continuing early here doesn't
+		// hurt anything because those cases weren't handled in the first place,
+		// this is just for mobs
 		var/mob/R = M
+		if(!istype(R))
+			continue
 
 		/* --- Loop through the receivers and categorize them --- */
 

--- a/code/game/machinery/tcomms/tcomms_base.dm
+++ b/code/game/machinery/tcomms/tcomms_base.dm
@@ -330,6 +330,10 @@ GLOBAL_LIST_EMPTY(tcomms_machines)
 	var/list/heard_gibberish= list() // completely screwed over message (ie "F%! (O*# *#!<>&**%!")
 
 	for(var/M in receive)
+		if(isnull(M))
+			log_debug("null found in list of radio hearers")
+			continue
+
 		var/mob/R = M
 
 		/* --- Loop through the receivers and categorize them --- */

--- a/code/game/machinery/tcomms/tcomms_base.dm
+++ b/code/game/machinery/tcomms/tcomms_base.dm
@@ -316,7 +316,7 @@ GLOBAL_LIST_EMPTY(tcomms_machines)
 					radios |= R
 
 	// Get a list of mobs who can hear from the radios we collected.
-	var/list/receive = get_mobs_in_radio_ranges(radios)
+	var/list/receive = get_hearers_in_radio_ranges(radios)
 
 /* ###### Organize the receivers into categories for displaying the message ###### */
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -224,7 +224,7 @@
 			. += "[bicon(ME)] [ME]"
 
 /obj/mecha/hear_talk(mob/M, list/message_pieces)
-	if(M == occupant && radio.broadcasting)
+	if(M == occupant && radio.get_broadcasting())
 		radio.talk_into(M, message_pieces)
 
 /obj/mecha/proc/click_action(atom/target, mob/user, params)

--- a/code/game/mecha/mecha_topic.dm
+++ b/code/game/mecha/mecha_topic.dm
@@ -99,8 +99,8 @@
 	. += "<div class='links'>"
 	. += "<a href='byond://?src=[UID()];toggle_lights=1'>Toggle Lights</a><br>"
 	. += "<b>Radio settings:</b><br>"
-	. += "Microphone: <a href='byond://?src=[UID()];rmictoggle=1'><span id='rmicstate'>[radio.broadcasting?"Engaged":"Disengaged"]</span></a><br>"
-	. += "Speaker: <a href='byond://?src=[UID()];rspktoggle=1'><span id='rspkstate'>[radio.listening?"Engaged":"Disengaged"]</span></a><br>"
+	. += "Microphone: <a href='byond://?src=[UID()];rmictoggle=1'><span id='rmicstate'>[radio.get_broadcasting()?"Engaged":"Disengaged"]</span></a><br>"
+	. += "Speaker: <a href='byond://?src=[UID()];rspktoggle=1'><span id='rspkstate'>[radio.get_listening()?"Engaged":"Disengaged"]</span></a><br>"
 	. += "Frequency:"
 	. += "<a href='byond://?src=[UID()];rfreq=-10'>-</a>"
 	. += "<a href='byond://?src=[UID()];rfreq=-2'>-</a>"
@@ -279,13 +279,13 @@
 		return
 	if(href_list["rmictoggle"])
 		if(usr != occupant)	return
-		radio.broadcasting = !radio.broadcasting
-		send_byjax(occupant,"exosuit.browser","rmicstate",(radio.broadcasting?"Engaged":"Disengaged"))
+		radio.set_broadcasting(!radio.get_broadcasting())
+		send_byjax(occupant,"exosuit.browser","rmicstate",(radio.get_broadcasting()?"Engaged":"Disengaged"))
 		return
 	if(href_list["rspktoggle"])
 		if(usr != occupant)	return
-		radio.listening = !radio.listening
-		send_byjax(occupant,"exosuit.browser","rspkstate",(radio.listening?"Engaged":"Disengaged"))
+		radio.set_listening(!radio.get_listening())
+		send_byjax(occupant,"exosuit.browser","rspkstate",(radio.get_listening()?"Engaged":"Disengaged"))
 		return
 	if(href_list["rfreq"])
 		if(usr != occupant)	return

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -176,13 +176,13 @@
 				<table class="request">
 					<tr>
 						<td class="radio">Transmit:</td>
-						<td><a href='byond://?src=[UID()];wires=4'>[radio.broadcasting ? "<font color=#55FF55>En" : "<font color=#FF5555>Dis" ]abled</font></a>
+						<td><a href='byond://?src=[UID()];wires=4'>[radio.get_broadcasting() ? "<font color=#55FF55>En" : "<font color=#FF5555>Dis" ]abled</font></a>
 
 						</td>
 					</tr>
 					<tr>
 						<td class="radio">Receive:</td>
-						<td><a href='byond://?src=[UID()];wires=2'>[radio.listening ? "<font color=#55FF55>En" : "<font color=#FF5555>Dis" ]abled</font></a>
+						<td><a href='byond://?src=[UID()];wires=2'>[radio.get_listening() ? "<font color=#55FF55>En" : "<font color=#FF5555>Dis" ]abled</font></a>
 
 						</td>
 					</tr>

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -15,7 +15,10 @@
 /obj/item/radio/intercom/custom
 	name = "station intercom (Custom)"
 	custom_name = TRUE
-	listening = FALSE
+
+/obj/item/radio/intercom/custom/Initialize(mapload, direction, building)
+	. = ..()
+	set_listening(FALSE)
 
 /obj/item/radio/intercom/interrogation
 	name = "station intercom (Interrogation)"

--- a/code/game/objects/items/devices/radio/radio_objects.dm
+++ b/code/game/objects/items/devices/radio/radio_objects.dm
@@ -31,7 +31,7 @@ GLOBAL_LIST_EMPTY(deadsay_radio_systems)
 	suffix = "\[3\]"
 	materials = list(MAT_METAL = 200, MAT_GLASS = 100)
 	/// boolean for radio enabled or not
-	var/on = TRUE
+	VAR_PRIVATE/on = TRUE
 	var/last_transmission
 	var/frequency = PUB_FREQ
 	/// tune to frequency to unlock traitor supplies
@@ -42,9 +42,17 @@ GLOBAL_LIST_EMPTY(deadsay_radio_systems)
 	var/b_stat = 0
 
 	/// Whether the radio will broadcast stuff it hears, out over the radio
-	var/broadcasting = FALSE
+	VAR_PRIVATE/broadcasting = FALSE
 	/// Whether the radio is currently receiving
-	var/listening = TRUE
+	VAR_PRIVATE/listening = TRUE
+
+	/// Used for tracking what broadcasting should be in the absence of things
+	/// forcing it off, eg its set to broadcast but gets emp'd temporarily
+	var/should_be_broadcasting = FALSE
+	/// Used for tracking what listening should be in the absence of things
+	/// forcing it off, eg its set to listen but gets emp'd temporarily
+	var/should_be_listening = TRUE
+
 	/// Whether the radio can be re-tuned to restricted channels it has no key for
 	var/freerange = FALSE
 	/// Whether the radio is able to have its primary frequency changed. Used for radios with weird primary frequencies, like DS, syndi, etc
@@ -108,6 +116,9 @@ GLOBAL_LIST_EMPTY(deadsay_radio_systems)
 /obj/item/radio/Initialize(mapload)
 	. = ..()
 	wires = new(src)
+	set_listening(listening)
+	set_broadcasting(broadcasting)
+	set_on(on)
 	internal_channels = GLOB.default_internal_channels.Copy()
 	GLOB.global_radios |= src
 
@@ -117,6 +128,58 @@ GLOBAL_LIST_EMPTY(deadsay_radio_systems)
 
 	for(var/ch_name in channels)
 		secure_radio_connections[ch_name] = SSradio.add_object(src, SSradio.radiochannels[ch_name],  RADIO_CHAT)
+
+/// Simple getter for the on variable. necessary due to VAR_PROTECTED
+/obj/item/radio/proc/is_on()
+	return on
+
+/// Simple getter for the broadcasting variable. necessary due to VAR_PROTECTED
+/obj/item/radio/proc/get_broadcasting()
+	return broadcasting
+
+/// Simple getter for the listening variable. necessary due to VAR_PROTECTED
+/obj/item/radio/proc/get_listening()
+	return listening
+
+/obj/item/radio/proc/set_on(new_on)
+	on = new_on
+
+	if(on)
+		// set them to whatever they're supposed to be
+		set_broadcasting(should_be_broadcasting)
+		set_listening(should_be_listening)
+	else
+		// fake set them to off
+		set_broadcasting(FALSE, actual_setting = FALSE)
+		set_listening(FALSE, actual_setting = FALSE)
+
+/**
+ * setter for broadcasting that makes us not hearing sensitive if not broadcasting and hearing sensitive if broadcasting
+ * hearing sensitive in this case only matters for the purposes of listening for words said in nearby tiles, talking into us directly bypasses hearing
+ *
+ * * new_broadcasting- the new value we want to set broadcasting to
+ * * actual_setting - whether or not the radio is supposed to be broadcasting, sets should_be_broadcasting to the new value if true, otherwise just changes broadcasting
+ */
+/obj/item/radio/proc/set_broadcasting(new_broadcasting, actual_setting = TRUE)
+	broadcasting = new_broadcasting
+	if(actual_setting)
+		should_be_broadcasting = broadcasting
+
+	if(broadcasting && on) //we don't need hearing sensitivity if we aren't broadcasting, because talk_into doesn't care about hearing
+		become_hearing_sensitive(INNATE_TRAIT)
+	else if(!broadcasting)
+		lose_hearing_sensitivity(INNATE_TRAIT)
+
+/**
+ * setter for the listener var
+ *
+ * * new_listening - the new value we want to set listening to
+ * * actual_setting - whether or not the radio is supposed to be listening, sets should_be_listening to the new listening value if true, otherwise just changes listening
+ */
+/obj/item/radio/proc/set_listening(new_listening, actual_setting = TRUE)
+	listening = new_listening
+	if(actual_setting)
+		should_be_listening = listening
 
 /obj/item/radio/attack_ghost(mob/user)
 	return interact(user)
@@ -765,7 +828,10 @@ GLOBAL_LIST_EMPTY(deadsay_radio_systems)
 	return
 
 /obj/item/radio/off
-	listening = FALSE
+
+/obj/item/radio/off/Initialize(mapload)
+	. = ..()
+	set_listening(FALSE)
 
 /obj/item/radio/phone
 	icon = 'icons/obj/items.dmi'

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -423,16 +423,16 @@
 	var/list/all_items = L.GetAllContents()
 	for(var/obj/item/radio/R in all_items)
 		R.radio_enable_timer = addtimer(CALLBACK(src, PROC_REF(enable_radio), R), radio_disable_time, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_STOPPABLE | TIMER_DELETE_ME)
-		R.on = FALSE
-		R.listening = FALSE
-		R.broadcasting = FALSE
+		R.set_on(FALSE)
+		R.set_listening(FALSE)
+		R.set_broadcasting(FALSE)
 		L.visible_message(SPAN_WARNING("[R] buzzes loudly as it short circuits!"), blind_message = SPAN_NOTICE("You hear a loud, electronic buzzing."))
 
 /obj/item/melee/baton/flayerprod/proc/enable_radio(obj/item/radio/R)
 	if(QDELETED(R))
 		return
-	R.on = TRUE
-	R.listening = TRUE
+	R.set_on(TRUE)
+	R.set_listening(TRUE)
 
 /obj/item/melee/baton/flayerprod/deductcharge(amount)
 	if(cell.charge < hitcost)

--- a/code/game/objects/starline_phone.dm
+++ b/code/game/objects/starline_phone.dm
@@ -119,12 +119,12 @@
 
 /obj/machinery/phone/proc/start_call()
 	phone_state = ACTIVE_CALL
-	handheld.listening = TRUE
-	connected_line.handheld.listening = TRUE
+	handheld.set_listening(TRUE)
+	connected_line.handheld.set_listening(TRUE)
 	connected_line.audible_message(SPAN_INFORMATION("The receiver clicks as the other line picks up."), hearing_distance = 3)
 
 /obj/machinery/phone/proc/end_call()
-	handheld.listening = FALSE
+	handheld.set_listening(FALSE)
 	phone_state = NO_CALLS
 	if(connected_line)
 		connected_line.audible_message(SPAN_INFORMATION("The receiver clicks as the other line hangs up"), hearing_distance = 3)
@@ -133,7 +133,7 @@
 			connected_line.phone_state = NO_CALLS
 		else
 			connected_line.phone_state = CALL_ENDED
-			connected_line.handheld.listening = FALSE
+			connected_line.handheld.set_listening(FALSE)
 		connected_line = null
 
 

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -94,7 +94,7 @@ USER_VERB(play_intercomm_sound, \
 		var/obj/item/radio/intercom/I = O
 		if(!is_station_level(I.z) && !ignore_z)
 			continue
-		if(!I.on && !ignore_power)
+		if(!I.is_on() && !ignore_power)
 			continue
 		playsound(I, melody, cvol)
 

--- a/code/modules/antagonists/_common/antag_exfiltration.dm
+++ b/code/modules/antagonists/_common/antag_exfiltration.dm
@@ -164,7 +164,7 @@
 	forceMove(F)
 	log_and_message_admins("[user] activated an exfiltration flare.")
 	var/obj/item/radio/radio = new
-	radio.listening = FALSE
+	radio.set_listening(FALSE)
 	radio.follow_target = src
 	radio.config(list("Security" = 0))
 	radio.autosay("<b>Unknown portal beacon detected at [get_area(src.loc)].</b>", "Automated Announcement", "Security")
@@ -451,7 +451,7 @@
 /obj/effect/portal/advanced/exfiltration/Initialize(mapload)
 	. = ..()
 	radio = new(src)
-	radio.listening = FALSE
+	radio.set_listening(FALSE)
 	radio.follow_target = src
 	radio.config(list("Security" = 0))
 

--- a/code/modules/antagonists/flockmind/actions/radio_blast.dm
+++ b/code/modules/antagonists/flockmind/actions/radio_blast.dm
@@ -13,7 +13,7 @@
 			if(istype(I, /obj/item/radio))
 				worn_radio = I
 				break
-		if(!istype(worn_radio) || !guy.can_hear() || !worn_radio.listening)
+		if(!istype(worn_radio) || !guy.can_hear() || !worn_radio.is_listening())
 			continue
 
 		targets += guy

--- a/code/modules/antagonists/flockmind/actions/radio_talk.dm
+++ b/code/modules/antagonists/flockmind/actions/radio_talk.dm
@@ -15,7 +15,7 @@
 
 	if(istype(target, /obj/item/radio))
 		worn_radio = target
-		if(!worn_radio.listening)
+		if(!worn_radio.is_listening())
 			to_chat(owner, SPAN_ALERT("[target] is not turned on!"))
 			return FALSE
 
@@ -25,7 +25,7 @@
 			if(istype(I, /obj/item/radio))
 				worn_radio = I
 				break
-		if(!istype(worn_radio) || !worn_radio.listening)
+		if(!istype(worn_radio) || !worn_radio.is_listening())
 			to_chat(owner, SPAN_ALERT("[target] does not have a working radio!"))
 			return FALSE
 

--- a/code/modules/economy/economy_machinery/fines.dm
+++ b/code/modules/economy/economy_machinery/fines.dm
@@ -25,7 +25,7 @@
 	account_database = GLOB.station_money_database
 	linked_account = account_database.get_account_by_department(DEPARTMENT_SECURITY)
 	radio = new /obj/item/radio(src)
-	radio.listening = FALSE
+	radio.set_listening(FALSE)
 	radio.config(list("Security" = 0))
 	radio.follow_target = src
 

--- a/code/modules/mob/living/basic/minebots/minebot.dm
+++ b/code/modules/mob/living/basic/minebots/minebot.dm
@@ -49,7 +49,7 @@
 	grant_actions_by_list(innate_actions)
 
 	radio = new(src)
-	radio.listening = FALSE
+	radio.set_listening(FALSE)
 	radio.follow_target = src
 	radio.config(list("Supply" = TRUE))
 

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -190,7 +190,7 @@
 
 /obj/item/mmi/proc/install_radio()
 	radio = new(src)
-	radio.broadcasting = TRUE
+	radio.set_broadcasting(TRUE)
 	radio_action = new(radio, src)
 	if(brainmob && brainmob.loc == src)
 		radio_action.Grant(brainmob)

--- a/code/modules/mob/living/silicon/pai/software/pai_apps.dm
+++ b/code/modules/mob/living/silicon/pai/software/pai_apps.dm
@@ -270,7 +270,7 @@
 	data["frequency"] = user.radio.frequency
 	data["minFrequency"] = PUBLIC_LOW_FREQ
 	data["maxFrequency"] = PUBLIC_HIGH_FREQ
-	data["broadcasting"] = user.radio.broadcasting
+	data["broadcasting"] = user.radio.get_broadcasting()
 	return data
 
 /datum/pai_software/radio_config/ui_act(action, list/params)
@@ -280,7 +280,7 @@
 	switch(action)
 		if("toggleBroadcast")
 			// Just toggle it
-			pai_holder.radio.broadcasting = !pai_holder.radio.broadcasting
+			pai_holder.radio.set_broadcasting(!pai_holder.radio.get_broadcasting())
 
 		if("freq")
 			var/new_frequency = sanitize_frequency(text2num(params["freq"]) * 10)

--- a/code/modules/mob/living/silicon/robot/robot_life.dm
+++ b/code/modules/mob/living/silicon/robot/robot_life.dm
@@ -70,9 +70,9 @@
 		uneq_all()
 
 	if(!is_component_functioning("radio") || stat == UNCONSCIOUS)
-		radio.on = FALSE
+		radio.set_on(FALSE)
 	else
-		radio.on = TRUE
+		radio.set_on(TRUE)
 
 /mob/living/silicon/robot/proc/SetEmagged(new_state)
 	emagged = new_state

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -42,6 +42,7 @@
 	reset_perspective(src)
 	prepare_huds()
 	update_runechat_msg_location()
+	become_hearing_sensitive()
 	ADD_TRAIT(src, TRAIT_CAN_STRIP, TRAIT_GENERIC)
 	. = ..()
 

--- a/code/modules/power/engines/fission/reactor.dm
+++ b/code/modules/power/engines/fission/reactor.dm
@@ -190,7 +190,7 @@
 	air_contents.set_temperature(T20C)
 	GLOB.poi_list |= src
 	radio = new(src)
-	radio.listening = FALSE
+	radio.set_listening(FALSE)
 	radio.follow_target = src
 	radio.config(list("Engineering" = 0))
 	if(primary_engine)

--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -256,7 +256,7 @@
 	countdown.start()
 	GLOB.poi_list |= src
 	radio = new(src)
-	radio.listening = FALSE
+	radio.set_listening(FALSE)
 	radio.follow_target = src
 	radio.config(list("Engineering" = 0))
 	investigate_log("has been created.", INVESTIGATE_SUPERMATTER)

--- a/code/modules/power/generators/turbine.dm
+++ b/code/modules/power/generators/turbine.dm
@@ -163,7 +163,7 @@
 
 	//Radio for screaming about overheats
 	radio = new(src)
-	radio.listening = FALSE
+	radio.set_listening(FALSE)
 	radio.follow_target = src
 	radio.config(list("Engineering" = 0))
 

--- a/code/modules/station_goals/bluespace_tap.dm
+++ b/code/modules/station_goals/bluespace_tap.dm
@@ -171,7 +171,7 @@
 		list(1, 0,		   1),
 	))
 	radio = new(src)
-	radio.listening = FALSE
+	radio.set_listening(FALSE)
 	radio.follow_target = src
 	radio.config(list("Engineering" = 0))
 


### PR DESCRIPTION
## What Does This PR Do
This PR removes the proc /proc/get_mobs_in_radio_ranges and replaces it with proper use of the hearing channel on the spatial grid.
## Why It's Good For The Game
Kills this:
<img width="1118" height="124" alt="2026_09_06__22_58_03__Paradise Profile Viewer" src="https://github.com/user-attachments/assets/344dfbb9-c97e-4a88-92c5-29d698dcc933" />
## Testing
Ensured I could talk into and hear out of my radio headset. More extensive testing needed on TM.
## Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
NPFC