### PR TITLE
Adjusts Medical Cargo Crates

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -400,6 +400,24 @@
 	for(var/I in 1 to 8)
 		new /obj/item/reagent_containers/pill/salicylic(src)
 
+/obj/item/storage/pill_bottle/salbutamol
+	name = "Pill Bottle (Salbutamol)"
+	desc = "Contains pills used to open up the airways in cases of pulmonary distress."
+	wrapper_color = COLOR_LIGHT_CYAN
+
+/obj/item/storage/pill_bottle/salbutamol/populate_contents()
+	for(var/I in 1 to 8)
+		new /obj/item/reagent_containers/pill/salbutamol(src)
+
+/obj/item/storage/pill_bottle/spaceacillin
+	name = "Pill Bottle (Spaceacillin)"
+	desc = "Contains pills used to treat bactieral infections."
+	wrapper_color = COLOR_LUMINOL 
+
+/obj/item/storage/pill_bottle/spaceacillin/populate_contents()
+	for(var/I in 1 to 8)
+		new /obj/item/reagent_containers/pill/spaceacillin(src)
+
 /obj/item/storage/pill_bottle/fakedeath
 	allow_wrap = FALSE
 

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -925,8 +925,8 @@
 	return
 
 /obj/item/storage/box/autoinjectors
-	name = "box of injectors"
-	desc = "Contains autoinjectors."
+	name = "box of epinephrine autoinjectors"
+	desc = "Contains autoinjectors pre-loaded with epinephrine."
 	icon_state = "injector_box"
 
 /obj/item/storage/box/autoinjectors/populate_contents()

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -165,6 +165,12 @@
 	icon_state = "pill8"
 	list_reagents = list("salbutamol" = 20)
 
+/obj/item/reagent_containers/pill/spaceacillin
+	name = "\improper Spaceacillin pill"
+	desc = "Used to treat bacterial infections."
+	icon_state = "pill3"
+	list_reagents = list("spaceacillin" = 5)
+
 /obj/item/reagent_containers/pill/hydrocodone
 	name = "\improper Hydrocodone pill"
 	desc = "Used to treat extreme pain."

--- a/code/modules/supply/supply_packs/pack_medical.dm
+++ b/code/modules/supply/supply_packs/pack_medical.dm
@@ -7,26 +7,44 @@
 
 
 /datum/supply_packs/medical/supplies
-	name = "Medical Supplies Crate"
-	contains = list(/obj/item/reagent_containers/glass/bottle/charcoal,
-					/obj/item/reagent_containers/glass/bottle/charcoal,
-					/obj/item/reagent_containers/glass/bottle/epinephrine,
-					/obj/item/reagent_containers/glass/bottle/epinephrine,
-					/obj/item/reagent_containers/glass/bottle/morphine,
-					/obj/item/reagent_containers/glass/bottle/morphine,
-					/obj/item/reagent_containers/glass/bottle/toxin,
-					/obj/item/reagent_containers/glass/bottle/toxin,
-					/obj/item/reagent_containers/glass/beaker/large,
-					/obj/item/reagent_containers/glass/beaker/large,
-					/obj/item/stack/medical/bruise_pack,
+	name = "Basic Medicines Crate"
+	contains = list(/obj/item/stack/medical/bruise_pack,
+					/obj/item/stack/medical/ointment,
 					/obj/item/reagent_containers/iv_bag/salglu,
+					/obj/item/storage/box/autoinjectors,
+					/obj/item/reagent_containers/glass/bottle/morphine,
+					/obj/item/reagent_containers/glass/bottle/morphine,
+					/obj/item/storage/pill_bottle/spaceacillin,
+					/obj/item/storage/pill_bottle/salbutamol,
+					/obj/item/storage/pill_bottle/painkillers)
+	cost = 250
+	containername = "basic medicines crate"
+
+/datum/supply_packs/medical/equipment
+	name = "Medical Equipment Crate"
+	contains = list(/obj/item/storage/box/bodybags,
 					/obj/item/storage/box/beakers,
+					/obj/item/reagent_containers/glass/beaker/large,
+					/obj/item/reagent_containers/glass/beaker/large,
 					/obj/item/storage/box/syringes,
-					/obj/item/storage/box/bodybags,
 					/obj/item/storage/box/iv_bags,
-					/obj/item/vending_refill/medical)
-	cost = 400
-	containername = "medical supplies crate"
+					/obj/item/storage/box/pillbottles,
+					/obj/item/storage/box/patch_packs,
+					/obj/item/storage/box/suture_pack,
+					/obj/item/storage/box/mesh_pack)
+	cost = 50
+	containername = "medical equipment crate"
+
+/datum/supply_packs/medical/body_bags
+	name = "Body Bag Crate"
+	contains = list(/obj/item/storage/box/bodybags,
+					/obj/item/storage/box/bodybags,
+					/obj/item/storage/box/bodybags,
+					/obj/item/storage/box/bodybags,
+					/obj/item/storage/box/bodybags,
+					/obj/item/storage/box/bodybags)
+	cost = 50
+	containername = "body bag crate"
 
 /datum/supply_packs/medical/firstaid
 	name = "First Aid Kits Crate"
@@ -34,7 +52,7 @@
 					/obj/item/storage/firstaid/regular,
 					/obj/item/storage/firstaid/regular,
 					/obj/item/storage/firstaid/regular)
-	cost = 250
+	cost = 200
 	containername = "first aid kits crate"
 
 /datum/supply_packs/medical/firstaidadv
@@ -59,6 +77,7 @@
 	name = "Brute Treatment Kits Crate"
 	contains = list(/obj/item/storage/firstaid/brute,
 					/obj/item/storage/firstaid/brute,
+					/obj/item/storage/firstaid/brute,
 					/obj/item/storage/firstaid/brute)
 	cost = 250
 	containername = "brute first aid kits crate"
@@ -66,6 +85,7 @@
 /datum/supply_packs/medical/firstaidburns
 	name = "Burns Treatment Kits Crate"
 	contains = list(/obj/item/storage/firstaid/fire,
+					/obj/item/storage/firstaid/fire,
 					/obj/item/storage/firstaid/fire,
 					/obj/item/storage/firstaid/fire)
 	cost = 250
@@ -75,16 +95,18 @@
 	name = "Toxin Treatment Kits Crate"
 	contains = list(/obj/item/storage/firstaid/toxin,
 					/obj/item/storage/firstaid/toxin,
+					/obj/item/storage/firstaid/toxin,
 					/obj/item/storage/firstaid/toxin)
-	cost = 250
+	cost = 150
 	containername = "toxin first aid kits crate"
 
 /datum/supply_packs/medical/firstaidoxygen
 	name = "Oxygen Treatment Kits Crate"
 	contains = list(/obj/item/storage/firstaid/o2,
 					/obj/item/storage/firstaid/o2,
+					/obj/item/storage/firstaid/o2,
 					/obj/item/storage/firstaid/o2)
-	cost = 250
+	cost = 50
 	containername = "oxygen first aid kits crate"
 
 /datum/supply_packs/medical/virus
@@ -140,6 +162,28 @@
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "blood pack crate"
 
+/datum/supply_packs/medical/vox_blood
+	name = "Vox Blood Pack Variety Crate"
+	contains = list(/obj/item/reagent_containers/iv_bag/blood/vox,
+					/obj/item/reagent_containers/iv_bag/blood/vox,
+					/obj/item/reagent_containers/iv_bag/blood/vox,
+					/obj/item/reagent_containers/iv_bag/blood/vox,
+					/obj/machinery/iv_drip)
+	cost = 350
+	containertype = /obj/structure/closet/crate/freezer
+	containername = "vox blood pack crate"
+
+/datum/supply_packs/medical/slime_jelly
+	name = "Slime Jelly Pack Crate"
+	contains = list(/obj/item/reagent_containers/iv_bag/slime,
+					/obj/item/reagent_containers/iv_bag/slime,
+					/obj/item/reagent_containers/iv_bag/slime,
+					/obj/item/reagent_containers/iv_bag/slime,
+					/obj/machinery/iv_drip)
+	cost = 350
+	containertype = /obj/structure/closet/crate/freezer
+	containername = "slime jelly pack crate"
+
 /datum/supply_packs/medical/surgery
 	name = "Surgery Crate"
 	contains = list(/obj/item/cautery,
@@ -154,8 +198,8 @@
 					/obj/item/bonesetter,
 					/obj/item/circular_saw,
 					/obj/item/surgical_drapes)
-	cost = 400
-	containertype = /obj/structure/closet/crate/secure
+	cost = 100
+	containertype = /obj/structure/closet/crate/secure/medisec
 	containername = "surgery crate"
 	access = ACCESS_MEDICAL
 
@@ -200,5 +244,5 @@
 					/obj/item/clothing/glasses/goggles,
 					/obj/item/clothing/glasses/goggles,
 				)
-	cost = 200
+	cost = 50
 	containername = "sterile mask shipment crate"

--- a/code/modules/supply/supply_packs/pack_medical.dm
+++ b/code/modules/supply/supply_packs/pack_medical.dm
@@ -163,7 +163,7 @@
 	containername = "blood pack crate"
 
 /datum/supply_packs/medical/vox_blood
-	name = "Vox Blood Pack Variety Crate"
+	name = "Vox Blood Pack Crate"
 	contains = list(/obj/item/reagent_containers/iv_bag/blood/vox,
 					/obj/item/reagent_containers/iv_bag/blood/vox,
 					/obj/item/reagent_containers/iv_bag/blood/vox,

--- a/code/modules/supply/supply_packs/pack_medical.dm
+++ b/code/modules/supply/supply_packs/pack_medical.dm
@@ -199,9 +199,7 @@
 					/obj/item/circular_saw,
 					/obj/item/surgical_drapes)
 	cost = 100
-	containertype = /obj/structure/closet/crate/secure/medisec
 	containername = "surgery crate"
-	access = ACCESS_MEDICAL
 
 /datum/supply_packs/medical/gloves
 	name = "Nitrile Glove Crate"


### PR DESCRIPTION
## What Does This PR Do
* Surgery crates have been given a medical crate instead of a generic grey secure crate.
* Cost of surgery crate reduced from 400 Cr to 100 Cr.
* Cost of the latex gloves and goggles 4-pack reduced from 200 Cr to 50 Cr.
* Cost of oxygen first aid kits crate reduced from 250 Cr to 50 Cr.
* Cost of toxin first aid kits crate reduced from 250 Cr to 150 Cr.
* Cost of Basic first aid kits crate reduced from 250 Cr to 200 Cr.
* The Toxins, Brute, Fire, and Oxygen first aid kits crates have had an extra first aid kit added to them (3 > 4) to match the other first aid crates.

* Removed Medical Supplies Crate.

* Added Medical Equipment crate for 50 Cr. It contains the following:
	Box of empty small beakers.
	2 empty large beakers.
	Box of empty syringes.
	Box of empty IV bags.
	Box of empty pill bottles.
	Box of empty patch packs.
	Box of empty suture packs.
	Box of empty mesh packs.
* Added Basic Medicines crate for 250 Cr. It contains the following:
	1 stack gauze
	1 stack ointment
	1 IV bag, saline-glucose solution
	1 box containing 7 epinephrine autoinjectors.
	2 bottles of morphine
	1 pill bottle containing 8 spaceacillin pills (5u each), equivalent to 2.6 spaceacillin syringes.
	1 pill bottle containing 8 salbutamol pills.
	1 pill bottle containing 8 acetylsalicylic acid pills.
* Added Body Bags crate for 50 Cr. It contains 6 boxes of body bags.
* Added Vox Blood Pack Crate for 350 Cr. It contains 4 vox blood IVs and an IV stand.
* Added Slime Jelly Pack Crate for 350 Cr. It contains 4 slime jelly IVs and an IV stand.
## Why It's Good For The Game
Multiple crates in the medical packs range are seriously overpriced for the value they actually provide.

Salbutamol is basically free, and is seriously outclassed by perflourodecilin, which is trival to manufacture in mass quantities. CPR, epinephrine, ephidrine, and handheld defibrillators also provide easy treatment of this damage type, and the first aid kits are common in maintenance. 50 Cr means that CMOs are more likely to buy a pack of these if they have a little bit of budget left over from buying other equipment.

Toxin damage is rarer than other damage types and does heal by itself outside of combat, and sleepers can produce infinite quantities of it, but charcoal is useful enough to be worth more than salbutamol, especially considering the fewer methods of treatment it has.

Brute and burn crates have not had their prices touched, but the extra crate makes them more competitive with the advanced first aid kit in terms of total healing (considering they're the same price).

Basic first aid kits cost slightly less than their more specialised versions, but the inclusion of brute and burn patches keeps them competitive enough to remain reasonably costly.

The basic medicines crate is mostly geared towards surgery and long-term low-intensity healing with the equipment it offers. It's distinctly unique to the first aid kits in how it can be used.

The medical equipment crate is very low cost and is mostly just stuff stripped out of the old medical supplies crate. It's convenient for medchem if they need more spots to cram their medicines into, but everything in the crate can be manufactured on station except for the body bags.

The surgery crate is mostly made of stuff that can be manufactured in the autolathe roundstart. The two things that are not, the sleeping gas and drapes, are not worth that much money, as the vendor restock crate provides morphine and spaceacillin to cover the niches of those items. Cost reduction makes it a more sensible proposition to buy.

Medical starts with huge numbers of blood bags for most species, and the variety crates give them lots more. Vox and slimes get a single blood bag each per crate, which is bad if there's a lot of them. Their own specialised blood crates give 4 of their blood type each, the cost efficiency is slightly lower, (to be equivalent it'd be about 326 Cr), but the universality of their blood makes up for this.
## Testing
Spawned in, gave myself infinite money, bought every medical crate, inspected them.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
add: Added vox and slime blood crates, body bag crates, and medical equipment crates.
tweak: Adjusts most medical cargo crates.
/:cl: