### PR TITLE
Adds the Ion Rifle to Cargo, Removes From Armoury

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -1522,6 +1522,7 @@
 	dir = 8
 	},
 /obj/structure/shelf/security,
+/obj/item/storage/box/flashbangs,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
 "aiq" = (
@@ -1640,7 +1641,6 @@
 	dir = 8
 	},
 /obj/item/clothing/suit/hooded/ablative,
-/obj/item/gun/energy/ionrifle,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
 "aiD" = (
@@ -6019,8 +6019,7 @@
 	},
 /obj/structure/sign/poster/official/random/directional/east,
 /obj/machinery/keycard_auth{
-	pixel_y = 27;
-	pixel_x = 0
+	pixel_y = 27
 	},
 /obj/structure/closet/secure_closet/blueshield,
 /turf/simulated/floor/wood,
@@ -26044,7 +26043,6 @@
 "bWw" = (
 /obj/structure/table/wood,
 /obj/item/paper/blueshield{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/item/lighter/zippo/blue{
@@ -60036,7 +60034,6 @@
 	},
 /obj/structure/table/wood,
 /obj/item/ashtray/glass{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/storage/fancy/cigarettes/cigpack_robustgold{
@@ -80411,7 +80408,6 @@
 	pixel_y = 2
 	},
 /obj/item/pen/multi/fountain{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /turf/simulated/floor/wood,
@@ -82438,8 +82434,7 @@
 /obj/item/paper_bin,
 /obj/item/pen/fancy,
 /obj/item/reagent_containers/drinks/drinkingglass/shotglass{
-	pixel_x = -10;
-	pixel_y = 0
+	pixel_x = -10
 	},
 /obj/item/reagent_containers/drinks/drinkingglass/shotglass{
 	pixel_x = -9;

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -53764,7 +53764,6 @@
 /area/station/security/main)
 "kpR" = (
 /obj/structure/rack,
-/obj/item/gun/energy/ionrifle,
 /obj/item/clothing/suit/hooded/ablative,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -92513,6 +92512,10 @@
 	pixel_y = -3
 	},
 /obj/structure/shelf/security,
+/obj/item/storage/box/flashbangs{
+	pixel_x = -2;
+	pixel_y = -2
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
 "sMt" = (

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -15650,6 +15650,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
+/obj/item/storage/box/flashbangs,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
 "bmg" = (
@@ -91245,7 +91246,6 @@
 "uJk" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/ablative,
-/obj/item/gun/energy/ionrifle,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
 "uJC" = (

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -35726,7 +35726,6 @@
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/ablative,
 /obj/structure/window/reinforced,
-/obj/item/gun/energy/ionrifle,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
 "het" = (
@@ -111123,6 +111122,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced,
+/obj/item/storage/box/flashbangs,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
 "vZo" = (

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -30973,9 +30973,6 @@
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/item/storage/secure/safe{
 	pixel_y = 32
 	},
@@ -37338,6 +37335,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/asmaint)
+"ghc" = (
+/obj/effect/turf_decal/trimline/department/security/line,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/armory/secure)
 "ghd" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/plasteel/dark,
@@ -47881,9 +47885,6 @@
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Armory_North_West";
 	location = "Armory_North"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/turf_decal/trimline/department/security/corner{
@@ -63554,22 +63555,9 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prison)
 "oKF" = (
-/obj/item/grenade/barrier{
-	pixel_x = -6;
-	pixel_y = -2
-	},
-/obj/item/grenade/barrier{
-	pixel_x = -1;
-	pixel_y = -1
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 4
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 9;
-	pixel_y = 1
-	},
 /obj/structure/shelf/security,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
 "oKH" = (
@@ -76928,7 +76916,9 @@
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 1
 	},
-/obj/machinery/economy/vending/security,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
 "tcP" = (
@@ -92084,8 +92074,7 @@
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 9
 	},
-/obj/structure/gunrack,
-/obj/item/gun/energy/ionrifle,
+/obj/machinery/economy/vending/security,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
 "xWt" = (
@@ -120665,7 +120654,7 @@ kEO
 oxt
 aHO
 tcK
-hIy
+ghc
 oKF
 iZz
 fWJ

--- a/_maps/map_files/stations/omegastation.dmm
+++ b/_maps/map_files/stations/omegastation.dmm
@@ -6335,7 +6335,6 @@
 	},
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/ablative,
-/obj/item/gun/energy/ionrifle,
 /obj/item/shield/riot,
 /obj/item/shield/riot,
 /obj/item/shield/riot,
@@ -6492,6 +6491,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
+/obj/item/storage/box/flashbangs,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
 "aBP" = (
@@ -41294,12 +41294,10 @@
 "qsg" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/surgical_tray{
-	pixel_x = 0;
 	pixel_y = -5
 	},
 /obj/effect/turf_decal/tiles/department/medical/side,
 /obj/machinery/autoclave{
-	pixel_x = 0;
 	pixel_y = 7
 	},
 /turf/simulated/floor/plasteel/dark,
@@ -54820,7 +54818,6 @@
 	dir = 1
 	},
 /obj/machinery/autoclave{
-	pixel_x = 0;
 	pixel_y = 7
 	},
 /turf/simulated/floor/plasteel/dark,

--- a/code/modules/supply/supply_packs/pack_security.dm
+++ b/code/modules/supply/supply_packs/pack_security.dm
@@ -204,6 +204,13 @@
 	cost = 1000
 	containername = "combat shotgun crate"
 
+/datum/supply_packs/security/armory/ionrifle
+	name = "Ion Rifle Crate"
+	contains = list(/obj/item/gun/energy/ionrifle,
+					/obj/item/gun/energy/ionrifle)
+	cost = 750
+	containername = "ion rifle crate"
+
 /datum/supply_packs/security/armory/expenergy
 	name = "Energy Guns Crate"
 	contains = list(/obj/item/gun/energy/gun,

--- a/code/modules/supply/supply_packs/pack_security.dm
+++ b/code/modules/supply/supply_packs/pack_security.dm
@@ -208,7 +208,7 @@
 	name = "Ion Rifle Crate"
 	contains = list(/obj/item/gun/energy/ionrifle,
 					/obj/item/gun/energy/ionrifle)
-	cost = 750
+	cost = 500
 	containername = "ion rifle crate"
 
 /datum/supply_packs/security/armory/expenergy


### PR DESCRIPTION
## What Does This PR Do
* Adds the ion gun to cargo. A crate of 2 ion guns costs 500 Cr.
* Removes the ion gun from the armoury.
* Adds a box of flashbangs to the armoury (for their anti-borg properties).

This is a potentially controversial change with balance implications, and will require a test-merge to see how it affects user behaviour.
## Why It's Good For The Game
Ion rifles are very quickly reached for by security whenever an IPC antagonist exists, despite the gun essentially being the robot version of the decloner in terms of escalation. The main driving force of this issue is the fact that it's always there, ready to use.

Moving it to cargo means that security still has access to it without RND, but they have to deliberately commit resources (their budget) to acquiring it. If they do decide on this course of action, they can get more ion guns than they would have, ideal for situations like swarmers or malf AI.

A box of flashbangs has been added to every armoury, these are improved anti-silicon stun weapons with a far greater area of effect and reduced collateral damage.

## Testing
* Visually inspected the armoury.
* Bought ion gun crates, opened them.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<img width="997" height="76" alt="image" src="https://github.com/user-attachments/assets/3ea81159-6ac2-498d-b03d-157881da6b3a" />
<img width="1383" height="118" alt="image" src="https://github.com/user-attachments/assets/10d971f0-28b4-4b3e-9559-b01cb07b0cfb" />

## Changelog
:cl:
add: Added a box of flashbangs to the armoury.
add: Added the ion rifle to cargo, 500 Cr for a crate of two.
del: Removed the ion rifle from the armoury.
/:cl: