### PR TITLE
Swaps Medical Doctors' automenders with medicated sutures and advanced regen mesh

### DIFF
--- a/code/game/jobs/job/medical_jobs.dm
+++ b/code/game/jobs/job/medical_jobs.dm
@@ -51,7 +51,7 @@
 	l_ear = /obj/item/radio/headset/heads/cmo
 	id = /obj/item/card/id/cmo
 	suit_store = /obj/item/flashlight/pen
-	l_hand = /obj/item/storage/firstaid/regular/doctor
+	l_hand = /obj/item/storage/firstaid/regular/doctor/cmo
 	pda = /obj/item/pda/heads/cmo
 	backpack_contents = list(
 		/obj/item/melee/classic_baton/telescopic = 1

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -47,6 +47,18 @@
 	desc = "A medical kit designed for Nanotrasen medical personnel."
 
 /obj/item/storage/firstaid/regular/doctor/populate_contents()
+	new /obj/item/stack/medical/suture/medicated(src)
+	new /obj/item/stack/medical/suture/regen_mesh/advanced(src)
+	new /obj/item/reagent_containers/patch/styptic(src)
+	new /obj/item/reagent_containers/patch/silver_sulf(src)
+	new /obj/item/reagent_containers/pill/salicylic(src)
+	new /obj/item/healthanalyzer/advanced(src)
+	new /obj/item/reagent_containers/hypospray/autoinjector/epinephrine(src)
+
+/obj/item/storage/firstaid/regular/doctor/cmo
+	desc = "A medical kit designed for Nanotrasen Chief Medical Officers."
+
+/obj/item/storage/firstaid/regular/doctor/cmo/populate_contents()
 	new /obj/item/reagent_containers/applicator/brute(src)
 	new /obj/item/reagent_containers/applicator/burn(src)
 	new /obj/item/reagent_containers/patch/styptic(src)


### PR DESCRIPTION
## What Does This PR Do
This PR is me taking over #32165 because it has been sitting untouched for months.
* Removes brute and burn menders from the first aid kit that medical doctors spawn with. They are replaced by advanced regen mesh and medicated sutures.
* Creates a subtype first aid kit for the CMO which retains the menders, per the request of [Stoniest](https://github.com/Stoniest).
## Why It's Good For The Game
From the original PR: "Automenders are very powerful, and should be limited to only very well funded parties (E.G. ERT, Nuclear Operatives)."
## Testing
Spawned as a medical doctor, looked inside medkit, had sutures and mesh.
Spawned as a CMO, looked inside medkit, had menders.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<img width="737" height="91" alt="image" src="https://github.com/user-attachments/assets/1948d698-c142-4076-ab4f-e4ce3aef83af" />

## Changelog
:cl:
tweak: Medical doctor first aid kits no longer have brute/burn menders, and instead have advanced burn mesh and medicated sutures. The CMO still has brute/burn menders.
/:cl: