### PR TITLE
Buffs Sontse Overdose

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol.dm
@@ -2339,6 +2339,11 @@
 			SPAN_USERDANGER("THE SUN BURNS YOU!"),
 			SPAN_WARNING("You briefly feel a wave of warmth wash over you.")
 		)
+		if(M.mind)
+			for(var/obj/structure/blob/B in hear(6, T))
+				var/damage = round(30 / (get_dist(B, T) + 1))
+				B.take_damage(damage, BURN, MELEE, FALSE)
+
 	return list(0, update_flags)
 
 /datum/reagent/consumable/ethanol/sontse/proc/on_species_change(mob/living/M)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Nians overdosing on Sontse that are sentient now damage nearby blob tiles when they unleash the sun.

## Why It's Good For The Game

*buzz. Nian abuse during blob.

## Testing

Spawned as nian. Spawned a blob. Chugged sontse. Watched blob tiles be destroyed by sontse flashbang.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<img width="355" height="333" alt="image" src="https://github.com/user-attachments/assets/f6284147-13b4-4ef7-8a22-2cc398361b7e" />

## Changelog

:cl:
tweak: Nian sontse OD now damages blob tiles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
