### PR TITLE
Xenobiology Organ Buffs

### DIFF
--- a/code/__HELPERS/trait_helpers.dm
+++ b/code/__HELPERS/trait_helpers.dm
@@ -644,6 +644,9 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 /// Trait from mob/living/update_transform()
 #define UPDATE_TRANSFORM_TRAIT "update_transform"
 
+/// Trait from hungry organ to allow for benefits from eaten food/drink
+#define TRAIT_GLUTTONOUS_GLORY "gluttonous_glory"
+
 //***** PROC WRAPPERS *****//
 /// Proc wrapper of add_trait. You should only use this for callback. Otherwise, use the macro.
 /proc/callback_add_trait(datum/target, trait, source)

--- a/code/__HELPERS/trait_helpers.dm
+++ b/code/__HELPERS/trait_helpers.dm
@@ -644,7 +644,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 /// Trait from mob/living/update_transform()
 #define UPDATE_TRANSFORM_TRAIT "update_transform"
 
-/// Trait from hungry organ to allow for benefits from eaten food/drink
+/// Trait from hungry organ to allow for benefits from eaten food/drink.
 #define TRAIT_GLUTTONOUS_GLORY "gluttonous_glory"
 
 //***** PROC WRAPPERS *****//

--- a/code/modules/mob/living/basic/hostile/megafauna/space_whale/space_whale.dm
+++ b/code/modules/mob/living/basic/hostile/megafauna/space_whale/space_whale.dm
@@ -10,6 +10,8 @@
 	icon_gib = "carp_gib"
 	butcher_results = list(/obj/item/food/meat = 30,
 		/obj/item/stack/sheet/leather = 30) // In the future might add more unique loot,
+	contains_xeno_organ = TRUE
+	surgery_container = /datum/xenobiology_surgery_container/whale
 	speak_emote = list("calls")
 	melee_attack_cooldown_min = 1 SECONDS
 	damage_coeff = list(BRUTE = 0.75, BURN = 1, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -1213,6 +1213,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 			return FALSE
 
 	consume(to_eat, bitesize_override)
+
 	SSticker.score.score_food_eaten++
 	return TRUE
 
@@ -1294,6 +1295,20 @@ so that different stomachs can handle things in different ways VB*/
 		var/fraction = min(this_bite / to_eat.reagents.total_volume, 1)
 		to_eat.reagents.reaction(src, REAGENT_INGEST, fraction)
 		to_eat.reagents.trans_to(src, this_bite)
+
+	if(HAS_TRAIT(src, TRAIT_GLUTTONOUS_GLORY))
+		if(istype(to_eat, /obj/item/food/burger/superbite))
+			to_chat(src, SPAN_BLOB("Finally, some good fucking food."))
+			adjustFireLoss(-2)
+			adjustBruteLoss(-2)
+		else if(to_eat.slice_path) // Stuff your face with a whole pizza/cake
+			to_chat(src, SPAN_BLOB("Sharing is for chumps. All for me!"))
+			adjustFireLoss(-1)
+			adjustBruteLoss(-1)
+
+		// Dont let them eat enough to OD themself.
+		reagents.check_and_add("kelotane", 20, 1)
+		reagents.check_and_add("bicaridine", 20, 1)
 
 /mob/living/carbon/get_access()
 	. = ..()

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -1301,12 +1301,12 @@ so that different stomachs can handle things in different ways VB*/
 			to_chat(src, SPAN_BLOB("Finally, some good fucking food."))
 			adjustFireLoss(-2)
 			adjustBruteLoss(-2)
-		else if(to_eat.slice_path) // Stuff your face with a whole pizza/cake
+		else if(to_eat.slice_path) // Stuff your face with a whole pizza/cake.
 			to_chat(src, SPAN_BLOB("Sharing is for chumps. All for me!"))
 			adjustFireLoss(-1)
 			adjustBruteLoss(-1)
 
-		// Dont let them eat enough to OD themself.
+		// Don't let them eat enough to OD themselves.
 		reagents.check_and_add("kelotane", 20, 1)
 		reagents.check_and_add("bicaridine", 20, 1)
 

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -289,6 +289,13 @@
 	L.reagents.add_reagent("nutriment", 0.4)
 	L.reagents.add_reagent("vitamin", 0.4)
 
+	if(HAS_TRAIT(L, TRAIT_GLUTTONOUS_GLORY))
+		to_chat(L, SPAN_BLOB("Delicious. The sin makes it that much more enjoyable."))
+		adjustFireLoss(-1)
+		adjustBruteLoss(-1)
+		reagents.check_and_add("kelotane", 20, 1)
+		reagents.check_and_add("bicaridine", 20, 1)
+
 /mob/living/simple_animal/pet/cat/cak/CheckParts(list/parts)
 	..()
 	var/obj/item/organ/internal/brain/B = locate(/obj/item/organ/internal/brain) in contents

--- a/code/modules/mob/living/simple_animal/hostile/angel_statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/angel_statue.dm
@@ -167,8 +167,6 @@
 	base_cooldown = 300
 	clothes_req = FALSE
 	aoe_range = 14
-	/// Is this ability granted from a xenobiology organ? Causes user to spark.
-	var/from_organ = FALSE
 
 /datum/spell/aoe/flicker_lights/create_new_targeting()
 	var/datum/spell_targeting/aoe/turf/targeting = new()
@@ -179,8 +177,6 @@
 	for(var/turf/T in targets)
 		for(var/obj/machinery/light/L in T)
 			L.forced_flicker()
-	if(from_organ)
-		do_sparks(3, FALSE, user)
 
 //Blind AOE
 /datum/spell/aoe/blindness

--- a/code/modules/research/xenobiology/xenobiology_dissections.dm
+++ b/code/modules/research/xenobiology/xenobiology_dissections.dm
@@ -122,7 +122,7 @@
 			break
 
 	var/inverted_chance = 100 - quality_chance
-	quality_chance += ((inverted_chance * 0.66) * -(I.bit_efficiency_mod - 1))
+	quality_chance += ((inverted_chance * 0.66) * -((I.bit_efficiency_mod - 1) * 1.5))
 	if(prob(quality_chance / 2)) // at best, ~50% chance
 		return ORGAN_PRISTINE
 	if(prob(quality_chance))
@@ -314,6 +314,9 @@
 		/obj/item/organ/internal/heart/xenobiology/bananium,
 		/obj/item/organ/internal/heart/xenobiology/cursed_bananium,
 	)
+
+/datum/xenobiology_surgery_container/whale
+	xeno_specialized_organs = list(/obj/item/organ/internal/kidneys/xenobiology/finned)
 
 /datum/xenobiology_surgery_container/revenant
 	xeno_specialized_organs = list(/obj/item/organ/internal/appendix/xenobiology/electro_strands)

--- a/code/modules/research/xenobiology/xenobiology_organs.dm
+++ b/code/modules/research/xenobiology/xenobiology_organs.dm
@@ -34,7 +34,7 @@
 	/// What type of object will this object turn into when analyzed?
 	var/true_organ_type = /obj/item/organ/internal/liver/xenobiology/toxic
 	/// What quality will be hidden from us?
-	var/unknown_quality = ORGAN_NORMAL
+	var/unknown_quality = ORGAN_PRISTINE
 
 /obj/item/xeno_organ/Initialize(mapload)
 	. = ..()
@@ -142,10 +142,10 @@
 	tough = TRUE
 	is_xeno_organ = TRUE
 
+// MARK: Toxic
 /obj/item/organ/internal/liver/xenobiology/toxic
 	name = "toxic glands"
 	desc = "These fleshy glands' alien chemistry are incompatible with most humanoid life."
-
 
 /obj/item/organ/internal/liver/xenobiology/toxic/on_life()
 	. = ..()
@@ -158,11 +158,12 @@
 		if(ORGAN_NORMAL)
 			owner.adjustToxLoss(2)
 		if(ORGAN_PRISTINE)
-			owner.adjustToxLoss(5)
+			owner.adjustToxLoss(4)
 			if(prob(5))
 				owner.add_vomit_floor(toxvomit = TRUE)
 				owner.AdjustConfused(rand(4 SECONDS, 6 SECONDS))
 
+// MARK: Gnesis Shard
 /obj/item/organ/internal/liver/xenobiology/gnesis_shard
 	name = "gnesis shard"
 	desc = "This bio-organic chunk of hardened gnesis will likely harm humanoid life more than help."
@@ -185,6 +186,7 @@
 	if(prob(10))
 		owner.reagents.add_reagent("gnesis_tox", 5 * multiplier)
 
+// MARK: Detox
 /obj/item/organ/internal/liver/xenobiology/detox
 	name = "chemical neutralizers"
 	desc = "These glands seem to absorb any liquid they come in contact with, neutralizing any unnatural substances."
@@ -206,6 +208,7 @@
 			for(var/datum/reagent/R in owner.reagents.reagent_list)
 				owner.reagents.remove_reagent(R.id,4)
 
+// MARK: Vestigial
 /obj/item/organ/internal/heart/xenobiology/vestigial
 	name = "vestigial organ"
 	desc = "Whether this has ever had any function is a mystery. It certainly doesn't work in its current state."
@@ -215,6 +218,7 @@
 	if(!owner.undergoing_cardiac_arrest())
 		owner.set_heartattack(TRUE) // what did you expect?
 
+// MARK: Incompatable
 /obj/item/organ/internal/heart/xenobiology/incompatible
 	name = "incompatible organ"
 	desc = "This organ is largely incompatible with humanoid physiology. You might be able to get it to work, but will likely cause a host of other issues."
@@ -230,26 +234,22 @@
 	if(prob(10))
 		owner.vomit(20)
 
+// MARK: Flame Sack
 /obj/item/organ/internal/lungs/xenobiology/flame_sack
 	name = "flame sack"
 	desc = "An unusual set of aerosolizing glands capable of starting light fires."
-	analyzer_price = 50
+	analyzer_price = 60
 	hidden_origin_tech = TECH_PLASMA
 	hidden_tech_level = 5
 
 /obj/item/organ/internal/lungs/xenobiology/flame_sack/insert(mob/living/carbon/M, special = 0, dont_remove_slot = 0)
 	. = ..()
-	if(!isunathi(M))
-		var/datum/action/innate/unathi_ignite/fire = new
-		fire.Grant(M)
-	if(organ_quality == ORGAN_PRISTINE) // grants a 3-range ash drake breath
-		M.AddSpell(new /datum/spell/drake_breath)
+	var/datum/spell/drake_breath/spell = new
+	spell.quality = organ_quality
+	M.AddSpell(new /datum/spell/drake_breath)
 
 /obj/item/organ/internal/lungs/xenobiology/flame_sack/remove(mob/living/carbon/M, special = 0)
 	. = ..()
-	if(!isunathi(M))
-		for(var/datum/action/innate/unathi_ignite/fire in M.actions)
-			fire.Remove(M)
 	M.RemoveSpell(/datum/spell/drake_breath)
 
 /datum/spell/drake_breath
@@ -260,6 +260,7 @@
 	action_icon_state = "fireball0"
 	sound = 'sound/magic/fireball.ogg'
 	antimagic_flags = NONE
+	var/quality = 3
 
 	selection_activated_message = SPAN_NOTICE("You take in a deep breath, readying to breathe fire!")
 	selection_deactivated_message = SPAN_NOTICE("You relax your breaths as you decide not to breathe fire.")
@@ -278,8 +279,20 @@
 /datum/spell/drake_breath/cast(list/targets, mob/living/user)
 	. = ..()
 	var/target = targets[1] //There is only ever one target
-	var/turfs = line_target(0, 3, target, user)
+
+	var/line_range = 3 // Pristine gets extra range.
+	if(quality == 3)
+		line_range = 6
+	var/turfs = line_target(0, line_range, target, user)
 	dragon_fire_line(user, turfs)
+
+	if(quality == 1) // Damaged will burn the user
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			H.adjustFireLossByPart(10, BODY_ZONE_HEAD)
+		else
+			user.adjustFireLoss(10)
+		to_chat(user, SPAN_USERDANGER("Your face burns from the searing flame billowing from your body!"))
 
 /datum/spell/drake_breath/proc/line_target(offset, range, atom/at, mob/living/user)
 	if(!at)
@@ -293,6 +306,7 @@
 		T = check
 	return (get_line(user, T) - get_turf(user))
 
+// MARK: Sinew
 /obj/item/organ/internal/kidneys/xenobiology/sinew
 	name = "sinewous bands"
 	desc = "Long, strands of durable fibers that seem to grow at astonishing speeds."
@@ -337,34 +351,39 @@
 			sinew_cuffs.breakouttime = 45 SECONDS
 			user.put_in_hands(sinew_cuffs)
 
+// MARK: Hyperactive
 /obj/item/organ/internal/heart/xenobiology/hyperactive
 	name = "hyperactive organ"
 	desc = "This organ replaces its own cells so quickly, that it appears to spread this effect to other cells around it in a rather exhaustive process."
-	analyzer_price = 25
+	analyzer_price = 80
 	can_paradox = TRUE
 	hidden_origin_tech = TECH_BIO
 	hidden_tech_level = 5
+
+	var/drain_delay = 4 SECONDS
+	COOLDOWN_DECLARE(drain_interval)
 
 /obj/item/organ/internal/heart/xenobiology/hyperactive/on_life()
 	. = ..()
 	switch(organ_quality)
 		if(ORGAN_DAMAGED)
-			if(prob(20)) // about saline level
-				owner.adjustBruteLoss(-2)
-				owner.adjustFireLoss(-2)
-			if(owner.getBruteLoss() > 10 || owner.getFireLoss() > 10) // this shits exhausting!
-				if(prob(30))
-					owner.setStaminaLoss(15)
+			owner.adjustBruteLoss(-3)
+			owner.adjustFireLoss(-3)
+			if((owner.getBruteLoss() > 10 || owner.getFireLoss() > 10) && !COOLDOWN_FINISHED(src, drain_delay)) // this shits exhausting!
+				owner.setStaminaLoss(15)
+				COOLDOWN_START(src, drain_interval, drain_delay)
 		if(ORGAN_NORMAL)
-			if(owner.getBruteLoss() > 10 || owner.getFireLoss() > 10) // this shits exhausting!
-				if(prob(20))
-					owner.setStaminaLoss(15)
-			owner.adjustBruteLoss(-1)
-			owner.adjustFireLoss(-1)
+			if((owner.getStaminaLoss() < 85 || owner.getBruteLoss() > 10 || owner.getFireLoss() > 10) && !COOLDOWN_FINISHED(src, drain_delay)) // this shits exhausting! But wont knock you over
+				owner.setStaminaLoss(15)
+				COOLDOWN_START(src, drain_interval, drain_delay)
+			owner.adjustBruteLoss(-2)
+			owner.adjustFireLoss(-2)
 		if(ORGAN_PRISTINE)
 			owner.adjustBruteLoss(-1)
 			owner.adjustFireLoss(-1)
+			owner.adjustCloneLoss(-1)
 
+// MARK: Metallic
 /obj/item/organ/internal/kidneys/xenobiology/metallic
 	name = "metallic processor"
 	desc = "A dense, metallic organ that enables the consumption of precious metals as food. No guarentee for taste, though"
@@ -428,12 +447,19 @@
 	special_tastes.RemoveComponent()
 	return ..()
 
+// MARK: Vocal Remnants
 /obj/item/organ/internal/cyberimp/mouth/xenobiology/vocal_remnants
-	name = "vocal cord remnants"
-	desc = "The remnants of a great beast's vocal coords. While only a fraction of the true organ's power, these could probably still get decently loud."
-	analyzer_price = 35
+	name = "angelic harmonizer"
+	desc = "A strange and otherwordly organ that emits a harmonic tone. Trying to touch it too quickly will push your hands away."
+	analyzer_price = 70
 	hidden_origin_tech = TECH_COMBAT
 	hidden_tech_level = 7
+	/// What is the percentage chance to block a shot?
+	var/shield_block_chance = 30
+	/// How often can we have a chance to block a shot?
+	var/shield_interval = 9 SECONDS
+
+	COOLDOWN_DECLARE(shield_delay)
 
 /obj/item/organ/internal/cyberimp/mouth/xenobiology/vocal_remnants/Initialize(mapload)
 	. = ..()
@@ -441,12 +467,37 @@
 
 /obj/item/organ/internal/cyberimp/mouth/xenobiology/vocal_remnants/insert(mob/living/carbon/M, special = 0, dont_remove_slot = 0)
 	. = ..()
-	ADD_TRAIT(M, TRAIT_LOUD, ORGAN_TRAIT)
+	ADD_TRAIT(owner, TRAIT_ANTIMAGIC, ORGAN_TRAIT)
+	REMOVE_TRAIT(M, TRAIT_LOUD, ORGAN_TRAIT)
+	RegisterSignal(owner, COMSIG_ATOM_BULLET_ACT, PROC_REF(shield_act))
+
 
 /obj/item/organ/internal/cyberimp/mouth/xenobiology/vocal_remnants/remove(mob/living/carbon/M, special = 0)
 	. = ..()
+	REMOVE_TRAIT(owner, TRAIT_ANTIMAGIC, ORGAN_TRAIT)
 	REMOVE_TRAIT(M, TRAIT_LOUD, ORGAN_TRAIT)
+	UnregisterSignal(owner, COMSIG_ATOM_BULLET_ACT)
 
+/obj/item/organ/internal/cyberimp/mouth/xenobiology/vocal_remnants/proc/shield_act(atom/target, obj/projectile/hit_projectile)
+	SIGNAL_HANDLER // COMSIG_ATOM_BULLET_ACT
+	if(owner.stat != CONSCIOUS)
+		return
+	if(!COOLDOWN_FINISHED(src, shield_delay))
+		return
+	if(!prob(shield_block_chance))
+		return
+	var/delay = shield_interval / organ_quality
+	COOLDOWN_START(src, shield_delay, delay)
+	hit_projectile.nodamage = TRUE
+	var/obj/effect/temp_visual/at_shield/AT = new /obj/effect/temp_visual/at_shield(target.loc, target)
+	var/random_x = rand(-8, 8)
+	AT.pixel_x += random_x
+	var/random_y = rand(8, 24)
+	AT.pixel_y += random_y
+	owner.visible_message(SPAN_DANGER("[hit_projectile] harmlessly collides against [owner]'s angelic aura!"), SPAN_DANGER("Your angelic voice renders the projectile harmless against you!"), SPAN_WARNING("You hear an angelic humming reverberate through the room."))
+	playsound(get_turf(owner), 'sound/magic/clockwork/invoke_general.ogg', 30, TRUE)
+
+// MARK: Toxin Stinger
 /obj/item/organ/internal/appendix/xenobiology/toxin_stinger
 	name = "hidden stinger"
 	desc = "This organ holds a deceptive stinger tucked inside of itself, dripping with venom."
@@ -522,6 +573,7 @@
 		to_chat(user, SPAN_WARNING("We wouldn't get much use out of stinging that."))
 		revert_cast()
 
+// MARK: Gneiss Converter
 /obj/item/organ/internal/appendix/xenobiology/flock_converter
 	name = "drone converter"
 	desc = "This teal organ holds a small gnesis fabricator, allowing the host to convert objects and similar to gnesis."
@@ -575,6 +627,7 @@
 	chemholder.reagents.reaction(target_turf)
 	StartCooldown()
 
+// MARK: Contortion
 /obj/item/organ/internal/heart/xenobiology/contortion
 	name = "contortion fibers"
 	desc = "A set of bands that wrap around joints and ligaments and muscles alike, pulling the body into unnatural shapes."
@@ -643,10 +696,11 @@
 		user.layer = initial(user.layer)
 	to_chat(user, SPAN_NOTICE("Our body stiffens and returns to form. That was exhausting!"))
 
+// MARK: Bloody Sack
 /obj/item/organ/internal/heart/xenobiology/bloody_sack
 	name = "bloody sack"
 	desc = "A large sack spilling with blood. Despite the fact it oozes with blood, you can feel its hunger for more."
-	analyzer_price = 75
+	analyzer_price = 80
 	can_paradox = TRUE
 	hidden_origin_tech = TECH_BLUESPACE
 	hidden_tech_level = 7
@@ -688,11 +742,13 @@
 		if(B.blood_state == BLOOD_STATE_HUMAN && (B.can_bloodcrawl_in()))
 			temp += 10
 		else
-			temp += max((B.bloodiness ** 2) / 800, 1)
+			temp += max((B.bloodiness ** 2) / 200, 1)
 		new /obj/effect/temp_visual/cult/turf/open/floor(get_turf(B))
 		qdel(B)
+
 	for(var/obj/effect/decal/cleanable/trail_holder/TH in range(T, 2))
 		new /obj/effect/temp_visual/cult/turf/open/floor(get_turf(TH))
+		temp += 1 // worth much less
 		qdel(TH)
 	if(temp)
 		user.Beam(T, icon_state = "drainbeam", time = 15)
@@ -705,39 +761,36 @@
 		temp = round(temp)
 		user.adjustBruteLoss(-temp)
 	else
-		user.playsound_local(T, 'sound/effects/heartbeat.ogg', 50, FALSE)
+		user.playsound_local(T, 'sound/effects/heartbeat.ogg', 50, FALSE, vary = TRUE)
 
-
+// MARK: Hungry
 /obj/item/organ/internal/liver/xenobiology/hungry
 	name = "hungry organ"
 	desc = "This organ seems to actively attempt to dissolve and absorb anything it touches."
-	analyzer_price = 40
+	analyzer_price = 55
 	hidden_origin_tech = TECH_BIO
 	hidden_tech_level = 7
 
 // checks with those with the eat gene from adding/removing matter eater
 /obj/item/organ/internal/liver/xenobiology/hungry/insert(mob/living/carbon/human/M, special = 0, dont_remove_slot = 0)
 	. = ..()
-	if(is_type_in_list(/datum/mutation/grant_spell/mattereater, M.active_mutations))
-		return
-	M.AddSpell(new /datum/spell/eat)
+	ADD_TRAIT(owner, TRAIT_GLUTTONOUS_GLORY, ORGAN_TRAIT)
 
 /obj/item/organ/internal/liver/xenobiology/hungry/remove(mob/living/carbon/M, special = 0)
 	. = ..()
-	if(is_type_in_list(/datum/mutation/grant_spell/mattereater, M.active_mutations))
-		return
-	M.RemoveSpell(/datum/spell/eat)
+	REMOVE_TRAIT(owner, TRAIT_GLUTTONOUS_GLORY, ORGAN_TRAIT)
 
 /obj/item/organ/internal/liver/xenobiology/hungry/on_life()
 	. = ..()
 	switch(organ_quality)
 		if(ORGAN_DAMAGED)
-			owner.adjust_nutrition(-2)
+			owner.adjust_nutrition(-4) // Dont wander far from a kitchen...
 		if(ORGAN_NORMAL)
-			owner.adjust_nutrition(-1)
+			owner.adjust_nutrition(-2)
 		if(ORGAN_PRISTINE)
-			owner.adjust_nutrition(-0.3)
+			owner.adjust_nutrition(-1)
 
+// MARK: Tendril
 /obj/item/organ/internal/appendix/xenobiology/tendril
 	name = "writhing tendrils"
 	desc = "This organ is constantly squirming and writhing around. Yuck."
@@ -815,10 +868,11 @@
 			else
 				T.visible_message(SPAN_WARNING("[T] refuses to budge!"))
 
+// MARK: Glowing
 /obj/item/organ/internal/eyes/cybernetic/xenobiology/glowing
 	name = "glowing core"
 	desc = "This organ glows with a strange energy from its depths. Is it even appropiate to call this an organ?"
-	analyzer_price = 40
+	analyzer_price = 55
 	hidden_origin_tech = TECH_BLUESPACE
 	hidden_tech_level = 6
 
@@ -835,7 +889,7 @@
 	if(organ_quality == ORGAN_PRISTINE)
 		spell.base_cooldown = 60 SECONDS
 		spell.inner_tele_radius = 5
-		spell.outer_tele_radius = 15
+		spell.outer_tele_radius = 20
 	M.AddSpell(spell)
 
 /obj/item/organ/internal/eyes/cybernetic/xenobiology/glowing/remove(mob/living/carbon/M, special = 0)
@@ -865,10 +919,6 @@
 		to_chat(user, SPAN_WARNING("We can only teleport living things!"))
 		revert_cast()
 		return
-	if(target == user)
-		to_chat(user, SPAN_WARNING("We are unable to teleport ourself!"))
-		revert_cast()
-		return
 	if(get_dist(target.loc, user.loc) > 2)
 		to_chat(user, SPAN_WARNING("They're too far away!"))
 		revert_cast()
@@ -877,18 +927,19 @@
 		revert_cast()
 		return
 	if(quality == ORGAN_BROKEN)
-		if(prob(25))
+		if(target != user && prob(25))
 			targets += user
 			user.adjustBruteLoss(10)
 			user.adjustFireLoss(10)
 			to_chat(user, SPAN_DANGER("You get dragged along into bluespace, your flesh searing from the unstable energies!"))
 		else
 			to_chat(user, SPAN_DANGER("Drawing upon unstable energy singes your flesh!"))
-			user.adjustFireLoss(8)
+			user.adjustFireLoss(rand(6, 12))
 	user.mob_light(LIGHT_COLOR_PURPLE, 3, _duration = 3)
 	new /obj/effect/temp_visual/hierophant/telegraph/teleport(get_turf(target))
 	return ..()
 
+// MARK: Shivering
 /obj/item/organ/internal/kidneys/xenobiology/shivering
 	name = "shivering organ"
 	desc = "It constantly shivers, seeking to warm itself from its environment."
@@ -903,10 +954,11 @@
 			if(ORGAN_DAMAGED)
 				owner.bodytemperature += 15
 			if(ORGAN_NORMAL)
-				owner.bodytemperature += 20
-			if(ORGAN_PRISTINE)
 				owner.bodytemperature += 30
+			if(ORGAN_PRISTINE)
+				owner.bodytemperature += 50
 
+// MARK: Sweating
 /obj/item/organ/internal/kidneys/xenobiology/sweating
 	name = "sweaty organ"
 	desc = "It constantly sweats, seeking to cool itself off from its environment."
@@ -923,10 +975,11 @@
 			if(ORGAN_DAMAGED)
 				owner.bodytemperature -= 15
 			if(ORGAN_NORMAL)
-				owner.bodytemperature -= 20
-			if(ORGAN_PRISTINE)
 				owner.bodytemperature -= 30
+			if(ORGAN_PRISTINE)
+				owner.bodytemperature -= 50
 
+// MARK: Soupy
 /obj/item/organ/internal/liver/xenobiology/soupy
 	name = "soupy organ"
 	desc = "This organ seems to barely keep its own form together. It also reeks of tomato sauce."
@@ -960,6 +1013,7 @@
 	M.dna.blood_type = original_blood_type
 	to_chat(owner, SPAN_USERDANGER("You no longer constantly taste ketchup."))
 
+// MARK: Stinger - Terror
 /obj/item/organ/internal/appendix/xenobiology/toxin_stinger/terror
 	name = "hidden terror stinger"
 	desc = "This organ holds a deceptive stinger tucked inside of itself, dripping with potent venom."
@@ -967,10 +1021,11 @@
 	terror = TRUE
 	hidden_tech_level = 7
 
+// MARK: Mirror
 /obj/item/organ/internal/lungs/xenobiology/mirror
 	name = "silvered organ"
 	desc = "This organ is dazzlingly reflective."
-	analyzer_price = 30
+	analyzer_price = 50
 	hidden_origin_tech = TECH_MATERIAL
 	hidden_tech_level = 7
 
@@ -1009,10 +1064,11 @@
 		M.icon = 'icons/mob/lavaland/lavaland_elites.dmi'
 		M.icon_state = "herald_mirror"
 
+// MARK: Squirming
 /obj/item/organ/internal/heart/xenobiology/squirming
 	name = "squirming organ"
 	desc = "This organ refuses to sit still, constantly moving about however it can."
-	analyzer_price = 75
+	analyzer_price = 80
 	can_paradox = TRUE
 	hidden_origin_tech = TECH_POWER
 	hidden_tech_level = 7
@@ -1023,36 +1079,56 @@
 
 /obj/item/organ/internal/heart/xenobiology/squirming/on_life()
 	. = ..()
+	owner.adjust_nutrition(-0.5) // This sure takes a lot of energy!
 	if(owner.getStaminaLoss() >= 5)
 		switch(organ_quality)
 			if(ORGAN_DAMAGED)
 				owner.adjustStaminaLoss(-5)
 			if(ORGAN_NORMAL)
-				owner.adjustStaminaLoss(-10)
-			if(ORGAN_PRISTINE) // slightly better/different than emagged cybernetic
-				owner.adjustStaminaLoss(-25)
+				owner.adjustStaminaLoss(-15)
+			if(ORGAN_PRISTINE) // better than emagged cybernetic
+				owner.adjustStaminaLoss(-30)
 				if(prob(20))
-					owner.AdjustStunned(-2 SECONDS)
-					owner.AdjustKnockDown(-2 SECONDS)
+					owner.AdjustStunned(-3 SECONDS)
+					owner.AdjustKnockDown(-3 SECONDS)
 
+// MARK: Electro Strands
 /obj/item/organ/internal/appendix/xenobiology/electro_strands
 	name = "electromagnetic strands"
 	desc = "A large number of electrically sensitive strands all bundled up together. It has lost most of its potential."
-	analyzer_price = 30
+	analyzer_price = 50
 	hidden_origin_tech = TECH_MAGNETS
 	hidden_tech_level = 7
+	/// How far are we allowed to shock someone from?
+	var/shock_range = 4
 
 /obj/item/organ/internal/appendix/xenobiology/electro_strands/insert(mob/living/carbon/human/M, special = 0, dont_remove_slot = 0)
 	. = ..()
-	var/datum/spell/aoe/flicker_lights/spell = new
-	spell.from_organ = TRUE
+	var/datum/spell/aoe/flicker_lights/electro_strands/spell = new
 	M.AddSpell(spell)
 
 /obj/item/organ/internal/appendix/xenobiology/electro_strands/remove(mob/living/carbon/M, special = 0)
 	. = ..()
-	M.RemoveSpell(/datum/spell/aoe/flicker_lights)
+	M.RemoveSpell(/datum/spell/aoe/flicker_lights/electro_strands)
 
+/datum/spell/aoe/flicker_lights/electro_strands
+	name = "Discharge power"
+	desc = "Quickly dump out a large voltage of power into the immediate area. Zap!"
 
+/datum/spell/aoe/flicker_lights/electro_strands/cast(list/targets, mob/user = usr)
+	. = ..()
+	do_sparks(3, FALSE, user)
+	var/list/mob_list = list()
+	for(var/mob/living/L in view(4, user))
+		if(L == user)
+			continue
+		mob_list += L
+	var/mob/living/chosen_victim = pick(mob_list)
+	var/turf/T = get_turf(user)
+	chosen_victim.Beam(T, icon_state = "lightning[rand(1, 12)]", icon = 'icons/effects/effects.dmi', time = 5)
+	chosen_victim.electrocute_act(3.5, "electrical blast")
+
+// MARK: Sharp
 /obj/item/organ/internal/liver/xenobiology/sharp
 	name = "sharp organ"
 	desc = "This organ sprouts several sharp points out of itself, which you can't imagine would feel good to get implanted."
@@ -1085,6 +1161,7 @@
 		var/datum/unarmed_attack/unarmed = owner.get_unarmed_attack()
 		unarmed.sharp = original_sharpened
 
+// MARK: Noisemaker
 /obj/item/organ/internal/appendix/xenobiology/noisemaker
 	name = "mimicry organ"
 	desc = "This organ continues to make odd sounds, copying things that it has heard."
@@ -1128,28 +1205,35 @@
 	playsound(owner.loc, chosen_sound, 50, TRUE)
 	COOLDOWN_START(src, migo_cooldown, 10 SECONDS)
 
+// MARK: Receptors
 /obj/item/organ/internal/eyes/xenobiology/receptors
 	name = "photosensitive receptors"
 	desc = "A set of organs receptive to light in the spectrum of -- hey, wait a second. Aren't these just eyes?"
-	analyzer_price = 40
+	analyzer_price = 55
 	hidden_origin_tech = TECH_BIO
 	hidden_tech_level = 7
 
 /obj/item/organ/internal/eyes/xenobiology/receptors/insert(mob/living/carbon/M, special, dont_remove_slot)
 	switch(organ_quality)
-		if(ORGAN_BROKEN)
+		if(ORGAN_BROKEN) // some NV but flash sensitive
+			flash_protect = FLASH_PROTECTION_SENSITIVE
 			see_in_dark = 4
-		if(ORGAN_NORMAL)
+		if(ORGAN_NORMAL) // slightly better mesons
+			see_in_dark = 4
+			flash_protect = FLASH_PROTECTION_FLASH
+			lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
+			vision_flags = SEE_OBJS | SEE_TURFS
+		if(ORGAN_PRISTINE) // xrays
 			see_in_dark = 8
-		if(ORGAN_PRISTINE)
-			see_in_dark = 8
-			vision_flags = SEE_OBJS | SEE_TURFS // slightly better mesons
+			flash_protect = FLASH_PROTECTION_FLASH
+			vision_flags = SEE_OBJS | SEE_TURFS | SEE_MOBS
 	return ..()
 
+// MARK: Paradox
 /obj/item/organ/internal/heart/xenobiology/paradox
 	name = "paradoxical organ"
 	desc = "The organ is constantly shifting and morphing; each time you look away it's something new."
-	analyzer_price = 40
+	analyzer_price = 80
 	/// holds the list what all the valid hearts that the paradox heart can swap out with
 	var/list/acceptable_hearts = list()
 
@@ -1168,6 +1252,7 @@
 	new_organ.insert(M)
 	qdel(src)
 
+// MARK: Bananium
 /obj/item/organ/internal/heart/xenobiology/bananium
 	name = "bananium laced heart"
 	desc = "Squeak squeak squeak sqonk honk honk snorf"
@@ -1205,9 +1290,13 @@
 	. = ..()
 	if(!owner.mind)
 		return
-	if(owner.mind.assigned_role == "Clown" && organ_quality == ORGAN_PRISTINE)
-		owner.adjustBruteLoss(-3)
-		owner.adjustFireLoss(-3)
+	if(owner.mind.assigned_role == "Clown")
+		if(organ_quality == ORGAN_PRISTINE)
+			owner.adjustBruteLoss(-3)
+			owner.adjustFireLoss(-3)
+		else
+			owner.adjustBruteLoss(-1)
+			owner.adjustFireLoss(-1)
 	else if(owner.mind.assigned_role == "Mime")
 		if(prob(3))
 			owner.emote("scream")
@@ -1220,7 +1309,7 @@
 			owner.adjustFireLoss(1, robotic = TRUE)
 		else
 			owner.adjustToxLoss(1)
-	if(prob(2))
+	if(prob(1))
 		var/list/clown_message = list(
 		"You feel light-headed.",
 		"You can't see straight.",
@@ -1249,6 +1338,7 @@
 			M.dna.SetSEState(GLOB.clumsyblock, FALSE, FALSE)
 			M.dna.SetSEState(GLOB.comicblock, FALSE, FALSE)
 
+// MARK: Cursed Bananium
 /obj/item/organ/internal/heart/xenobiology/cursed_bananium
 	name = "cursed bananium heart"
 	desc = "This organ is wreathed in foul energy from cursed bananium. There may be great power here, but only the truest of souls could bring it forward."
@@ -1264,6 +1354,7 @@
 		"TEEHEE!",
 		"HONK HONK HONK HONK HONK!!!",
 		"THEY MUST ALL BE HONKED!",
+		"JOY! LAUGHTER! SMILES! WHEEEEEEEE!~"
 	)
 
 /obj/item/organ/internal/heart/xenobiology/cursed_bananium/insert(mob/living/carbon/human/M, special, dont_remove_slot)
@@ -1312,13 +1403,13 @@
 			if(prob(10))
 				to_chat(owner, SPAN_USERDANGER("[pick(clown_noises)]"))
 
+// MARK: Supercharged
 /obj/item/organ/internal/cell/xenobiology/supercharged
 	name = "supercharged core"
 	desc = "This specialized core thrumms with potental and energy. It desperately seeks release."
 	analyzer_price = 80
 	hidden_origin_tech = TECH_TOXINS
 	hidden_tech_level = 7
-
 
 /obj/item/organ/internal/cell/xenobiology/supercharged/Initialize(mapload)
 	. = ..()
@@ -1364,25 +1455,45 @@
 			if(!try_stop_buildup(usr))
 				return // Don't remove the click intercept
 
+/datum/spell/charge_up/explode/can_cast(mob/user, charge_check, show_message)
+	if(!..())
+		return FALSE
+	if(user.nutrition <= 140)
+		to_chat(user, SPAN_DANGER("Your power source is too drained to charge it effectively"))
+		return FALSE
+	return TRUE
+
 /datum/spell/charge_up/explode/Discharge(mob/user)
 	. = ..()
 	if(quality == ORGAN_DAMAGED)
 		explosion(user.loc, 1, 2, 3, 3, cause = user) // gaurenteed gib, just about
-	else
-		explosion(user.loc, 0, 2, 3, 3, cause = user)
+		return
+
+	ADD_TRAIT(user, TRAIT_EXPLOSION_PROOF, ORGAN_TRAIT)
+	ADD_TRAIT(user, TRAIT_EMP_RESIST, ORGAN_TRAIT)
+	addtimer(CALLBACK(src, PROC_REF(cleanup), user), 0.3 SECONDS) // juuust long enough to survive the blast itself.
+
+	explosion(user.loc, 0, 3, 4, 4, cause = user)
 	if(quality == ORGAN_PRISTINE)
-		user.status_flags |= GODMODE
-		addtimer(CALLBACK(src, PROC_REF(cleanup), user), 0.3 SECONDS) // juuust long enough to survive the blast itself.
+		empulse(user, 4, 10, 1, cause = user)
 
 /datum/spell/charge_up/explode/proc/cleanup(mob/living/carbon/human/user)
-	user.status_flags &= ~GODMODE
+	REMOVE_TRAIT(user, TRAIT_EXPLOSION_PROOF, ORGAN_TRAIT)
+	REMOVE_TRAIT(user, TRAIT_EMP_RESIST, ORGAN_TRAIT)
 	if(user.nutrition > 140) // overloading your powersource will do that
 		user.nutrition = 140
 	else
 		user.nutrition = max(user.nutrition - 75, 5)
 	for(var/obj/item/organ/internal/cell/C in user.internal_organs)
-		C.damage += 20 // ouch. Maybe dont blow up
+		switch(C.organ_quality)
+			if(ORGAN_BROKEN)
+				C.damage += 20 // ouch. Maybe dont blow up
+			if(ORGAN_NORMAL)
+				C.damage += 15
+			if(ORGAN_PRISTINE)
+				C.damage += 10
 
+// MARK: Megacarp
 /obj/item/organ/internal/heart/xenobiology/megacarp
 	name = "rancid clump"
 	desc = "It reeks of fish and... soy sauce?"
@@ -1445,11 +1556,11 @@
 	universal_understand = TRUE
 	pass_flags = PASSTABLE
 
+// MARK: Feverish
 /obj/item/organ/internal/appendix/xenobiology/feverish
 	name = "feverish organ"
 	desc = "This organ is warm, and looks sickly. Yet by all means, there doesnt appear to be any infections."
 	analyzer_price = 15
-
 
 /obj/item/organ/internal/appendix/xenobiology/feverish/on_life()
 	. = ..()
@@ -1459,10 +1570,11 @@
 		if(ORGAN_DAMAGED)
 			owner.bodytemperature += 15
 		if(ORGAN_NORMAL)
-			owner.bodytemperature += 20
-		if(ORGAN_PRISTINE)
 			owner.bodytemperature += 30
+		if(ORGAN_PRISTINE)
+			owner.bodytemperature += 50
 
+// MARK: Freezing
 /obj/item/organ/internal/appendix/xenobiology/freezing
 	name = "Freezing Organ"
 	desc = "This organ is cold to the touch, despite seeming to be very active."
@@ -1476,10 +1588,11 @@
 		if(ORGAN_DAMAGED)
 			owner.bodytemperature -= 15
 		if(ORGAN_NORMAL)
-			owner.bodytemperature -= 20
-		if(ORGAN_PRISTINE)
 			owner.bodytemperature -= 30
+		if(ORGAN_PRISTINE)
+			owner.bodytemperature -= 50
 
+// MARK: Lethargic
 /obj/item/organ/internal/kidneys/xenobiology/lethargic
 	name = "lethargic organ"
 	desc = "This organ barely seems to do anything, only being just active enough to keep itself alive. However, it seems exceptionally hardy."
@@ -1495,27 +1608,28 @@
 	ADD_TRAIT(M, TRAIT_GOTTAGOSLOW, ORGAN_TRAIT)
 	if(organ_quality == ORGAN_DAMAGED)
 		organ_resistance_boost = new /datum/armor(5, 5, 5, 5, 5, 5, 5, 5, 0)
-		owner.physiology.stamina_mod *= 0.9
+		owner.physiology.stamina_mod *= 0.8
 	if(organ_quality == ORGAN_NORMAL)
-		organ_resistance_boost = new /datum/armor(15, 15, 15, 15, 15, 15, 15, 15, 0)
-		owner.physiology.stamina_mod *= 0.75
+		organ_resistance_boost = new /datum/armor(20, 20, 20, 20, 20, 20, 20, 20, 0)
+		owner.physiology.stamina_mod *= 0.6
 	if(organ_quality == ORGAN_PRISTINE)
-		organ_resistance_boost = new /datum/armor(50, 50, 50, 50, 50, 50, 50, 50, 0)
-		owner.physiology.stamina_mod *= 0.5
+		organ_resistance_boost = new /datum/armor(60, 60, 60, 60, 60, 60, 60, 60, 0)
+		owner.physiology.stamina_mod *= 0.4
 	owner.physiology.armor = owner.physiology.armor.attachArmor(organ_resistance_boost)
 
 /obj/item/organ/internal/kidneys/xenobiology/lethargic/remove(mob/living/carbon/M, special)
 	. = ..()
 	REMOVE_TRAIT(M, TRAIT_GOTTAGOSLOW, ORGAN_TRAIT)
 	if(organ_quality == ORGAN_DAMAGED)
-		owner.physiology.stamina_mod /= 0.9
+		owner.physiology.stamina_mod /= 0.8
 	if(organ_quality == ORGAN_NORMAL)
-		owner.physiology.stamina_mod /= 0.75
+		owner.physiology.stamina_mod /= 0.6
 	if(organ_quality == ORGAN_PRISTINE)
-		owner.physiology.stamina_mod /= 0.5
+		owner.physiology.stamina_mod /= 0.4
 	owner.physiology.armor = owner.physiology.armor.detachArmor(organ_resistance_boost)
 	QDEL_NULL(organ_resistance_boost)
 
+// MARK: Gnesis Filters
 /obj/item/organ/internal/kidneys/xenobiology/gnesis_filters
 	name = "gnesis mesh kidneys"
 	desc = "This strange organ resembles a pair of biological kidneys, but their micro-structure is interlaced with nanotubules of gnesis."
@@ -1532,9 +1646,10 @@
 	owner.adjustToxLoss(-0.6 * mult)
 	owner.reagents.add_reagent("gnesis_tox", 0.1 * mult)
 
+// MARK: Colorful
 /obj/item/organ/internal/ears/xenobiology/colorful
 	name = "colorful organ"
-	desc = "This organ seems to constantly color and mold the other flesh around it. Thankfully, the changes are only aesthetic."
+	desc = "This organ seems to constantly color and mold any surrounding flesh. Thankfully, the changes are only aesthetic."
 	analyzer_price = 20
 
 	COOLDOWN_DECLARE(hair_change)
@@ -1549,10 +1664,11 @@
 	COOLDOWN_START(src, hair_change, 1 MINUTES)
 	scramble(1, owner, 100)
 
+// MARK: Sinister
 /obj/item/organ/internal/ears/xenobiology/sinister
 	name = "sinister organ"
 	desc = "This organ is brimming with foul aura. Small buds seem to be growing out of it"
-	analyzer_price = 60
+	analyzer_price = 70
 	hidden_origin_tech = TECH_COMBAT
 	hidden_tech_level = 6
 
@@ -1678,3 +1794,12 @@
 		src.visible_message(SPAN_NOTICE("\The [src] loses energy, and it crumbles into a pile of flesh."))
 		death()
 	return ..()
+
+// MARK: Finned
+// currently does nothign until TRAIT_SPACEWALK is merged
+/obj/item/organ/internal/kidneys/xenobiology/finned
+	name = "finned organ"
+	desc = "This organ has large fins that protrude through the skin. Special molecular fibers help to catch ionic compouds to propel through space."
+	analyzer_price = 40
+	hidden_origin_tech = TECH_BIO
+	hidden_tech_level = 6

--- a/code/modules/research/xenobiology/xenobiology_organs.dm
+++ b/code/modules/research/xenobiology/xenobiology_organs.dm
@@ -899,7 +899,7 @@
 /datum/spell/turf_teleport/organ_teleport
 	name = "Unstable Blink"
 	desc = "Touch someone to destabilize their location in bluespace for a moment."
-	base_cooldown = 2 MINUTES
+	base_cooldown = 20 SECONDS
 	clothes_req = FALSE
 	action_icon_state = "spell_teleport"
 	sound = null
@@ -912,6 +912,13 @@
 	var/datum/spell_targeting/clicked_atom/external/C = new()
 	C.range = 20
 	return C
+
+/datum/spell/turf_teleport/organ_teleport/can_cast(mob/user, charge_check, show_message)
+	. = ..()
+	if(HAS_TRAIT(user, TRAIT_BLIND))
+		to_chat(user, SPAN_WARNING("You can't cast upon what you cant see!"))
+		return FALSE
+	return TRUE
 
 /datum/spell/turf_teleport/organ_teleport/cast(list/targets, mob/living/user)
 	var/atom/target = targets[1]

--- a/code/modules/research/xenobiology/xenobiology_organs.dm
+++ b/code/modules/research/xenobiology/xenobiology_organs.dm
@@ -286,7 +286,7 @@
 	var/turfs = line_target(0, line_range, target, user)
 	dragon_fire_line(user, turfs)
 
-	if(quality == 1) // Damaged will burn the user
+	if(quality == 1) // Damaged will burn the user.
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
 			H.adjustFireLossByPart(10, BODY_ZONE_HEAD)
@@ -373,7 +373,7 @@
 				owner.setStaminaLoss(15)
 				COOLDOWN_START(src, drain_interval, drain_delay)
 		if(ORGAN_NORMAL)
-			if((owner.getStaminaLoss() < 85 || owner.getBruteLoss() > 10 || owner.getFireLoss() > 10) && !COOLDOWN_FINISHED(src, drain_delay)) // this shits exhausting! But wont knock you over
+			if((owner.getStaminaLoss() < 85 || owner.getBruteLoss() > 10 || owner.getFireLoss() > 10) && !COOLDOWN_FINISHED(src, drain_delay)) // This shit's exhausting! But won't knock you over.
 				owner.setStaminaLoss(15)
 				COOLDOWN_START(src, drain_interval, drain_delay)
 			owner.adjustBruteLoss(-2)
@@ -748,7 +748,7 @@
 
 	for(var/obj/effect/decal/cleanable/trail_holder/TH in range(T, 2))
 		new /obj/effect/temp_visual/cult/turf/open/floor(get_turf(TH))
-		temp += 1 // worth much less
+		temp += 1 // Worth much less.
 		qdel(TH)
 	if(temp)
 		user.Beam(T, icon_state = "drainbeam", time = 15)
@@ -1093,7 +1093,7 @@
 				owner.adjustStaminaLoss(-5)
 			if(ORGAN_NORMAL)
 				owner.adjustStaminaLoss(-15)
-			if(ORGAN_PRISTINE) // better than emagged cybernetic
+			if(ORGAN_PRISTINE) // Better than emagged cybernetic heart.
 				owner.adjustStaminaLoss(-30)
 				if(prob(20))
 					owner.AdjustStunned(-3 SECONDS)
@@ -1222,15 +1222,15 @@
 
 /obj/item/organ/internal/eyes/xenobiology/receptors/insert(mob/living/carbon/M, special, dont_remove_slot)
 	switch(organ_quality)
-		if(ORGAN_BROKEN) // some NV but flash sensitive
+		if(ORGAN_BROKEN) // Some night vision, but flash sensitive.
 			flash_protect = FLASH_PROTECTION_SENSITIVE
 			see_in_dark = 4
-		if(ORGAN_NORMAL) // slightly better mesons
+		if(ORGAN_NORMAL) // Slightly better mesons.
 			see_in_dark = 4
 			flash_protect = FLASH_PROTECTION_FLASH
 			lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 			vision_flags = SEE_OBJS | SEE_TURFS
-		if(ORGAN_PRISTINE) // xrays
+		if(ORGAN_PRISTINE) // X-ray vision.
 			see_in_dark = 8
 			flash_protect = FLASH_PROTECTION_FLASH
 			vision_flags = SEE_OBJS | SEE_TURFS | SEE_MOBS
@@ -1478,7 +1478,7 @@
 
 	ADD_TRAIT(user, TRAIT_EXPLOSION_PROOF, ORGAN_TRAIT)
 	ADD_TRAIT(user, TRAIT_EMP_RESIST, ORGAN_TRAIT)
-	addtimer(CALLBACK(src, PROC_REF(cleanup), user), 0.3 SECONDS) // juuust long enough to survive the blast itself.
+	addtimer(CALLBACK(src, PROC_REF(cleanup), user), 0.3 SECONDS) // Juuust long enough to survive the blast itself.
 
 	explosion(user.loc, 0, 3, 4, 4, cause = user)
 	if(quality == ORGAN_PRISTINE)
@@ -1494,7 +1494,7 @@
 	for(var/obj/item/organ/internal/cell/C in user.internal_organs)
 		switch(C.organ_quality)
 			if(ORGAN_BROKEN)
-				C.damage += 20 // ouch. Maybe dont blow up
+				C.damage += 20 // Ouch! Maybe don't blow up.
 			if(ORGAN_NORMAL)
 				C.damage += 15
 			if(ORGAN_PRISTINE)
@@ -1803,7 +1803,7 @@
 	return ..()
 
 // MARK: Finned
-// currently does nothign until TRAIT_SPACEWALK is merged
+// Currently does nothing until TRAIT_SPACEWALK is merged.
 /obj/item/organ/internal/kidneys/xenobiology/finned
 	name = "finned organ"
 	desc = "This organ has large fins that protrude through the skin. Special molecular fibers help to catch ionic compouds to propel through space."

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -16,7 +16,7 @@
 	/// How much is this organ worth in the xenobiology organ analyzer?
 	var/analyzer_price = 10
 	/// what quality is this organ? Only useful for xeno organs
-	var/organ_quality = ORGAN_NORMAL
+	var/organ_quality = ORGAN_PRISTINE
 	/// Does this organ originate from the xenobiology dissection loop?
 	var/is_xeno_organ = FALSE
 	/// Does this organ give a warning upon being inserted?


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Addresses each individual organ and several underlying systems to massively buff many organs as well as some other related parts of the dissection system. Listed below is a comprehensive note on every change:

- Organs now default to pristine if spawned by an admin
- Smith tool bits are 50% more effective
- Every megafauna-sourced organ and then some have had their analyze prices increased.
- Flame sac now ALWAYS provides a flame breath attack, scaling with range and potential for self damage.
- Hyperactive organ is now less random, and wont make you pass out at non-broken quality. Pristine now heals clone damage too.
- Vocal Coord Remnants completely redesigned to Angelic Harmonizer, which has a chance to block projectiles, on a cooldown as well as making the user anti-magic.
- Bloody Sack now gets usable healing from bloody tracks on the floor, at 1/10 the rate of a puddle.
- Hungry Organ does not give the matter eater perk, but now provides healing benefits for eating food (especially big food), but the hunger rate has increased.
- Glowing organ can now teleport the user willingly, and has the maximum distance traveled on pristine quality raised to 20 tiles. Burns caused by damaged organ slightly randomized. Cast time reduced to 20 seconds, but is stopped with blindness.
- Shivering/Freezing/Sweating/Feverish organs all more powerful at their respective temp changes.
- Squirming organ now removes more stamina, and is better at removing stuns. (All around better than emagged cyber heart)
- Electro strands now provide an arc of electricity to a random living mob nearby when used. (It still flickers lights too)
- Photoreceptors now provide better-meson vision at normal quality, and pristine gives true xray vision as well as flash protection.
- Bananium Heart now provides *some* healing when not pristine.
- Supercharged organ now provides immunity to the user's own explosion on any non-damaged organ. Pristine organs now have an EMP effect. (As well as using proper traits instead of brief godmode). Quality now affects how much damage the core takes. removed ability to use the explosion when starving.
- Lethargic organ armor/stamina resistance increased
- Added an organ to the whale, but its effect will need to wait until TRAIT_SPACEWALK gets in. Its useless in its base form.

## Why It's Good For The Game

These organs are so horribly underused and widely considered not good/not worth the effort it takes to obtain them. This should help encourage its use more and see people engaging in the other half of xenobiology.

## Images of changes

<img width="806" height="531" alt="dreamseeker_bkebj42U3i" src="https://github.com/user-attachments/assets/75221001-53d7-451f-a79c-d130327ee730" />
<img width="108" height="230" alt="dreamseeker_waT3eMoPvQ" src="https://github.com/user-attachments/assets/f98ad4ec-d951-498e-87ae-405b0fff4499" />

## Testing

Spawned in each organ and installed to ensure its functionality and intended changes are in effect.

## Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Changelog

:cl:
add: Added the finned organ to whales
tweak:  Buffed most xenobiology organs
tweak:  Buffed smith tool bit effect on dissections
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
