### PR TITLE
Adds Slime Tot Item: Insulated Protein Applicator

### DIFF
--- a/code/__HELPERS/trait_helpers.dm
+++ b/code/__HELPERS/trait_helpers.dm
@@ -194,6 +194,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_HYPOSPRAY_IMMUNE	"hypospray_immune" // For making crew-accessable hyposprays not pierce your clothing
 #define TRAIT_RSG_IMMUNE		"rsgimmune" //prevents RSG syringes from piercing your clothing
 #define TRAIT_DRASK_SUPERCOOL	"drask_supercool"
+#define TRAIT_SLIMEPERSON_INSUL	"slime_insulated"
 #define TRAIT_BRITTLE_BONES		"brittle_bones"
 
 /// trait determines if this mob can breed given by /datum/component/breeding

--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -442,8 +442,8 @@
 
 // Slime
 /datum/uplink_item/species_restricted/subdermal_applicator
-	name = "Insulated Protein Applicator"
-	desc = "This device contains specially-formulated proteins that bond with a slime person's surface tension to create a transparent, insulative barrier."
+	name = "Thermal Protein Applicator"
+	desc = "This device contains specially-formulated proteins that bond with a slime person's surface membrane and inner organelles to provide insulation against the cold and greatly improved resistance to extreme temperatures."
 	reference = "IPA"
 	item = /obj/item/subdermal_applicator
 	cost = 15

--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -440,6 +440,16 @@
 	species = list("Drask")
 	surplus = 0
 
+// Slime
+/datum/uplink_item/species_restricted/subdermal_applicator
+	name = "Insulated Protein Applicator"
+	desc = "This device contains specially-formulated proteins that bond with a slime person's surface tension to create a transparent, insulative barrier."
+	reference = "IPA"
+	item = /obj/item/subdermal_applicator
+	cost = 15
+	species = list("Slime People")
+	surplus = 0
+
 // Unathi
 /datum/uplink_item/species_restricted/breach_cleaver
 	name = "Breach Cleaver"

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -372,8 +372,8 @@
 	ADD_TRAIT(user, TRAIT_SLIMEPERSON_INSUL, "subdermal_applicator")
 	var/mob/living/carbon/human/slime = user
 	var/datum/species/S = slime.dna.species
-	S.cold_level_1 = 120 //Default 260 - Lower is better
-	S.cold_level_2 = -1 //Default 200
+	S.cold_level_1 = 160 //Default 260 - Lower is better
+	S.cold_level_2 = 100 //Default 200
 	S.cold_level_3 = -1 //Default 120
 	S.coldmod = 1
 	S.heat_level_1 = 505 //Default 360 - Higher is better

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -341,8 +341,8 @@
 	ADD_TRAIT(user, TRAIT_DRASK_SUPERCOOL, "cryoregenerative_enhancer")
 
 /obj/item/subdermal_applicator
-	name = "insulated protein applicator"
-	desc = "This device contains specially-formulated proteins that bond with a slime person's surface tension to create a transparent, insulative barrier."
+	name = "thermal protein applicator"
+	desc = "This device contains specially-formulated proteins that bond with a slime person's surface membrane and inner organelles to provide insulation against the cold and greatly improved resistance to extreme temperatures."
 	icon = 'icons/obj/hypo.dmi'
 	icon_state = "combat_hypo"
 	new_attack_chain = TRUE
@@ -352,7 +352,7 @@
 	if(..())
 		return
 	if(HAS_TRAIT(user, TRAIT_SLIMEPERSON_INSUL))
-		to_chat(user, SPAN_WARNING("Your body is already covered in a layer of insulation!"))
+		to_chat(user, SPAN_WARNING("Your body is already augmented with thermal proteins!"))
 		return
 	if(user.mind && (IS_CHANGELING(user) || user.mind.has_antag_datum(/datum/antagonist/vampire)) || !isslimeperson(user))
 		to_chat(user, SPAN_WARNING("The injector is not compatable with your biology!"))

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -340,6 +340,46 @@
 	to_chat(user, SPAN_NOTICE("You inject yourself with the enhancer!"))
 	ADD_TRAIT(user, TRAIT_DRASK_SUPERCOOL, "cryoregenerative_enhancer")
 
+/obj/item/subdermal_applicator
+	name = "insulated protein applicator"
+	desc = "This device contains specially-formulated proteins that bond with a slime person's surface tension to create a transparent, insulative barrier."
+	icon = 'icons/obj/hypo.dmi'
+	icon_state = "combat_hypo"
+	new_attack_chain = TRUE
+	var/used = FALSE
+
+/obj/item/subdermal_applicator/activate_self(mob/user)
+	if(..())
+		return
+	if(HAS_TRAIT(user, TRAIT_SLIMEPERSON_INSUL))
+		to_chat(user, SPAN_WARNING("Your body is already covered in a layer of insulation!"))
+		return
+	if(user.mind && (IS_CHANGELING(user) || user.mind.has_antag_datum(/datum/antagonist/vampire)) || !isslimeperson(user))
+		to_chat(user, SPAN_WARNING("The injector is not compatable with your biology!"))
+		return
+	if(used)
+		to_chat(user, SPAN_NOTICE("The injector is empty!"))
+		return
+	var/choice = tgui_alert(user, "The injector is still unused. Do you wish to use it?", src.name, list("Yes", "No"))
+	if(choice != "Yes")
+		to_chat(user, SPAN_NOTICE("You decide against using [src]."))
+		return
+	if(used)
+		to_chat(user, SPAN_WARNING("The injector is empty!"))
+		return
+	used = TRUE
+	to_chat(user, SPAN_NOTICE("You inject yourself with the applicator!"))
+	ADD_TRAIT(user, TRAIT_SLIMEPERSON_INSUL, "subdermal_applicator")
+	var/mob/living/carbon/human/slime = user
+	var/datum/species/S = slime.dna.species
+	S.cold_level_1 = 120 //Default 260 - Lower is better
+	S.cold_level_2 = -1 //Default 200
+	S.cold_level_3 = -1 //Default 120
+	S.coldmod = 1
+	S.heat_level_1 = 505 //Default 360 - Higher is better
+	S.heat_level_2 = 540 //Default 400
+	S.heat_level_3 = 600 //Default 460
+
 /obj/item/batterer
 	name = "mind batterer"
 	desc = "A dangerous syndicate device focused on crowd control and escapes. Causes brain damage, confusion, and other nasty effects to those surrounding the user."


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

This PR adds a new traitor item for Slime People: The Insulated Protein Applicator.

This device is a single-use injector similar to the drask or the plasmaman applicators. On use, it will vastly improve your temperature resilience to both cold and heat so that you will only find yourself damaged by extreme cold or heat. This will serve as a way to avoid your species weakness, or be generally more resilient to extreme conditions. It costs 15 TC.

## Why It's Good For The Game

Slime people lack a traitor item. This item fits slime people due to their infamously hurtful cold weakness, and serves as a way to patch that.

## Testing

Became slime person. Bought and used item. Shot self repeatedly with temp gun set to cold.

## Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<img width="522" height="504" alt="image" src="https://github.com/user-attachments/assets/521fc2a7-acf5-45cf-b9ef-801d0fec3e4c" />

## Changelog

:cl:
add: Added the insulated protein applicator traitor item for slime people
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
