### PR TITLE
Adjusts Material Crates, Adds 3 New Material Crates

### DIFF
--- a/code/modules/events/shuttle_loan/shuttle_loan_datum.dm
+++ b/code/modules/events/shuttle_loan/shuttle_loan_datum.dm
@@ -163,9 +163,9 @@
 
 /datum/shuttle_loan_situation/mineral_haul/spawn_items(list/spawn_list, list/empty_shuttle_turfs)
 	var/static/list/crate_types = list(
-		/datum/supply_packs/materials/metal50,
-		/datum/supply_packs/materials/glass50,
-		/datum/supply_packs/materials/sandstone30,
+		/datum/supply_packs/materials/metal,
+		/datum/supply_packs/materials/glass,
+		/datum/supply_packs/materials/sandstone,
 	)
 	for(var/crate in crate_types)
 		var/datum/supply_packs/new_crate = new crate()

--- a/code/modules/supply/supply_packs/pack_materials.dm
+++ b/code/modules/supply/supply_packs/pack_materials.dm
@@ -4,45 +4,66 @@
 	announce_beacons = list("Engineering" = list("Engineering", "Chief Engineer's Desk", "Atmospherics"))
 
 
-/datum/supply_packs/materials/metal50
+/datum/supply_packs/materials/metal
 	name = "50 Metal Sheets Crate"
 	contains = list(/obj/item/stack/sheet/metal)
 	amount = 50
-	cost = 400
+	cost = 100
 	containername = "metal sheets crate"
 
-/datum/supply_packs/materials/glass50
+/datum/supply_packs/materials/glass
 	name = "50 Glass Sheets Crate"
 	contains = list(/obj/item/stack/sheet/glass)
 	amount = 50
-	cost = 400
+	cost = 100
 	containername = "glass sheets crate"
 
-/datum/supply_packs/materials/wood30
-	name = "30 Wood Planks Crate"
+/datum/supply_packs/materials/wood
+	name = "50 Wood Planks Crate"
 	contains = list(/obj/item/stack/sheet/wood)
-	amount = 30
-	cost = 400
+	amount = 50
+	cost = 100
 	containername = "wood planks crate"
 
-/datum/supply_packs/materials/cardboard50
+/datum/supply_packs/materials/cardboard
 	name = "50 Cardboard Sheets Crate"
 	contains = list(/obj/item/stack/sheet/cardboard)
 	amount = 50
-	cost = 200
+	cost = 30
 	containername = "cardboard sheets crate"
 
-/datum/supply_packs/materials/sandstone30
-	name = "30 Sandstone Blocks Crate"
+/datum/supply_packs/materials/sandstone
+	name = "50 Sandstone Blocks Crate"
 	contains = list(/obj/item/stack/sheet/mineral/sandstone)
-	amount = 30
-	cost = 400
+	amount = 50
+	cost = 100
 	containername = "sandstone blocks crate"
 
-
-/datum/supply_packs/materials/plastic30
-	name = "30 Plastic Sheets Crate"
+// In order for crew to profit from this, it'd need to be worth 29 Cr. Making this into crates and reselling it is break-even.
+/datum/supply_packs/materials/plastic
+	name = "50 Plastic Sheets Crate"
 	contains = list(/obj/item/stack/sheet/plastic)
-	amount = 30
-	cost = 400
+	amount = 50
+	cost = 30
 	containername = "plastic sheets crate"
+
+/datum/supply_packs/materials/platinum
+	name = "20 Platinum Sheets Crate"
+	contains = list(/obj/item/stack/sheet/mineral/platinum)
+	amount = 20
+	cost = 500
+	containername = "platinum sheets crate"
+
+/datum/supply_packs/materials/palladium
+	name = "20 Palladium Sheets Crate"
+	contains = list(/obj/item/stack/sheet/mineral/palladium)
+	amount = 20
+	cost = 500
+	containername = "palladium sheets crate"
+
+/datum/supply_packs/materials/iridium
+	name = "20 Iridium Sheets Crate"
+	contains = list(/obj/item/stack/sheet/mineral/iridium)
+	amount = 20
+	cost = 500
+	containername = "iridium sheets crate"


### PR DESCRIPTION
## What Does This PR Do
* Adds 3 new material crates containing platinum, iridium, and palladium. Each crate contains 20 sheets of the selected material, and costs 500 Cr (making it equal to 25 Cr per sheet).
* Plastic sheet crates have had their amount increased from 30 to 50, and the cost reduced from 400 Cr to 30 Cr. Plastic is trivial to mass produce in chemistry and should not be that expensive. It is impossible to make a profit on this crate by making plastic crates, you will break-even.
* Cardboard sheet crates have has their cost reduced from 400 Cr to 30 Cr. It's cardboard, it's cheap (botany can also trivially mass-produce it).
* Sandstone crates have had their amount increased from 30 to 50, and the cost reduced from 400 Cr to 100 Cr.
* Wood crates have had their amount increased from 30 to 50, and the cost reduced from 400 Cr to 100 Cr.
* Metal and glass crates have had their costs reduced from 400 Cr to 100 Cr. Because it'd be a bit weird for the most basic material to be similar in price to rare space ores.
## Why It's Good For The Game
Space ores are only available from mining asteroids. The strongest lavaland miner in the world will NEVER find any. Explorers have lots of gamer loot to chase after that they are likely to find more alluring than mining rocks in space, if they are present at all. This allows the Smith to engage in content requiring the space ores in these cases.
The other materials were honestly way way overpriced, heavily disincentivising people from buying them. They're now actually reasonable for someone to buy for personal project stuff using their own bank account (yay, people have incentives to spend money!)
## Testing
Ordered every material crate, inspected contents.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
add: Added platinum, iridium, and palladium crates to cargo. 20 sheets per 400 Cr.
tweak: Reduced the costs of all pre-existing material crates.
/:cl: