### PR TITLE
Enables Borgs to Knock on Walls/Windows & Operate False Walls + Updates & Adds Messages

### DIFF
--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -97,7 +97,7 @@
 		user.visible_message(
 			SPAN_WARNING("[user] pushes the wall, and it begins to slide [density ? "closed" : "open"]!"),
 			SPAN_WARNING("You push the wall, and it begins to slide [density ? "closed" : "open"]!"),
-			SPAN_WARNING("You hear a pushing sound and metallic grinding!")
+			SPAN_WARNING("You hear metallic grinding!")
 		)
 	recalculate_atmos_connectivity()
 	opening = FALSE

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -61,7 +61,7 @@
 
 /obj/structure/falsewall/attack_ghost(mob/user)
 	if(user.can_advanced_admin_interact())
-		toggle(user, TRUE)
+		toggle(user, silent = TRUE)
 
 /obj/structure/falsewall/attack_hand(mob/user)
 	. = ..()

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -61,13 +61,18 @@
 
 /obj/structure/falsewall/attack_ghost(mob/user)
 	if(user.can_advanced_admin_interact())
-		toggle(user)
+		toggle(user, TRUE)
 
 /obj/structure/falsewall/attack_hand(mob/user)
 	. = ..()
 	toggle(user)
 
-/obj/structure/falsewall/proc/toggle(mob/user)
+/obj/structure/falsewall/attack_robot(mob/living/user)
+	. = ..()
+	if(Adjacent(user) && !isdrone(user))
+		toggle(user)
+
+/obj/structure/falsewall/proc/toggle(mob/user, silent = FALSE)
 	if(opening)
 		return
 	opening = TRUE
@@ -88,6 +93,12 @@
 		density = TRUE
 		set_opacity(TRUE)
 		icon_state = "fwall_closing"
+	if(!silent)
+		user.visible_message(
+			SPAN_WARNING("[user] pushes the wall, and it begins to slide [density ? "closed" : "open"]!"),
+			SPAN_WARNING("You push the wall, and it begins to slide [density ? "closed" : "open"]!"),
+			SPAN_WARNING("You hear a pushing sound and metallic grinding!")
+		)
 	recalculate_atmos_connectivity()
 	opening = FALSE
 	update_icon()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -179,17 +179,27 @@
 	if(user.a_intent == INTENT_HARM)
 		user.changeNext_move(CLICK_CD_MELEE)
 		playsound(src, 'sound/effects/glassbang.ogg', 100, 1)
-		user.visible_message(SPAN_WARNING("[user] bangs against [src]!"), \
-							SPAN_WARNING("You bang against [src]!"), \
-							"You hear a banging sound.")
+		user.visible_message(
+			SPAN_WARNING("[user] bangs against [src]!"),
+			SPAN_WARNING("You bang against [src]!"),
+			SPAN_WARNING("You hear a banging sound!")
+		)
 		add_fingerprint(user)
 	else
 		user.changeNext_move(CLICK_CD_MELEE)
 		playsound(src, 'sound/effects/glassknock.ogg', 50, 1)
-		user.visible_message("[user] knocks on [src].", \
-							"You knock on [src].", \
-							"You hear a knocking sound.")
+		user.visible_message(
+			SPAN_NOTICE("[user] knocks on [src]."),
+			SPAN_NOTICE("You knock on [src]."),
+			SPAN_HEAR("You hear a knocking sound.")
+		)
 		add_fingerprint(user)
+
+/obj/structure/window/attack_robot(mob/user)
+	if(isdrone(user) || !Adjacent(user))
+		return ..()
+
+	attack_hand(user)
 
 /obj/structure/window/attack_generic(mob/user, damage_amount = 0, damage_type = BRUTE, damage_flag = 0, sound_effect = 1)	//used by attack_alien, attack_animal, and attack_slime
 	if(!can_be_reached(user))

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -312,17 +312,35 @@
 	user.changeNext_move(CLICK_CD_MELEE)
 	if(rotting)
 		if(hardness <= 10)
-			to_chat(user, SPAN_NOTICE("This wall feels rather unstable."))
+			user.visible_message(
+				SPAN_WARNING("[user] pushes the wall, cusing it to let out a concerning metallic groan!"),
+				SPAN_WARNING("You push the wall, it feels rather unstable and lets out a concerning metallic groan!"),
+				SPAN_WARNING("You hear a pushing sound and a concerning metallic groan!")
+			)
 			return
 		else
-			to_chat(user, SPAN_NOTICE("The wall crumbles under your touch."))
+			user.visible_message(
+				SPAN_WARNING("[user] pushes the wall, and it crumbles under [user.p_their()] touch!"),
+				SPAN_WARNING("You push the wall, and it crumbles under your touch!"),
+				SPAN_WARNING("You hear a pushing sound and something crumbling!")
+			)
 			dismantle_wall()
 			return
 
-	to_chat(user, SPAN_NOTICE("You push the wall but nothing happens!"))
+	user.visible_message(
+		SPAN_NOTICE("[user] pushes the wall, but nothing happens."),
+		SPAN_NOTICE("You push the wall, but nothing happens."),
+		SPAN_HEAR("You hear a pushing sound.")
+	)
 	playsound(src, 'sound/weapons/genhit.ogg', 25, 1)
 	add_fingerprint(user)
 	return ..()
+
+/turf/simulated/wall/attack_robot(mob/user)
+	if(!Adjacent(user) || isdrone(user))
+		return ..()
+	
+	attack_hand(user)
 
 /turf/simulated/wall/attack_by(obj/item/attacking, mob/user, params)
 	if(..())

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -315,14 +315,14 @@
 			user.visible_message(
 				SPAN_WARNING("[user] pushes the wall, cusing it to let out a concerning metallic groan!"),
 				SPAN_WARNING("You push the wall, it feels rather unstable and lets out a concerning metallic groan!"),
-				SPAN_WARNING("You hear a pushing sound and a concerning metallic groan!")
+				SPAN_WARNING("You hear a concerning metallic groan!")
 			)
 			return
 		else
 			user.visible_message(
 				SPAN_WARNING("[user] pushes the wall, and it crumbles under [user.p_their()] touch!"),
 				SPAN_WARNING("You push the wall, and it crumbles under your touch!"),
-				SPAN_WARNING("You hear a pushing sound and something crumbling!")
+				SPAN_WARNING("You hear something crumbling!")
 			)
 			dismantle_wall()
 			return
@@ -330,7 +330,7 @@
 	user.visible_message(
 		SPAN_NOTICE("[user] pushes the wall, but nothing happens."),
 		SPAN_NOTICE("You push the wall, but nothing happens."),
-		SPAN_HEAR("You hear a pushing sound.")
+		SPAN_HEAR("You hear a solid thud.")
 	)
 	playsound(src, 'sound/weapons/genhit.ogg', 25, 1)
 	add_fingerprint(user)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -313,7 +313,7 @@
 	if(rotting)
 		if(hardness <= 10)
 			user.visible_message(
-				SPAN_WARNING("[user] pushes the wall, cusing it to let out a concerning metallic groan!"),
+				SPAN_WARNING("[user] pushes the wall, causing it to let out a concerning metallic groan!"),
 				SPAN_WARNING("You push the wall, it feels rather unstable and lets out a concerning metallic groan!"),
 				SPAN_WARNING("You hear a pushing sound and a concerning metallic groan!")
 			)


### PR DESCRIPTION
## What Does This PR Do
* Cyborgs can now knock on walls and windows, and operate false walls. Maintenance drones are blocked from this functionality.
* Walls, false walls, and windows now use visible messages when they are interacted with.
* Adds missing spans for knocking on windows.
## Why It's Good For The Game
* Enables engineering borgs to fix false walls that have been left open without building a second wall on top of the first wall, which is very jank.
* * They already have the ability to tear through closed false walls and then replace the metal covering afterwards.
* * They also have the ability to operate many other manually operated objects such as mineral doors, curtains, closets, crates, and body bags.
* The act of pushing on a wall or knocking on a window is a visible action that other people would see and hear.

## Testing
Spawned a borg. Pushed a wall. Pushed a wallrotted wall. Pushed a false wall. Knocked on a window. All worked as expected.
Did the above as an AI dragged next to the objects in question and as a drone. Failed to do anything.

## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<img width="860" height="157" alt="image" src="https://github.com/user-attachments/assets/dbbda7b1-97b3-4941-b5f2-be11096106d8" />

## Changelog

:cl:
tweak: Borgs can now operate false walls and knock on windows.
add: Adds chat visible chat messages when pushing walls, including false walls.
/:cl: