### PR TITLE
Flockphase and Spaceflock Nerfs

### DIFF
--- a/code/__DEFINES/flockmind_defines.dm
+++ b/code/__DEFINES/flockmind_defines.dm
@@ -41,7 +41,7 @@
 #define FLOCK_SUBSTRATE_COST_LAY_EGG 150
 
 /// Egg cost does not start scaling until there are this many drones.
-#define FLOCK_MIN_DESIRED_POP 6
+#define FLOCK_MIN_DESIRED_POP 10
 /// Each drone above the min desired pop adds this much to the substrate required to be able to lay an egg.
 #define FLOCK_ADDITIONAL_RESOURCE_RESERVATION_PER_DRONE 15
 #define FLOCK_DRONE_LIMIT 50

--- a/code/__DEFINES/flockmind_defines.dm
+++ b/code/__DEFINES/flockmind_defines.dm
@@ -38,7 +38,7 @@
 /// Amount to repair a flock construct.
 #define FLOCK_SUBSTRATE_COST_REPAIR 10
 /// BASE amount to lay an egg.
-#define FLOCK_SUBSTRATE_COST_LAY_EGG 100
+#define FLOCK_SUBSTRATE_COST_LAY_EGG 150
 
 /// Egg cost does not start scaling until there are this many drones.
 #define FLOCK_MIN_DESIRED_POP 6

--- a/code/__DEFINES/flockmind_defines.dm
+++ b/code/__DEFINES/flockmind_defines.dm
@@ -41,9 +41,9 @@
 #define FLOCK_SUBSTRATE_COST_LAY_EGG 100
 
 /// Egg cost does not start scaling until there are this many drones.
-#define FLOCK_MIN_DESIRED_POP 10
+#define FLOCK_MIN_DESIRED_POP 6
 /// Each drone above the min desired pop adds this much to the substrate required to be able to lay an egg.
-#define FLOCK_ADDITIONAL_RESOURCE_RESERVATION_PER_DRONE 8
+#define FLOCK_ADDITIONAL_RESOURCE_RESERVATION_PER_DRONE 15
 #define FLOCK_DRONE_LIMIT 50
 
 #define FLOCK_ENDGAME_LOST 1

--- a/code/modules/antagonists/flockmind/flock_mob/flockdrone.dm
+++ b/code/modules/antagonists/flockmind/flock_mob/flockdrone.dm
@@ -39,6 +39,15 @@
 	if(stat == CONSCIOUS)
 		flock_talk(src, pick(GLOB.flockdrone_created_phrases), flock, TRUE)
 
+/mob/living/basic/flock/drone/Life(seconds_per_tick, times_fired)
+	. = ..()
+	if(HAS_TRAIT(src, TRAIT_FLOCKPHASE))
+		if(avoid_stop_flockphase())
+			flockphase_tax()
+		else
+			stop_flockphase()
+
+
 /mob/living/basic/flock/drone/Destroy()
 	release_control()
 	QDEL_NULL(substrate)

--- a/code/modules/antagonists/flockmind/flock_mob/flockdrone.dm
+++ b/code/modules/antagonists/flockmind/flock_mob/flockdrone.dm
@@ -103,6 +103,8 @@
 			flockphase_tax()
 		else
 			stop_flockphase()
+	if(isspaceturf(get_turf(src)))
+		substrate.remove_points(20)
 
 /mob/living/basic/flock/drone/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change)
 	. = ..()

--- a/code/modules/antagonists/flockmind/flock_mob/flockdrone.dm
+++ b/code/modules/antagonists/flockmind/flock_mob/flockdrone.dm
@@ -376,7 +376,7 @@
 
 /// Deducts the substrate tax for flockphasing, ending flockphase if the drone ran out of points.
 /mob/living/basic/flock/drone/proc/flockphase_tax()
-	substrate.remove_points(1)
+	substrate.remove_points(20)
 	if(!substrate.has_points())
 		stop_flockphase(TRUE)
 		return FALSE

--- a/code/modules/antagonists/flockmind/flock_mob/flockdrone.dm
+++ b/code/modules/antagonists/flockmind/flock_mob/flockdrone.dm
@@ -46,7 +46,8 @@
 			flockphase_tax()
 		else
 			stop_flockphase()
-
+	if(isspaceturf(get_turf(src)))
+		substrate.remove_points(20)
 
 /mob/living/basic/flock/drone/Destroy()
 	release_control()
@@ -95,16 +96,6 @@
 	var/datum/flockdrone_part/absorber/absorber = locate() in parts
 	absorber.try_drop_item()
 	return ..()
-
-/mob/living/basic/flock/drone/Life(seconds_per_tick, times_fired)
-	. = ..()
-	if(HAS_TRAIT(src, TRAIT_FLOCKPHASE))
-		if(avoid_stop_flockphase())
-			flockphase_tax()
-		else
-			stop_flockphase()
-	if(isspaceturf(get_turf(src)))
-		substrate.remove_points(20)
 
 /mob/living/basic/flock/drone/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change)
 	. = ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Increase cost to phase from 1 substrate (ha) to 20 (oh dear)
Substrate will drain on Life() if you're flockphasing or on a space tile
Increase base cost of making a new drone from 100 to 150
Increase scaling cost of making new drones after 10 from 8 to 15

## Why It's Good For The Game

Flock drones are currently a bit too mobile and it's a bit easy to mass produce them. This puts limiters on their ability to operate in space and their ability to phase.

## Testing

Became flock. Watched substrate go down fast.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<img width="531" height="283" alt="image" src="https://github.com/user-attachments/assets/41cd17c1-e091-45cc-b9cd-40b40b06a01e" />

## Changelog

:cl:
tweak: Increased substrate costs for flockdrones to phase, move in space, and reproduce
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
