### PR TITLE
Migrate robot paper dispenser to the new attack chain.

### DIFF
--- a/code/modules/mob/living/silicon/robot/misc_robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/misc_robot_items.dm
@@ -45,25 +45,22 @@
 	name = "paper dispenser"
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "paper_bin1"
+	new_attack_chain = TRUE
 
-/obj/item/form_printer/attack__legacy__attackchain(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	return
-
-/obj/item/form_printer/afterattack__legacy__attackchain(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, flag, params)
-
-	if(!target || !flag)
-		return
-
-	if(istype(target,/obj/structure/table))
+/obj/item/form_printer/interact_with_atom(atom/target, mob/living/user, list/modifiers)
+	if(istype(target, /obj/structure/table))
 		deploy_paper(get_turf(target))
+		return ITEM_INTERACT_COMPLETE
 
-/obj/item/form_printer/attack_self__legacy__attackchain(mob/user as mob)
+/obj/item/form_printer/activate_self(mob/user)
+	if(..())
+		return ITEM_INTERACT_COMPLETE
 	deploy_paper(get_turf(src))
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/form_printer/proc/deploy_paper(turf/T)
-	T.visible_message(SPAN_NOTICE("\The [src.loc] dispenses a sheet of crisp white paper."))
+	T.visible_message(SPAN_NOTICE("[src.loc] dispenses a sheet of crisp white paper."))
 	new /obj/item/paper(T)
-
 
 //Personal shielding for the combat module.
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Migrates the form printer, or "paper dispenser" to the new attack chain.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

I dunno if we even need it, what with the rapid service printer thing, but it'll be on the new attack chain now.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled. Requesting assistance finding and using the printer, if it's even available in the game.

<!-- How did you test the PR, if at all? -->

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
